### PR TITLE
Add ResponseBuilder and refactor controllers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
+++ b/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.Authentication;
 import com.project.tracking_system.utils.AuthUtils;
+import com.project.tracking_system.utils.ResponseBuilder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -176,14 +177,14 @@ public class AnalyticsController {
             userStoreIds.forEach(storeAnalyticsService::updateStoreAnalytics);
 
             webSocketController.sendUpdateStatus(userId, "Обновлена аналитика по всем вашим магазинам!", true);
-            return ResponseEntity.ok(Map.of("message", "Аналитика обновлена по всем магазинам!"));
+            return ResponseBuilder.ok(Map.of("message", "Аналитика обновлена по всем магазинам!"));
         }
 
         Store store = storeService.getStore(storeId, userId);
         storeAnalyticsService.updateStoreAnalytics(storeId);
         webSocketController.sendUpdateStatus(userId, "Аналитика обновлена для магазина: " + store.getName(), true);
 
-        return ResponseEntity.ok(Map.of("message", "Аналитика обновлена для магазина: " + store.getName()));
+        return ResponseBuilder.ok(Map.of("message", "Аналитика обновлена для магазина: " + store.getName()));
     }
 
     /**
@@ -258,7 +259,7 @@ public class AnalyticsController {
     public ResponseEntity<Void> resetAllAnalyticsForUser(@AuthenticationPrincipal User user) {
         analyticsResetService.resetAllAnalytics(user.getId());
         webSocketController.sendUpdateStatus(user.getId(), "Аналитика удалена", true);
-        return ResponseEntity.ok().build();
+        return ResponseBuilder.ok(null);
     }
 
     /**
@@ -269,7 +270,7 @@ public class AnalyticsController {
                                                        @AuthenticationPrincipal User user) {
         analyticsResetService.resetStoreAnalytics(user.getId(), storeId);
         webSocketController.sendUpdateStatus(user.getId(), "Аналитика магазина удалена", true);
-        return ResponseEntity.ok().build();
+        return ResponseBuilder.ok(null);
     }
 
 }

--- a/src/main/java/com/project/tracking_system/controller/FileDownloadController.java
+++ b/src/main/java/com/project/tracking_system/controller/FileDownloadController.java
@@ -6,6 +6,8 @@ import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import com.project.tracking_system.utils.ResponseBuilder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,14 +26,14 @@ public class FileDownloadController {
      * @return ResponseEntity с файлом для скачивания
      */
     @GetMapping("/download-sample")
