### PR TITLE
Refactor controllers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AuthController.java
+++ b/src/main/java/com/project/tracking_system/controller/AuthController.java
@@ -1,0 +1,152 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.UserRegistrationDTO;
+import com.project.tracking_system.exception.UserAlreadyExistsException;
+import com.project.tracking_system.service.user.LoginAttemptService;
+import com.project.tracking_system.service.user.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Контроллер для регистрации и авторизации пользователей.
+ * <p>
+ * Обрабатывает показ страницы регистрации, сам процесс регистрации
+ * и отображение формы входа с учётом блокировок по email и IP.
+ * </p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/")
+public class AuthController {
+
+    private final UserService userService;
+    private final LoginAttemptService loginAttemptService;
+
+    /**
+     * Отображает страницу регистрации нового пользователя.
+     *
+     * @param userRegistrationDTO DTO для регистрации пользователя
+     * @param model модель для добавления данных в представление
+     * @return имя представления страницы регистрации
+     */
+    @GetMapping("/registration")
+    public String registration(@ModelAttribute("userDTO") UserRegistrationDTO userRegistrationDTO, Model model) {
+        model.addAttribute("userDTO", new UserRegistrationDTO());
+        return "registration";
+    }
+
+    /**
+     * Обрабатывает POST-запросы на регистрацию пользователя.
+     * Выполняет отправку кода подтверждения и финальное подтверждение.
+     *
+     * @param userDTO DTO для регистрации пользователя
+     * @param result результат валидации формы
+     * @param model модель для добавления данных в представление
+     * @return имя представления для регистрации
+     */
+    @PostMapping("/registration")
+    public String registration(@Valid @ModelAttribute("userDTO") UserRegistrationDTO userDTO,
+                               BindingResult result, Model model) {
+        boolean isInitialRegistration = userDTO.getConfirmCodRegistration() == null
+                || userDTO.getConfirmCodRegistration().isEmpty();
+
+        if (isInitialRegistration) {
+            if (result.hasFieldErrors("email") || result.hasFieldErrors("password")
+                    || result.hasFieldErrors("confirmPassword") || result.hasFieldErrors("agreeToTerms")) {
+                return "registration";
+            }
+
+            if (!userDTO.getPassword().equals(userDTO.getConfirmPassword())) {
+                result.rejectValue("confirmPassword", "password.mismatch", "Пароли не совпадают");
+                return "registration";
+            }
+
+            try {
+                userService.sendConfirmationCode(userDTO);
+                model.addAttribute("confirmCodRegistration", true);
+                model.addAttribute("message", "Код подтверждения отправлен на вашу почту.");
+                return "registration";
+            } catch (UserAlreadyExistsException e) {
+                model.addAttribute("errorMessage", "Данная почта уже используется, авторизуйтесь или используйте другую почту");
+                return "registration";
+            } catch (Exception e) {
+                model.addAttribute("errorMessage", "Ошибка регистрации пользователя: " + e.getMessage());
+                return "registration";
+            }
+        } else {
+            if (result.hasFieldErrors("confirmCodRegistration")) {
+                model.addAttribute("confirmCodRegistration", true);
+                return "registration";
+            }
+
+            try {
+                userService.confirmRegistration(userDTO);
+                return "redirect:/login";
+            } catch (IllegalArgumentException e) {
+                model.addAttribute("confirmCodRegistration", true);
+                model.addAttribute("errorMessage", e.getMessage());
+                return "registration";
+            } catch (UserAlreadyExistsException e) {
+                model.addAttribute("errorMessage", "Данная почта уже используется, авторизуйтесь или используйте другую почту");
+                return "registration";
+            } catch (Exception e) {
+                model.addAttribute("errorMessage", "Ошибка регистрации пользователя: " + e.getMessage());
+                return "registration";
+            }
+        }
+    }
+
+    /**
+     * Отображает страницу входа в систему.
+     *
+     * @param error сообщение об ошибке входа
+     * @param blocked сообщение о блокировке аккаунта
+     * @param blockedIP сообщение о блокировке IP
+     * @param session сессия для проверки состояния пользователя
+     * @param model модель для добавления данных в представление
+     * @param principal информация о текущем пользователе
+     * @param request HTTP-запрос для получения IP
+     * @return имя представления страницы входа
+     */
+    @GetMapping("/login")
+    public String loginPage(@RequestParam(value = "error", required = false) String error,
+                            @RequestParam(value = "blocked", required = false) String blocked,
+                            @RequestParam(value = "blockedIP", required = false) String blockedIP,
+                            HttpSession session, Model model, Principal principal, HttpServletRequest request) {
+        if (principal != null) {
+            return "redirect:/";
+        }
+
+        String email = (String) session.getAttribute("email");
+
+        if (blocked != null && email != null) {
+            ZonedDateTime unlockTime = loginAttemptService.getUnlockTime(email);
+            model.addAttribute("blockedMessage", "Ваш аккаунт заблокирован из-за превышения количества попыток входа. Попробуйте снова после: "
+                    + unlockTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        }
+
+        if (blockedIP != null) {
+            String ip = request.getRemoteAddr();
+            model.addAttribute("blockedIPMessage", "Ваш IP (" + ip + ") временно заблокирован из-за множественных неудачных попыток входа. Попробуйте снова позже.");
+        }
+
+        if (error != null && email != null) {
+            int remainingAttempts = loginAttemptService.getRemainingAttempts(email);
+            model.addAttribute("remainingAttempts", remainingAttempts);
+        }
+
+        return "login";
+    }
+}

--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -1,46 +1,24 @@
 package com.project.tracking_system.controller;
 
-import com.project.tracking_system.dto.PasswordResetDTO;
-import com.project.tracking_system.dto.TrackingResultAdd;
-import com.project.tracking_system.dto.UserRegistrationDTO;
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
-import com.project.tracking_system.exception.UserAlreadyExistsException;
-import com.project.tracking_system.model.TrackingResponse;
-import com.project.tracking_system.service.track.TrackNumberOcrService;
-import com.project.tracking_system.service.track.TrackingNumberServiceXLS;
 import com.project.tracking_system.service.store.StoreService;
-import com.project.tracking_system.service.user.LoginAttemptService;
 import com.project.tracking_system.service.track.TrackParcelService;
-import com.project.tracking_system.service.user.PasswordResetService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
-import jakarta.validation.Valid;
-import com.project.tracking_system.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.security.Principal;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Optional;
 
 /**
- * Контроллер для обработки запросов на главной странице, регистрации, входа, сброса пароля и загрузки файлов.
+/**
+ * Контроллер для отображения главной страницы и отслеживания посылок.
  * <p>
- * Этот контроллер предоставляет методы для отображения домашней страницы, обработки регистрации пользователя,
- * входа в систему, сброса пароля и загрузки файлов (в том числе изображений и XLS/XLSX файлов).
- * Также контроллер взаимодействует с сервисами для обработки информации об отслеживаемых посылках.
+ * Обрабатывает домашнюю страницу и взаимодействует с сервисами отслеживания.
  * </p>
  *
  * @author Dmitriy Anisimov
@@ -52,13 +30,8 @@ import java.util.Optional;
 @RequestMapping("/")
 public class HomeController {
 
-    private final UserService userService;
     private final TrackParcelService trackParcelService;
-    private final LoginAttemptService loginAttemptService;
-    private final PasswordResetService passwordResetService;
-    private final TrackingNumberServiceXLS trackingNumberServiceXLS;
     private final StoreService storeService;
-    private final TrackNumberOcrService trackNumberOcrService;
 
     /**
      * Обрабатывает запросы на главной странице. Отображает домашнюю страницу.
@@ -124,275 +97,6 @@ public class HomeController {
         return "home";
     }
 
-    /**
-     * Отображает страницу регистрации нового пользователя.
-     *
-     * @param userRegistrationDTO DTO для регистрации пользователя
-     * @param model модель для добавления данных в представление
-     * @return имя представления страницы регистрации
-     */
-    @GetMapping("/registration")
-    public String registration(@ModelAttribute("userDTO") UserRegistrationDTO userRegistrationDTO, Model model) {
-        model.addAttribute("userDTO", new UserRegistrationDTO());
-        return "registration";
-    }
-
-    /**
-     * Обрабатывает POST-запросы на регистрацию пользователя.
-     * Выполняет проверку и регистрацию пользователя, отправку кода подтверждения.
-     *
-     * @param userDTO DTO для регистрации пользователя
-     * @param result результат валидации формы
-     * @param model модель для добавления данных в представление
-     * @return имя представления для регистрации
-     */
-    @PostMapping("/registration")
-    public String registration(@Valid @ModelAttribute("userDTO") UserRegistrationDTO userDTO, BindingResult result, Model model) {
-        // Проверка, на каком этапе находится процесс регистрации
-        boolean isInitialRegistration = userDTO.getConfirmCodRegistration() == null || userDTO.getConfirmCodRegistration().isEmpty();
-
-        // Первый этап регистрации: проверка email и паролей
-        if (isInitialRegistration) {
-            if (result.hasFieldErrors("email") || result.hasFieldErrors("password") || result.hasFieldErrors("confirmPassword") || result.hasFieldErrors("agreeToTerms")) {
-                return "registration";
-            }
-
-            if (!userDTO.getPassword().equals(userDTO.getConfirmPassword())) {
-                result.rejectValue("confirmPassword", "password.mismatch", "Пароли не совпадают");
-                return "registration";
-            }
-
-            try {
-                // Отправка кода подтверждения и отображение поля для его ввода
-                userService.sendConfirmationCode(userDTO);
-                model.addAttribute("confirmCodRegistration", true);
-                model.addAttribute("message", "Код подтверждения отправлен на вашу почту.");
-                return "registration";
-            } catch (UserAlreadyExistsException e) {
-                model.addAttribute("errorMessage", "Данная почта уже используется, авторизуйтесь или используйте другую почту");
-                return "registration";
-            } catch (Exception e) {
-                model.addAttribute("errorMessage", "Ошибка регистрации пользователя: " + e.getMessage());
-                return "registration";
-            }
-        } else {
-            // Проверка кода подтверждения
-            if (result.hasFieldErrors("confirmCodRegistration")) {
-                model.addAttribute("confirmCodRegistration", true);
-                return "registration";
-            }
-
-            try {
-                userService.confirmRegistration(userDTO);
-                return "redirect:/login";
-            } catch (IllegalArgumentException e) {
-                model.addAttribute("confirmCodRegistration", true);
-                model.addAttribute("errorMessage", e.getMessage());
-                return "registration";
-            } catch (UserAlreadyExistsException e) {
-                model.addAttribute("errorMessage", "Данная почта уже используется, авторизуйтесь или используйте другую почту");
-                return "registration";
-            } catch (Exception e) {
-                model.addAttribute("errorMessage", "Ошибка регистрации пользователя: " + e.getMessage());
-                return "registration";
-            }
-        }
-    }
-
-    /**
-     * Отображает страницу входа в систему.
-     *
-     * @param error сообщение об ошибке входа
-     * @param blocked сообщение о блокировке аккаунта
-     * @param session сессия для проверки состояния пользователя
-     * @param model модель для добавления данных в представление
-     * @param principal информация о текущем пользователе
-     * @return имя представления страницы входа
-     */
-    @GetMapping("/login")
-    public String loginPage(@RequestParam(value = "error", required = false) String error,
-                            @RequestParam(value = "blocked", required = false) String blocked,
-                            @RequestParam(value = "blockedIP", required = false) String blockedIP,
-                            HttpSession session, Model model, Principal principal, HttpServletRequest request) {
-        if (principal != null) {
-            return "redirect:/";
-        }
-
-        String email = (String) session.getAttribute("email");
-
-        if (blocked != null && email != null) {
-            ZonedDateTime unlockTime = loginAttemptService.getUnlockTime(email);
-            model.addAttribute("blockedMessage", "Ваш аккаунт заблокирован из-за превышения количества попыток входа. Попробуйте снова после: " + unlockTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-        }
-
-        if (blockedIP != null) {
-            String ip = request.getRemoteAddr();
-            model.addAttribute("blockedIPMessage", "Ваш IP (" + ip + ") временно заблокирован из-за множественных неудачных попыток входа. Попробуйте снова позже.");
-        }
-
-        if (error != null && email != null) {
-            int remainingAttempts = loginAttemptService.getRemainingAttempts(email);
-            model.addAttribute("remainingAttempts", remainingAttempts);
-        }
-
-        return "login";
-    }
-
-    /**
-     * Отображает страницу для восстановления пароля.
-     *
-     * @param model модель для добавления данных в представление
-     * @return имя представления страницы восстановления пароля
-     */
-    @GetMapping("/forgot-password")
-    public String showForgotPasswordForm(Model model) {
-        model.addAttribute("email", "");
-        return "forgot-password";
-    }
-
-    /**
-     * Обрабатывает запросы на восстановление пароля.
-     *
-     * @param email адрес электронной почты для восстановления пароля
-     * @param model модель для добавления данных в представление
-     * @return имя представления страницы восстановления пароля
-     */
-    @PostMapping("/forgot-password")
-    public String handleForgotPassword(@RequestParam String email, Model model) {
-        Optional<User> byUser = userService.findByUserEmail(email);
-        if (byUser.isEmpty()) {
-            model.addAttribute("error", "Пользователь с таким адресом электронной почты не найден.");
-            return "forgot-password";
-        }
-        try {
-            passwordResetService.createPasswordResetToken(email);
-            model.addAttribute("message", "Ссылка для сброса пароля была отправлена на ваш адрес электронной почты.");
-        } catch (UsernameNotFoundException e) {
-            model.addAttribute("error", "Пользователь с таким адресом электронной почты не найден.");
-        } catch (Exception e) {
-            model.addAttribute("error", "Не удалось выполнить сброс пароля. Попробуйте снова.");
-        }
-        return "forgot-password";
-    }
-
-    /**
-     * Отображает страницу для сброса пароля по токену.
-     *
-     * @param token токен для сброса пароля
-     * @param passwordResetDTO DTO для сброса пароля
-     * @param model модель для добавления данных в представление
-     * @return имя представления страницы сброса пароля
-     */
-    @GetMapping("/reset-password")
-    public String showResetPasswordForm(@RequestParam String token, @ModelAttribute("passwordResetDTO") PasswordResetDTO passwordResetDTO, Model model) {
-        if (!passwordResetService.isTokenValid(token)) {
-            model.addAttribute("error", "Неверный или просроченный токен.");
-            return "forgot-password";
-        }
-        model.addAttribute("token", token);
-        return "reset-password";
-    }
-
-    /**
-     * Обрабатывает запросы на сброс пароля по токену.
-     *
-     * @param token токен для сброса пароля
-     * @param passwordResetDTO DTO для сброса пароля
-     * @param bindingResult результат валидации формы
-     * @param model модель для добавления данных в представление
-     * @return имя представления страницы сброса пароля
-     */
-    @PostMapping("/reset-password")
-    public String handleResetPassword(@RequestParam String token,
-                                      @Valid @ModelAttribute("passwordResetDTO") PasswordResetDTO passwordResetDTO,
-                                      BindingResult bindingResult,
-                                      Model model) {
-
-        if (bindingResult.hasErrors()) {
-            model.addAttribute("token", token);
-            return "reset-password";
-        }
-
-        if (!passwordResetDTO.passwordsMatch()) {
-            bindingResult.rejectValue("confirmPassword", "error.confirmPassword", "Пароли не совпадают");
-            model.addAttribute("token", token);
-            return "reset-password";
-        }
-
-        try {
-            passwordResetService.resetPassword(token, passwordResetDTO.getNewPassword());
-            model.addAttribute("message", "Ваш пароль успешно сброшен. Пожалуйста, войдите с новым паролем.");
-            return "login";
-        } catch (IllegalArgumentException e) {
-            model.addAttribute("error", "Токен сброса пароля недействителен или срок его действия истек.");
-            return "reset-password";
-        } catch (Exception e) {
-            model.addAttribute("error", "Не удалось сбросить пароль. Попробуйте снова.");
-            return "reset-password";
-        }
-    }
-
-    /**
-     * Обрабатывает загрузку файла (XLS, XLSX или изображения).
-     * В зависимости от типа файла выполняется обработка данных или распознавание текста.
-     *
-     * @param file загружаемый файл
-     * @param model модель для добавления данных в представление
-     * @return имя представления домашней страницы
-     */
-    @PostMapping("/upload")
-    public String uploadFile(@RequestParam("file") MultipartFile file,
-                             @RequestParam(value = "storeId", required = false) Long storeId,
-                             Model model,
-                             @AuthenticationPrincipal User user) {
-        Long userId = null;
-
-        if (user != null) {
-            userId = user.getId();
-            model.addAttribute("authenticatedUser", user.getEmail());
-        } else {
-            model.addAttribute("authenticatedUser", null);
-        }
-
-        if (file.isEmpty()) {
-            model.addAttribute("customError", "Пожалуйста, выберите XLS, XLSX или изображение для загрузки.");
-            return "home";
-        }
-
-        String contentType = file.getContentType();
-        if (contentType == null) {
-            model.addAttribute("customError", "Не удалось определить тип файла.");
-            return "home";
-        }
-
-        try {
-            if (contentType.equals("application/vnd.ms-excel") || contentType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
-                TrackingResponse trackingResponse = trackingNumberServiceXLS.processTrackingNumber(file, userId);
-
-                log.info("Передаём в модель limitExceededMessage: {}", trackingResponse.getLimitExceededMessage());
-
-                model.addAttribute("trackingResults", trackingResponse.getTrackingResults());
-                model.addAttribute("limitExceededMessage", trackingResponse.getLimitExceededMessage());
-            } else if (contentType.startsWith("image/")) {
-                String recognizedText = trackNumberOcrService.processImage(file);
-                List<TrackingResultAdd> trackingResults = trackNumberOcrService.extractAndProcessTrackingNumbers(recognizedText, storeId, userId);
-                model.addAttribute("trackingResults", trackingResults);
-
-                return "home";
-            } else {
-                model.addAttribute("customError", "Неподдерживаемый тип файла. Загрузите XLS, XLSX или изображение.");
-                return "home";
-            }
-        } catch (IOException e) {
-            model.addAttribute("generalError", "Ошибка при обработке файла: " + e.getMessage());
-            log.error("IOException при обработке файла: {}", e.getMessage(), e);
-        } catch (Exception e) {
-            model.addAttribute("generalError", "Ошибка: " + e.getMessage());
-            log.error("Ошибка при обработке файла: {}", e.getMessage(), e);
-        }
-
-        return "home";
-    }
 
     @GetMapping("/privacy-policy")
     public String privacyPolicy() {

--- a/src/main/java/com/project/tracking_system/controller/PasswordController.java
+++ b/src/main/java/com/project/tracking_system/controller/PasswordController.java
@@ -1,0 +1,125 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.PasswordResetDTO;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.user.PasswordResetService;
+import com.project.tracking_system.service.user.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+/**
+ * Контроллер для восстановления и сброса пароля пользователя.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/")
+public class PasswordController {
+
+    private final PasswordResetService passwordResetService;
+    private final UserService userService;
+
+    /**
+     * Отображает страницу для восстановления пароля.
+     *
+     * @param model модель для добавления данных в представление
+     * @return имя представления страницы восстановления пароля
+     */
+    @GetMapping("/forgot-password")
+    public String showForgotPasswordForm(Model model) {
+        model.addAttribute("email", "");
+        return "forgot-password";
+    }
+
+    /**
+     * Обрабатывает запросы на восстановление пароля.
+     *
+     * @param email адрес электронной почты для восстановления пароля
+     * @param model модель для добавления данных в представление
+     * @return имя представления страницы восстановления пароля
+     */
+    @PostMapping("/forgot-password")
+    public String handleForgotPassword(@RequestParam String email, Model model) {
+        Optional<User> byUser = userService.findByUserEmail(email);
+        if (byUser.isEmpty()) {
+            model.addAttribute("error", "Пользователь с таким адресом электронной почты не найден.");
+            return "forgot-password";
+        }
+        try {
+            passwordResetService.createPasswordResetToken(email);
+            model.addAttribute("message", "Ссылка для сброса пароля была отправлена на ваш адрес электронной почты.");
+        } catch (UsernameNotFoundException e) {
+            model.addAttribute("error", "Пользователь с таким адресом электронной почты не найден.");
+        } catch (Exception e) {
+            model.addAttribute("error", "Не удалось выполнить сброс пароля. Попробуйте снова.");
+        }
+        return "forgot-password";
+    }
+
+    /**
+     * Отображает страницу для сброса пароля по токену.
+     *
+     * @param token токен для сброса пароля
+     * @param passwordResetDTO DTO для сброса пароля
+     * @param model модель для добавления данных в представление
+     * @return имя представления страницы сброса пароля
+     */
+    @GetMapping("/reset-password")
+    public String showResetPasswordForm(@RequestParam String token,
+                                         @ModelAttribute("passwordResetDTO") PasswordResetDTO passwordResetDTO,
+                                         Model model) {
+        if (!passwordResetService.isTokenValid(token)) {
+            model.addAttribute("error", "Неверный или просроченный токен.");
+            return "forgot-password";
+        }
+        model.addAttribute("token", token);
+        return "reset-password";
+    }
+
+    /**
+     * Обрабатывает запросы на сброс пароля по токену.
+     *
+     * @param token токен для сброса пароля
+     * @param passwordResetDTO DTO для сброса пароля
+     * @param bindingResult результат валидации формы
+     * @param model модель для добавления данных в представление
+     * @return имя представления страницы сброса пароля
+     */
+    @PostMapping("/reset-password")
+    public String handleResetPassword(@RequestParam String token,
+                                      @Valid @ModelAttribute("passwordResetDTO") PasswordResetDTO passwordResetDTO,
+                                      BindingResult bindingResult,
+                                      Model model) {
+
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("token", token);
+            return "reset-password";
+        }
+
+        if (!passwordResetDTO.passwordsMatch()) {
+            bindingResult.rejectValue("confirmPassword", "error.confirmPassword", "Пароли не совпадают");
+            model.addAttribute("token", token);
+            return "reset-password";
+        }
+
+        try {
+            passwordResetService.resetPassword(token, passwordResetDTO.getNewPassword());
+            model.addAttribute("message", "Ваш пароль успешно сброшен. Пожалуйста, войдите с новым паролем.");
+            return "login";
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("error", "Токен сброса пароля недействителен или срок его действия истек.");
+            return "reset-password";
+        } catch (Exception e) {
+            model.addAttribute("error", "Не удалось сбросить пароль. Попробуйте снова.");
+            return "reset-password";
+        }
+    }
+}

--- a/src/main/java/com/project/tracking_system/controller/UploadController.java
+++ b/src/main/java/com/project/tracking_system/controller/UploadController.java
@@ -1,0 +1,95 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.model.TrackingResponse;
+import com.project.tracking_system.service.track.TrackNumberOcrService;
+import com.project.tracking_system.service.track.TrackingNumberServiceXLS;
+import com.project.tracking_system.service.store.StoreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import com.project.tracking_system.entity.User;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Контроллер для загрузки файлов и распознавания номеров посылок.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/")
+public class UploadController {
+
+    private final TrackingNumberServiceXLS trackingNumberServiceXLS;
+    private final TrackNumberOcrService trackNumberOcrService;
+    private final StoreService storeService;
+
+    /**
+     * Обрабатывает загрузку файла (XLS, XLSX или изображения).
+     *
+     * @param file загружаемый файл
+     * @param storeId идентификатор магазина (может быть null)
+     * @param model модель для добавления данных в представление
+     * @param user текущий пользователь
+     * @return имя представления домашней страницы
+     */
+    @PostMapping("/upload")
+    public String uploadFile(@RequestParam("file") MultipartFile file,
+                             @RequestParam(value = "storeId", required = false) Long storeId,
+                             Model model,
+                             @AuthenticationPrincipal User user) {
+        Long userId = null;
+
+        if (user != null) {
+            userId = user.getId();
+            model.addAttribute("authenticatedUser", user.getEmail());
+        } else {
+            model.addAttribute("authenticatedUser", null);
+        }
+
+        if (file.isEmpty()) {
+            model.addAttribute("customError", "Пожалуйста, выберите XLS, XLSX или изображение для загрузки.");
+            return "home";
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            model.addAttribute("customError", "Не удалось определить тип файла.");
+            return "home";
+        }
+
+        try {
+            if (contentType.equals("application/vnd.ms-excel") || contentType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
+                TrackingResponse trackingResponse = trackingNumberServiceXLS.processTrackingNumber(file, userId);
+
+                log.info("Передаём в модель limitExceededMessage: {}", trackingResponse.getLimitExceededMessage());
+
+                model.addAttribute("trackingResults", trackingResponse.getTrackingResults());
+                model.addAttribute("limitExceededMessage", trackingResponse.getLimitExceededMessage());
+            } else if (contentType.startsWith("image/")) {
+                String recognizedText = trackNumberOcrService.processImage(file);
+                List<TrackingResultAdd> trackingResults = trackNumberOcrService.extractAndProcessTrackingNumbers(recognizedText, storeId, userId);
+                model.addAttribute("trackingResults", trackingResults);
+
+                return "home";
+            } else {
+                model.addAttribute("customError", "Неподдерживаемый тип файла. Загрузите XLS, XLSX или изображение.");
+                return "home";
+            }
+        } catch (IOException e) {
+            model.addAttribute("generalError", "Ошибка при обработке файла: " + e.getMessage());
+            log.error("IOException при обработке файла: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            model.addAttribute("generalError", "Ошибка: " + e.getMessage());
+            log.error("Ошибка при обработке файла: {}", e.getMessage(), e);
+        }
+
+        return "home";
+    }
+}

--- a/src/test/java/AuthControllerTest.java
+++ b/src/test/java/AuthControllerTest.java
@@ -1,0 +1,50 @@
+import com.project.tracking_system.controller.AuthController;
+import com.project.tracking_system.service.user.LoginAttemptService;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+    @MockBean
+    private LoginAttemptService loginAttemptService;
+
+    @Test
+    void registrationPage_ReturnsOk() throws Exception {
+        mockMvc.perform(get("/registration"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void loginPage_WithPrincipal_Redirects() throws Exception {
+        mockMvc.perform(get("/login").principal(() -> "user"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    @Test
+    void registrationPost_CallsService() throws Exception {
+        mockMvc.perform(post("/registration")
+                        .param("email", "test@test.com")
+                        .param("password", "pass123")
+                        .param("confirmPassword", "pass123")
+                        .param("agreeToTerms", "true"))
+                .andExpect(status().isOk());
+        verify(userService).sendConfirmationCode(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/PasswordControllerTest.java
+++ b/src/test/java/PasswordControllerTest.java
@@ -1,0 +1,49 @@
+import com.project.tracking_system.controller.PasswordController;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.user.PasswordResetService;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PasswordController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class PasswordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PasswordResetService passwordResetService;
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void forgotPasswordPage_ReturnsOk() throws Exception {
+        mockMvc.perform(get("/forgot-password"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void resetPassword_InvalidToken_ReturnsForgotPassword() throws Exception {
+        when(passwordResetService.isTokenValid("bad")).thenReturn(false);
+        mockMvc.perform(get("/reset-password").param("token", "bad"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void forgotPasswordPost_CallsService() throws Exception {
+        when(userService.findByUserEmail("a@b.c")).thenReturn(java.util.Optional.of(new User()));
+        mockMvc.perform(post("/forgot-password").param("email", "a@b.c"))
+                .andExpect(status().isOk());
+        verify(passwordResetService).createPasswordResetToken("a@b.c");
+    }
+}

--- a/src/test/java/UploadControllerTest.java
+++ b/src/test/java/UploadControllerTest.java
@@ -1,0 +1,35 @@
+import com.project.tracking_system.controller.UploadController;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.track.TrackNumberOcrService;
+import com.project.tracking_system.service.track.TrackingNumberServiceXLS;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UploadController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class UploadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TrackingNumberServiceXLS trackingNumberServiceXLS;
+    @MockBean
+    private TrackNumberOcrService trackNumberOcrService;
+    @MockBean
+    private StoreService storeService;
+
+    @Test
+    void uploadFile_Empty_ReturnsHome() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", new byte[0]);
+        mockMvc.perform(multipart("/upload").file(file))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- extract auth endpoints into `AuthController`
- split password reset logic into `PasswordController`
- move file upload to `UploadController`
- slim down `HomeController`
- add MVC tests for new controllers

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684b43bc0b20832d8af57e0eb56eaac9