### PR TITLE
Fix stray semicolon in repository interface

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
@@ -20,7 +20,7 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
         SELECT s FROM StoreStatistics s
         WHERE s.store.owner.id = :userId
     """)
-    List<StoreStatistics> findAllByUserId(@Param("userId") Long userId);;
+    List<StoreStatistics> findAllByUserId(@Param("userId") Long userId);
 
 
 }


### PR DESCRIPTION
## Summary
- remove extraneous semicolon in `StoreAnalyticsRepository`

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419810a978832da78343c96864ba22