### PR TITLE
Refactor analytics to use stored counters

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.sql.Timestamp;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,65 +15,6 @@ public interface DeliveryHistoryRepository extends JpaRepository<DeliveryHistory
 
     Optional<DeliveryHistory> findByTrackParcelId(Long trackParcelId);
 
-    @Query(value = """
-    SELECT AVG(EXTRACT(EPOCH FROM (arrived_date - send_date)) / 86400)
-    FROM tb_delivery_history
-    WHERE store_id = :storeId
-    AND arrived_date IS NOT NULL
-    AND send_date IS NOT NULL
-    """, nativeQuery = true)
-    Double findAverageDeliveryTimeToFinalPoint(@Param("storeId") Long storeId);
-
-
-    @Query(value = """
-    SELECT 
-        postal_service AS postalService,
-        COUNT(*) AS sent,
-        SUM(CASE WHEN arrived_date IS NOT NULL THEN 1 ELSE 0 END) AS delivered,
-        SUM(CASE WHEN returned_date IS NOT NULL THEN 1 ELSE 0 END) AS returned,
-        AVG(EXTRACT(EPOCH FROM (arrived_date - send_date)) / 86400) AS avgDeliveryDays,
-        AVG(EXTRACT(EPOCH FROM (received_date - arrived_date)) / 86400) AS avgPickupTimeDays
-    FROM tb_delivery_history
-    WHERE store_id = :storeId
-    GROUP BY postal_service
-    """, nativeQuery = true)
-    List<Object[]> getRawStatsByPostalService(@Param("storeId") Long storeId);
-
-
-    @Query(value = """
-    SELECT 
-        postal_service AS postalService,
-        COUNT(*) AS sent,
-        SUM(CASE WHEN arrived_date IS NOT NULL THEN 1 ELSE 0 END) AS delivered,
-        SUM(CASE WHEN returned_date IS NOT NULL THEN 1 ELSE 0 END) AS returned,
-        AVG(EXTRACT(EPOCH FROM (arrived_date - send_date)) / 86400) AS avgDeliveryDays,
-        AVG(EXTRACT(EPOCH FROM (received_date - arrived_date)) / 86400) AS avgPickupTimeDays
-    FROM tb_delivery_history
-    WHERE store_id IN (:storeIds)
-    GROUP BY postal_service
-    """, nativeQuery = true)
-    List<Object[]> getRawStatsByPostalServiceForStores(@Param("storeIds") List<Long> storeIds);
-
-
-    @Query(value = """
-    SELECT 
-        DATE_TRUNC(:interval, send_date) AS period,
-        COUNT(*) AS sent,
-        SUM(CASE WHEN received_date IS NOT NULL THEN 1 ELSE 0 END) AS delivered,
-        SUM(CASE WHEN returned_date IS NOT NULL THEN 1 ELSE 0 END) AS returned
-    FROM tb_delivery_history
-    WHERE store_id IN (:storeIds)
-      AND send_date IS NOT NULL
-      AND send_date BETWEEN :from AND :to
-    GROUP BY period
-    ORDER BY period
-    """, nativeQuery = true)
-    List<Object[]> getSentDeliveredReturnedGroupedByPeriod(
-            @Param("storeIds") List<Long> storeIds,
-            @Param("interval") String interval,
-            @Param("from") Timestamp from,
-            @Param("to") Timestamp to
-    );
 
     @Query(value = """
     SELECT AVG(EXTRACT(EPOCH FROM (received_date - arrived_date)) / 86400)

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
@@ -1,18 +1,17 @@
 package com.project.tracking_system.service.analytics;
 
 import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
-import com.project.tracking_system.repository.DeliveryHistoryRepository;
+import com.project.tracking_system.entity.StoreStatistics;
+import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * @author Dmitriy Anisimov
@@ -23,7 +22,8 @@ import java.util.Locale;
 @Slf4j
 public class DeliveryAnalyticsService {
 
-    private final DeliveryHistoryRepository deliveryHistoryRepository;
+    private final StoreAnalyticsRepository storeAnalyticsRepository;
+    private final StoreAnalyticsService storeAnalyticsService;
 
     public List<DeliveryFullPeriodStatsDTO> getFullPeriodStats(List<Long> storeIds,
                                                                ChronoUnit interval,
@@ -31,43 +31,15 @@ public class DeliveryAnalyticsService {
                                                                ZonedDateTime to,
                                                                ZoneId userZone) {
 
-        String intervalStr = switch (interval) {
-            case DAYS -> "day";
-            case WEEKS -> "week";
-            case MONTHS -> "month";
-            default -> throw new IllegalArgumentException("Unsupported interval: " + interval);
-        };
+        List<StoreStatistics> stats = storeAnalyticsRepository.findAllById(storeIds);
+        StoreStatistics aggregate = storeAnalyticsService.aggregateStatistics(stats);
 
-        Timestamp fromTs = Timestamp.from(from.toInstant());
-        Timestamp toTs = Timestamp.from(to.toInstant());
-
-        List<Object[]> rows = deliveryHistoryRepository.getSentDeliveredReturnedGroupedByPeriod(
-                storeIds, intervalStr, fromTs, toTs
-        );
-
-        DateTimeFormatter formatter = switch (interval) {
-            case DAYS -> DateTimeFormatter.ofPattern("dd.MM");
-            case WEEKS -> DateTimeFormatter.ofPattern("'Неделя' w");
-            case MONTHS -> DateTimeFormatter.ofPattern("LLLL yyyy", new Locale("ru"));
-            default -> DateTimeFormatter.ISO_DATE;
-        };
-
-        return rows.stream()
-                .map(row -> {
-                    Timestamp ts = (Timestamp) row[0];
-                    ZonedDateTime period = ts.toInstant().atZone(userZone);
-                    long sent = ((Number) row[1]).longValue();
-                    long delivered = ((Number) row[2]).longValue();
-                    long returned = ((Number) row[3]).longValue();
-
-                    return new DeliveryFullPeriodStatsDTO(
-                            formatter.format(period),
-                            sent,
-                            delivered,
-                            returned
-                    );
-                })
-                .toList();
+        return List.of(new DeliveryFullPeriodStatsDTO(
+                "Всего",
+                aggregate.getTotalSent(),
+                aggregate.getTotalDelivered(),
+                aggregate.getTotalReturned()
+        ));
     }
 
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatsService.java
@@ -1,8 +1,9 @@
 package com.project.tracking_system.service.analytics;
 
 import com.project.tracking_system.dto.PostalServiceStatsDTO;
-import com.project.tracking_system.entity.PostalServiceType;
-import com.project.tracking_system.repository.DeliveryHistoryRepository;
+import com.project.tracking_system.entity.StoreStatistics;
+import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,40 +13,29 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostalServiceStatsService {
 
-    private final DeliveryHistoryRepository deliveryHistoryRepository;
+    private final StoreAnalyticsRepository storeAnalyticsRepository;
+    private final StoreAnalyticsService storeAnalyticsService;
 
     public List<PostalServiceStatsDTO> getStatsByStore(Long storeId) {
-        List<Object[]> raw = deliveryHistoryRepository.getRawStatsByPostalService(storeId);
-        return raw.stream()
-                .map(this::mapToDto)
-                .toList();
+        StoreStatistics stats = storeAnalyticsRepository.findByStoreId(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("Статистика не найдена"));
+        return List.of(mapToDto(stats));
     }
 
     public List<PostalServiceStatsDTO> getStatsForStores(List<Long> storeIds) {
-        List<Object[]> raw = deliveryHistoryRepository.getRawStatsByPostalServiceForStores(storeIds);
-        return raw.stream()
-                .map(this::mapToDto)
-                .toList();
+        List<StoreStatistics> stats = storeAnalyticsRepository.findAllById(storeIds);
+        StoreStatistics aggregate = storeAnalyticsService.aggregateStatistics(stats);
+        return List.of(mapToDto(aggregate));
     }
 
-    private PostalServiceStatsDTO mapToDto(Object[] row) {
-        String code = (String) row[0];
-        PostalServiceType type = PostalServiceType.fromCode(code);
-        String displayName = type.getDisplayName();
-
-        int sent = row[1] != null ? ((Number) row[1]).intValue() : 0;
-        int delivered = row[2] != null ? ((Number) row[2]).intValue() : 0;
-        int returned = row[3] != null ? ((Number) row[3]).intValue() : 0;
-        double avgDeliveryDays = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
-        double avgPickupTimeDays = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
-
+    private PostalServiceStatsDTO mapToDto(StoreStatistics stats) {
         return new PostalServiceStatsDTO(
-                displayName,
-                sent,
-                delivered,
-                returned,
-                avgDeliveryDays,
-                avgPickupTimeDays
+                "Все службы",
+                stats.getTotalSent(),
+                stats.getTotalDelivered(),
+                stats.getTotalReturned(),
+                stats.getAverageDeliveryDays().doubleValue(),
+                stats.getAveragePickupDays().doubleValue()
         );
     }
 }


### PR DESCRIPTION
## Summary
- drop unused delivery history queries
- update `PostalServiceStatsService` to read counters from `StoreStatistics`
- update `DeliveryAnalyticsService` to aggregate counters from stores

## Testing
- `./mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6840c018b164832da16c0056bed979ff