### PR TITLE
Fix analytics reset to zero stats

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
@@ -3,6 +3,10 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.PostalServiceDailyStatistics;
 import com.project.tracking_system.entity.PostalServiceType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -60,4 +64,20 @@ public interface PostalServiceDailyStatisticsRepository extends JpaRepository<Po
      * @return список ежедневной статистики
      */
     List<PostalServiceDailyStatistics> findByDate(LocalDate date);
+
+    /**
+     * Delete daily statistics for a store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceDailyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete daily statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceDailyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
@@ -66,7 +66,7 @@ public interface PostalServiceDailyStatisticsRepository extends JpaRepository<Po
     List<PostalServiceDailyStatistics> findByDate(LocalDate date);
 
     /**
-     * Delete daily statistics for a store.
+     * Удалить ежедневную статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -74,7 +74,7 @@ public interface PostalServiceDailyStatisticsRepository extends JpaRepository<Po
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete daily statistics for all stores of a user.
+     * Удалить ежедневную статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
@@ -3,6 +3,10 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.PostalServiceMonthlyStatistics;
 import com.project.tracking_system.entity.PostalServiceType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -21,4 +25,20 @@ public interface PostalServiceMonthlyStatisticsRepository extends JpaRepository<
      * @return статистика почтовой службы за месяц, если найдена
      */
     Optional<PostalServiceMonthlyStatistics> findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(Long storeId, PostalServiceType postalServiceType, int periodYear, int periodNumber);
+
+    /**
+     * Delete monthly statistics for a store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceMonthlyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete monthly statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceMonthlyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
@@ -27,7 +27,7 @@ public interface PostalServiceMonthlyStatisticsRepository extends JpaRepository<
     Optional<PostalServiceMonthlyStatistics> findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(Long storeId, PostalServiceType postalServiceType, int periodYear, int periodNumber);
 
     /**
-     * Delete monthly statistics for a store.
+     * Удалить месячную статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -35,7 +35,7 @@ public interface PostalServiceMonthlyStatisticsRepository extends JpaRepository<
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete monthly statistics for all stores of a user.
+     * Удалить месячную статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
@@ -52,4 +52,42 @@ public interface PostalServiceStatisticsRepository extends JpaRepository<PostalS
     @Query("DELETE FROM PostalServiceStatistics p WHERE p.store.owner.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
 
+    /**
+     * Reset statistics counters for all postal services of the user's stores.
+     *
+     * @param userId user identifier
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE PostalServiceStatistics p
+        SET p.totalSent = 0,
+            p.totalDelivered = 0,
+            p.totalReturned = 0,
+            p.sumDeliveryDays = 0,
+            p.sumPickupDays = 0,
+            p.updatedAt = NULL
+        WHERE p.store.owner.id = :userId
+        """)
+    void resetByUserId(@Param("userId") Long userId);
+
+    /**
+     * Reset statistics counters for a single store.
+     *
+     * @param storeId store identifier
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE PostalServiceStatistics p
+        SET p.totalSent = 0,
+            p.totalDelivered = 0,
+            p.totalReturned = 0,
+            p.sumDeliveryDays = 0,
+            p.sumPickupDays = 0,
+            p.updatedAt = NULL
+        WHERE p.store.id = :storeId
+        """)
+    void resetByStoreId(@Param("storeId") Long storeId);
+
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
@@ -53,9 +53,9 @@ public interface PostalServiceStatisticsRepository extends JpaRepository<PostalS
     void deleteByUserId(@Param("userId") Long userId);
 
     /**
-     * Reset statistics counters for all postal services of the user's stores.
+     * Обнулить счётчики для всех служб доставки магазинов пользователя.
      *
-     * @param userId user identifier
+     * @param userId идентификатор пользователя
      */
     @Modifying
     @Transactional
