### PR TITLE
Remove unused repository/service fields

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
@@ -1,10 +1,7 @@
 package com.project.tracking_system.service.analytics;
 
 import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
-import com.project.tracking_system.entity.StoreStatistics;
-import com.project.tracking_system.repository.StoreAnalyticsRepository;
 import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
-import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,7 +9,6 @@ import org.springframework.stereotype.Service;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -24,9 +20,7 @@ import java.util.List;
 @Slf4j
 public class DeliveryAnalyticsService {
 
-    private final StoreAnalyticsRepository storeAnalyticsRepository;
     private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
-    private final StoreAnalyticsService storeAnalyticsService;
 
     /**
      * Aggregates delivery statistics for the given stores within the specified period.

--- a/src/test/java/DeliveryAnalyticsServiceTest.java
+++ b/src/test/java/DeliveryAnalyticsServiceTest.java
@@ -1,10 +1,8 @@
 import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.StoreDailyStatistics;
-import com.project.tracking_system.repository.StoreAnalyticsRepository;
 import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
 import com.project.tracking_system.service.analytics.DeliveryAnalyticsService;
-import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,7 +14,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -25,11 +22,7 @@ import static org.mockito.Mockito.when;
 public class DeliveryAnalyticsServiceTest {
 
     @Mock
-    private StoreAnalyticsRepository storeAnalyticsRepository;
-    @Mock
     private StoreDailyStatisticsRepository storeDailyStatisticsRepository;
-    @Mock
-    private StoreAnalyticsService storeAnalyticsService;
 
     @InjectMocks
     private DeliveryAnalyticsService deliveryAnalyticsService;


### PR DESCRIPTION
## Summary
- remove unused `storeAnalyticsRepository` and `storeAnalyticsService` from `DeliveryAnalyticsService`
- clean up corresponding unit test

## Testing
- `./mvnw test` *(fails: `mvnw` not executable or wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_68421c9a907c832db95b13f676dfa1c6