### PR TITLE
Add unique constraints for period statistics

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/PostalServiceMonthlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceMonthlyStatistics.java
@@ -18,7 +18,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_postal_service_statistics_monthly")
+@Table(name = "tb_postal_service_statistics_monthly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "postal_service_type", "period_year", "period_number"}))
 public class PostalServiceMonthlyStatistics {
 
     @Id

--- a/src/main/java/com/project/tracking_system/entity/PostalServiceWeeklyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceWeeklyStatistics.java
@@ -18,7 +18,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_postal_service_statistics_weekly")
+@Table(name = "tb_postal_service_statistics_weekly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "postal_service_type", "period_year", "period_number"}))
 public class PostalServiceWeeklyStatistics {
 
     @Id

--- a/src/main/java/com/project/tracking_system/entity/PostalServiceYearlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceYearlyStatistics.java
@@ -18,7 +18,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_postal_service_statistics_yearly")
+@Table(name = "tb_postal_service_statistics_yearly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "postal_service_type", "period_year", "period_number"}))
 public class PostalServiceYearlyStatistics {
 
     @Id

--- a/src/main/java/com/project/tracking_system/entity/StoreMonthlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreMonthlyStatistics.java
@@ -18,7 +18,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_store_statistics_monthly")
+@Table(name = "tb_store_statistics_monthly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "period_year", "period_number"}))
 public class StoreMonthlyStatistics {
 
     @Id

--- a/src/main/java/com/project/tracking_system/entity/StoreWeeklyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreWeeklyStatistics.java
@@ -18,7 +18,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_store_statistics_weekly")
+@Table(name = "tb_store_statistics_weekly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "period_year", "period_number"}))
 public class StoreWeeklyStatistics {
 
     @Id

--- a/src/main/java/com/project/tracking_system/entity/StoreYearlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreYearlyStatistics.java
@@ -18,7 +18,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_store_statistics_yearly")
+@Table(name = "tb_store_statistics_yearly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "period_year", "period_number"}))
 public class StoreYearlyStatistics {
 
     @Id

--- a/src/main/resources/db/migration/V8.1__add_unique_constraints_to_period_statistics.sql
+++ b/src/main/resources/db/migration/V8.1__add_unique_constraints_to_period_statistics.sql
@@ -1,0 +1,24 @@
+-- Add unique constraints to prevent duplicate period statistics entries
+ALTER TABLE tb_store_statistics_weekly
+    ADD CONSTRAINT IF NOT EXISTS uk_store_stats_weekly
+        UNIQUE (store_id, period_year, period_number);
+
+ALTER TABLE tb_store_statistics_monthly
+    ADD CONSTRAINT IF NOT EXISTS uk_store_stats_monthly
+        UNIQUE (store_id, period_year, period_number);
+
+ALTER TABLE tb_store_statistics_yearly
+    ADD CONSTRAINT IF NOT EXISTS uk_store_stats_yearly
+        UNIQUE (store_id, period_year, period_number);
+
+ALTER TABLE tb_postal_service_statistics_weekly
+    ADD CONSTRAINT IF NOT EXISTS uk_postal_stats_weekly
+        UNIQUE (store_id, postal_service_type, period_year, period_number);
+
+ALTER TABLE tb_postal_service_statistics_monthly
+    ADD CONSTRAINT IF NOT EXISTS uk_postal_stats_monthly
+        UNIQUE (store_id, postal_service_type, period_year, period_number);
+
+ALTER TABLE tb_postal_service_statistics_yearly
+    ADD CONSTRAINT IF NOT EXISTS uk_postal_stats_yearly
+        UNIQUE (store_id, postal_service_type, period_year, period_number);

--- a/src/test/java/PeriodStatisticsUniqueConstraintTest.java
+++ b/src/test/java/PeriodStatisticsUniqueConstraintTest.java
@@ -1,0 +1,84 @@
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+public class PeriodStatisticsUniqueConstraintTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private StoreRepository storeRepository;
+    @Autowired
+    private StoreWeeklyStatisticsRepository storeWeeklyRepo;
+    @Autowired
+    private StoreMonthlyStatisticsRepository storeMonthlyRepo;
+    @Autowired
+    private StoreYearlyStatisticsRepository storeYearlyRepo;
+    @Autowired
+    private PostalServiceWeeklyStatisticsRepository psWeeklyRepo;
+    @Autowired
+    private PostalServiceMonthlyStatisticsRepository psMonthlyRepo;
+    @Autowired
+    private PostalServiceYearlyStatisticsRepository psYearlyRepo;
+
+    private Store prepareStore() {
+        User user = new User();
+        user.setEmail("user@example.com");
+        user.setPassword("pass");
+        user.setRole(Role.ROLE_USER);
+        userRepository.saveAndFlush(user);
+
+        Store store = new Store();
+        store.setName("Store");
+        store.setDefault(false);
+        store.setOwner(user);
+        return storeRepository.saveAndFlush(store);
+    }
+
+    @Test
+    void duplicateStoreWeeklyStatistics_throwsException() {
+        Store store = prepareStore();
+
+        StoreWeeklyStatistics first = new StoreWeeklyStatistics();
+        first.setStore(store);
+        first.setPeriodYear(2024);
+        first.setPeriodNumber(1);
+        storeWeeklyRepo.saveAndFlush(first);
+
+        StoreWeeklyStatistics duplicate = new StoreWeeklyStatistics();
+        duplicate.setStore(store);
+        duplicate.setPeriodYear(2024);
+        duplicate.setPeriodNumber(1);
+
+        // unique constraint should trigger upon flush
+        org.junit.jupiter.api.Assertions.assertThrows(DataIntegrityViolationException.class, () -> {
+            storeWeeklyRepo.saveAndFlush(duplicate);
+        });
+    }
+
+    @Test
+    void duplicatePostalServiceMonthlyStatistics_throwsException() {
+        Store store = prepareStore();
+
+        PostalServiceMonthlyStatistics first = new PostalServiceMonthlyStatistics();
+        first.setStore(store);
+        first.setPostalServiceType(PostalServiceType.BELPOST);
+        first.setPeriodYear(2024);
+        first.setPeriodNumber(1);
+        psMonthlyRepo.saveAndFlush(first);
+
+        PostalServiceMonthlyStatistics duplicate = new PostalServiceMonthlyStatistics();
+        duplicate.setStore(store);
+        duplicate.setPostalServiceType(PostalServiceType.BELPOST);
+        duplicate.setPeriodYear(2024);
+        duplicate.setPeriodNumber(1);
+
+        org.junit.jupiter.api.Assertions.assertThrows(DataIntegrityViolationException.class, () -> {
+            psMonthlyRepo.saveAndFlush(duplicate);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a Flyway migration to enforce uniqueness on period statistic tables
- enforce unique constraints via `@Table` annotations
- add JPA tests verifying duplicates fail

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_68449866f220832d82b67ae99dab13a4