@@ -72,9 +72,9 @@ public interface PostalServiceStatisticsRepository extends JpaRepository<PostalS
     void resetByUserId(@Param("userId") Long userId);
 
     /**
-     * Reset statistics counters for a single store.
+     * Обнулить счётчики служб доставки конкретного магазина.
      *
-     * @param storeId store identifier
+     * @param storeId идентификатор магазина
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
@@ -3,6 +3,10 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.PostalServiceWeeklyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -21,4 +25,20 @@ public interface PostalServiceWeeklyStatisticsRepository extends JpaRepository<P
      * @return статистика почтовой службы за неделю, если найдена
      */
     Optional<PostalServiceWeeklyStatistics> findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(Long storeId, PostalServiceType postalServiceType, int periodYear, int periodNumber);
+
+    /**
+     * Delete weekly statistics for a store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceWeeklyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete weekly statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceWeeklyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
@@ -27,7 +27,7 @@ public interface PostalServiceWeeklyStatisticsRepository extends JpaRepository<P
     Optional<PostalServiceWeeklyStatistics> findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(Long storeId, PostalServiceType postalServiceType, int periodYear, int periodNumber);
 
     /**
-     * Delete weekly statistics for a store.
+     * Удалить недельную статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -35,7 +35,7 @@ public interface PostalServiceWeeklyStatisticsRepository extends JpaRepository<P
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete weekly statistics for all stores of a user.
+     * Удалить недельную статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
@@ -27,7 +27,7 @@ public interface PostalServiceYearlyStatisticsRepository extends JpaRepository<P
     Optional<PostalServiceYearlyStatistics> findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(Long storeId, PostalServiceType postalServiceType, int periodYear, int periodNumber);
 
     /**
-     * Delete yearly statistics for a store.
+     * Удалить годовую статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -35,7 +35,7 @@ public interface PostalServiceYearlyStatisticsRepository extends JpaRepository<P
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete yearly statistics for all stores of a user.
+     * Удалить годовую статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
@@ -3,6 +3,10 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.PostalServiceYearlyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -21,4 +25,20 @@ public interface PostalServiceYearlyStatisticsRepository extends JpaRepository<P
      * @return статистика почтовой службы за год, если найдена
      */
     Optional<PostalServiceYearlyStatistics> findByStoreIdAndPostalServiceTypeAndPeriodYearAndPeriodNumber(Long storeId, PostalServiceType postalServiceType, int periodYear, int periodNumber);
+
+    /**
+     * Delete yearly statistics for a store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceYearlyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete yearly statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostalServiceYearlyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
@@ -55,5 +55,43 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
     @Query("DELETE FROM StoreStatistics s WHERE s.store.owner.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
 
+    /**
+     * Reset counters for all stores of a user.
+     *
+     * @param userId user identifier
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE StoreStatistics s
+        SET s.totalSent = 0,
+            s.totalDelivered = 0,
+            s.totalReturned = 0,
+            s.sumDeliveryDays = 0,
+            s.sumPickupDays = 0,
+            s.updatedAt = NULL
+        WHERE s.store.owner.id = :userId
+        """)
+    void resetByUserId(@Param("userId") Long userId);
+
+    /**
+     * Reset counters for a single store.
+     *
+     * @param storeId store identifier
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE StoreStatistics s
+        SET s.totalSent = 0,
+            s.totalDelivered = 0,
+            s.totalReturned = 0,
+            s.sumDeliveryDays = 0,
+            s.sumPickupDays = 0,
+            s.updatedAt = NULL
+        WHERE s.store.id = :storeId
+        """)
+    void resetByStoreId(@Param("storeId") Long storeId);
+
 
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
@@ -56,9 +56,9 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
     void deleteByUserId(@Param("userId") Long userId);
 
     /**
-     * Reset counters for all stores of a user.
+     * Обнулить счётчики для всех магазинов пользователя.
      *
-     * @param userId user identifier
+     * @param userId идентификатор пользователя
      */
     @Modifying
     @Transactional
