### PR TITLE
Fix blank analytics charts

### DIFF
--- a/src/main/resources/static/js/analytics.js
+++ b/src/main/resources/static/js/analytics.js
@@ -306,6 +306,9 @@ document.addEventListener("DOMContentLoaded", function () {
         renderBarChart(analyticsData.periodStats);
         updateStoreStats(analyticsData.storeStatistics);
         updatePostalServiceStats(analyticsData.postalStats);
+    } else {
+        // Если данные не были переданы сервером напрямую, загружаем их
+        loadAnalyticsData();
     }
 
     // Кнопка обновления


### PR DESCRIPTION
## Summary
- ensure `analytics.js` fetches data when inline variables missing

## Testing
- `mvn test` *(fails: maven not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684623f12f18832da4e74a298b8fa4f2