### PR TITLE
Improve delivery analytics by interval

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -24,5 +26,20 @@ public interface DeliveryHistoryRepository extends JpaRepository<DeliveryHistory
     AND arrived_date IS NOT NULL
     """, nativeQuery = true)
     Double findAvgPickupTimeForStore(@Param("storeId") Long storeId);
+
+    // Получить записи по дате отправки в указанном диапазоне
+    List<DeliveryHistory> findByStoreIdInAndSendDateBetween(List<Long> storeIds,
+                                                            ZonedDateTime from,
+                                                            ZonedDateTime to);
+
+    // Получить записи по дате получения в указанном диапазоне
+    List<DeliveryHistory> findByStoreIdInAndReceivedDateBetween(List<Long> storeIds,
+                                                                ZonedDateTime from,
+                                                                ZonedDateTime to);
+
+    // Получить записи по дате возврата в указанном диапазоне
+    List<DeliveryHistory> findByStoreIdInAndReturnedDateBetween(List<Long> storeIds,
+                                                                ZonedDateTime from,
+                                                                ZonedDateTime to);
 
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
@@ -3,6 +3,8 @@ package com.project.tracking_system.service.analytics;
 import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
 import com.project.tracking_system.entity.StoreStatistics;
 import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.repository.DeliveryHistoryRepository;
+import com.project.tracking_system.entity.DeliveryHistory;
 import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ public class DeliveryAnalyticsService {
 
     private final StoreAnalyticsRepository storeAnalyticsRepository;
     private final StoreAnalyticsService storeAnalyticsService;
+    private final DeliveryHistoryRepository deliveryHistoryRepository;
 
     public List<DeliveryFullPeriodStatsDTO> getFullPeriodStats(List<Long> storeIds,
                                                                ChronoUnit interval,
@@ -31,36 +34,81 @@ public class DeliveryAnalyticsService {
                                                                ZonedDateTime to,
                                                                ZoneId userZone) {
 
-        List<StoreStatistics> stats = storeAnalyticsRepository.findAllById(storeIds);
-        StoreStatistics aggregate = storeAnalyticsService.aggregateStatistics(stats);
+        ZonedDateTime start = alignToPeriod(from, interval, userZone);
+        ZonedDateTime end   = alignToPeriod(to, interval, userZone);
 
-        ZonedDateTime current = from;
+        ZonedDateTime fromUtc = from.withZoneSameInstant(java.time.ZoneOffset.UTC);
+        ZonedDateTime toUtc = to.withZoneSameInstant(java.time.ZoneOffset.UTC);
+
+        // Подготавливаем контейнер для подсчёта статистики по каждому интервалу
+        java.util.Map<ZonedDateTime, long[]> counters = new java.util.LinkedHashMap<>();
+        ZonedDateTime cursor = start;
+        while (!cursor.isAfter(end)) {
+            counters.put(cursor, new long[]{0, 0, 0}); // sent, delivered, returned
+            cursor = nextPeriod(cursor, interval);
+        }
+
+        // Загружаем события доставки из истории
+        List<DeliveryHistory> sentEvents = deliveryHistoryRepository
+                .findByStoreIdInAndSendDateBetween(storeIds, fromUtc, toUtc);
+        List<DeliveryHistory> deliveredEvents = deliveryHistoryRepository
+                .findByStoreIdInAndReceivedDateBetween(storeIds, fromUtc, toUtc);
+        List<DeliveryHistory> returnedEvents = deliveryHistoryRepository
+                .findByStoreIdInAndReturnedDateBetween(storeIds, fromUtc, toUtc);
+
+        for (DeliveryHistory dh : sentEvents) {
+            ZonedDateTime key = alignToPeriod(dh.getSendDate(), interval, userZone);
+            long[] arr = counters.get(key);
+            if (arr != null) arr[0]++;
+        }
+        for (DeliveryHistory dh : deliveredEvents) {
+            ZonedDateTime key = alignToPeriod(dh.getReceivedDate(), interval, userZone);
+            long[] arr = counters.get(key);
+            if (arr != null) arr[1]++;
+        }
+        for (DeliveryHistory dh : returnedEvents) {
+            ZonedDateTime key = alignToPeriod(dh.getReturnedDate(), interval, userZone);
+            long[] arr = counters.get(key);
+            if (arr != null) arr[2]++;
+        }
+
         List<DeliveryFullPeriodStatsDTO> list = new java.util.ArrayList<>();
-
-        while (!current.isAfter(to)) {
-            String label = switch (interval) {
-                case DAYS -> current.toLocalDate().toString();
-                case WEEKS -> "Week " + current.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
-                case MONTHS -> current.getMonth() + " " + current.getYear();
-                default -> current.toLocalDate().toString();
-            };
-
-            list.add(new DeliveryFullPeriodStatsDTO(
-                    label,
-                    aggregate.getTotalSent(),
-                    aggregate.getTotalDelivered(),
-                    aggregate.getTotalReturned()
-            ));
-
-            current = switch (interval) {
-                case DAYS -> current.plusDays(1);
-                case WEEKS -> current.plusWeeks(1);
-                case MONTHS -> current.plusMonths(1);
-                default -> current.plusDays(1);
-            };
+        for (java.util.Map.Entry<ZonedDateTime, long[]> entry : counters.entrySet()) {
+            ZonedDateTime periodStart = entry.getKey();
+            long[] arr = entry.getValue();
+            String label = formatLabel(periodStart, interval);
+            list.add(new DeliveryFullPeriodStatsDTO(label, arr[0], arr[1], arr[2]));
         }
 
         return list;
+    }
+
+    private ZonedDateTime alignToPeriod(ZonedDateTime date, ChronoUnit interval, ZoneId zone) {
+        ZonedDateTime zoned = date.withZoneSameInstant(zone);
+        return switch (interval) {
+            case DAYS -> zoned.truncatedTo(ChronoUnit.DAYS);
+            case WEEKS -> zoned.with(java.time.DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
+            case MONTHS -> zoned.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+            default -> zoned.truncatedTo(ChronoUnit.DAYS);
+        };
+    }
+
+    private ZonedDateTime nextPeriod(ZonedDateTime current, ChronoUnit interval) {
+        return switch (interval) {
+            case DAYS -> current.plusDays(1);
+            case WEEKS -> current.plusWeeks(1);
+            case MONTHS -> current.plusMonths(1);
+            default -> current.plusDays(1);
+        };
+    }
+
+    private String formatLabel(ZonedDateTime date, ChronoUnit interval) {
+        return switch (interval) {
+            case DAYS -> date.toLocalDate().toString();
+            case WEEKS -> "Week " + date.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            case MONTHS -> date.getMonth() + " " + date.getYear();
+            default -> date.toLocalDate().toString();
+        };
     }
 
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/StoreDashboardDataService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/StoreDashboardDataService.java
@@ -37,7 +37,7 @@ public class StoreDashboardDataService {
     public Map<String, Object> getFullPeriodStatsChart(List<Long> storeIds,
                                                        ChronoUnit interval,
                                                        ZoneId userZone) {
-        ZonedDateTime now = ZonedDateTime.now(userZone);
+        ZonedDateTime now = ZonedDateTime.now(userZone).truncatedTo(ChronoUnit.DAYS);
         ZonedDateTime from = switch (interval) {
             case DAYS -> now.minusDays(7);
             case WEEKS -> now.minusWeeks(4);


### PR DESCRIPTION
## Summary
- track delivery history by date ranges in repository
- compute period-based delivery stats from history
- trim dashboard charts to day precision before calculating

## Testing
- `./mvnw test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684180360568832dbde4b02d706977f3