### PR TITLE
Fix repository method typo

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
@@ -20,7 +20,7 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
         SELECT s FROM StoreStatistics s
         WHERE s.store.owner.id = :userId
     """)
-    List<StoreStatistics> findAllByUserId(@Param("userId") Long userId);;
+    List<StoreStatistics> findAllByUserId(@Param("userId") Long userId);
 
 
 }


### PR DESCRIPTION
## Summary
- fix extra semicolon in StoreAnalyticsRepository

## Testing
- `sh mvnw test` *(fails: cannot open wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6840a15f260c832dab499a7159814242