### PR TITLE
Update postal service stats retrieval

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
+++ b/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
@@ -4,7 +4,7 @@ import com.project.tracking_system.dto.PostalServiceStatsDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.StoreStatistics;
 import com.project.tracking_system.entity.User;
-import com.project.tracking_system.service.analytics.PostalServiceStatsService;
+import com.project.tracking_system.service.analytics.PostalServiceStatisticsService;
 import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import com.project.tracking_system.service.analytics.StoreDashboardDataService;
 import com.project.tracking_system.service.store.StoreService;
@@ -34,7 +34,7 @@ import java.util.Map;
 @RequestMapping("/analytics")
 public class AnalyticsController {
 
-    private final PostalServiceStatsService postalServiceStatsService;
+    private final PostalServiceStatisticsService postalStatisticsService;
     private final StoreAnalyticsService storeAnalyticsService;
     private final StoreService storeService;
     private final StoreDashboardDataService storeDashboardDataService;
@@ -97,7 +97,7 @@ public class AnalyticsController {
 
             statistics     = List.of(stat);
             storeStatistics = stat;
-            postalStats    = postalServiceStatsService.getStatsByStore(storeId);
+            postalStats    = postalStatisticsService.getStatsByStore(storeId);
             visibleStats   = statistics;
             storeIds       = List.of(storeId);
 
@@ -106,7 +106,7 @@ public class AnalyticsController {
 
             statistics     = storeAnalyticsService.getUserStatistics(userId);
             storeStatistics = storeAnalyticsService.aggregateStatistics(statistics);
-            postalStats    = postalServiceStatsService.getStatsForStores(
+            postalStats    = postalStatisticsService.getStatsForStores(
                     stores.stream().map(Store::getId).toList());
             visibleStats   = statistics;
             storeIds       = stores.stream().map(Store::getId).toList();

--- a/src/main/java/com/project/tracking_system/dto/PostalServiceStatsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/PostalServiceStatsDTO.java
@@ -17,7 +17,16 @@ public class PostalServiceStatsDTO {
     private int sent;
     private int delivered;
     private int returned;
-    private double avgDeliveryDays;
-    private double avgPickupTimeDays;
+    private double sumDeliveryDays;
+    private double sumPickupTimeDays;
+
+    public double getAvgDeliveryDays() {
+        return delivered > 0 ? sumDeliveryDays / delivered : 0.0;
+    }
+
+    public double getAvgPickupTimeDays() {
+        int pickedUp = delivered + returned;
+        return pickedUp > 0 ? sumPickupTimeDays / pickedUp : 0.0;
+    }
 
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
@@ -10,4 +10,10 @@ public interface PostalServiceStatisticsRepository extends JpaRepository<PostalS
 
     Optional<PostalServiceStatistics> findByStoreIdAndPostalServiceType(Long storeId, PostalServiceType postalServiceType);
 
+    // Fetch statistics for all postal services of one store
+    List<PostalServiceStatistics> findByStoreId(Long storeId);
+
+    // Fetch statistics for multiple stores
+    List<PostalServiceStatistics> findByStoreIdIn(List<Long> storeIds);
+
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
@@ -1,0 +1,57 @@
+package com.project.tracking_system.service.analytics;
+
+import com.project.tracking_system.dto.PostalServiceStatsDTO;
+import com.project.tracking_system.entity.PostalServiceStatistics;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PostalServiceStatisticsService {
+
+    private final PostalServiceStatisticsRepository repository;
+
+    public List<PostalServiceStatsDTO> getStatsByStore(Long storeId) {
+        return repository.findByStoreId(storeId)
+                .stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    public List<PostalServiceStatsDTO> getStatsForStores(List<Long> storeIds) {
+        List<PostalServiceStatistics> stats = repository.findByStoreIdIn(storeIds);
+        Map<PostalServiceType, PostalServiceStatistics> aggregated = new EnumMap<>(PostalServiceType.class);
+        for (PostalServiceStatistics stat : stats) {
+            aggregated.merge(stat.getPostalServiceType(), stat, this::mergeStats);
+        }
+        return aggregated.values().stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    private PostalServiceStatistics mergeStats(PostalServiceStatistics a, PostalServiceStatistics b) {
+        a.setTotalSent(a.getTotalSent() + b.getTotalSent());
+        a.setTotalDelivered(a.getTotalDelivered() + b.getTotalDelivered());
+        a.setTotalReturned(a.getTotalReturned() + b.getTotalReturned());
+        a.setSumDeliveryDays(a.getSumDeliveryDays().add(b.getSumDeliveryDays()));
+        a.setSumPickupDays(a.getSumPickupDays().add(b.getSumPickupDays()));
+        return a;
+    }
+
+    private PostalServiceStatsDTO mapToDto(PostalServiceStatistics stats) {
+        PostalServiceStatsDTO dto = new PostalServiceStatsDTO();
+        dto.setPostalService(stats.getPostalServiceType().getDisplayName());
+        dto.setSent(stats.getTotalSent());
+        dto.setDelivered(stats.getTotalDelivered());
+        dto.setReturned(stats.getTotalReturned());
+        dto.setSumDeliveryDays(stats.getSumDeliveryDays().doubleValue());
+        dto.setSumPickupTimeDays(stats.getSumPickupDays().doubleValue());
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary
- add repository queries for postal service stats
- compute averages in `PostalServiceStatsDTO`
- implement `PostalServiceStatisticsService`
- use the new service in `AnalyticsController`

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0e9e3b4832d86f0e9c41e71d0d6