@@ -75,9 +75,9 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
     void resetByUserId(@Param("userId") Long userId);
 
     /**
-     * Reset counters for a single store.
+     * Обнулить счётчики конкретного магазина.
      *
-     * @param storeId store identifier
+     * @param storeId идентификатор магазина
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
@@ -54,7 +54,7 @@ public interface StoreDailyStatisticsRepository extends JpaRepository<StoreDaily
     List<StoreDailyStatistics> findByDate(LocalDate date);
 
     /**
-     * Delete all daily statistics of a single store.
+     * Удалить всю ежедневную статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -62,7 +62,7 @@ public interface StoreDailyStatisticsRepository extends JpaRepository<StoreDaily
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete all daily statistics of all stores of a user.
+     * Удалить ежедневную статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
@@ -2,6 +2,10 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreDailyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -48,4 +52,20 @@ public interface StoreDailyStatisticsRepository extends JpaRepository<StoreDaily
      * @return список ежедневной статистики
      */
     List<StoreDailyStatistics> findByDate(LocalDate date);
+
+    /**
+     * Delete all daily statistics of a single store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreDailyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete all daily statistics of all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreDailyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
@@ -28,7 +28,7 @@ public interface StoreMonthlyStatisticsRepository extends JpaRepository<StoreMon
     List<StoreMonthlyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 
     /**
-     * Delete monthly statistics for a store.
+     * Удалить месячную статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -36,7 +36,7 @@ public interface StoreMonthlyStatisticsRepository extends JpaRepository<StoreMon
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete monthly statistics for all stores of a user.
+     * Удалить месячную статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
@@ -2,6 +2,10 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreMonthlyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +26,20 @@ public interface StoreMonthlyStatisticsRepository extends JpaRepository<StoreMon
      * @return список месячной статистики, по одному элементу на магазин
      */
     List<StoreMonthlyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
+
+    /**
+     * Delete monthly statistics for a store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreMonthlyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete monthly statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreMonthlyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
@@ -28,7 +28,7 @@ public interface StoreWeeklyStatisticsRepository extends JpaRepository<StoreWeek
     List<StoreWeeklyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 
     /**
-     * Delete weekly statistics for a specific store.
+     * Удалить недельную статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -36,7 +36,7 @@ public interface StoreWeeklyStatisticsRepository extends JpaRepository<StoreWeek
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete weekly statistics for all stores of a user.
+     * Удалить недельную статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
@@ -2,6 +2,10 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreWeeklyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +26,20 @@ public interface StoreWeeklyStatisticsRepository extends JpaRepository<StoreWeek
      * @return список недельной статистики, по одному элементу на магазин
      */
     List<StoreWeeklyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
+
+    /**
+     * Delete weekly statistics for a specific store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreWeeklyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete weekly statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreWeeklyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
@@ -2,6 +2,10 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreYearlyStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +26,20 @@ public interface StoreYearlyStatisticsRepository extends JpaRepository<StoreYear
      * @return список годовой статистики, по одному элементу на магазин
      */
     List<StoreYearlyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
+
+    /**
+     * Delete yearly statistics for a store.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreYearlyStatistics s WHERE s.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Delete yearly statistics for all stores of a user.
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StoreYearlyStatistics s WHERE s.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
@@ -28,7 +28,7 @@ public interface StoreYearlyStatisticsRepository extends JpaRepository<StoreYear
     List<StoreYearlyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 
     /**
-     * Delete yearly statistics for a store.
+     * Удалить годовую статистику конкретного магазина.
      */
     @Modifying
     @Transactional
@@ -36,7 +36,7 @@ public interface StoreYearlyStatisticsRepository extends JpaRepository<StoreYear
     void deleteByStoreId(@Param("storeId") Long storeId);
 
     /**
-     * Delete yearly statistics for all stores of a user.
+     * Удалить годовую статистику всех магазинов пользователя.
      */
     @Modifying
     @Transactional

