### PR TITLE
Add unified date parser

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -25,9 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.*;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
+import com.project.tracking_system.utils.DateParserUtils;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -159,16 +157,8 @@ public class TrackParcelService {
         trackParcel.setStatus(newStatus);
 
         String lastDate = trackInfoListDTO.getList().get(0).getTimex();
-        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
-                .appendPattern("dd.MM.yyyy ")
-                .appendValue(ChronoField.HOUR_OF_DAY)  // Позволяет и 9, и 09
-                .appendLiteral(':')
-                .appendPattern("mm:ss")
-                .toFormatter();
-        LocalDateTime localDateTime = LocalDateTime.parse(lastDate, formatter);
-        ZoneId userZone = ZoneId.of(userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден")).getTimeZone());
-        ZonedDateTime zonedDateTime = localDateTime.atZone(userZone).withZoneSameInstant(ZoneOffset.UTC);
+        ZoneId userZone = userService.getUserZone(userId);
+        ZonedDateTime zonedDateTime = DateParserUtils.parse(lastDate, userZone);
         trackParcel.setData(zonedDateTime);
 
         trackParcelRepository.save(trackParcel);

--- a/src/main/java/com/project/tracking_system/utils/DateParserUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/DateParserUtils.java
@@ -1,0 +1,65 @@
+package com.project.tracking_system.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+
+/**
+ * Утилитный класс для парсинга дат в различных форматах.
+ * <p>
+ * Поддерживает форматы "dd.MM.yyyy, HH:mm" (Белпочта) и
+ * "dd.MM.yyyy HH:mm:ss" (Европочта). Возвращает дату в UTC
+ * с учётом часового пояса пользователя.
+ * </p>
+ */
+@Slf4j
+public final class DateParserUtils {
+
+    private static final DateTimeFormatter BELPOST_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("dd.MM.yyyy, ")
+            .appendValue(ChronoField.HOUR_OF_DAY)
+            .appendLiteral(':')
+            .appendPattern("mm")
+            .toFormatter();
+
+    private static final DateTimeFormatter EVROPOST_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("dd.MM.yyyy ")
+            .appendValue(ChronoField.HOUR_OF_DAY)
+            .appendLiteral(':')
+            .appendPattern("mm:ss")
+            .toFormatter();
+
+    private DateParserUtils() {
+    }
+
+    /**
+     * Парсит строковую дату в {@link ZonedDateTime} в зоне UTC.
+     *
+     * @param rawDate  исходная строка даты
+     * @param userZone часовой пояс пользователя
+     * @return распарсенная дата в UTC
+     * @throws DateTimeParseException если дата не соответствует ожидаемым форматам
+     */
+    public static ZonedDateTime parse(String rawDate, ZoneId userZone) {
+        if (rawDate == null || userZone == null) {
+            throw new IllegalArgumentException("Дата и часовой пояс не могут быть null");
+        }
+
+        LocalDateTime ldt;
+        try {
+            ldt = LocalDateTime.parse(rawDate, BELPOST_FORMATTER);
+        } catch (DateTimeParseException ex) {
+            try {
+                ldt = LocalDateTime.parse(rawDate, EVROPOST_FORMATTER);
+            } catch (DateTimeParseException e) {
+                log.error("Ошибка парсинга даты: {}", rawDate, e);
+                throw e;
+            }
+        }
+        return ldt.atZone(userZone).withZoneSameInstant(ZoneOffset.UTC);
+    }
+}

--- a/src/test/java/DateParserUtilsTest.java
+++ b/src/test/java/DateParserUtilsTest.java
@@ -1,0 +1,43 @@
+import com.project.tracking_system.utils.DateParserUtils;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DateParserUtilsTest {
+
+    @Test
+    void parse_BelpostFormat() {
+        ZoneId zone = ZoneId.of("Europe/Minsk");
+        String raw = "01.02.2024, 10:15";
+
+        ZonedDateTime result = DateParserUtils.parse(raw, zone);
+
+        ZonedDateTime expected = ZonedDateTime.of(2024,2,1,10,15,0,0, zone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parse_EvropostFormat() {
+        ZoneId zone = ZoneId.of("Europe/Moscow");
+        String raw = "02.03.2024 14:05:30";
+
+        ZonedDateTime result = DateParserUtils.parse(raw, zone);
+
+        ZonedDateTime expected = ZonedDateTime.of(2024,3,2,14,5,30,0, zone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void parse_InvalidFormat_Throws() {
+        ZoneId zone = ZoneId.of("UTC");
+        String raw = "invalid";
+
+        assertThrows(java.time.format.DateTimeParseException.class, () -> DateParserUtils.parse(raw, zone));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DateParserUtils` for parsing dates from Belpost and Evropost
- use `DateParserUtils` in `TrackParcelService`
- cover parser with unit tests

## Testing
- `mvn test -q` *(fails: command not found)*
- `./mvnw test -q` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_684a19022430832da0ccccc9a4cf8bfd