### PR TITLE
Add AuthUtils for retrieving current user

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -16,8 +16,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import com.project.tracking_system.util.AuthUtils;
+import com.project.tracking_system.exception.UserNotAuthenticatedException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -66,7 +67,10 @@ public class DeparturesController {
             Model model,
             Authentication authentication) {
 
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.debug("Попытка доступа к странице 'Отправления' без аутентификации.");
             return "redirect:/login";
         }
@@ -151,9 +155,7 @@ public class DeparturesController {
             @PathVariable("itemNumber") String itemNumber,
             Authentication authentication) {
 
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
-            throw new RuntimeException("Пользователь не аутентифицирован.");
-        }
+        User user = AuthUtils.getCurrentUser(authentication);
 
         Long userId = user.getId();
         log.info("🔍 Запрос информации о посылке {} для пользователя ID={}", itemNumber, userId);
@@ -185,8 +187,10 @@ public class DeparturesController {
             @RequestParam(required = false) List<String> selectedNumbers,
             Authentication authentication
     ) {
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth)
-                || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("❌ Попытка обновления посылок без аутентификации.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
@@ -228,7 +232,10 @@ public class DeparturesController {
             @RequestParam List<String> selectedNumbers,
             Authentication authentication) {
 
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка удаления посылок без аутентификации.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Ошибка: Необходимо войти в систему.");
         }

--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -37,6 +37,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
+import com.project.tracking_system.util.AuthUtils;
+
 /**
  * Контроллер для обработки запросов на главной странице, регистрации, входа, сброса пароля и загрузки файлов.
  * <p>
@@ -72,7 +74,7 @@ public class HomeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated() &&
                 !(authentication instanceof AnonymousAuthenticationToken)) {
-            User user = (User) authentication.getPrincipal();
+            User user = AuthUtils.getCurrentUser(authentication);
             model.addAttribute("authenticatedUser", user.getEmail());
 
             // Получаем магазины пользователя
@@ -353,8 +355,9 @@ public class HomeController {
         Long userId = null;
 
         if (auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) {
-            userId = ((User) auth.getPrincipal()).getId();
-            model.addAttribute("authenticatedUser", ((User) auth.getPrincipal()).getEmail());
+            User user = AuthUtils.getCurrentUser(auth);
+            userId = user.getId();
+            model.addAttribute("authenticatedUser", user.getEmail());
         } else {
             model.addAttribute("authenticatedUser", null);
         }

--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -6,6 +6,8 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.util.AuthUtils;
+import com.project.tracking_system.exception.UserNotAuthenticatedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -13,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
@@ -58,7 +59,10 @@ public class ProfileController {
      */
     @GetMapping
     public String profile(Model model, Authentication authentication) {
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка доступа к профилю неаутентифицированного пользователя.");
             return "redirect:/login"; // Перенаправляем на страницу входа
         }
@@ -95,7 +99,10 @@ public class ProfileController {
             Model model,
             Authentication authentication) {
 
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка доступа к настройкам без аутентификации.");
             return "redirect:/login"; // Перенаправление, если пользователь не аутентифицирован
         }
@@ -118,7 +125,10 @@ public class ProfileController {
             @Valid @ModelAttribute("evropostCredentialsDTO") EvropostCredentialsDTO evropostCredentialsDTO,
             BindingResult bindingResult, Model model, Authentication authentication) {
 
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка обновления данных Европочты без аутентификации.");
             return "redirect:/login"; // Защита от неаутентифицированных пользователей
         }
@@ -159,7 +169,10 @@ public class ProfileController {
             @RequestParam(value = "useCustomCredentials", required = false) Boolean useCustomCredentials,
             Authentication authentication) {
 
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка обновления настроек без аутентификации.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Необходима аутентификация");
         }
@@ -200,7 +213,10 @@ public class ProfileController {
                                  @Valid @ModelAttribute("userSettingsDTO") UserSettingsDTO userSettingsDTO,
                                  BindingResult result,
                                  Authentication authentication) {
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка смены пароля без аутентификации.");
             return "redirect:/login"; // Защита от неаутентифицированных пользователей
         }
@@ -240,7 +256,10 @@ public class ProfileController {
      */
     @PostMapping("/settings/delete")
     public String delete(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        if (authentication == null || !(authentication.getPrincipal() instanceof User user)) {
+        User user;
+        try {
+            user = AuthUtils.getCurrentUser(authentication);
+        } catch (UserNotAuthenticatedException ex) {
             log.warn("Попытка удаления учетной записи без аутентификации.");
             return "redirect:/login"; // Отправляем на логин, если пользователь не аутентифицирован
         }
@@ -323,10 +342,7 @@ public class ProfileController {
     @GetMapping("/stores/limit")
     @ResponseBody
     public String getStoreLimit(Authentication authentication) {
-        if (!(authentication instanceof UsernamePasswordAuthenticationToken auth) || !(auth.getPrincipal() instanceof User user)) {
-            throw new SecurityException("Необходима аутентификация");
-        }
-
+        User user = AuthUtils.getCurrentUser(authentication);
         return userService.getUserStoreLimit(user.getId());
     }
 

--- a/src/main/java/com/project/tracking_system/exception/UserNotAuthenticatedException.java
+++ b/src/main/java/com/project/tracking_system/exception/UserNotAuthenticatedException.java
@@ -1,0 +1,17 @@
+package com.project.tracking_system.exception;
+
+/**
+ * Исключение, выбрасываемое когда попытка получить текущего
+ * пользователя завершается неудачей из-за отсутствия аутентификации.
+ */
+public class UserNotAuthenticatedException extends RuntimeException {
+
+    /**
+     * Создаёт исключение с описанием причины.
+     *
+     * @param message сообщение об ошибке
+     */
+    public UserNotAuthenticatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/tracking_system/util/AuthUtils.java
+++ b/src/main/java/com/project/tracking_system/util/AuthUtils.java
@@ -1,0 +1,29 @@
+package com.project.tracking_system.util;
+
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.exception.UserNotAuthenticatedException;
+import lombok.experimental.UtilityClass;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Вспомогательные методы для работы с аутентификацией.
+ */
+@UtilityClass
+public class AuthUtils {
+
+    /**
+     * Возвращает текущего аутентифицированного пользователя.
+     *
+     * @param authentication объект аутентификации
+     * @return текущий пользователь
+     * @throws UserNotAuthenticatedException если пользователь отсутствует
+     */
+    public static User getCurrentUser(Authentication authentication) {
+        if (authentication instanceof UsernamePasswordAuthenticationToken token
+                && token.getPrincipal() instanceof User user) {
+            return user;
+        }
+        throw new UserNotAuthenticatedException("Пользователь не аутентифицирован");
+    }
+}

--- a/src/test/java/AuthUtilsTest.java
+++ b/src/test/java/AuthUtilsTest.java
@@ -1,0 +1,31 @@
+import com.project.tracking_system.entity.Role;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.exception.UserNotAuthenticatedException;
+import com.project.tracking_system.util.AuthUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AuthUtilsTest {
+
+    @Test
+    void getCurrentUser_ReturnsUser() {
+        User user = new User();
+        user.setId(1L);
+        user.setRole(Role.ROLE_USER);
+        Authentication auth = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+
+        User result = AuthUtils.getCurrentUser(auth);
+
+        assertEquals(1L, result.getId());
+    }
+
+    @Test
+    void getCurrentUser_InvalidAuth_ThrowsException() {
+        Authentication auth = new UsernamePasswordAuthenticationToken("anonymous", null);
+
+        assertThrows(UserNotAuthenticatedException.class, () -> AuthUtils.getCurrentUser(auth));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `AuthUtils` to get current user from `Authentication`
- throw `UserNotAuthenticatedException` when no user is present
- refactor controllers to use `AuthUtils`
- add `AuthUtilsTest`

## Testing
- `./mvnw -q -Dtest=AuthUtilsTest test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6848a42ff1ec832d8d57e7782abc4088