### PR TITLE
Implement period grouping in analytics

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.analytics;
 import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
 import com.project.tracking_system.entity.StoreStatistics;
 import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
 import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,25 +25,60 @@ import java.util.List;
 public class DeliveryAnalyticsService {
 
     private final StoreAnalyticsRepository storeAnalyticsRepository;
+    private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
     private final StoreAnalyticsService storeAnalyticsService;
 
+    /**
+     * Aggregates delivery statistics for the given stores within the specified period.
+     * <p>
+     * Daily statistics are grouped by the provided {@link ChronoUnit} and summed.
+     * The method always returns a DTO for each interval between {@code from} and {@code to}.
+     * </p>
+     *
+     * @param storeIds list of store identifiers
+     * @param interval grouping interval (days, weeks, months, years)
+     * @param from     start date-time in user's zone
+     * @param to       end date-time in user's zone
+     * @param userZone user's time zone
+     * @return list of aggregated statistics ordered by period
+     */
     public List<DeliveryFullPeriodStatsDTO> getFullPeriodStats(List<Long> storeIds,
                                                                ChronoUnit interval,
                                                                ZonedDateTime from,
                                                                ZonedDateTime to,
                                                                ZoneId userZone) {
 
-        List<StoreStatistics> stats = storeAnalyticsRepository.findByStoreIdIn(storeIds);
+        // Запрашиваем ежедневную статистику выбранных магазинов в указанном диапазоне
+        var dailyStats = storeDailyStatisticsRepository
+                .findByStoreIdInAndDateBetween(storeIds, from.toLocalDate(), to.toLocalDate());
 
-        long totalSent = stats.stream().mapToLong(StoreStatistics::getTotalSent).sum();
-        long totalDelivered = stats.stream().mapToLong(StoreStatistics::getTotalDelivered).sum();
-        long totalReturned = stats.stream().mapToLong(StoreStatistics::getTotalReturned).sum();
+        // Группируем по нужному интервалу и суммируем счетчики
+        var grouped = new java.util.TreeMap<ZonedDateTime, long[]>();
+        for (var stat : dailyStats) {
+            ZonedDateTime date = stat.getDate().atStartOfDay(userZone);
+            ZonedDateTime key = alignToPeriod(date, interval, userZone);
+            long[] arr = grouped.computeIfAbsent(key, k -> new long[3]);
+            arr[0] += stat.getSent();
+            arr[1] += stat.getDelivered();
+            arr[2] += stat.getReturned();
+        }
 
-        String label = formatLabel(alignToPeriod(from, interval, userZone), interval);
+        // Формируем итоговый список, включая периоды без данных
+        List<DeliveryFullPeriodStatsDTO> result = new java.util.ArrayList<>();
+        ZonedDateTime cursor = alignToPeriod(from, interval, userZone);
+        ZonedDateTime end = alignToPeriod(to, interval, userZone);
+        while (!cursor.isAfter(end)) {
+            long[] arr = grouped.getOrDefault(cursor, new long[3]);
+            result.add(new DeliveryFullPeriodStatsDTO(
+                    formatLabel(cursor, interval),
+                    arr[0],
+                    arr[1],
+                    arr[2]
+            ));
+            cursor = cursor.plus(1, interval);
+        }
 
-        return Collections.singletonList(
-                new DeliveryFullPeriodStatsDTO(label, totalSent, totalDelivered, totalReturned)
-        );
+        return result;
     }
 
     private ZonedDateTime alignToPeriod(ZonedDateTime date, ChronoUnit interval, ZoneId zone) {
@@ -51,6 +87,7 @@ public class DeliveryAnalyticsService {
             case DAYS -> zoned.truncatedTo(ChronoUnit.DAYS);
             case WEEKS -> zoned.with(java.time.DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
             case MONTHS -> zoned.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+            case YEARS -> zoned.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS);
             default -> zoned.truncatedTo(ChronoUnit.DAYS);
         };
     }
@@ -60,6 +97,7 @@ public class DeliveryAnalyticsService {
             case DAYS -> date.toLocalDate().toString();
             case WEEKS -> "Week " + date.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
             case MONTHS -> date.getMonth() + " " + date.getYear();
+            case YEARS -> String.valueOf(date.getYear());
             default -> date.toLocalDate().toString();
         };
     }

--- a/src/main/java/com/project/tracking_system/service/analytics/StoreDashboardDataService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/StoreDashboardDataService.java
@@ -34,6 +34,14 @@ public class StoreDashboardDataService {
         );
     }
 
+    /**
+     * Builds chart data for the selected period.
+     *
+     * @param storeIds ids of stores to aggregate
+     * @param interval requested interval (days, weeks, months, years)
+     * @param userZone user time zone
+     * @return map with labels and series values
+     */
     public Map<String, Object> getFullPeriodStatsChart(List<Long> storeIds,
                                                        ChronoUnit interval,
                                                        ZoneId userZone) {
@@ -42,6 +50,7 @@ public class StoreDashboardDataService {
             case DAYS -> now.minusDays(7);
             case WEEKS -> now.minusWeeks(4);
             case MONTHS -> now.minusMonths(6);
+            case YEARS -> now.minusYears(5);
             default -> throw new IllegalArgumentException("Unsupported interval: " + interval);
         };
         ZonedDateTime to = now;


### PR DESCRIPTION
## Summary
- group daily stats by interval in `DeliveryAnalyticsService`
- support yearly interval in label/period alignment
- extend dashboard service to request yearly stats

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6841b97024b0832d8672f28818911683