### PR TITLE
Switch postal stats to new service

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
+++ b/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
@@ -4,7 +4,7 @@ import com.project.tracking_system.dto.PostalServiceStatsDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.StoreStatistics;
 import com.project.tracking_system.entity.User;
-import com.project.tracking_system.service.analytics.DeliveryHistoryService;
+import com.project.tracking_system.service.analytics.PostalServiceStatsService;
 import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import com.project.tracking_system.service.analytics.StoreDashboardDataService;
 import com.project.tracking_system.service.store.StoreService;
@@ -34,7 +34,7 @@ import java.util.Map;
 @RequestMapping("/analytics")
 public class AnalyticsController {
 
-    private final DeliveryHistoryService deliveryHistoryService;
+    private final PostalServiceStatsService postalServiceStatsService;
     private final StoreAnalyticsService storeAnalyticsService;
     private final StoreService storeService;
     private final StoreDashboardDataService storeDashboardDataService;
@@ -97,7 +97,7 @@ public class AnalyticsController {
 
             statistics     = List.of(stat);
             storeStatistics = stat;
-            postalStats    = deliveryHistoryService.getStatsByPostalService(storeId);
+            postalStats    = postalServiceStatsService.getStatsByStore(storeId);
             visibleStats   = statistics;
             storeIds       = List.of(storeId);
 
@@ -106,7 +106,7 @@ public class AnalyticsController {
 
             statistics     = storeAnalyticsService.getUserStatistics(userId);
             storeStatistics = storeAnalyticsService.aggregateStatistics(statistics);
-            postalStats    = deliveryHistoryService.getStatsByPostalServiceForStores(
+            postalStats    = postalServiceStatsService.getStatsForStores(
                     stores.stream().map(Store::getId).toList());
             visibleStats   = statistics;
             storeIds       = stores.stream().map(Store::getId).toList();

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -254,46 +254,5 @@ public class DeliveryHistoryService {
         }
     }
 
-    public List<PostalServiceStatsDTO> getStatsByPostalService(Long storeId) {
-        List<Object[]> rawData = deliveryHistoryRepository.getRawStatsByPostalService(storeId);
-        return rawData.stream()
-                .map(this::mapToDto)
-                .toList();
-    }
-
-    public List<PostalServiceStatsDTO> getStatsByPostalServiceForStores(List<Long> storeIds) {
-        List<Object[]> rawData = deliveryHistoryRepository.getRawStatsByPostalServiceForStores(storeIds);
-        return rawData.stream()
-                .map(this::mapToDto)
-                .toList();
-    }
-
-    /**
-     * Преобразует массив данных, полученных из запроса к БД,
-     * в объект {@link PostalServiceStatsDTO} c локализованным названием почтовой службы.
-     *
-     * @param row массив полей: [кодСлужбы, отправлено, доставлено, возвращено, средняяДоставка]
-     * @return заполненный DTO со строковым именем почтовой службы, числом отправленных, доставленных и возвращённых
-     */
-    private PostalServiceStatsDTO mapToDto(Object[] row) {
-        String code = (String) row[0];
-        PostalServiceType type = PostalServiceType.fromCode(code);
-        String displayName = type.getDisplayName();
-
-        int sent = row[1] != null ? ((Number) row[1]).intValue() : 0;
-        int delivered = row[2] != null ? ((Number) row[2]).intValue() : 0;
-        int returned = row[3] != null ? ((Number) row[3]).intValue() : 0;
-        double avgDeliveryDays = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
-        double avgPickupTimeDays = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
-
-        return new PostalServiceStatsDTO(
-                displayName,
-                sent,
-                delivered,
-                returned,
-                avgDeliveryDays,
-                avgPickupTimeDays
-        );
-    }
 
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatsService.java
@@ -1,0 +1,51 @@
+package com.project.tracking_system.service.analytics;
+
+import com.project.tracking_system.dto.PostalServiceStatsDTO;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.repository.DeliveryHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostalServiceStatsService {
+
+    private final DeliveryHistoryRepository deliveryHistoryRepository;
+
+    public List<PostalServiceStatsDTO> getStatsByStore(Long storeId) {
+        List<Object[]> raw = deliveryHistoryRepository.getRawStatsByPostalService(storeId);
+        return raw.stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    public List<PostalServiceStatsDTO> getStatsForStores(List<Long> storeIds) {
+        List<Object[]> raw = deliveryHistoryRepository.getRawStatsByPostalServiceForStores(storeIds);
+        return raw.stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    private PostalServiceStatsDTO mapToDto(Object[] row) {
+        String code = (String) row[0];
+        PostalServiceType type = PostalServiceType.fromCode(code);
+        String displayName = type.getDisplayName();
+
+        int sent = row[1] != null ? ((Number) row[1]).intValue() : 0;
+        int delivered = row[2] != null ? ((Number) row[2]).intValue() : 0;
+        int returned = row[3] != null ? ((Number) row[3]).intValue() : 0;
+        double avgDeliveryDays = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
+        double avgPickupTimeDays = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
+
+        return new PostalServiceStatsDTO(
+                displayName,
+                sent,
+                delivered,
+                returned,
+                avgDeliveryDays,
+                avgPickupTimeDays
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- remove postal-service stat queries from `DeliveryHistoryService`
- introduce `PostalServiceStatsService` with same queries
- update `AnalyticsController` to use new service for postal metrics

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840be439594832db65ddd8cc4121b59