### PR TITLE
Fix chart title initialization

### DIFF
--- a/src/main/resources/static/js/analytics.js
+++ b/src/main/resources/static/js/analytics.js
@@ -17,6 +17,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const storeSelect = document.getElementById("analyticsStoreSelect");
     const periodSelect = document.getElementById("periodSelect");
     let selectedPeriod = periodSelect?.value || "WEEKS";
+    updateChartTitle(selectedPeriod); // установить заголовок при первой загрузке
 
     const pieCtx = document.getElementById('statusPieChart')?.getContext('2d');
     const barCtx = document.getElementById('periodBarChart')?.getContext('2d');


### PR DESCRIPTION
## Summary
- call `updateChartTitle` when analytics page loads so the heading matches the selected interval

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc0cf0a8832db2024d82e80fd280