### PR TITLE
Adjust postal service stats on parcel removal

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -245,14 +245,15 @@ public class DeliveryHistoryService {
             stats.setTotalSent(stats.getTotalSent() - 1);
             stats.setUpdatedAt(ZonedDateTime.now());
             storeAnalyticsRepository.save(stats);
-            if (psStats != null && psStats.getTotalSent() > 0) {
-                psStats.setTotalSent(psStats.getTotalSent() - 1);
-                psStats.setUpdatedAt(ZonedDateTime.now());
-                postalServiceStatisticsRepository.save(psStats);
-            }
             log.info("➖ Уменьшили totalSent после удаления неучтённой посылки: {}", parcel.getNumber());
         } else {
             log.warn("Попытка уменьшить totalSent, но он уже 0. Посылка: {}", parcel.getNumber());
+        }
+
+        if (psStats != null && psStats.getTotalSent() > 0) {
+            psStats.setTotalSent(psStats.getTotalSent() - 1);
+            psStats.setUpdatedAt(ZonedDateTime.now());
+            postalServiceStatisticsRepository.save(psStats);
         }
     }
 


### PR DESCRIPTION
## Summary
- update handleTrackParcelBeforeDelete so postal service statistics are also decreased

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dab43f20832dba96c5f6ae0f9a67