### PR TITLE
Add yearly interval option

### DIFF
--- a/src/main/resources/static/js/analytics.js
+++ b/src/main/resources/static/js/analytics.js
@@ -299,6 +299,9 @@ document.addEventListener("DOMContentLoaded", function () {
             case "MONTHS":
                 title = "Динамика отправлений по месяцам";
                 break;
+            case "YEARS":
+                title = "Динамика отправлений по годам";
+                break;
             default:
                 title = "Динамика отправлений";
         }

--- a/src/main/resources/templates/analytics/dashboard.html
+++ b/src/main/resources/templates/analytics/dashboard.html
@@ -48,6 +48,7 @@
                         <option value="DAYS" th:selected="${selectedInterval == 'DAYS'}">День</option>
                         <option value="WEEKS" th:selected="${selectedInterval == 'WEEKS'}">Неделя</option>
                         <option value="MONTHS" th:selected="${selectedInterval == 'MONTHS'}">Месяц</option>
+                        <option value="YEARS" th:selected="${selectedInterval == 'YEARS'}">Год</option>
                     </select>
                 </div>
 


### PR DESCRIPTION
## Summary
- add "Год" option in analytics dashboard
- display yearly dynamics title in the dashboard chart
- ensure analytics.js handles YEARS interval

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841badf7a14832da0cb6019c4ff2438