### PR TITLE
Add multi-day stats aggregation

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -17,7 +17,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -153,6 +155,24 @@ public class AdminController {
     @PostMapping("/aggregate-stats")
     public String triggerAggregation() {
         statsAggregationService.aggregateYesterday();
+        return "redirect:/admin";
+    }
+
+    /**
+     * Triggers aggregation of statistics for the specified date range.
+     *
+     * @param from start date in ISO format (yyyy-MM-dd)
+     * @param to   end date in ISO format (yyyy-MM-dd)
+     * @return redirect to admin page
+     */
+    @PostMapping("/aggregate-stats/range")
+    public String triggerAggregationRange(@RequestParam("from")
+                                          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                                          LocalDate from,
+                                          @RequestParam("to")
+                                          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                                          LocalDate to) {
+        statsAggregationService.aggregateForRange(from, to);
         return "redirect:/admin";
     }
 

--- a/src/main/java/com/project/tracking_system/service/analytics/StatsAggregationService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/StatsAggregationService.java
@@ -44,6 +44,23 @@ public class StatsAggregationService {
     }
 
     /**
+     * Iterates over each day in the provided range and aggregates statistics.
+     * The operation is idempotent and can be safely re-run for the same period.
+     *
+     * @param from start date (inclusive)
+     * @param to   end date (inclusive)
+     */
+    @Transactional
+    public void aggregateForRange(LocalDate from, LocalDate to) {
+        LocalDate current = from;
+        // Iterate over each date and invoke daily aggregation
+        while (!current.isAfter(to)) {
+            aggregateForDate(current);
+            current = current.plusDays(1);
+        }
+    }
+
+    /**
      * Aggregates statistics for the given date.
      *
      * @param date date to aggregate

--- a/src/test/java/StatsAggregationServiceTest.java
+++ b/src/test/java/StatsAggregationServiceTest.java
@@ -175,4 +175,28 @@ public class StatsAggregationServiceTest {
         assertEquals(saved.get(0).getDelivered(), saved.get(1).getDelivered());
         assertEquals(saved.get(0).getReturned(), saved.get(1).getReturned());
     }
+
+    @Test
+    void aggregateForRange_CallsDailyAggregationForEachDay() {
+        StatsAggregationService spyService = spy(new StatsAggregationService(
+                storeDailyRepo,
+                postalDailyRepo,
+                storeWeeklyRepo,
+                storeMonthlyRepo,
+                storeYearlyRepo,
+                psWeeklyRepo,
+                psMonthlyRepo,
+                psYearlyRepo));
+
+        doNothing().when(spyService).aggregateForDate(any());
+
+        LocalDate from = LocalDate.of(2024, 1, 1);
+        LocalDate to = LocalDate.of(2024, 1, 3);
+
+        spyService.aggregateForRange(from, to);
+
+        verify(spyService).aggregateForDate(LocalDate.of(2024, 1, 1));
+        verify(spyService).aggregateForDate(LocalDate.of(2024, 1, 2));
+        verify(spyService).aggregateForDate(LocalDate.of(2024, 1, 3));
+    }
 }


### PR DESCRIPTION
## Summary
- support aggregating stats for arbitrary date ranges
- expose new admin endpoint to rebuild stats for a custom period
- test that range aggregation triggers daily aggregation per day

## Testing
- `mvn -q test` *(fails: command not found)*
- `sh ./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68449a44a88c832d971609404b0f82bf