### PR TITLE
Implement bulk repository queries for period resolver

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.StoreMonthlyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,4 +12,14 @@ import java.util.Optional;
 public interface StoreMonthlyStatisticsRepository extends JpaRepository<StoreMonthlyStatistics, Long> {
 
     Optional<StoreMonthlyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
+
+    /**
+     * Find statistics for multiple stores for the given month of a year.
+     *
+     * @param storeIds    list of store identifiers
+     * @param periodYear  year of the month
+     * @param periodNumber number of the month (1-12)
+     * @return list of monthly statistics, one per store if present
+     */
+    List<StoreMonthlyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.StoreWeeklyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,4 +12,14 @@ import java.util.Optional;
 public interface StoreWeeklyStatisticsRepository extends JpaRepository<StoreWeeklyStatistics, Long> {
 
     Optional<StoreWeeklyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
+
+    /**
+     * Find statistics for multiple stores for the given week of a year.
+     *
+     * @param storeIds    list of store identifiers
+     * @param periodYear  year of the week
+     * @param periodNumber number of the week within the year
+     * @return list of weekly statistics, one per store if present
+     */
+    List<StoreWeeklyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.StoreYearlyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,4 +12,14 @@ import java.util.Optional;
 public interface StoreYearlyStatisticsRepository extends JpaRepository<StoreYearlyStatistics, Long> {
 
     Optional<StoreYearlyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
+
+    /**
+     * Find statistics for multiple stores for the given year.
+     *
+     * @param storeIds    list of store identifiers
+     * @param periodYear  year of the statistics
+     * @param periodNumber always 1 for yearly aggregation
+     * @return list of yearly statistics, one per store if present
+     */
+    List<StoreYearlyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/PeriodDataResolver.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PeriodDataResolver.java
@@ -98,21 +98,15 @@ public class PeriodDataResolver {
                                   ZoneId zone) {
         int week = start.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
         int year = start.get(IsoFields.WEEK_BASED_YEAR);
-        boolean complete = true;
-        long[] totals = new long[3];
-        for (Long id : storeIds) {
-            var opt = weeklyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(id, year, week);
-            if (opt.isPresent()) {
-                StoreWeeklyStatistics s = opt.get();
+        List<StoreWeeklyStatistics> stats =
+                weeklyRepo.findByStoreIdInAndPeriodYearAndPeriodNumber(storeIds, year, week);
+        if (stats.size() == storeIds.size()) {
+            long[] totals = new long[3];
+            for (StoreWeeklyStatistics s : stats) {
                 totals[0] += s.getSent();
                 totals[1] += s.getDelivered();
                 totals[2] += s.getReturned();
-            } else {
-                complete = false;
-                break;
             }
-        }
-        if (complete) {
             return new PeriodStatsDTO(formatLabel(start, ChronoUnit.WEEKS),
                     totals[0], totals[1], totals[2], PeriodStatsSource.WEEKLY);
         }
@@ -125,21 +119,15 @@ public class PeriodDataResolver {
                                    ZoneId zone) {
         int month = start.getMonthValue();
         int year = start.getYear();
-        boolean complete = true;
-        long[] totals = new long[3];
-        for (Long id : storeIds) {
-            var opt = monthlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(id, year, month);
-            if (opt.isPresent()) {
-                StoreMonthlyStatistics s = opt.get();
+        List<StoreMonthlyStatistics> stats =
+                monthlyRepo.findByStoreIdInAndPeriodYearAndPeriodNumber(storeIds, year, month);
+        if (stats.size() == storeIds.size()) {
+            long[] totals = new long[3];
+            for (StoreMonthlyStatistics s : stats) {
                 totals[0] += s.getSent();
                 totals[1] += s.getDelivered();
                 totals[2] += s.getReturned();
-            } else {
-                complete = false;
-                break;
             }
-        }
-        if (complete) {
             return new PeriodStatsDTO(formatLabel(start, ChronoUnit.MONTHS),
                     totals[0], totals[1], totals[2], PeriodStatsSource.MONTHLY);
         }
@@ -151,21 +139,15 @@ public class PeriodDataResolver {
                                   ZonedDateTime start,
                                   ZoneId zone) {
         int year = start.getYear();
-        boolean complete = true;
-        long[] totals = new long[3];
-        for (Long id : storeIds) {
-            var opt = yearlyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(id, year, 1);
-            if (opt.isPresent()) {
-                StoreYearlyStatistics s = opt.get();
+        List<StoreYearlyStatistics> stats =
+                yearlyRepo.findByStoreIdInAndPeriodYearAndPeriodNumber(storeIds, year, 1);
+        if (stats.size() == storeIds.size()) {
+            long[] totals = new long[3];
+            for (StoreYearlyStatistics s : stats) {
                 totals[0] += s.getSent();
                 totals[1] += s.getDelivered();
                 totals[2] += s.getReturned();
-            } else {
-                complete = false;
-                break;
             }
-        }
-        if (complete) {
             return new PeriodStatsDTO(formatLabel(start, ChronoUnit.YEARS),
                     totals[0], totals[1], totals[2], PeriodStatsSource.YEARLY);
         }

--- a/src/test/java/PeriodDataResolverTest.java
+++ b/src/test/java/PeriodDataResolverTest.java
@@ -20,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -68,8 +67,8 @@ public class PeriodDataResolverTest {
 
         int week = from.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
         int year = from.get(IsoFields.WEEK_BASED_YEAR);
-        when(weeklyRepo.findByStoreIdAndPeriodYearAndPeriodNumber(1L, year, week))
-                .thenReturn(Optional.of(createWeekly(3)));
+        when(weeklyRepo.findByStoreIdInAndPeriodYearAndPeriodNumber(storeIds, year, week))
+                .thenReturn(List.of(createWeekly(3))); 
         // second week not available -> daily fallback
         LocalDate fromDaily = LocalDate.of(2024,1,8);
         LocalDate toDaily = LocalDate.of(2024,1,14);


### PR DESCRIPTION
## Summary
- add bulk search methods to Store statistics repositories
- optimize PeriodDataResolver to fetch aggregated stats in batches
- adjust tests to use new repository methods

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b2443340832dbea2baeef04917b7