### PR TITLE
Add PeriodDataResolver and update analytics flow

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/PeriodStatsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/PeriodStatsDTO.java
@@ -1,0 +1,12 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Statistics aggregated for a particular period.
+ */
+public record PeriodStatsDTO(
+        String periodLabel,
+        long sent,
+        long delivered,
+        long returned,
+        PeriodStatsSource source
+) {}

--- a/src/main/java/com/project/tracking_system/dto/PeriodStatsSource.java
+++ b/src/main/java/com/project/tracking_system/dto/PeriodStatsSource.java
@@ -1,0 +1,11 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Indicates which table was used to retrieve statistics.
+ */
+public enum PeriodStatsSource {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    YEARLY
+}

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryAnalyticsService.java
@@ -1,7 +1,6 @@
 package com.project.tracking_system.service.analytics;
 
-import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
-import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
+import com.project.tracking_system.dto.PeriodStatsDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,7 @@ import java.util.List;
 @Slf4j
 public class DeliveryAnalyticsService {
 
-    private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    private final PeriodDataResolver periodDataResolver;
 
     /**
      * Aggregates delivery statistics for the given stores within the specified period.
@@ -36,64 +35,13 @@ public class DeliveryAnalyticsService {
      * @param userZone user's time zone
      * @return list of aggregated statistics ordered by period
      */
-    public List<DeliveryFullPeriodStatsDTO> getFullPeriodStats(List<Long> storeIds,
-                                                               ChronoUnit interval,
-                                                               ZonedDateTime from,
-                                                               ZonedDateTime to,
-                                                               ZoneId userZone) {
-
-        // Запрашиваем ежедневную статистику выбранных магазинов в указанном диапазоне
-        var dailyStats = storeDailyStatisticsRepository
-                .findByStoreIdInAndDateBetween(storeIds, from.toLocalDate(), to.toLocalDate());
-
-        // Группируем по нужному интервалу и суммируем счетчики
-        var grouped = new java.util.TreeMap<ZonedDateTime, long[]>();
-        for (var stat : dailyStats) {
-            ZonedDateTime date = stat.getDate().atStartOfDay(userZone);
-            ZonedDateTime key = alignToPeriod(date, interval, userZone);
-            long[] arr = grouped.computeIfAbsent(key, k -> new long[3]);
-            arr[0] += stat.getSent();
-            arr[1] += stat.getDelivered();
-            arr[2] += stat.getReturned();
-        }
-
-        // Формируем итоговый список, включая периоды без данных
-        List<DeliveryFullPeriodStatsDTO> result = new java.util.ArrayList<>();
-        ZonedDateTime cursor = alignToPeriod(from, interval, userZone);
-        ZonedDateTime end = alignToPeriod(to, interval, userZone);
-        while (!cursor.isAfter(end)) {
-            long[] arr = grouped.getOrDefault(cursor, new long[3]);
-            result.add(new DeliveryFullPeriodStatsDTO(
-                    formatLabel(cursor, interval),
-                    arr[0],
-                    arr[1],
-                    arr[2]
-            ));
-            cursor = cursor.plus(1, interval);
-        }
-
-        return result;
-    }
-
-    private ZonedDateTime alignToPeriod(ZonedDateTime date, ChronoUnit interval, ZoneId zone) {
-        ZonedDateTime zoned = date.withZoneSameInstant(zone);
-        return switch (interval) {
-            case DAYS -> zoned.truncatedTo(ChronoUnit.DAYS);
-            case WEEKS -> zoned.with(java.time.DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
-            case MONTHS -> zoned.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
-            case YEARS -> zoned.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS);
-            default -> zoned.truncatedTo(ChronoUnit.DAYS);
-        };
-    }
-
-    private String formatLabel(ZonedDateTime date, ChronoUnit interval) {
-        return switch (interval) {
-            case DAYS -> date.toLocalDate().toString();
-            case WEEKS -> "Week " + date.get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
-            case MONTHS -> date.getMonth() + " " + date.getYear();
-            case YEARS -> String.valueOf(date.getYear());
-            default -> date.toLocalDate().toString();
-        };
+    public List<PeriodStatsDTO> getFullPeriodStats(List<Long> storeIds,
+                                                   ChronoUnit interval,
+                                                   ZonedDateTime from,
+                                                   ZonedDateTime to,
+                                                   ZoneId userZone) {
+        // Delegate to resolver which chooses optimal data source
+        return periodDataResolver.resolve(storeIds, interval, from, to, userZone);
     }
 
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/PeriodDataResolver.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PeriodDataResolver.java
@@ -1,0 +1,196 @@
+package com.project.tracking_system.service.analytics;
+
+import com.project.tracking_system.dto.PeriodStatsDTO;
+import com.project.tracking_system.dto.PeriodStatsSource;
+import com.project.tracking_system.entity.StoreDailyStatistics;
+import com.project.tracking_system.entity.StoreMonthlyStatistics;
+import com.project.tracking_system.entity.StoreWeeklyStatistics;
+import com.project.tracking_system.entity.StoreYearlyStatistics;
+import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
+import com.project.tracking_system.repository.StoreMonthlyStatisticsRepository;
+import com.project.tracking_system.repository.StoreWeeklyStatisticsRepository;
+import com.project.tracking_system.repository.StoreYearlyStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves statistics for a date range by checking aggregated tables
+ * and falling back to daily records when necessary.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PeriodDataResolver {
+
+    private final StoreDailyStatisticsRepository dailyRepo;
+    private final StoreWeeklyStatisticsRepository weeklyRepo;
+    private final StoreMonthlyStatisticsRepository monthlyRepo;
+    private final StoreYearlyStatisticsRepository yearlyRepo;
+
+    /**
+     * Returns statistics for each period between {@code from} and {@code to}.
+     * The method uses aggregated tables when available and falls back to
+     * daily data when a period has no precomputed entry.
+     *
+     * @param storeIds list of store identifiers
+     * @param interval requested interval
+     * @param from     start date-time in user's zone
+     * @param to       end date-time in user's zone
+     * @param zone     user's time zone
+     * @return list of statistics ordered by period
+     */
+    public List<PeriodStatsDTO> resolve(List<Long> storeIds,
+                                        ChronoUnit interval,
+                                        ZonedDateTime from,
+                                        ZonedDateTime to,
+                                        ZoneId zone) {
+        ZonedDateTime cursor = alignToPeriod(from, interval, zone);
+        ZonedDateTime end = alignToPeriod(to, interval, zone);
+        List<PeriodStatsDTO> list = new ArrayList<>();
+        while (!cursor.isAfter(end)) {
+            list.add(resolveSingle(storeIds, interval, cursor, zone));
+            cursor = cursor.plus(1, interval);
+        }
+        return list;
+    }
+
+    private PeriodStatsDTO resolveSingle(List<Long> storeIds,
+                                         ChronoUnit interval,
+                                         ZonedDateTime start,
+                                         ZoneId zone) {
+        return switch (interval) {
+            case DAYS -> daily(storeIds, start, start, zone);
+            case WEEKS -> weekly(storeIds, start, zone);
+            case MONTHS -> monthly(storeIds, start, zone);
+            case YEARS -> yearly(storeIds, start, zone);
+            default -> daily(storeIds, start, start, zone);
+        };
+    }
+
+    private PeriodStatsDTO daily(List<Long> storeIds,
+                                 ZonedDateTime start,
+                                 ZonedDateTime end,
+                                 ZoneId zone) {
+        LocalDate from = start.withZoneSameInstant(zone).toLocalDate();
+        LocalDate to = end.withZoneSameInstant(zone).toLocalDate();
+        List<StoreDailyStatistics> stats = dailyRepo.findByStoreIdInAndDateBetween(storeIds, from, to);
+        long[] totals = new long[3];
+        for (StoreDailyStatistics s : stats) {
+            totals[0] += s.getSent();
+            totals[1] += s.getDelivered();
+            totals[2] += s.getReturned();
+        }
+        return new PeriodStatsDTO(formatLabel(start, ChronoUnit.DAYS),
+                totals[0], totals[1], totals[2], PeriodStatsSource.DAILY);
+    }
+
+    private PeriodStatsDTO weekly(List<Long> storeIds,
+                                  ZonedDateTime start,
+                                  ZoneId zone) {
+        int week = start.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+        int year = start.get(IsoFields.WEEK_BASED_YEAR);
+        boolean complete = true;
+        long[] totals = new long[3];
+        for (Long id : storeIds) {
+            var opt = weeklyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(id, year, week);
+            if (opt.isPresent()) {
+                StoreWeeklyStatistics s = opt.get();
+                totals[0] += s.getSent();
+                totals[1] += s.getDelivered();
+                totals[2] += s.getReturned();
+            } else {
+                complete = false;
+                break;
+            }
+        }
+        if (complete) {
+            return new PeriodStatsDTO(formatLabel(start, ChronoUnit.WEEKS),
+                    totals[0], totals[1], totals[2], PeriodStatsSource.WEEKLY);
+        }
+        ZonedDateTime end = start.plusWeeks(1).minusDays(1);
+        return daily(storeIds, start, end, zone);
+    }
+
+    private PeriodStatsDTO monthly(List<Long> storeIds,
+                                   ZonedDateTime start,
+                                   ZoneId zone) {
+        int month = start.getMonthValue();
+        int year = start.getYear();
+        boolean complete = true;
+        long[] totals = new long[3];
+        for (Long id : storeIds) {
+            var opt = monthlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(id, year, month);
+            if (opt.isPresent()) {
+                StoreMonthlyStatistics s = opt.get();
+                totals[0] += s.getSent();
+                totals[1] += s.getDelivered();
+                totals[2] += s.getReturned();
+            } else {
+                complete = false;
+                break;
+            }
+        }
+        if (complete) {
+            return new PeriodStatsDTO(formatLabel(start, ChronoUnit.MONTHS),
+                    totals[0], totals[1], totals[2], PeriodStatsSource.MONTHLY);
+        }
+        ZonedDateTime end = start.plusMonths(1).minusDays(1);
+        return daily(storeIds, start, end, zone);
+    }
+
+    private PeriodStatsDTO yearly(List<Long> storeIds,
+                                  ZonedDateTime start,
+                                  ZoneId zone) {
+        int year = start.getYear();
+        boolean complete = true;
+        long[] totals = new long[3];
+        for (Long id : storeIds) {
+            var opt = yearlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(id, year, 1);
+            if (opt.isPresent()) {
+                StoreYearlyStatistics s = opt.get();
+                totals[0] += s.getSent();
+                totals[1] += s.getDelivered();
+                totals[2] += s.getReturned();
+            } else {
+                complete = false;
+                break;
+            }
+        }
+        if (complete) {
+            return new PeriodStatsDTO(formatLabel(start, ChronoUnit.YEARS),
+                    totals[0], totals[1], totals[2], PeriodStatsSource.YEARLY);
+        }
+        ZonedDateTime end = start.plusYears(1).minusDays(1);
+        return daily(storeIds, start, end, zone);
+    }
+
+    private ZonedDateTime alignToPeriod(ZonedDateTime date, ChronoUnit interval, ZoneId zone) {
+        ZonedDateTime zoned = date.withZoneSameInstant(zone);
+        return switch (interval) {
+            case DAYS -> zoned.truncatedTo(ChronoUnit.DAYS);
+            case WEEKS -> zoned.with(java.time.DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
+            case MONTHS -> zoned.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+            case YEARS -> zoned.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS);
+            default -> zoned.truncatedTo(ChronoUnit.DAYS);
+        };
+    }
+
+    private String formatLabel(ZonedDateTime date, ChronoUnit interval) {
+        return switch (interval) {
+            case DAYS -> date.toLocalDate().toString();
+            case WEEKS -> "Week " + date.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            case MONTHS -> date.getMonth() + " " + date.getYear();
+            case YEARS -> String.valueOf(date.getYear());
+            default -> date.toLocalDate().toString();
+        };
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/analytics/StoreDashboardDataService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/StoreDashboardDataService.java
@@ -1,6 +1,6 @@
 package com.project.tracking_system.service.analytics;
 
-import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
+import com.project.tracking_system.dto.PeriodStatsDTO;
 import com.project.tracking_system.entity.StoreStatistics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -68,15 +68,15 @@ public class StoreDashboardDataService {
         };
         ZonedDateTime to = now;
 
-        List<DeliveryFullPeriodStatsDTO> list = deliveryAnalyticsService.getFullPeriodStats(
+        List<PeriodStatsDTO> list = deliveryAnalyticsService.getFullPeriodStats(
                 storeIds, interval, from, to, userZone
         );
 
         return Map.of(
-                "labels", list.stream().map(DeliveryFullPeriodStatsDTO::periodLabel).toList(),
-                "sent", list.stream().map(DeliveryFullPeriodStatsDTO::sent).toList(),
-                "delivered", list.stream().map(DeliveryFullPeriodStatsDTO::delivered).toList(),
-                "returned", list.stream().map(DeliveryFullPeriodStatsDTO::returned).toList()
+                "labels", list.stream().map(PeriodStatsDTO::periodLabel).toList(),
+                "sent", list.stream().map(PeriodStatsDTO::sent).toList(),
+                "delivered", list.stream().map(PeriodStatsDTO::delivered).toList(),
+                "returned", list.stream().map(PeriodStatsDTO::returned).toList()
         );
     }
 

--- a/src/test/java/DeliveryAnalyticsServiceTest.java
+++ b/src/test/java/DeliveryAnalyticsServiceTest.java
@@ -1,74 +1,43 @@
-import com.project.tracking_system.dto.DeliveryFullPeriodStatsDTO;
-import com.project.tracking_system.entity.Store;
-import com.project.tracking_system.entity.StoreDailyStatistics;
-import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
+import com.project.tracking_system.dto.PeriodStatsDTO;
+import com.project.tracking_system.dto.PeriodStatsSource;
 import com.project.tracking_system.service.analytics.DeliveryAnalyticsService;
+import com.project.tracking_system.service.analytics.PeriodDataResolver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DeliveryAnalyticsServiceTest {
 
     @Mock
-    private StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    private PeriodDataResolver resolver;
 
     @InjectMocks
-    private DeliveryAnalyticsService deliveryAnalyticsService;
-
-    private StoreDailyStatistics createDaily(Store store, LocalDate date, int sent, int delivered, int returned) {
-        StoreDailyStatistics d = new StoreDailyStatistics();
-        d.setStore(store);
-        d.setDate(date);
-        d.setSent(sent);
-        d.setDelivered(delivered);
-        d.setReturned(returned);
-        return d;
-    }
+    private DeliveryAnalyticsService service;
 
     @Test
-    void getFullPeriodStats_ByIntervals() {
-        Store store = new Store();
-        store.setId(1L);
-        List<Long> storeIds = List.of(store.getId());
+    void getFullPeriodStats_DelegatesToResolver() {
+        List<Long> storeIds = List.of(1L);
+        ZonedDateTime from = ZonedDateTime.now();
+        ZonedDateTime to = from.plusDays(1);
         ZoneId zone = ZoneId.of("UTC");
-        ZonedDateTime from = ZonedDateTime.of(2024,1,1,0,0,0,0, zone);
-        ZonedDateTime to = ZonedDateTime.of(2024,1,14,0,0,0,0, zone);
+        List<PeriodStatsDTO> expected = List.of(new PeriodStatsDTO("p",1,1,0, PeriodStatsSource.DAILY));
+        when(resolver.resolve(storeIds, ChronoUnit.DAYS, from, to, zone)).thenReturn(expected);
 
-        List<StoreDailyStatistics> data = List.of(
-                createDaily(store, LocalDate.of(2024,1,1),1,1,0),
-                createDaily(store, LocalDate.of(2024,1,2),2,0,1),
-                createDaily(store, LocalDate.of(2024,1,10),1,1,0)
-        );
-        when(storeDailyStatisticsRepository.findByStoreIdInAndDateBetween(storeIds, from.toLocalDate(), to.toLocalDate()))
-                .thenReturn(data);
+        List<PeriodStatsDTO> result = service.getFullPeriodStats(storeIds, ChronoUnit.DAYS, from, to, zone);
 
-        List<DeliveryFullPeriodStatsDTO> byDay = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.DAYS, from, to, zone);
-        assertEquals(14, byDay.size());
-        assertEquals(1, byDay.get(0).sent());
-
-        List<DeliveryFullPeriodStatsDTO> byWeek = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.WEEKS, from, to, zone);
-        assertEquals(2, byWeek.size());
-        assertEquals(3, byWeek.get(0).sent());
-        assertEquals(1, byWeek.get(1).sent());
-
-        List<DeliveryFullPeriodStatsDTO> byMonth = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.MONTHS, from, to, zone);
-        assertEquals(1, byMonth.size());
-        assertEquals(4, byMonth.get(0).sent());
-
-        List<DeliveryFullPeriodStatsDTO> byYear = deliveryAnalyticsService.getFullPeriodStats(storeIds, ChronoUnit.YEARS, from, to, zone);
-        assertEquals(1, byYear.size());
-        assertEquals(4, byYear.get(0).sent());
+        assertSame(expected, result);
+        verify(resolver).resolve(storeIds, ChronoUnit.DAYS, from, to, zone);
     }
 }

--- a/src/test/java/PeriodDataResolverTest.java
+++ b/src/test/java/PeriodDataResolverTest.java
@@ -1,0 +1,87 @@
+import com.project.tracking_system.dto.PeriodStatsDTO;
+import com.project.tracking_system.dto.PeriodStatsSource;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreDailyStatistics;
+import com.project.tracking_system.entity.StoreWeeklyStatistics;
+import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
+import com.project.tracking_system.repository.StoreMonthlyStatisticsRepository;
+import com.project.tracking_system.repository.StoreWeeklyStatisticsRepository;
+import com.project.tracking_system.repository.StoreYearlyStatisticsRepository;
+import com.project.tracking_system.service.analytics.PeriodDataResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PeriodDataResolverTest {
+
+    @Mock
+    private StoreDailyStatisticsRepository dailyRepo;
+    @Mock
+    private StoreWeeklyStatisticsRepository weeklyRepo;
+    @Mock
+    private StoreMonthlyStatisticsRepository monthlyRepo;
+    @Mock
+    private StoreYearlyStatisticsRepository yearlyRepo;
+
+    @InjectMocks
+    private PeriodDataResolver resolver;
+
+    private StoreWeeklyStatistics createWeekly(int sent) {
+        StoreWeeklyStatistics w = new StoreWeeklyStatistics();
+        w.setSent(sent);
+        w.setDelivered(0);
+        w.setReturned(0);
+        return w;
+    }
+
+    private StoreDailyStatistics createDaily(LocalDate date, int sent) {
+        StoreDailyStatistics d = new StoreDailyStatistics();
+        d.setDate(date);
+        d.setSent(sent);
+        d.setDelivered(0);
+        d.setReturned(0);
+        d.setStore(new Store());
+        return d;
+    }
+
+    @Test
+    void resolve_UsesWeeklyAndDailyFallback() {
+        ZoneId zone = ZoneId.of("UTC");
+        List<Long> storeIds = List.of(1L);
+        ZonedDateTime from = ZonedDateTime.of(2024,1,1,0,0,0,0, zone);
+        ZonedDateTime to = ZonedDateTime.of(2024,1,14,0,0,0,0, zone);
+
+        int week = from.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+        int year = from.get(IsoFields.WEEK_BASED_YEAR);
+        when(weeklyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(1L, year, week))
+                .thenReturn(Optional.of(createWeekly(3)));
+        // second week not available -> daily fallback
+        LocalDate fromDaily = LocalDate.of(2024,1,8);
+        LocalDate toDaily = LocalDate.of(2024,1,14);
+        when(dailyRepo.findByStoreIdInAndDateBetween(storeIds, fromDaily, toDaily))
+                .thenReturn(List.of(createDaily(LocalDate.of(2024,1,8),1)));
+
+        List<PeriodStatsDTO> list = resolver.resolve(storeIds, ChronoUnit.WEEKS, from, to, zone);
+
+        assertEquals(2, list.size());
+        assertEquals(PeriodStatsSource.WEEKLY, list.get(0).source());
+        assertEquals(3, list.get(0).sent());
+        assertEquals(PeriodStatsSource.DAILY, list.get(1).source());
+        assertEquals(1, list.get(1).sent());
+    }
+}


### PR DESCRIPTION
## Summary
- add `PeriodStatsDTO` and `PeriodStatsSource`
- implement `PeriodDataResolver` for aggregated stats with daily fallback
- refactor `DeliveryAnalyticsService` to use the resolver
- update dashboard data service
- add tests for resolver and service

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684493521c78832d8644e6b330af3b00