### PR TITLE
Remove unused delivery history queries

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
@@ -3,8 +3,6 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.DeliveryHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -14,22 +12,4 @@ import java.util.Optional;
 public interface DeliveryHistoryRepository extends JpaRepository<DeliveryHistory, Integer> {
 
     Optional<DeliveryHistory> findByTrackParcelId(Long trackParcelId);
-
-
-
-    // Получить записи по дате отправки в указанном диапазоне
-    List<DeliveryHistory> findByStoreIdInAndSendDateBetween(List<Long> storeIds,
-                                                            ZonedDateTime from,
-                                                            ZonedDateTime to);
-
-    // Получить записи по дате получения в указанном диапазоне
-    List<DeliveryHistory> findByStoreIdInAndReceivedDateBetween(List<Long> storeIds,
-                                                                ZonedDateTime from,
-                                                                ZonedDateTime to);
-
-    // Получить записи по дате возврата в указанном диапазоне
-    List<DeliveryHistory> findByStoreIdInAndReturnedDateBetween(List<Long> storeIds,
-                                                                ZonedDateTime from,
-                                                                ZonedDateTime to);
-
 }


### PR DESCRIPTION
## Summary
- remove unused date range queries from `DeliveryHistoryRepository`

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434cfb1cd0832da6382ffb1a047d80