### PR TITLE
Fix store change and enhance analytics

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/PostalServiceDailyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceDailyStatistics.java
@@ -26,6 +26,9 @@ public class PostalServiceDailyStatistics {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;

--- a/src/main/java/com/project/tracking_system/entity/PostalServiceStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceStatistics.java
@@ -22,6 +22,9 @@ public class PostalServiceStatistics {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;

--- a/src/main/java/com/project/tracking_system/entity/StoreDailyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreDailyStatistics.java
@@ -26,6 +26,9 @@ public class StoreDailyStatistics {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;

--- a/src/main/java/com/project/tracking_system/entity/StoreStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreStatistics.java
@@ -26,6 +26,9 @@ public class StoreStatistics {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;

--- a/src/test/java/TrackParcelServiceTest.java
+++ b/src/test/java/TrackParcelServiceTest.java
@@ -112,7 +112,43 @@ public class TrackParcelServiceTest {
     }
 
     @Test
-    void save_ExistingTrack_StoreChanged_UpdatesStats() {
+    void save_MultipleNewTracks_IncrementsStatisticsEachTime() {
+        Long storeId = 1L;
+        Long userId = 2L;
+
+        TrackInfoDTO info = new TrackInfoDTO("01.01.2024 10:00:00", "info");
+        TrackInfoListDTO listDTO = new TrackInfoListDTO(List.of(info));
+
+        Store store = new Store();
+        store.setId(storeId);
+        User user = new User();
+        user.setTimeZone("UTC");
+        StoreStatistics stats = new StoreStatistics();
+        stats.setStore(store);
+
+        when(subscriptionService.canSaveMoreTracks(userId, 1)).thenReturn(1);
+        when(storeRepository.getReferenceById(storeId)).thenReturn(store);
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(statusTrackService.setStatus(any())).thenReturn(GlobalStatus.IN_TRANSIT);
+        when(storeAnalyticsRepository.findByStoreId(storeId)).thenReturn(Optional.of(stats));
+        when(typeDefinitionTrackPostService.detectPostalService(any())).thenReturn(PostalServiceType.BELPOST);
+        when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(eq(storeId), any()))
+                .thenReturn(Optional.empty());
+        when(storeDailyStatisticsRepository.findByStoreIdAndDate(eq(storeId), any())).thenReturn(Optional.empty());
+        when(postalServiceDailyStatisticsRepository.findByStoreIdAndPostalServiceTypeAndDate(eq(storeId), any(), any()))
+                .thenReturn(Optional.empty());
+
+        when(trackParcelRepository.findByNumberAndUserId(any(), eq(userId))).thenReturn(null);
+
+        trackParcelService.save("TR1", listDTO, storeId, userId);
+        trackParcelService.save("TR2", listDTO, storeId, userId);
+
+        assertEquals(2, stats.getTotalSent());
+    }
+
+    @Test
+    void save_ExistingTrack_StoreChanged_NotAllowed() {
         Long oldStoreId = 1L;
         Long newStoreId = 2L;
         Long userId = 3L;
@@ -139,74 +175,43 @@ public class TrackParcelServiceTest {
         StoreStatistics oldStats = new StoreStatistics();
         oldStats.setStore(oldStore);
         oldStats.setTotalSent(5);
-        StoreStatistics newStats = new StoreStatistics();
-        newStats.setStore(newStore);
 
         PostalServiceStatistics oldPsStats = new PostalServiceStatistics();
         oldPsStats.setStore(oldStore);
         oldPsStats.setPostalServiceType(PostalServiceType.BELPOST);
         oldPsStats.setTotalSent(5);
-        PostalServiceStatistics newPsStats = new PostalServiceStatistics();
-        newPsStats.setStore(newStore);
-        newPsStats.setPostalServiceType(PostalServiceType.BELPOST);
 
         StoreDailyStatistics oldDaily = new StoreDailyStatistics();
         oldDaily.setStore(oldStore);
         oldDaily.setDate(existing.getData().toLocalDate());
         oldDaily.setSent(5);
-        StoreDailyStatistics newDaily = new StoreDailyStatistics();
-        newDaily.setStore(newStore);
-        newDaily.setDate(LocalDate.of(2024, 1, 2));
 
         PostalServiceDailyStatistics oldPsDaily = new PostalServiceDailyStatistics();
         oldPsDaily.setStore(oldStore);
         oldPsDaily.setPostalServiceType(PostalServiceType.BELPOST);
         oldPsDaily.setDate(existing.getData().toLocalDate());
         oldPsDaily.setSent(5);
-        PostalServiceDailyStatistics newPsDaily = new PostalServiceDailyStatistics();
-        newPsDaily.setStore(newStore);
-        newPsDaily.setPostalServiceType(PostalServiceType.BELPOST);
-        newPsDaily.setDate(LocalDate.of(2024, 1, 2));
 
         when(trackParcelRepository.findByNumberAndUserId(number, userId)).thenReturn(existing);
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(statusTrackService.setStatus(any())).thenReturn(GlobalStatus.IN_TRANSIT);
-        when(storeRepository.getReferenceById(newStoreId)).thenReturn(newStore);
         when(typeDefinitionTrackPostService.detectPostalService(number)).thenReturn(PostalServiceType.BELPOST);
         when(storeAnalyticsRepository.findByStoreId(oldStoreId)).thenReturn(Optional.of(oldStats));
-        when(storeAnalyticsRepository.findByStoreId(newStoreId)).thenReturn(Optional.of(newStats));
         when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(oldStoreId, PostalServiceType.BELPOST))
                 .thenReturn(Optional.of(oldPsStats));
-        when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(newStoreId, PostalServiceType.BELPOST))
-                .thenReturn(Optional.of(newPsStats));
         when(storeDailyStatisticsRepository.findByStoreIdAndDate(oldStoreId, existing.getData().toLocalDate()))
                 .thenReturn(Optional.of(oldDaily));
-        when(storeDailyStatisticsRepository.findByStoreIdAndDate(eq(newStoreId), any()))
-                .thenReturn(Optional.of(newDaily));
         when(postalServiceDailyStatisticsRepository.findByStoreIdAndPostalServiceTypeAndDate(oldStoreId, PostalServiceType.BELPOST, existing.getData().toLocalDate()))
                 .thenReturn(Optional.of(oldPsDaily));
-        when(postalServiceDailyStatisticsRepository.findByStoreIdAndPostalServiceTypeAndDate(eq(newStoreId), eq(PostalServiceType.BELPOST), any()))
-                .thenReturn(Optional.of(newPsDaily));
 
         trackParcelService.save(number, listDTO, newStoreId, userId);
 
-        assertEquals(newStore, existing.getStore());
-        assertEquals(4, oldStats.getTotalSent());
-        assertEquals(1, newStats.getTotalSent());
-        assertEquals(4, oldDaily.getSent());
-        assertEquals(1, newDaily.getSent());
-        assertEquals(4, oldPsStats.getTotalSent());
-        assertEquals(1, newPsStats.getTotalSent());
-        assertEquals(4, oldPsDaily.getSent());
-        assertEquals(1, newPsDaily.getSent());
+        assertEquals(oldStore, existing.getStore());
+        assertEquals(5, oldStats.getTotalSent());
 
-        verify(storeAnalyticsRepository).save(oldStats);
-        verify(storeAnalyticsRepository).save(newStats);
-        verify(postalServiceStatisticsRepository).save(oldPsStats);
-        verify(postalServiceStatisticsRepository).save(newPsStats);
-        verify(storeDailyStatisticsRepository).save(oldDaily);
-        verify(storeDailyStatisticsRepository).save(newDaily);
-        verify(postalServiceDailyStatisticsRepository).save(oldPsDaily);
-        verify(postalServiceDailyStatisticsRepository).save(newPsDaily);
+        verify(storeAnalyticsRepository, never()).save(any());
+        verify(postalServiceStatisticsRepository, never()).save(any());
+        verify(storeDailyStatisticsRepository, never()).save(any());
+        verify(postalServiceDailyStatisticsRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- prevent changing store for existing parcels
- log analytics updates and create store statistics if missing
- add optimistic locking to statistics entities
- update and expand unit tests

## Testing
- `./mvnw -q -DskipTests package` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c91f388832d9c8944dab6e3ea5b