### PR TITLE
Fix StoreStatistics initialization for new store

### DIFF
--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -101,10 +101,8 @@ public class StoreService {
         statistics.setTotalSent(0);
         statistics.setTotalDelivered(0);
         statistics.setTotalReturned(0);
-        statistics.setAverageDeliveryDays(0.0);
-        statistics.setAveragePickupDays(0.0);
-        statistics.setDeliverySuccessRate(BigDecimal.ZERO);
-        statistics.setReturnRate(BigDecimal.ZERO);
+        statistics.setSumDeliveryDays(BigDecimal.ZERO);
+        statistics.setSumPickupDays(BigDecimal.ZERO);
         statistics.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
 
         storeAnalyticsRepository.save(statistics);


### PR DESCRIPTION
## Summary
- streamline statistics setup when creating a store

## Testing
- `./mvnw -q -DskipTests=true package` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68417f6d4f00832d9c1d642c435741b1