--- a/src/main/java/com/project/tracking_system/service/analytics/AnalyticsResetService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/AnalyticsResetService.java
@@ -2,6 +2,14 @@ package com.project.tracking_system.service.analytics;
 
 import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
 import com.project.tracking_system.repository.StoreAnalyticsRepository;
+import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
+import com.project.tracking_system.repository.StoreWeeklyStatisticsRepository;
+import com.project.tracking_system.repository.StoreMonthlyStatisticsRepository;
+import com.project.tracking_system.repository.StoreYearlyStatisticsRepository;
+import com.project.tracking_system.repository.PostalServiceDailyStatisticsRepository;
+import com.project.tracking_system.repository.PostalServiceWeeklyStatisticsRepository;
+import com.project.tracking_system.repository.PostalServiceMonthlyStatisticsRepository;
+import com.project.tracking_system.repository.PostalServiceYearlyStatisticsRepository;
 import com.project.tracking_system.service.store.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +26,14 @@ public class AnalyticsResetService {
 
     private final StoreAnalyticsRepository storeAnalyticsRepository;
     private final PostalServiceStatisticsRepository postalStatisticsRepository;
+    private final StoreDailyStatisticsRepository storeDailyRepo;
+    private final StoreWeeklyStatisticsRepository storeWeeklyRepo;
+    private final StoreMonthlyStatisticsRepository storeMonthlyRepo;
+    private final StoreYearlyStatisticsRepository storeYearlyRepo;
+    private final PostalServiceDailyStatisticsRepository psDailyRepo;
+    private final PostalServiceWeeklyStatisticsRepository psWeeklyRepo;
+    private final PostalServiceMonthlyStatisticsRepository psMonthlyRepo;
+    private final PostalServiceYearlyStatisticsRepository psYearlyRepo;
     private final StoreService storeService;
 
     /**
@@ -27,9 +43,22 @@ public class AnalyticsResetService {
      */
     @Transactional
     public void resetAllAnalytics(Long userId) {
-        log.info("\uD83D\uDD04 Удаляем всю аналитику пользователя ID={}", userId);
-        storeAnalyticsRepository.deleteByUserId(userId);
-        postalStatisticsRepository.deleteByUserId(userId);
+        log.info("\uD83D\uDD04 Сбрасываем аналитику пользователя ID={}", userId);
+
+        // Обнуляем суммарные счётчики
+        storeAnalyticsRepository.resetByUserId(userId);
+        postalStatisticsRepository.resetByUserId(userId);
+
+        // Удаляем агрегированные данные по периодам
+        storeDailyRepo.deleteByUserId(userId);
+        storeWeeklyRepo.deleteByUserId(userId);
+        storeMonthlyRepo.deleteByUserId(userId);
+        storeYearlyRepo.deleteByUserId(userId);
+
+        psDailyRepo.deleteByUserId(userId);
+        psWeeklyRepo.deleteByUserId(userId);
+        psMonthlyRepo.deleteByUserId(userId);
+        psYearlyRepo.deleteByUserId(userId);
     }
 
     /**
@@ -42,8 +71,23 @@ public class AnalyticsResetService {
     @Transactional
     public void resetStoreAnalytics(Long userId, Long storeId) {
         storeService.checkStoreOwnership(storeId, userId);
-        log.info("\uD83D\uDD04 Удаляем аналитику магазина ID={} пользователя ID={}", storeId, userId);
-        storeAnalyticsRepository.deleteByStoreId(storeId);
-        postalStatisticsRepository.deleteByStoreId(storeId);
+        log.info("\uD83D\uDD04 Сбрасываем аналитику магазина ID={} пользователя ID={}", storeId, userId);
+
+        // Обнуляем суммарные счётчики магазина
+        storeAnalyticsRepository.resetByStoreId(storeId);
+        postalStatisticsRepository.resetByStoreId(storeId);
+
+        // Удаляем периодическую статистику
+        storeDailyRepo.deleteByStoreId(storeId);
+        storeWeeklyRepo.deleteByStoreId(storeId);
+        storeMonthlyRepo.deleteByStoreId(storeId);
+        storeYearlyRepo.deleteByStoreId(storeId);
+
+        psDailyRepo.deleteByStoreId(storeId);
+        psWeeklyRepo.deleteByStoreId(storeId);
+        psMonthlyRepo.deleteByStoreId(storeId);
+        psYearlyRepo.deleteByStoreId(storeId);
+
+        log.info("Analytics reset for store {} by user {}", storeId, userId);
     }
 }

--- a/src/test/java/AnalyticsResetServiceTest.java
+++ b/src/test/java/AnalyticsResetServiceTest.java
@@ -1,0 +1,73 @@
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.analytics.AnalyticsResetService;
+import com.project.tracking_system.service.store.StoreService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AnalyticsResetServiceTest {
+
+    @Mock
+    private StoreAnalyticsRepository storeAnalyticsRepository;
+    @Mock
+    private PostalServiceStatisticsRepository postalStatisticsRepository;
+    @Mock
+    private StoreDailyStatisticsRepository storeDailyRepo;
+    @Mock
+    private StoreWeeklyStatisticsRepository storeWeeklyRepo;
+    @Mock
+    private StoreMonthlyStatisticsRepository storeMonthlyRepo;
+    @Mock
+    private StoreYearlyStatisticsRepository storeYearlyRepo;
+    @Mock
+    private PostalServiceDailyStatisticsRepository psDailyRepo;
+    @Mock
+    private PostalServiceWeeklyStatisticsRepository psWeeklyRepo;
+    @Mock
+    private PostalServiceMonthlyStatisticsRepository psMonthlyRepo;
+    @Mock
+    private PostalServiceYearlyStatisticsRepository psYearlyRepo;
+    @Mock
+    private StoreService storeService;
+
+    @InjectMocks
+    private AnalyticsResetService service;
+
+    @Test
+    void resetAllAnalytics_ResetsAllRepositories() {
+        service.resetAllAnalytics(1L);
+
+        verify(storeAnalyticsRepository).resetByUserId(1L);
+        verify(postalStatisticsRepository).resetByUserId(1L);
+        verify(storeDailyRepo).deleteByUserId(1L);
+        verify(storeWeeklyRepo).deleteByUserId(1L);
+        verify(storeMonthlyRepo).deleteByUserId(1L);
+        verify(storeYearlyRepo).deleteByUserId(1L);
+        verify(psDailyRepo).deleteByUserId(1L);
+        verify(psWeeklyRepo).deleteByUserId(1L);
+        verify(psMonthlyRepo).deleteByUserId(1L);
+        verify(psYearlyRepo).deleteByUserId(1L);
+    }
+
+    @Test
+    void resetStoreAnalytics_ChecksOwnershipAndResets() {
+        service.resetStoreAnalytics(2L, 3L);
+
+        verify(storeService).checkStoreOwnership(3L, 2L);
+        verify(storeAnalyticsRepository).resetByStoreId(3L);
+        verify(postalStatisticsRepository).resetByStoreId(3L);
+        verify(storeDailyRepo).deleteByStoreId(3L);
+        verify(storeWeeklyRepo).deleteByStoreId(3L);
+        verify(storeMonthlyRepo).deleteByStoreId(3L);
+        verify(storeYearlyRepo).deleteByStoreId(3L);
+        verify(psDailyRepo).deleteByStoreId(3L);
+        verify(psWeeklyRepo).deleteByStoreId(3L);
+        verify(psMonthlyRepo).deleteByStoreId(3L);
+        verify(psYearlyRepo).deleteByStoreId(3L);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid deleting analytics rows when resetting statistics
- zero all counters in store and postal service statistics
- wipe period data for stores and postal services
- expand `AnalyticsResetService` with new repositories
- add tests for analytics reset logic

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684876ea7b04832da00ce5f4fb205bdc