### PR TITLE
Add JavaDocs for analytics endpoints

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
+++ b/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
@@ -146,6 +146,15 @@ public class AnalyticsController {
         return "analytics/dashboard";
     }
 
+    /**
+     * Обновляет таймстемп и собирает новую аналитику для магазина или всех магазинов
+     * пользователя. Данные пересчитываются инкрементально.
+     *
+     * @param storeId        идентификатор магазина. Если не указан, обновляется
+     *                       аналитика по всем магазинам пользователя
+     * @param authentication текущая аутентификация пользователя
+     * @return JSON-ответ с сообщением о результате обновления
+     */
     @PostMapping("/update")
     public ResponseEntity<?> updateAnalytics(@RequestParam(required = false) Long storeId,
                                              Authentication authentication) {
@@ -173,6 +182,16 @@ public class AnalyticsController {
         return ResponseEntity.ok(Map.of("message", "Аналитика обновлена для магазина: " + store.getName()));
     }
 
+    /**
+     * Возвращает агрегированную аналитику в формате JSON. Используется для
+     * построения графиков на клиенте.
+     *
+     * @param storeId        идентификатор магазина. Если null, данные собираются
+     *                       по всем магазинам пользователя
+     * @param interval       интервал агрегации (DAYS/WEEKS/MONTHS/YEARS)
+     * @param authentication текущая аутентификация пользователя
+     * @return карта с данными для круговой диаграммы и статистикой по периодам
+     */
     @GetMapping("/json")
     @ResponseBody
     public Map<String, Object> getAnalyticsJson(@RequestParam(required = false) Long storeId,


### PR DESCRIPTION
## Summary
- document `updateAnalytics` endpoint
- document `getAnalyticsJson` endpoint
- clarify yearly interval in analytics docs

## Testing
- `sh mvnw -q test` *(fails: cannot open mvnw/.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68421d749aac832da0ada120812931fe