### PR TITLE
Align status naming

### DIFF
--- a/src/main/resources/db/migration/V6.1__add_unknown_status.sql
+++ b/src/main/resources/db/migration/V6.1__add_unknown_status.sql
@@ -10,7 +10,7 @@ ALTER TABLE tb_track_parcels
                                                 'CUSTOMER_NOT_PICKING_UP',
                                                 'RETURN_IN_PROGRESS',
                                                 'RETURN_PENDING_PICKUP',
-                                                'RETURNED_TO_SENDER',
+                                                'RETURNED',
                                                 'REGISTERED',
                                                 'UNKNOWN_STATUS' -- Добавленный статус
         ));

--- a/src/main/resources/db/migration/V6__update_tracking_system.sql
+++ b/src/main/resources/db/migration/V6__update_tracking_system.sql
@@ -23,7 +23,7 @@ UPDATE tb_track_parcels SET status = 'IN_TRANSIT' WHERE status = 'В пути';
 UPDATE tb_track_parcels SET status = 'CUSTOMER_NOT_PICKING_UP' WHERE status = 'Клиент не забирает';
 UPDATE tb_track_parcels SET status = 'RETURN_IN_PROGRESS' WHERE status = 'Возврат в пути';
 UPDATE tb_track_parcels SET status = 'RETURN_PENDING_PICKUP' WHERE status = 'Возврат ожидает забора';
-UPDATE tb_track_parcels SET status = 'RETURNED_TO_SENDER' WHERE status = 'Возврат забран';
+UPDATE tb_track_parcels SET status = 'RETURNED' WHERE status = 'Возврат забран';
 UPDATE tb_track_parcels SET status = 'REGISTERED' WHERE status = 'Заявка зарегистрирована';
 
 -- 5. Обновляем статус, ограничивая его значениями GlobalStatus
@@ -31,7 +31,7 @@ ALTER TABLE tb_track_parcels
     ALTER COLUMN status TYPE VARCHAR(50) USING status::VARCHAR,
     ADD CONSTRAINT chk_status CHECK (status IN (
                                                 'DELIVERED', 'WAITING_FOR_CUSTOMER', 'IN_TRANSIT', 'CUSTOMER_NOT_PICKING_UP',
-                                                'RETURN_IN_PROGRESS', 'RETURN_PENDING_PICKUP', 'RETURNED_TO_SENDER', 'REGISTERED'
+                                                'RETURN_IN_PROGRESS', 'RETURN_PENDING_PICKUP', 'RETURNED', 'REGISTERED'
         ));
 
 -- 6. Создаём таблицу статистики магазинов, если её ещё нет

--- a/src/main/resources/db/migration/V7.1__rename_returned_status.sql
+++ b/src/main/resources/db/migration/V7.1__rename_returned_status.sql
@@ -1,0 +1,12 @@
+-- Update existing RETURNED_TO_SENDER values to RETURNED and fix constraint
+UPDATE tb_track_parcels SET status = 'RETURNED'
+WHERE status = 'RETURNED_TO_SENDER';
+
+ALTER TABLE tb_track_parcels DROP CONSTRAINT IF EXISTS chk_status;
+ALTER TABLE tb_track_parcels
+    ADD CONSTRAINT chk_status CHECK (
+        status IN ('DELIVERED', 'WAITING_FOR_CUSTOMER', 'IN_TRANSIT',
+                   'CUSTOMER_NOT_PICKING_UP', 'RETURN_IN_PROGRESS',
+                   'RETURN_PENDING_PICKUP', 'RETURNED', 'REGISTERED',
+                   'UNKNOWN_STATUS')
+    );


### PR DESCRIPTION
## Summary
- fix migration scripts to use `RETURNED`
- add migration to rename `RETURNED_TO_SENDER` records

## Testing
- `java -version`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684227d3b008832dbb0659b0d1986cf9