### PR TITLE
Create shared deletion repo

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeletableByStoreOrUser.java
+++ b/src/main/java/com/project/tracking_system/repository/DeletableByStoreOrUser.java
@@ -1,0 +1,38 @@
+package com.project.tracking_system.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Базовый репозиторий с методами удаления по магазину или пользователю.
+ *
+ * @param <T>  тип сущности
+ * @param <ID> тип идентификатора
+ */
+@NoRepositoryBean
+public interface DeletableByStoreOrUser<T, ID> extends JpaRepository<T, ID> {
+
+    /**
+     * Удалить все записи конкретного магазина.
+     *
+     * @param storeId идентификатор магазина
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM #{#entityName} e WHERE e.store.id = :storeId")
+    void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Удалить все записи всех магазинов пользователя.
+     *
+     * @param userId идентификатор пользователя
+     */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM #{#entityName} e WHERE e.store.owner.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
@@ -2,18 +2,14 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.PostalServiceMonthlyStatistics;
 import com.project.tracking_system.entity.PostalServiceType;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.Optional;
 
 /**
  * Репозиторий для месячной статистики по почтовым службам.
  */
-public interface PostalServiceMonthlyStatisticsRepository extends JpaRepository<PostalServiceMonthlyStatistics, Long> {
+public interface PostalServiceMonthlyStatisticsRepository
+        extends DeletableByStoreOrUser<PostalServiceMonthlyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы за конкретный месяц.
@@ -29,16 +25,5 @@ public interface PostalServiceMonthlyStatisticsRepository extends JpaRepository<
     /**
      * Удалить месячную статистику конкретного магазина.
      */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceMonthlyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить месячную статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceMonthlyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    // Методы удаления определены в DeletableByStoreOrUser
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
@@ -2,18 +2,14 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.PostalServiceWeeklyStatistics;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.Optional;
 
 /**
  * Репозиторий для недельной статистики по почтовым службам.
  */
-public interface PostalServiceWeeklyStatisticsRepository extends JpaRepository<PostalServiceWeeklyStatistics, Long> {
+public interface PostalServiceWeeklyStatisticsRepository
+        extends DeletableByStoreOrUser<PostalServiceWeeklyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы за конкретную неделю.
@@ -29,16 +25,5 @@ public interface PostalServiceWeeklyStatisticsRepository extends JpaRepository<P
     /**
      * Удалить недельную статистику конкретного магазина.
      */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceWeeklyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить недельную статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceWeeklyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    // Методы удаления определены в DeletableByStoreOrUser
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
@@ -2,18 +2,14 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.PostalServiceYearlyStatistics;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.Optional;
 
 /**
  * Репозиторий для годовой статистики по почтовым службам.
  */
-public interface PostalServiceYearlyStatisticsRepository extends JpaRepository<PostalServiceYearlyStatistics, Long> {
+public interface PostalServiceYearlyStatisticsRepository
+        extends DeletableByStoreOrUser<PostalServiceYearlyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы за конкретный год.
@@ -29,16 +25,5 @@ public interface PostalServiceYearlyStatisticsRepository extends JpaRepository<P
     /**
      * Удалить годовую статистику конкретного магазина.
      */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceYearlyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить годовую статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceYearlyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    // Методы удаления определены в DeletableByStoreOrUser
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
@@ -1,19 +1,15 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreMonthlyStatistics;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * Репозиторий для статистики магазинов по месяцам.
  */
-public interface StoreMonthlyStatisticsRepository extends JpaRepository<StoreMonthlyStatistics, Long> {
+public interface StoreMonthlyStatisticsRepository
+        extends DeletableByStoreOrUser<StoreMonthlyStatistics, Long> {
 
     Optional<StoreMonthlyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
 
@@ -30,16 +26,5 @@ public interface StoreMonthlyStatisticsRepository extends JpaRepository<StoreMon
     /**
      * Удалить месячную статистику конкретного магазина.
      */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreMonthlyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить месячную статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreMonthlyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    // Методы удаления определены в DeletableByStoreOrUser
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
@@ -1,19 +1,15 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreWeeklyStatistics;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * Репозиторий для статистики магазинов по неделям.
  */
-public interface StoreWeeklyStatisticsRepository extends JpaRepository<StoreWeeklyStatistics, Long> {
+public interface StoreWeeklyStatisticsRepository
+        extends DeletableByStoreOrUser<StoreWeeklyStatistics, Long> {
 
     Optional<StoreWeeklyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
 
@@ -27,19 +23,5 @@ public interface StoreWeeklyStatisticsRepository extends JpaRepository<StoreWeek
      */
     List<StoreWeeklyStatistics> findByStoreIdInAndPeriodYearAndPeriodNumber(List<Long> storeIds, int periodYear, int periodNumber);
 
-    /**
-     * Удалить недельную статистику конкретного магазина.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreWeeklyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить недельную статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreWeeklyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    // Методы удаления определены в DeletableByStoreOrUser
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
@@ -1,19 +1,15 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreYearlyStatistics;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * Репозиторий для статистики магазинов по годам.
  */
-public interface StoreYearlyStatisticsRepository extends JpaRepository<StoreYearlyStatistics, Long> {
+public interface StoreYearlyStatisticsRepository
+        extends DeletableByStoreOrUser<StoreYearlyStatistics, Long> {
 
     Optional<StoreYearlyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
 
@@ -30,16 +26,5 @@ public interface StoreYearlyStatisticsRepository extends JpaRepository<StoreYear
     /**
      * Удалить годовую статистику конкретного магазина.
      */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreYearlyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить годовую статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreYearlyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    // Методы удаления определены в DeletableByStoreOrUser
 }


### PR DESCRIPTION
## Summary
- provide `DeletableByStoreOrUser` with generic delete queries
- let periodical statistics repositories extend the new interface
- remove duplicated delete methods

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684b37f53c8c832d93bb9a9f2930362a