### PR TITLE
Refine analytics management UI in profile

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -480,15 +480,15 @@ async function loadAnalyticsButtons() {
     stores.forEach(store => {
         const btn = document.createElement('button');
         btn.type = 'button';
-        btn.className = 'btn btn-outline-warning btn-sm me-2 reset-store-analytics-btn';
+        btn.className = 'btn btn-outline-secondary w-100 reset-store-analytics-btn mb-2 d-flex align-items-center';
         btn.dataset.storeId = store.id;
         btn.dataset.storeName = store.name;
-        btn.innerHTML = `🧹 Очистить аналитику — ${store.name}`;
-        const wrap = document.createElement('div');
-        wrap.className = 'mb-2';
-        wrap.appendChild(btn);
-        container.appendChild(wrap);
+        btn.setAttribute('data-bs-toggle', 'tooltip');
+        btn.title = `Очистить аналитику магазина «${store.name}»`;
+        btn.innerHTML = `<i class="bi bi-brush me-2"></i> Очистить аналитику — ${store.name}`;
+        container.appendChild(btn);
     });
+    enableTooltips(container);
 }
 
 /**

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -111,9 +111,9 @@
 
                     <div class="mt-4" id="analytics-management">
                         <h5 class="mb-3">Управление аналитикой</h5>
-                        <div id="storeAnalyticsButtons" class="mb-3"><!-- JS --></div>
-                        <button type="button" class="btn btn-danger" id="resetAllAnalyticsBtn">
-                            🧨 Удалить всю аналитику
+                        <div id="storeAnalyticsButtons" class="d-flex flex-column w-100 mb-3"><!-- JS --></div>
+                        <button type="button" class="btn btn-danger w-100 d-flex align-items-center" id="resetAllAnalyticsBtn">
+                            <i class="bi bi-trash me-2"></i> Удалить всю аналитику
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- redesign analytics control panel buttons for cleaner layout
- add Bootstrap icons and tooltips for clarity

## Testing
- `npm run build:css` *(fails: `sass: not found`)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6848826f68b8832d84cf2276cd078e40