### PR TITLE
Add daily statistics handling

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
@@ -6,11 +6,24 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository for daily postal service statistics.
  */
 public interface PostalServiceDailyStatisticsRepository extends JpaRepository<PostalServiceDailyStatistics, Long> {
+
+    /**
+     * Find statistics for a postal service of a store for a particular date.
+     *
+     * @param storeId           store identifier
+     * @param postalServiceType type of postal service
+     * @param date              date of statistics
+     * @return optional daily statistics
+     */
+    Optional<PostalServiceDailyStatistics> findByStoreIdAndPostalServiceTypeAndDate(Long storeId,
+                                                                                   PostalServiceType postalServiceType,
+                                                                                   LocalDate date);
 
     /**
      * Find statistics for a postal service of a store within a date range.

--- a/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
@@ -5,11 +5,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository for daily statistics of stores.
  */
 public interface StoreDailyStatisticsRepository extends JpaRepository<StoreDailyStatistics, Long> {
+
+    /**
+     * Find statistics for a store on a particular date.
+     *
+     * @param storeId store identifier
+     * @param date    date of statistics
+     * @return optional daily statistics
+     */
+    Optional<StoreDailyStatistics> findByStoreIdAndDate(Long storeId, LocalDate date);
 
     /**
      * Find statistics for a single store within a date range.


### PR DESCRIPTION
## Summary
- track creation updates daily statistics
- register final status updates daily counters
- deletion before final status decrements daily stats
- expose new daily statistics repository methods
- extend delivery history tests

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6736d84832d9a8edc33a35cbc1f