### PR TITLE
Fix analytics for UNKNOWN postal service

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
@@ -32,6 +32,7 @@ public class PostalServiceStatisticsService {
     public List<PostalServiceStatsDTO> getStatsByStore(Long storeId) {
         return repository.findByStoreId(storeId)
                 .stream()
+                .filter(stat -> stat.getPostalServiceType() != PostalServiceType.UNKNOWN)
                 .map(this::mapToDto)
                 .toList();
     }
@@ -53,6 +54,9 @@ public class PostalServiceStatisticsService {
         List<PostalServiceStatistics> stats = repository.findByStoreIdIn(storeIds);
         Map<PostalServiceType, PostalServiceStatistics> aggregated = new EnumMap<>(PostalServiceType.class);
         for (PostalServiceStatistics stat : stats) {
+            if (stat.getPostalServiceType() == PostalServiceType.UNKNOWN) {
+                continue;
+            }
             aggregated.merge(stat.getPostalServiceType(), stat, this::mergeStats);
         }
         return aggregated.values().stream()


### PR DESCRIPTION
## Summary
- skip analytics updates when postal service type is UNKNOWN
- ignore UNKNOWN rows when aggregating postal statistics
- avoid creating daily and total stats for UNKNOWN service

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684627e96a9c832d859d57ca70e88e75