### PR TITLE
Introduce MapStruct mappers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,18 @@
             <artifactId>modelmapper</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <!-- MapStruct for автоматического маппинга DTO -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -178,6 +190,22 @@
                             <artifactId>lombok</artifactId>
                         </exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -1,7 +1,6 @@
 package com.project.tracking_system.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +12,7 @@ import org.springframework.web.client.RestTemplate;
  * Конфигурационный класс для приложения.
  * <p>
  * Этот класс содержит бин-конфигурации, которые необходимы для работы приложения,
- * включая создание экземпляров {@link RestTemplate}, {@link ObjectMapper} и {@link ModelMapper}.
+ * включая создание экземпляров {@link RestTemplate} и {@link ObjectMapper}.
  * </p>
  *
  * @author Dmitriy Anisimov
@@ -49,18 +48,6 @@ public class AppConfiguration {
         return new ObjectMapper();
     }
 
-    /**
-     * Создает бин {@link ModelMapper} для преобразования объектов между различными слоями приложения.
-     * <p>
-     * {@link ModelMapper} используется для маппинга данных между объектами, например, между моделями и DTO.
-     * </p>
-     *
-     * @return Экземпляр {@link ModelMapper}.
-     */
-    @Bean
-    public ModelMapper getMapper() {
-        return new ModelMapper();
-    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/project/tracking_system/mapper/JsonEvroTrackingResponseMapper.java
+++ b/src/main/java/com/project/tracking_system/mapper/JsonEvroTrackingResponseMapper.java
@@ -2,50 +2,31 @@ package com.project.tracking_system.mapper;
 
 import com.project.tracking_system.dto.TrackInfoDTO;
 import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.model.evropost.jsonResponseModel.JsonEvroTracking;
 import com.project.tracking_system.model.evropost.jsonResponseModel.JsonEvroTrackingResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
- * Маппер для преобразования объекта {@link JsonEvroTrackingResponse} в объект {@link TrackInfoListDTO}.
- * <p>
- * Этот компонент используется для преобразования данных о статусах посылок, полученных от EuroPost,
- * в формат, пригодный для передачи в бизнес-логику приложения.
- * </p>
- *
- * @author Dmitriy Anisimov
- * @date 07.01.2025
+ * Маппер для преобразования ответа EuroPost в DTO.
  */
-@Slf4j
-@Component
-public class JsonEvroTrackingResponseMapper {
-
-    private final ModelMapper modelMapper;
-
-    @Autowired
-    public JsonEvroTrackingResponseMapper(ModelMapper modelMapper) {
-        this.modelMapper = modelMapper;
-    }
+@Mapper(componentModel = "spring")
+public interface JsonEvroTrackingResponseMapper {
 
     /**
-     * Преобразует объект {@link JsonEvroTrackingResponse} в объект {@link TrackInfoListDTO}.
-     * <p>
-     * Метод извлекает таблицу данных из ответа и преобразует каждый элемент в объект {@link TrackInfoDTO}.
-     * </p>
+     * Преобразует {@link JsonEvroTrackingResponse} в {@link TrackInfoListDTO}.
      *
-     * @param response Объект {@link JsonEvroTrackingResponse}, содержащий данные отслеживания посылки.
-     * @return {@link TrackInfoListDTO}, содержащий список информации о статусах посылки.
+     * @param response ответ от EuroPost
+     * @return список данных о статусах
      */
-    public TrackInfoListDTO mapJsonEvroTrackingResponseToDTO(JsonEvroTrackingResponse response) {
-        TrackInfoListDTO dto = new TrackInfoListDTO();
-        dto.setList(response.getTable().stream()
-                .map(jsonEvroTracking -> modelMapper.map(jsonEvroTracking, TrackInfoDTO.class))
-                .collect(Collectors.toList()));
-        log.info("✅ Маппинг завершён: {} записей", dto.getList().size());
-        return dto;
-    }
+    @Mapping(target = "list", source = "table")
+    TrackInfoListDTO mapJsonEvroTrackingResponseToDTO(JsonEvroTrackingResponse response);
+
+    /**
+     * Преобразует единичный элемент ответа в DTO.
+     *
+     * @param tracking модель ответа
+     * @return DTO со статусом
+     */
+    TrackInfoDTO mapJsonEvroTrackingToDTO(JsonEvroTracking tracking);
 }

--- a/src/main/java/com/project/tracking_system/mapper/PostalServiceStatisticsMapper.java
+++ b/src/main/java/com/project/tracking_system/mapper/PostalServiceStatisticsMapper.java
@@ -1,0 +1,27 @@
+package com.project.tracking_system.mapper;
+
+import com.project.tracking_system.dto.PostalServiceStatsDTO;
+import com.project.tracking_system.entity.PostalServiceStatistics;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Маппер для преобразования статистики почтовых служб в DTO.
+ */
+@Mapper(componentModel = "spring")
+public interface PostalServiceStatisticsMapper {
+
+    /**
+     * Конвертирует сущность статистики в DTO.
+     *
+     * @param stats сущность статистики
+     * @return объект DTO
+     */
+    @Mapping(target = "postalService", expression = "java(stats.getPostalServiceType().getDisplayName())")
+    @Mapping(target = "sent", source = "totalSent")
+    @Mapping(target = "delivered", source = "totalDelivered")
+    @Mapping(target = "returned", source = "totalReturned")
+    @Mapping(target = "sumDeliveryDays", expression = "java(stats.getSumDeliveryDays().doubleValue())")
+    @Mapping(target = "sumPickupTimeDays", expression = "java(stats.getSumPickupDays().doubleValue())")
+    PostalServiceStatsDTO toDto(PostalServiceStatistics stats);
+}

--- a/src/main/java/com/project/tracking_system/mapper/TrackParcelMapper.java
+++ b/src/main/java/com/project/tracking_system/mapper/TrackParcelMapper.java
@@ -1,0 +1,41 @@
+package com.project.tracking_system.mapper;
+
+import com.project.tracking_system.dto.TrackParcelDTO;
+import com.project.tracking_system.entity.TrackParcel;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Маппер для преобразования сущности {@link TrackParcel} в DTO.
+ */
+@Mapper(componentModel = "spring")
+public interface TrackParcelMapper {
+
+    /**
+     * Преобразует сущность посылки в DTO.
+     *
+     * @param parcel   сущность посылки
+     * @param userZone часовой пояс пользователя
+     * @return DTO с информацией о посылке
+     */
+    @Mapping(target = "status", expression = "java(parcel.getStatus().getDescription())")
+    @Mapping(target = "data", source = "data", qualifiedByName = "formatDate")
+    @Mapping(target = "storeId", expression = "java(parcel.getStore().getId())")
+    TrackParcelDTO toDto(TrackParcel parcel, @Context ZoneId userZone);
+
+    /**
+     * Форматирует дату с учётом часового пояса пользователя.
+     */
+    @Named("formatDate")
+    default String formatDate(ZonedDateTime date, @Context ZoneId userZone) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss")
+                .withZone(userZone);
+        return formatter.format(date);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.dto.PostalServiceStatsDTO;
 import com.project.tracking_system.entity.PostalServiceStatistics;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
+import com.project.tracking_system.mapper.PostalServiceStatisticsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 public class PostalServiceStatisticsService {
 
     private final PostalServiceStatisticsRepository repository;
+    private final PostalServiceStatisticsMapper mapper;
 
     /**
      * Возвращает статистику по всем службам доставки одного магазина.
@@ -33,7 +35,7 @@ public class PostalServiceStatisticsService {
         return repository.findByStoreId(storeId)
                 .stream()
                 .filter(stat -> stat.getPostalServiceType() != PostalServiceType.UNKNOWN)
-                .map(this::mapToDto)
+                .map(mapper::toDto)
                 .toList();
     }
 
@@ -60,7 +62,7 @@ public class PostalServiceStatisticsService {
             aggregated.merge(stat.getPostalServiceType(), stat, this::mergeStats);
         }
         return aggregated.values().stream()
-                .map(this::mapToDto)
+                .map(mapper::toDto)
                 .toList();
     }
 
@@ -73,14 +75,5 @@ public class PostalServiceStatisticsService {
         return a;
     }
 
-    private PostalServiceStatsDTO mapToDto(PostalServiceStatistics stats) {
-        PostalServiceStatsDTO dto = new PostalServiceStatsDTO();
-        dto.setPostalService(stats.getPostalServiceType().getDisplayName());
-        dto.setSent(stats.getTotalSent());
-        dto.setDelivered(stats.getTotalDelivered());
-        dto.setReturned(stats.getTotalReturned());
-        dto.setSumDeliveryDays(stats.getSumDeliveryDays().doubleValue());
-        dto.setSumPickupTimeDays(stats.getSumPickupDays().doubleValue());
-        return dto;
-    }
+    // Маппинг в DTO выполняется через {@link PostalServiceStatisticsMapper}
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -15,6 +15,7 @@ import com.project.tracking_system.repository.PostalServiceDailyStatisticsReposi
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.analytics.DeliveryHistoryService;
 import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.mapper.TrackParcelMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -69,6 +70,7 @@ public class TrackParcelService {
     private final PostalServiceStatisticsRepository postalServiceStatisticsRepository;
     private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
     private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
+    private final TrackParcelMapper trackParcelMapper;
 
     @Transactional
     public TrackInfoListDTO processTrack(String number, Long storeId, Long userId, boolean canSave) {
@@ -301,7 +303,7 @@ public class TrackParcelService {
         Pageable pageable = PageRequest.of(page, size);
         Page<TrackParcel> trackParcels = trackParcelRepository.findByStoreIdIn(storeIds, pageable);
         ZoneId userZone = userService.getUserZone(userId);
-        return trackParcels.map(track -> new TrackParcelDTO(track, userZone));
+        return trackParcels.map(track -> trackParcelMapper.toDto(track, userZone));
     }
 
     /**
@@ -321,7 +323,7 @@ public class TrackParcelService {
         Pageable pageable = PageRequest.of(page, size);
         Page<TrackParcel> trackParcels = trackParcelRepository.findByStoreIdInAndStatus(storeIds, status, pageable);
         ZoneId userZone = userService.getUserZone(userId);
-        return trackParcels.map(track -> new TrackParcelDTO(track, userZone));
+        return trackParcels.map(track -> trackParcelMapper.toDto(track, userZone));
     }
 
     @Transactional
@@ -363,7 +365,7 @@ public class TrackParcelService {
         List<TrackParcel> trackParcels = trackParcelRepository.findByStoreId(storeId);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.stream()
-                .map(track -> new TrackParcelDTO(track, userZone))
+                .map(track -> trackParcelMapper.toDto(track, userZone))
                 .toList();
     }
 
@@ -378,7 +380,7 @@ public class TrackParcelService {
         List<TrackParcel> trackParcels = trackParcelRepository.findByUserId(userId);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.stream()
-                .map(track -> new TrackParcelDTO(track, userZone))
+                .map(track -> trackParcelMapper.toDto(track, userZone))
                 .toList();
     }
 


### PR DESCRIPTION
## Summary
- add MapStruct dependencies and compiler plugin
- use MapStruct in JsonEvroTrackingResponseMapper
- implement TrackParcelMapper and PostalServiceStatisticsMapper
- remove ModelMapper bean from configuration
- refactor services to use the new mappers

## Testing
- `./mvnw -q -DskipTests package` *(fails: cannot open .mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6849e925ef58832d82cf5397710b7205