### PR TITLE
Add analytics reset feature

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
+++ b/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.analytics.PostalServiceStatisticsService;
 import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import com.project.tracking_system.service.analytics.StoreDashboardDataService;
+import com.project.tracking_system.service.analytics.AnalyticsResetService;
 import com.project.tracking_system.service.store.StoreService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class AnalyticsController {
     private final StoreAnalyticsService storeAnalyticsService;
     private final StoreService storeService;
     private final StoreDashboardDataService storeDashboardDataService;
+    private final AnalyticsResetService analyticsResetService;
     private final WebSocketController webSocketController;
 
     /**
@@ -256,6 +258,27 @@ public class AnalyticsController {
                 "periodStats",   periodStats,
                 "storeStatistics", storeStats
         );
+    }
+
+    /**
+     * Удаляет всю аналитику пользователя.
+     */
+    @PostMapping("/reset/all")
+    public ResponseEntity<Void> resetAllAnalyticsForUser(@AuthenticationPrincipal User user) {
+        analyticsResetService.resetAllAnalytics(user.getId());
+        webSocketController.sendUpdateStatus(user.getId(), "Аналитика удалена", true);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Удаляет аналитику конкретного магазина пользователя.
+     */
+    @PostMapping("/reset/store/{storeId}")
+    public ResponseEntity<Void> resetAnalyticsForStore(@PathVariable Long storeId,
+                                                       @AuthenticationPrincipal User user) {
+        analyticsResetService.resetStoreAnalytics(user.getId(), storeId);
+        webSocketController.sendUpdateStatus(user.getId(), "Аналитика магазина удалена", true);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
@@ -3,6 +3,10 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.PostalServiceStatistics;
 import com.project.tracking_system.entity.PostalServiceType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,5 +31,25 @@ public interface PostalServiceStatisticsRepository extends JpaRepository<PostalS
      * Получить статистику для нескольких магазинов.
      */
     List<PostalServiceStatistics> findByStoreIdIn(List<Long> storeIds);
+
+    /**
+     * Удалить статистику почтовых служб конкретного магазина.
+     *
+     * @param storeId идентификатор магазина
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceStatistics p WHERE p.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Удалить всю статистику почтовых служб пользователя.
+     *
+     * @param userId идентификатор пользователя
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceStatistics p WHERE p.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
@@ -2,8 +2,10 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +34,26 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
      * Получить статистику сразу по нескольким магазинам.
      */
     List<StoreStatistics> findByStoreIdIn(List<Long> storeIds);
+
+    /**
+     * Удалить статистику конкретного магазина.
+     *
+     * @param storeId идентификатор магазина
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Удалить всю статистику всех магазинов пользователя.
+     *
+     * @param userId идентификатор пользователя
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 
 
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/AnalyticsResetService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/AnalyticsResetService.java
@@ -1,0 +1,49 @@
+package com.project.tracking_system.service.analytics;
+
+import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
+import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.service.store.StoreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис для удаления аналитики магазинов и служб доставки.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsResetService {
+
+    private final StoreAnalyticsRepository storeAnalyticsRepository;
+    private final PostalServiceStatisticsRepository postalStatisticsRepository;
+    private final StoreService storeService;
+
+    /**
+     * Удаляет всю аналитику пользователя по всем его магазинам.
+     *
+     * @param userId идентификатор пользователя
+     */
+    @Transactional
+    public void resetAllAnalytics(Long userId) {
+        log.info("\uD83D\uDD04 Удаляем всю аналитику пользователя ID={}", userId);
+        storeAnalyticsRepository.deleteByUserId(userId);
+        postalStatisticsRepository.deleteByUserId(userId);
+    }
+
+    /**
+     * Удаляет аналитику одного магазина пользователя.
+     * Предварительно проверяется принадлежность магазина пользователю.
+     *
+     * @param userId  идентификатор пользователя
+     * @param storeId идентификатор магазина
+     */
+    @Transactional
+    public void resetStoreAnalytics(Long userId, Long storeId) {
+        storeService.checkStoreOwnership(storeId, userId);
+        log.info("\uD83D\uDD04 Удаляем аналитику магазина ID={} пользователя ID={}", storeId, userId);
+        storeAnalyticsRepository.deleteByStoreId(storeId);
+        postalStatisticsRepository.deleteByStoreId(storeId);
+    }
+}

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -108,6 +108,14 @@
 
                         <button type="button" class="btn btn-primary mt-3" id="addStoreBtn">Добавить магазин</button>
                     </form>
+
+                    <div class="mt-4" id="analytics-management">
+                        <h5 class="mb-3">Управление аналитикой</h5>
+                        <div id="storeAnalyticsButtons" class="mb-3"><!-- JS --></div>
+                        <button type="button" class="btn btn-danger" id="resetAllAnalyticsBtn">
+                            🧨 Удалить всю аналитику
+                        </button>
+                    </div>
                 </div>
 
                 <div class="tab-pane fade card p-4 shadow-sm rounded-4"
@@ -320,6 +328,23 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
                     <button class="btn btn-danger" id="confirmDeleteStore">Да, удалить</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Модальное окно подтверждения очистки аналитики -->
+    <div class="modal fade" id="resetAnalyticsModal" tabindex="-1" aria-labelledby="resetAnalyticsModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content border-danger">
+                <div class="modal-header">
+                    <h5 class="modal-title text-danger" id="resetAnalyticsModalLabel">Подтверждение действия</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body" id="resetAnalyticsMessage"></div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+                    <button class="btn btn-danger" id="confirmResetAnalytics">Да, удалить</button>
                 </div>
             </div>
         </div>

--- a/src/test/java/AnalyticsControllerTest.java
+++ b/src/test/java/AnalyticsControllerTest.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.analytics.PostalServiceStatisticsService;
 import com.project.tracking_system.service.analytics.StoreAnalyticsService;
 import com.project.tracking_system.service.analytics.StoreDashboardDataService;
+import com.project.tracking_system.service.analytics.AnalyticsResetService;
 import com.project.tracking_system.service.store.StoreService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,8 @@ public class AnalyticsControllerTest {
     private StoreDashboardDataService storeDashboardDataService;
     @MockBean
     private WebSocketController webSocketController;
+    @MockBean
+    private AnalyticsResetService analyticsResetService;
 
     private Authentication auth(User user) {
         return new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities());
@@ -147,5 +150,31 @@ public class AnalyticsControllerTest {
                 .andExpect(status().isOk());
 
         verify(storeAnalyticsService).updateStoreAnalytics(2L);
+    }
+
+    @Test
+    void resetAllAnalytics_CallsService() throws Exception {
+        User user = new User();
+        user.setId(1L);
+        user.setRole(Role.ROLE_USER);
+
+        mockMvc.perform(post("/analytics/reset/all")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(auth(user))))
+                .andExpect(status().isOk());
+
+        verify(analyticsResetService).resetAllAnalytics(1L);
+    }
+
+    @Test
+    void resetAnalyticsForStore_CallsService() throws Exception {
+        User user = new User();
+        user.setId(1L);
+        user.setRole(Role.ROLE_USER);
+
+        mockMvc.perform(post("/analytics/reset/store/5")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(auth(user))))
+                .andExpect(status().isOk());
+
+        verify(analyticsResetService).resetStoreAnalytics(1L, 5L);
     }
 }


### PR DESCRIPTION
## Summary
- allow resetting analytics in AnalyticsController
- add AnalyticsResetService
- add repository delete methods
- add analytics management section in profile page
- support analytics reset actions with JavaScript
- test analytics reset endpoints

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684831f7e804832db3c70a23e1b287ea