### PR TITLE
Refactor status checks with isFinal helper

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
@@ -42,4 +42,13 @@ public enum GlobalStatus {
         return UNKNOWN_STATUS; // Если не найдено, возвращаем UNKNOWN_STATUS
     }
 
+    /**
+     * Проверяет, является ли статус финальным (DELIVERED или RETURNED).
+     *
+     * @return {@code true}, если статус DELIVERED или RETURNED
+     */
+    public boolean isFinal() {
+        return this == DELIVERED || this == RETURNED;
+    }
+
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -93,7 +93,7 @@ public class DeliveryHistoryService {
         }
 
         // Считаем и обновляем среднее время доставки
-        if (newStatus == GlobalStatus.DELIVERED || newStatus == GlobalStatus.RETURNED) {
+        if (newStatus.isFinal()) {
             registerFinalStatus(history, newStatus);
         }
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -400,10 +400,9 @@ public class TrackParcelService {
         // Получаем все треки пользователя
         List<TrackParcelDTO> allParcels = findAllByUserTracks(userId);
 
-        // Фильтруем треки, исключая те, что уже в финальном статусе
+        // Фильтруем треки, исключая финальные статусы
         List<TrackParcelDTO> parcelsToUpdate = allParcels.stream()
-                .filter(dto -> !(dto.getStatus().equals(GlobalStatus.DELIVERED.getDescription()) ||
-                        dto.getStatus().equals(GlobalStatus.RETURNED.getDescription())))
+                .filter(dto -> !GlobalStatus.fromDescription(dto.getStatus()).isFinal())
                 .toList();
 
         log.info("📦 Запущено обновление всех {} треков для userId={}", parcelsToUpdate.size(), userId);
@@ -494,8 +493,7 @@ public class TrackParcelService {
         // Считаем количество финальных и обновляемых треков
         int totalRequested = selectedParcels.size();
         List<TrackParcel> updatableParcels = selectedParcels.stream()
-                .filter(parcel -> !(parcel.getStatus() == GlobalStatus.DELIVERED ||
-                        parcel.getStatus() == GlobalStatus.RETURNED))
+                .filter(parcel -> !parcel.getStatus().isFinal())
                 .toList();
         int nonUpdatableCount = totalRequested - updatableParcels.size();
 


### PR DESCRIPTION
## Summary
- add `isFinal()` to `GlobalStatus` for DELIVERED and RETURNED
- use `isFinal()` in `DeliveryHistoryService`
- simplify status filtering in `TrackParcelService`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684224daaa48832d8607351170923a29