### PR TITLE
Fix arrivedDate extraction for final parcel statuses

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -97,8 +97,8 @@ public class DeliveryHistoryService {
             setHistoryDate("Дата возврата", history.getReturnedDate(), deliveryDates.returnedDate(), history::setReturnedDate);
         }
 
-        if (newStatus == GlobalStatus.WAITING_FOR_CUSTOMER && history.getArrivedDate() == null) {
-            // Фиксируем дату прибытия на пункт выдачи, если ранее не была установлена
+        if (history.getArrivedDate() == null && deliveryDates.arrivedDate() != null) {
+            // Фиксируем дату прибытия на пункт выдачи, даже если текущий статус уже финальный
             setHistoryDate(
                     "Дата прибытия на пункт выдачи",
                     history.getArrivedDate(),
@@ -156,6 +156,7 @@ public class DeliveryHistoryService {
             GlobalStatus status = statusTrackService.setStatus(List.of(info));
             if (status == GlobalStatus.WAITING_FOR_CUSTOMER) {
                 arrivedDate = parseDate(info.getTimex());
+                log.info("Извлечена дата прибытия на пункт выдачи: {}", arrivedDate);
                 break;
             }
         }

--- a/src/test/java/TrackParcelFinalStatusIntegrationTest.java
+++ b/src/test/java/TrackParcelFinalStatusIntegrationTest.java
@@ -19,6 +19,10 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -149,6 +153,100 @@ public class TrackParcelFinalStatusIntegrationTest {
         });
 
         trackParcelService.save(number, listDTO, storeId, userId);
+
+        assertEquals(GlobalStatus.DELIVERED, saved[0].getStatus());
+        assertTrue(saved[0].isIncludedInStatistics());
+
+        assertEquals(1, storeStats.getTotalSent());
+        assertEquals(1, storeStats.getTotalDelivered());
+        assertEquals(BigDecimal.valueOf(1.0), storeStats.getSumDeliveryDays());
+        assertEquals(BigDecimal.valueOf(1.0), storeStats.getSumPickupDays());
+
+        assertEquals(1, psStats.getTotalSent());
+        assertEquals(1, psStats.getTotalDelivered());
+        assertEquals(BigDecimal.valueOf(1.0), psStats.getSumDeliveryDays());
+        assertEquals(BigDecimal.valueOf(1.0), psStats.getSumPickupDays());
+
+        assertEquals(1, daily.getSent());
+        assertEquals(1, daily.getDelivered());
+        assertEquals(BigDecimal.valueOf(1.0), daily.getSumDeliveryDays());
+        assertEquals(BigDecimal.valueOf(1.0), daily.getSumPickupDays());
+
+        assertEquals(1, psDaily.getSent());
+        assertEquals(1, psDaily.getDelivered());
+        assertEquals(BigDecimal.valueOf(1.0), psDaily.getSumDeliveryDays());
+        assertEquals(BigDecimal.valueOf(1.0), psDaily.getSumPickupDays());
+    }
+
+    @Test
+    void save_FinalStatusWithWaitingHistory_SetsArrivedDateAndMetrics() {
+        Long storeId = 10L;
+        Long userId = 20L;
+        String number = "PC222222222BY";
+
+        TrackInfoDTO delivered = new TrackInfoDTO("03.06.2024 08:00:00", "Почтовое отправление выдано");
+        TrackInfoDTO waiting = new TrackInfoDTO("02.06.2024 08:00:00", "Почтовое отправление прибыло на ОПС выдачи");
+        TrackInfoDTO shipped = new TrackInfoDTO("01.06.2024 08:00:00", "Почтовое отправление принято на ОПС");
+        TrackInfoListDTO listDTO = new TrackInfoListDTO(List.of(delivered, waiting, shipped));
+
+        Store store = new Store();
+        store.setId(storeId);
+        User user = new User();
+        user.setTimeZone("UTC");
+
+        StoreStatistics storeStats = new StoreStatistics();
+        storeStats.setStore(store);
+        PostalServiceStatistics psStats = new PostalServiceStatistics();
+        psStats.setStore(store);
+        psStats.setPostalServiceType(PostalServiceType.BELPOST);
+        StoreDailyStatistics daily = new StoreDailyStatistics();
+        daily.setStore(store);
+        daily.setDate(LocalDate.of(2024,6,3));
+        PostalServiceDailyStatistics psDaily = new PostalServiceDailyStatistics();
+        psDaily.setStore(store);
+        psDaily.setPostalServiceType(PostalServiceType.BELPOST);
+        psDaily.setDate(LocalDate.of(2024,6,3));
+
+        when(trackParcelRepository.findByNumberAndUserId(number, userId)).thenReturn(null);
+        when(subscriptionService.canSaveMoreTracks(userId, 1)).thenReturn(1);
+        when(storeRepository.getReferenceById(storeId)).thenReturn(store);
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(typeDefinitionTrackPostService.detectPostalService(number)).thenReturn(PostalServiceType.BELPOST);
+        when(storeAnalyticsRepository.findByStoreId(storeId)).thenReturn(Optional.of(storeStats));
+        when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(storeId, PostalServiceType.BELPOST))
+                .thenReturn(Optional.of(psStats));
+        when(storeDailyStatisticsRepository.findByStoreIdAndDate(storeId, LocalDate.of(2024,6,3)))
+                .thenReturn(Optional.of(daily));
+        when(postalServiceDailyStatisticsRepository.findByStoreIdAndPostalServiceTypeAndDate(storeId, PostalServiceType.BELPOST, LocalDate.of(2024,6,3)))
+                .thenReturn(Optional.of(psDaily));
+        when(deliveryHistoryRepository.findByTrackParcelId(any())).thenReturn(Optional.empty());
+
+        final TrackParcel[] saved = new TrackParcel[1];
+        when(trackParcelRepository.save(any())).thenAnswer(invocation -> {
+            saved[0] = invocation.getArgument(0);
+            return saved[0];
+        });
+
+        ArgumentCaptor<DeliveryHistory> captor = ArgumentCaptor.forClass(DeliveryHistory.class);
+        when(deliveryHistoryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(statusTrackService.setStatus(any())).thenAnswer(invocation -> {
+            List<TrackInfoDTO> list = invocation.getArgument(0);
+            String info = list.get(0).getInfoTrack();
+            if (info.startsWith("Почтовое отправление выдано")) return GlobalStatus.DELIVERED;
+            if (info.startsWith("Почтовое отправление прибыло")) return GlobalStatus.WAITING_FOR_CUSTOMER;
+            return GlobalStatus.IN_TRANSIT;
+        });
+
+        trackParcelService.save(number, listDTO, storeId, userId);
+
+        verify(deliveryHistoryRepository).save(captor.capture());
+        DeliveryHistory history = captor.getValue();
+
+        ZonedDateTime expectedArrived = ZonedDateTime.of(2024,6,2,8,0,0,0, ZoneId.of("Europe/Minsk"))
+                .withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(expectedArrived, history.getArrivedDate());
 
         assertEquals(GlobalStatus.DELIVERED, saved[0].getStatus());
         assertTrue(saved[0].isIncludedInStatistics());


### PR DESCRIPTION
## Summary
- ensure DeliveryHistoryService always sets arrivedDate when present
- log arrivedDate extraction from tracking history
- add integration test for final statuses with waiting event

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68461c5308ec832da080368fc902ef6f