### PR TITLE
Implement Aggregatable interface and refactor stats aggregation

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/Aggregatable.java
+++ b/src/main/java/com/project/tracking_system/entity/Aggregatable.java
@@ -1,0 +1,51 @@
+package com.project.tracking_system.entity;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+/**
+ * Интерфейс сущностей, поддерживающих установку агрегированных значений статистики.
+ */
+public interface Aggregatable {
+    /**
+     * Устанавливает количество отправленных отправлений.
+     *
+     * @param sent число отправлений
+     */
+    void setSent(int sent);
+
+    /**
+     * Устанавливает количество доставленных отправлений.
+     *
+     * @param delivered число доставленных
+     */
+    void setDelivered(int delivered);
+
+    /**
+     * Устанавливает количество возвращённых отправлений.
+     *
+     * @param returned число возвратов
+     */
+    void setReturned(int returned);
+
+    /**
+     * Устанавливает суммарное количество дней доставки.
+     *
+     * @param sumDeliveryDays общая длительность доставки
+     */
+    void setSumDeliveryDays(BigDecimal sumDeliveryDays);
+
+    /**
+     * Устанавливает суммарное количество дней получения.
+     *
+     * @param sumPickupDays общая длительность ожидания получения
+     */
+    void setSumPickupDays(BigDecimal sumPickupDays);
+
+    /**
+     * Устанавливает момент последнего обновления.
+     *
+     * @param updatedAt время обновления
+     */
+    void setUpdatedAt(ZonedDateTime updatedAt);
+}

--- a/src/main/java/com/project/tracking_system/entity/PostalServiceMonthlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceMonthlyStatistics.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "tb_postal_service_statistics_monthly",
        uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "postal_service_type", "period_year", "period_number"}))
-public class PostalServiceMonthlyStatistics {
+public class PostalServiceMonthlyStatistics implements Aggregatable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/tracking_system/entity/PostalServiceWeeklyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceWeeklyStatistics.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "tb_postal_service_statistics_weekly",
        uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "postal_service_type", "period_year", "period_number"}))
-public class PostalServiceWeeklyStatistics {
+public class PostalServiceWeeklyStatistics implements Aggregatable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/tracking_system/entity/PostalServiceYearlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceYearlyStatistics.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "tb_postal_service_statistics_yearly",
        uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "postal_service_type", "period_year", "period_number"}))
-public class PostalServiceYearlyStatistics {
+public class PostalServiceYearlyStatistics implements Aggregatable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/tracking_system/entity/StoreMonthlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreMonthlyStatistics.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "tb_store_statistics_monthly",
        uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "period_year", "period_number"}))
-public class StoreMonthlyStatistics {
+public class StoreMonthlyStatistics implements Aggregatable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/tracking_system/entity/StoreWeeklyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreWeeklyStatistics.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.ZonedDateTime;
@@ -20,7 +21,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "tb_store_statistics_weekly",
        uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "period_year", "period_number"}))
-public class StoreWeeklyStatistics {
+public class StoreWeeklyStatistics implements Aggregatable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/tracking_system/entity/StoreYearlyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreYearlyStatistics.java
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "tb_store_statistics_yearly",
        uniqueConstraints = @UniqueConstraint(columnNames = {"store_id", "period_year", "period_number"}))
-public class StoreYearlyStatistics {
+public class StoreYearlyStatistics implements Aggregatable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/tracking_system/service/analytics/StatsAggregationService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/StatsAggregationService.java
@@ -199,58 +199,17 @@ public class StatsAggregationService {
         psYearlyRepo.save(yearly);
     }
 
-    private void setStoreValues(StoreWeeklyStatistics target, List<StoreDailyStatistics> stats) {
+    private void setStoreValues(Aggregatable target, List<StoreDailyStatistics> stats) {
         Totals totals = sumStore(stats);
-        target.setSent(totals.sent);
-        target.setDelivered(totals.delivered);
-        target.setReturned(totals.returned);
-        target.setSumDeliveryDays(totals.sumDeliveryDays);
-        target.setSumPickupDays(totals.sumPickupDays);
-        target.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        applyStats(target, totals);
     }
 
-    private void setStoreValues(StoreMonthlyStatistics target, List<StoreDailyStatistics> stats) {
-        Totals totals = sumStore(stats);
-        target.setSent(totals.sent);
-        target.setDelivered(totals.delivered);
-        target.setReturned(totals.returned);
-        target.setSumDeliveryDays(totals.sumDeliveryDays);
-        target.setSumPickupDays(totals.sumPickupDays);
-        target.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-    }
-
-    private void setStoreValues(StoreYearlyStatistics target, List<StoreDailyStatistics> stats) {
-        Totals totals = sumStore(stats);
-        target.setSent(totals.sent);
-        target.setDelivered(totals.delivered);
-        target.setReturned(totals.returned);
-        target.setSumDeliveryDays(totals.sumDeliveryDays);
-        target.setSumPickupDays(totals.sumPickupDays);
-        target.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-    }
-
-    private void setPsValues(PostalServiceWeeklyStatistics target, List<PostalServiceDailyStatistics> stats) {
+    private void setPsValues(Aggregatable target, List<PostalServiceDailyStatistics> stats) {
         Totals totals = sumPostal(stats);
-        target.setSent(totals.sent);
-        target.setDelivered(totals.delivered);
-        target.setReturned(totals.returned);
-        target.setSumDeliveryDays(totals.sumDeliveryDays);
-        target.setSumPickupDays(totals.sumPickupDays);
-        target.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        applyStats(target, totals);
     }
 
-    private void setPsValues(PostalServiceMonthlyStatistics target, List<PostalServiceDailyStatistics> stats) {
-        Totals totals = sumPostal(stats);
-        target.setSent(totals.sent);
-        target.setDelivered(totals.delivered);
-        target.setReturned(totals.returned);
-        target.setSumDeliveryDays(totals.sumDeliveryDays);
-        target.setSumPickupDays(totals.sumPickupDays);
-        target.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-    }
-
-    private void setPsValues(PostalServiceYearlyStatistics target, List<PostalServiceDailyStatistics> stats) {
-        Totals totals = sumPostal(stats);
+    private void applyStats(Aggregatable target, Totals totals) {
         target.setSent(totals.sent);
         target.setDelivered(totals.delivered);
         target.setReturned(totals.returned);


### PR DESCRIPTION
## Summary
- add `Aggregatable` interface for unified statistic setters
- implement `Aggregatable` in weekly/monthly/yearly statistics entities
- refactor `StatsAggregationService` to apply stats via new interface

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684a061821e0832dbf25567cdc0ce0c6