-    public ResponseEntity<Resource> downloadSample() {
+    public ResponseEntity<?> downloadSample() {
         // Имя файла, которое должно использоваться при скачивании
         String filename = "Пример заполнения.XLSX";
         // Загружаем ресурс из папки sample в classpath
         Resource resource = new ClassPathResource("sample/" + filename);
 
         if (!resource.exists()) {
-            return ResponseEntity.notFound().build();
+            return ResponseBuilder.error(HttpStatus.NOT_FOUND, "Файл не найден");
         }
 
         // Используем ContentDisposition builder для корректного формирования заголовка

--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import com.project.tracking_system.utils.ResponseBuilder;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.Authentication;
 import com.project.tracking_system.utils.AuthUtils;
@@ -143,7 +144,7 @@ public class ProfileController {
     }
 
     @PostMapping("/settings/use-custom-credentials")
-    public ResponseEntity<String> updateUseCustomCredentials(
+    public ResponseEntity<?> updateUseCustomCredentials(
             @RequestParam(value = "useCustomCredentials", required = false) Boolean useCustomCredentials,
             Authentication authentication) {
 
@@ -153,17 +154,16 @@ public class ProfileController {
 
         if (useCustomCredentials == null) {
             log.warn("Не указан параметр 'useCustomCredentials' для пользователя с ID: {}", userId);
-            return ResponseEntity.badRequest().body("Не указан параметр useCustomCredentials");
+            return ResponseBuilder.error(HttpStatus.BAD_REQUEST, "Не указан параметр useCustomCredentials");
         }
 
         try {
             userService.updateUseCustomCredentials(userId, useCustomCredentials);
             log.info("Флаг 'useCustomCredentials' успешно обновлён для пользователя с ID: {}", userId);
-            return ResponseEntity.ok("Настройки успешно обновлены.");
+            return ResponseBuilder.ok("Настройки успешно обновлены.");
         } catch (Exception e) {
             log.error("Ошибка при обновлении настройки для пользователя с ID {}: {}", userId, e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Ошибка при обновлении настроек.");
+            return ResponseBuilder.error(HttpStatus.INTERNAL_SERVER_ERROR, "Ошибка при обновлении настроек.");
         }
     }
 
@@ -250,10 +250,10 @@ public class ProfileController {
                                          @RequestBody Map<String, String> request) {
         try {
             Store store = storeService.createStore(user.getId(), request.get("name"));
-            return ResponseEntity.ok(store);
+            return ResponseBuilder.ok(store);
         } catch (IllegalStateException e) {
             webSocketController.sendUpdateStatus(user.getId(), "❌ Ошибка: " + e.getMessage(), false);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+            return ResponseBuilder.error(HttpStatus.FORBIDDEN, e.getMessage());
         }
     }
 
@@ -267,10 +267,10 @@ public class ProfileController {
                                          @RequestBody Map<String, String> request) {
         try {
             Store updatedStore = storeService.updateStore(storeId, user.getId(), request.get("name"));
-            return ResponseEntity.ok(updatedStore);
+            return ResponseBuilder.ok(updatedStore);
         } catch (SecurityException e) {
             webSocketController.sendUpdateStatus(user.getId(), "❌ Ошибка: " + e.getMessage(), false);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+            return ResponseBuilder.error(HttpStatus.FORBIDDEN, e.getMessage());
         }
     }
 
@@ -283,10 +283,10 @@ public class ProfileController {
                                          @PathVariable Long storeId) {
         try {
             storeService.deleteStore(storeId, user.getId());
-            return ResponseEntity.ok().build();
+            return ResponseBuilder.ok(null);
         } catch (SecurityException e) {
             webSocketController.sendUpdateStatus(user.getId(), "❌ Ошибка: " + e.getMessage(), false);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+            return ResponseBuilder.error(HttpStatus.FORBIDDEN, e.getMessage());
         }
     }
 
@@ -305,14 +305,14 @@ public class ProfileController {
 
     @PostMapping("/stores/default/{storeId}")
     @ResponseBody
-    public ResponseEntity<String> setDefaultStore(@AuthenticationPrincipal User user,
+    public ResponseEntity<?> setDefaultStore(@AuthenticationPrincipal User user,
                                                   @PathVariable Long storeId) {
         try {
             storeService.setDefaultStore(user.getId(), storeId);
-            return ResponseEntity.ok("Магазин по умолчанию установлен.");
+            return ResponseBuilder.ok("Магазин по умолчанию установлен.");
         } catch (Exception e) {
             log.error("Ошибка установки магазина по умолчанию: {}", e.getMessage());
-            return ResponseEntity.badRequest().body(e.getMessage());
+            return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         }
     }
 

--- a/src/main/java/com/project/tracking_system/utils/ResponseBuilder.java
+++ b/src/main/java/com/project/tracking_system/utils/ResponseBuilder.java
@@ -1,0 +1,41 @@
+package com.project.tracking_system.utils;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+/**
+ * Утилита для упрощённого создания {@link ResponseEntity}.
+ * <p>
+ * Позволяет быстро формировать успешные и ошибочные ответы в контроллерах,
+ * избегая дублирования кода.
+ * </p>
+ */
+public final class ResponseBuilder {
+
+    private ResponseBuilder() {
+    }
+
+    /**
+     * Создает успешный ответ со статусом 200.
+     *
+     * @param data тело ответа
+     * @param <T>  тип возвращаемых данных
+     * @return объект {@link ResponseEntity} с указанными данными
+     */
+    public static <T> ResponseEntity<T> ok(T data) {
+        return ResponseEntity.ok(data);
+    }
+
+    /**
+     * Создает ответ с заданным статусом и сообщением об ошибке.
+     *
+     * @param status статус HTTP
+     * @param msg    сообщение об ошибке
+     * @return объект {@link ResponseEntity} с сообщением об ошибке
+     */
+    public static ResponseEntity<Map<String, String>> error(HttpStatus status, String msg) {
+        return ResponseEntity.status(status).body(Map.of("error", msg));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResponseBuilder` utility for building HTTP responses
- use `ResponseBuilder` across controllers
- fix return types for error responses

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0073a534832d92ce0574b768539c