### PR TITLE
Add analytics service tests

### DIFF
--- a/src/test/java/DeliveryAnalyticsServiceTest.java
+++ b/src/test/java/DeliveryAnalyticsServiceTest.java
@@ -1,0 +1,81 @@
+import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreDailyStatistics;
+import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
+import com.project.tracking_system.service.analytics.DeliveryAnalyticsService;
+import com.project.tracking_system.service.analytics.StoreAnalyticsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DeliveryAnalyticsServiceTest {
+
+    @Mock
+    private StoreAnalyticsRepository storeAnalyticsRepository;
+    @Mock
+    private StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    @Mock
+    private StoreAnalyticsService storeAnalyticsService;
+
+    @InjectMocks
+    private DeliveryAnalyticsService deliveryAnalyticsService;
+
+    private StoreDailyStatistics createDaily(Store store, LocalDate date, int sent, int delivered, int returned) {
+        StoreDailyStatistics d = new StoreDailyStatistics();
+        d.setStore(store);
+        d.setDate(date);
+        d.setSent(sent);
+        d.setDelivered(delivered);
+        d.setReturned(returned);
+        return d;
+    }
+
+    @Test
+    void getFullPeriodStats_ByIntervals() {
+        Store store = new Store();
+        store.setId(1L);
+        List<Long> storeIds = List.of(store.getId());
+        ZoneId zone = ZoneId.of("UTC");
+        ZonedDateTime from = ZonedDateTime.of(2024,1,1,0,0,0,0, zone);
+        ZonedDateTime to = ZonedDateTime.of(2024,1,14,0,0,0,0, zone);
+
+        List<StoreDailyStatistics> data = List.of(
+                createDaily(store, LocalDate.of(2024,1,1),1,1,0),
+                createDaily(store, LocalDate.of(2024,1,2),2,0,1),
+                createDaily(store, LocalDate.of(2024,1,10),1,1,0)
+        );
+        when(storeDailyStatisticsRepository.findByStoreIdInAndDateBetween(storeIds, from.toLocalDate(), to.toLocalDate()))
+                .thenReturn(data);
+
+        List<DeliveryFullPeriodStatsDTO> byDay = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.DAYS, from, to, zone);
+        assertEquals(14, byDay.size());
+        assertEquals(1, byDay.get(0).sent());
+
+        List<DeliveryFullPeriodStatsDTO> byWeek = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.WEEKS, from, to, zone);
+        assertEquals(2, byWeek.size());
+        assertEquals(3, byWeek.get(0).sent());
+        assertEquals(1, byWeek.get(1).sent());
+
+        List<DeliveryFullPeriodStatsDTO> byMonth = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.MONTHS, from, to, zone);
+        assertEquals(1, byMonth.size());
+        assertEquals(4, byMonth.get(0).sent());
+
+        List<DeliveryFullPeriodStatsDTO> byYear = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.YEARS, from, to, zone);
+        assertEquals(1, byYear.size());
+        assertEquals(4, byYear.get(0).sent());
+    }
+}

--- a/src/test/java/TrackParcelServiceTest.java
+++ b/src/test/java/TrackParcelServiceTest.java
@@ -1,0 +1,113 @@
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.analytics.DeliveryHistoryService;
+import com.project.tracking_system.service.track.StatusTrackService;
+import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.*;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackParcelServiceTest {
+
+    @Mock
+    private WebSocketController webSocketController;
+    @Mock
+    private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+    @Mock
+    private StatusTrackService statusTrackService;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private DeliveryHistoryService deliveryHistoryService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private UserSubscriptionRepository userSubscriptionRepository;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private StoreAnalyticsRepository storeAnalyticsRepository;
+    @Mock
+    private PostalServiceStatisticsRepository postalServiceStatisticsRepository;
+    @Mock
+    private StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    @Mock
+    private PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
+
+    @InjectMocks
+    private TrackParcelService trackParcelService;
+
+    @Test
+    void save_NewTrack_CreatesDailyStats() {
+        Long storeId = 1L;
+        Long userId = 2L;
+        String number = "PC123456789BY";
+        ZoneId zone = ZoneOffset.UTC;
+
+        // track info with single status
+        TrackInfoDTO info = new TrackInfoDTO("01.01.2024 10:00:00", "info");
+        TrackInfoListDTO listDTO = new TrackInfoListDTO(List.of(info));
+
+        Store store = new Store();
+        store.setId(storeId);
+        User user = new User();
+        user.setTimeZone("UTC");
+        StoreStatistics storeStats = new StoreStatistics();
+        storeStats.setStore(store);
+        PostalServiceStatistics psStats = new PostalServiceStatistics();
+        psStats.setStore(store);
+        psStats.setPostalServiceType(PostalServiceType.BELPOST);
+
+        when(trackParcelRepository.findByNumberAndUserId(number, userId)).thenReturn(null);
+        when(subscriptionService.canSaveMoreTracks(userId, 1)).thenReturn(1);
+        when(storeRepository.getReferenceById(storeId)).thenReturn(store);
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(statusTrackService.setStatus(any())).thenReturn(GlobalStatus.IN_TRANSIT);
+        when(storeAnalyticsRepository.findByStoreId(storeId)).thenReturn(Optional.of(storeStats));
+        when(typeDefinitionTrackPostService.detectPostalService(number)).thenReturn(PostalServiceType.BELPOST);
+        when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(storeId, PostalServiceType.BELPOST))
+                .thenReturn(Optional.empty());
+        when(storeDailyStatisticsRepository.findByStoreIdAndDate(eq(storeId), any()))
+                .thenReturn(Optional.empty());
+        when(postalServiceDailyStatisticsRepository.findByStoreIdAndPostalServiceTypeAndDate(eq(storeId), eq(PostalServiceType.BELPOST), any()))
+                .thenReturn(Optional.empty());
+        ArgumentCaptor<StoreDailyStatistics> dailyCaptor = ArgumentCaptor.forClass(StoreDailyStatistics.class);
+        ArgumentCaptor<PostalServiceDailyStatistics> psDailyCaptor = ArgumentCaptor.forClass(PostalServiceDailyStatistics.class);
+
+        trackParcelService.save(number, listDTO, storeId, userId);
+
+        assertEquals(1, storeStats.getTotalSent());
+        verify(storeDailyStatisticsRepository).save(dailyCaptor.capture());
+        verify(postalServiceDailyStatisticsRepository).save(psDailyCaptor.capture());
+        verify(postalServiceStatisticsRepository).save(any());
+
+        StoreDailyStatistics dailySaved = dailyCaptor.getValue();
+        assertEquals(1, dailySaved.getSent());
+        assertEquals(LocalDate.of(2024,1,1), dailySaved.getDate());
+
+        PostalServiceDailyStatistics psDailySaved = psDailyCaptor.getValue();
+        assertEquals(1, psDailySaved.getSent());
+        assertEquals(LocalDate.of(2024,1,1), psDailySaved.getDate());
+    }
+}


### PR DESCRIPTION
## Summary
- verify creation of daily stats in `DeliveryHistoryService`
- test creation of daily counters on adding a parcel
- add tests for `DeliveryAnalyticsService.getFullPeriodStats`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bbbae738832dac56d9ed79559a97