### PR TITLE
Fix mapper package name

### DIFF
--- a/src/main/java/com/project/tracking_system/mapper/JsonEvroTrackingResponseMapper.java
+++ b/src/main/java/com/project/tracking_system/mapper/JsonEvroTrackingResponseMapper.java
@@ -1,4 +1,4 @@
-package com.project.tracking_system.maper;
+package com.project.tracking_system.mapper;
 
 import com.project.tracking_system.dto.TrackInfoDTO;
 import com.project.tracking_system.dto.TrackInfoListDTO;

--- a/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
@@ -2,7 +2,7 @@ package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.entity.PostalServiceType;
-import com.project.tracking_system.maper.JsonEvroTrackingResponseMapper;
+import com.project.tracking_system.mapper.JsonEvroTrackingResponseMapper;
 import com.project.tracking_system.model.evropost.jsonResponseModel.JsonEvroTrackingResponse;
 import com.project.tracking_system.service.belpost.WebBelPost;
 import com.project.tracking_system.service.jsonEvropostService.JsonEvroTrackingService;


### PR DESCRIPTION
## Summary
- rename `maper` package to `mapper`
- update all imports referencing the renamed package

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842215f9dc0832da83b632dcc3152a5