### PR TITLE
Add generic deletion repository

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeletableByStoreOrUser.java
+++ b/src/main/java/com/project/tracking_system/repository/DeletableByStoreOrUser.java
@@ -1,6 +1,5 @@
 package com.project.tracking_system.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
@@ -14,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @param <ID> тип идентификатора
  */
 @NoRepositoryBean
-public interface DeletableByStoreOrUser<T, ID> extends JpaRepository<T, ID> {
+public interface DeletableByStoreOrUser<T, ID> {
 
     /**
      * Удалить все записи конкретного магазина.

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceDailyStatisticsRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +17,9 @@ import java.util.Optional;
 /**
  * Репозиторий для ежедневной статистики по почтовым службам.
  */
-public interface PostalServiceDailyStatisticsRepository extends JpaRepository<PostalServiceDailyStatistics, Long> {
+public interface PostalServiceDailyStatisticsRepository
+        extends JpaRepository<PostalServiceDailyStatistics, Long>,
+        DeletableByStoreOrUser<PostalServiceDailyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы магазина за конкретную дату.
@@ -65,19 +69,4 @@ public interface PostalServiceDailyStatisticsRepository extends JpaRepository<Po
      */
     List<PostalServiceDailyStatistics> findByDate(LocalDate date);
 
-    /**
-     * Удалить ежедневную статистику конкретного магазина.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceDailyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить ежедневную статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceDailyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceMonthlyStatisticsRepository.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.PostalServiceMonthlyStatistics;
 import com.project.tracking_system.entity.PostalServiceType;
+import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.Optional;
 
@@ -9,7 +10,8 @@ import java.util.Optional;
  * Репозиторий для месячной статистики по почтовым службам.
  */
 public interface PostalServiceMonthlyStatisticsRepository
-        extends DeletableByStoreOrUser<PostalServiceMonthlyStatistics, Long> {
+        extends JpaRepository<PostalServiceMonthlyStatistics, Long>,
+        DeletableByStoreOrUser<PostalServiceMonthlyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы за конкретный месяц.

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceStatisticsRepository.java
@@ -8,10 +8,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+// Интерфейс для удаления записей
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
+
 import java.util.List;
 import java.util.Optional;
 
-public interface PostalServiceStatisticsRepository extends JpaRepository<PostalServiceStatistics, Long> {
+public interface PostalServiceStatisticsRepository
+        extends JpaRepository<PostalServiceStatistics, Long>,
+        DeletableByStoreOrUser<PostalServiceStatistics, Long> {
 
     /**
      * Получить статистику конкретной почтовой службы магазина.
@@ -32,25 +37,6 @@ public interface PostalServiceStatisticsRepository extends JpaRepository<PostalS
      */
     List<PostalServiceStatistics> findByStoreIdIn(List<Long> storeIds);
 
-    /**
-     * Удалить статистику почтовых служб конкретного магазина.
-     *
-     * @param storeId идентификатор магазина
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceStatistics p WHERE p.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить всю статистику почтовых служб пользователя.
-     *
-     * @param userId идентификатор пользователя
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM PostalServiceStatistics p WHERE p.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
 
     /**
      * Обнулить счётчики для всех служб доставки магазинов пользователя.

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceWeeklyStatisticsRepository.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.PostalServiceWeeklyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.Optional;
 
@@ -9,7 +10,8 @@ import java.util.Optional;
  * Репозиторий для недельной статистики по почтовым службам.
  */
 public interface PostalServiceWeeklyStatisticsRepository
-        extends DeletableByStoreOrUser<PostalServiceWeeklyStatistics, Long> {
+        extends JpaRepository<PostalServiceWeeklyStatistics, Long>,
+        DeletableByStoreOrUser<PostalServiceWeeklyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы за конкретную неделю.

--- a/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/PostalServiceYearlyStatisticsRepository.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.PostalServiceYearlyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.Optional;
 
@@ -9,7 +10,8 @@ import java.util.Optional;
  * Репозиторий для годовой статистики по почтовым службам.
  */
 public interface PostalServiceYearlyStatisticsRepository
-        extends DeletableByStoreOrUser<PostalServiceYearlyStatistics, Long> {
+        extends JpaRepository<PostalServiceYearlyStatistics, Long>,
+        DeletableByStoreOrUser<PostalServiceYearlyStatistics, Long> {
 
     /**
      * Найти статистику почтовой службы за конкретный год.

--- a/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreAnalyticsRepository.java
@@ -2,10 +2,13 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreStatistics;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
+// Интерфейс для удалений
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,7 +17,9 @@ import java.util.Optional;
  * @author Dmitriy Anisimov
  * @date 11.03.2025
  */
-public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics, Long> {
+public interface StoreAnalyticsRepository
+        extends JpaRepository<StoreStatistics, Long>,
+        DeletableByStoreOrUser<StoreStatistics, Long> {
 
     /**
      * Найти статистику магазина по его идентификатору.
@@ -35,25 +40,6 @@ public interface StoreAnalyticsRepository extends JpaRepository<StoreStatistics,
      */
     List<StoreStatistics> findByStoreIdIn(List<Long> storeIds);
 
-    /**
-     * Удалить статистику конкретного магазина.
-     *
-     * @param storeId идентификатор магазина
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить всю статистику всех магазинов пользователя.
-     *
-     * @param userId идентификатор пользователя
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
 
     /**
      * Обнулить счётчики для всех магазинов пользователя.

--- a/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreDailyStatisticsRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.project.tracking_system.repository.DeletableByStoreOrUser;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -14,7 +16,9 @@ import java.util.Optional;
 /**
  * Репозиторий для ежедневной статистики магазинов.
  */
-public interface StoreDailyStatisticsRepository extends JpaRepository<StoreDailyStatistics, Long> {
+public interface StoreDailyStatisticsRepository
+        extends JpaRepository<StoreDailyStatistics, Long>,
+        DeletableByStoreOrUser<StoreDailyStatistics, Long> {
 
     /**
      * Найти статистику для магазина на конкретную дату.
@@ -53,19 +57,4 @@ public interface StoreDailyStatisticsRepository extends JpaRepository<StoreDaily
      */
     List<StoreDailyStatistics> findByDate(LocalDate date);
 
-    /**
-     * Удалить всю ежедневную статистику конкретного магазина.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreDailyStatistics s WHERE s.store.id = :storeId")
-    void deleteByStoreId(@Param("storeId") Long storeId);
-
-    /**
-     * Удалить ежедневную статистику всех магазинов пользователя.
-     */
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM StoreDailyStatistics s WHERE s.store.owner.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreMonthlyStatisticsRepository.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreMonthlyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +10,8 @@ import java.util.Optional;
  * Репозиторий для статистики магазинов по месяцам.
  */
 public interface StoreMonthlyStatisticsRepository
-        extends DeletableByStoreOrUser<StoreMonthlyStatistics, Long> {
+        extends JpaRepository<StoreMonthlyStatistics, Long>,
+        DeletableByStoreOrUser<StoreMonthlyStatistics, Long> {
 
     Optional<StoreMonthlyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
 

--- a/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreWeeklyStatisticsRepository.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreWeeklyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +10,8 @@ import java.util.Optional;
  * Репозиторий для статистики магазинов по неделям.
  */
 public interface StoreWeeklyStatisticsRepository
-        extends DeletableByStoreOrUser<StoreWeeklyStatistics, Long> {
+        extends JpaRepository<StoreWeeklyStatistics, Long>,
+        DeletableByStoreOrUser<StoreWeeklyStatistics, Long> {
 
     Optional<StoreWeeklyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
 

--- a/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreYearlyStatisticsRepository.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.StoreYearlyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.tracking_system.repository.DeletableByStoreOrUser;
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +10,8 @@ import java.util.Optional;
  * Репозиторий для статистики магазинов по годам.
  */
 public interface StoreYearlyStatisticsRepository
-        extends DeletableByStoreOrUser<StoreYearlyStatistics, Long> {
+        extends JpaRepository<StoreYearlyStatistics, Long>,
+        DeletableByStoreOrUser<StoreYearlyStatistics, Long> {
 
     Optional<StoreYearlyStatistics> findByStoreIdAndPeriodYearAndPeriodNumber(Long storeId, int periodYear, int periodNumber);
 


### PR DESCRIPTION
## Summary
- create `DeletableByStoreOrUser` repository fragment
- extend statistics repositories with the new interface
- remove duplicate delete queries

## Testing
- `mvn test` *(fails: maven not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3fd2ddcc832db559671f61d3790e