### PR TITLE
Remove unused pickup time query

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
@@ -2,8 +2,6 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.DeliveryHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -18,14 +16,6 @@ public interface DeliveryHistoryRepository extends JpaRepository<DeliveryHistory
     Optional<DeliveryHistory> findByTrackParcelId(Long trackParcelId);
 
 
-    @Query(value = """
-    SELECT AVG(EXTRACT(EPOCH FROM (received_date - arrived_date)) / 86400)
-    FROM tb_delivery_history
-    WHERE store_id = :storeId
-    AND received_date IS NOT NULL
-    AND arrived_date IS NOT NULL
-    """, nativeQuery = true)
-    Double findAvgPickupTimeForStore(@Param("storeId") Long storeId);
 
     // Получить записи по дате отправки в указанном диапазоне
     List<DeliveryHistory> findByStoreIdInAndSendDateBetween(List<Long> storeIds,


### PR DESCRIPTION
## Summary
- drop unused `findAvgPickupTimeForStore` method

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684188b8727c832dacb0171d76001fdc