### PR TITLE
Fix stats aggregation sums

### DIFF
--- a/src/test/java/StatsAggregationServiceTest.java
+++ b/src/test/java/StatsAggregationServiceTest.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.time.temporal.IsoFields;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -53,8 +54,21 @@ public class StatsAggregationServiceTest {
         daily.setSumDeliveryDays(BigDecimal.valueOf(3));
         daily.setSumPickupDays(BigDecimal.valueOf(1));
 
+        LocalDate weekStart = daily.getDate().with(IsoFields.DAY_OF_WEEK, 1);
+        LocalDate weekEnd = daily.getDate().with(IsoFields.DAY_OF_WEEK, 7);
+        LocalDate monthStart = daily.getDate().withDayOfMonth(1);
+        LocalDate monthEnd = monthStart.plusMonths(1).minusDays(1);
+        LocalDate yearStart = daily.getDate().withDayOfYear(1);
+        LocalDate yearEnd = yearStart.plusYears(1).minusDays(1);
+
         when(storeDailyRepo.findByDate(daily.getDate())).thenReturn(List.of(daily));
         when(postalDailyRepo.findByDate(daily.getDate())).thenReturn(List.of());
+        when(storeDailyRepo.findByStoreIdAndDateBetween(store.getId(), weekStart, weekEnd))
+                .thenReturn(List.of(daily));
+        when(storeDailyRepo.findByStoreIdAndDateBetween(store.getId(), monthStart, monthEnd))
+                .thenReturn(List.of(daily));
+        when(storeDailyRepo.findByStoreIdAndDateBetween(store.getId(), yearStart, yearEnd))
+                .thenReturn(List.of(daily));
         when(storeWeeklyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(anyLong(), anyInt(), anyInt())).thenReturn(Optional.empty());
         when(storeMonthlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(anyLong(), anyInt(), anyInt())).thenReturn(Optional.empty());
         when(storeYearlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(anyLong(), anyInt(), anyInt())).thenReturn(Optional.empty());
@@ -92,8 +106,21 @@ public class StatsAggregationServiceTest {
         daily.setSumDeliveryDays(BigDecimal.valueOf(2));
         daily.setSumPickupDays(BigDecimal.valueOf(1));
 
+        LocalDate weekStartPs = daily.getDate().with(IsoFields.DAY_OF_WEEK, 1);
+        LocalDate weekEndPs = daily.getDate().with(IsoFields.DAY_OF_WEEK, 7);
+        LocalDate monthStartPs = daily.getDate().withDayOfMonth(1);
+        LocalDate monthEndPs = monthStartPs.plusMonths(1).minusDays(1);
+        LocalDate yearStartPs = daily.getDate().withDayOfYear(1);
+        LocalDate yearEndPs = yearStartPs.plusYears(1).minusDays(1);
+
         when(storeDailyRepo.findByDate(daily.getDate())).thenReturn(List.of());
         when(postalDailyRepo.findByDate(daily.getDate())).thenReturn(List.of(daily));
+        when(postalDailyRepo.findByStoreIdAndPostalServiceTypeAndDateBetween(store.getId(), daily.getPostalServiceType(), weekStartPs, weekEndPs))
+                .thenReturn(List.of(daily));
+        when(postalDailyRepo.findByStoreIdAndPostalServiceTypeAndDateBetween(store.getId(), daily.getPostalServiceType(), monthStartPs, monthEndPs))
+                .thenReturn(List.of(daily));
+        when(postalDailyRepo.findByStoreIdAndPostalServiceTypeAndDateBetween(store.getId(), daily.getPostalServiceType(), yearStartPs, yearEndPs))
+                .thenReturn(List.of(daily));
         when(psWeeklyRepo.findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(anyLong(), any(), anyInt(), anyInt())).thenReturn(Optional.empty());
         when(psMonthlyRepo.findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(anyLong(), any(), anyInt(), anyInt())).thenReturn(Optional.empty());
         when(psYearlyRepo.findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(anyLong(), any(), anyInt(), anyInt())).thenReturn(Optional.empty());
@@ -107,5 +134,45 @@ public class StatsAggregationServiceTest {
 
         verify(psWeeklyRepo).save(wCap.capture());
         assertEquals(1, wCap.getValue().getDelivered());
+    }
+
+    @Test
+    void aggregateForDate_RepeatedCallsDoNotChangeResults() {
+        Store store = new Store();
+        store.setId(1L);
+        StoreDailyStatistics daily = new StoreDailyStatistics();
+        daily.setStore(store);
+        daily.setDate(LocalDate.of(2024,1,2));
+        daily.setSent(2);
+        daily.setDelivered(1);
+        daily.setReturned(0);
+
+        LocalDate weekStart = daily.getDate().with(IsoFields.DAY_OF_WEEK, 1);
+        LocalDate weekEnd = daily.getDate().with(IsoFields.DAY_OF_WEEK, 7);
+        LocalDate monthStart = daily.getDate().withDayOfMonth(1);
+        LocalDate monthEnd = monthStart.plusMonths(1).minusDays(1);
+        LocalDate yearStart = daily.getDate().withDayOfYear(1);
+        LocalDate yearEnd = yearStart.plusYears(1).minusDays(1);
+
+        when(storeDailyRepo.findByDate(daily.getDate())).thenReturn(List.of(daily));
+        when(postalDailyRepo.findByDate(daily.getDate())).thenReturn(List.of());
+        when(storeDailyRepo.findByStoreIdAndDateBetween(store.getId(), weekStart, weekEnd)).thenReturn(List.of(daily));
+        when(storeDailyRepo.findByStoreIdAndDateBetween(store.getId(), monthStart, monthEnd)).thenReturn(List.of(daily));
+        when(storeDailyRepo.findByStoreIdAndDateBetween(store.getId(), yearStart, yearEnd)).thenReturn(List.of(daily));
+        when(storeWeeklyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(anyLong(), anyInt(), anyInt())).thenReturn(Optional.empty());
+        when(storeMonthlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(anyLong(), anyInt(), anyInt())).thenReturn(Optional.empty());
+        when(storeYearlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(anyLong(), anyInt(), anyInt())).thenReturn(Optional.empty());
+
+        ArgumentCaptor<StoreWeeklyStatistics> wCap = ArgumentCaptor.forClass(StoreWeeklyStatistics.class);
+        when(storeWeeklyRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.aggregateForDate(daily.getDate());
+        service.aggregateForDate(daily.getDate());
+
+        verify(storeWeeklyRepo, times(2)).save(wCap.capture());
+        List<StoreWeeklyStatistics> saved = wCap.getAllValues();
+        assertEquals(saved.get(0).getSent(), saved.get(1).getSent());
+        assertEquals(saved.get(0).getDelivered(), saved.get(1).getDelivered());
+        assertEquals(saved.get(0).getReturned(), saved.get(1).getReturned());
     }
 }


### PR DESCRIPTION
## Summary
- recompute aggregated store and postal service stats using period sums
- update aggregation tests and add idempotence check

## Testing
- `bash mvnw -q test` *(fails: mvnw/.mvn/wrapper/maven-wrapper.properties: Not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_684496e40668832da65e98fa17827262