### PR TITLE
Fix store-based new track detection

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
@@ -159,8 +159,8 @@ public class TrackingNumberServiceXLS {
 
                 log.info("Трек={}, магазин={} (userId={})", trackingNumber, storeId, userId);
 
-                // Для авторизованных пользователей проверяем, является ли трек новым, и определяем возможность сохранения
-                boolean isNewTrack = isUserAuthorized && trackParcelService.isNewTrack(trackingNumber, userId);
+                // Для авторизованных пользователей проверяем, является ли трек новым в рамках выбранного магазина
+                boolean isNewTrack = isUserAuthorized && trackParcelService.isNewTrack(trackingNumber, storeId);
                 boolean canSaveThis;
                 if (isNewTrack) {
                     if (savedNewCount < availableSaveSlots) {

--- a/src/test/java/TrackParcelServiceTest.java
+++ b/src/test/java/TrackParcelServiceTest.java
@@ -209,4 +209,32 @@ public class TrackParcelServiceTest {
         verify(postalServiceDailyStatisticsRepository).save(oldPsDaily);
         verify(postalServiceDailyStatisticsRepository).save(newPsDaily);
     }
+
+    @Test
+    void isNewTrack_NoExisting_ReturnsTrue() {
+        String number = "RR123";
+        Long storeId = 10L;
+
+        when(trackParcelRepository.findByNumberAndStoreId(number, storeId)).thenReturn(null);
+
+        assertTrue(trackParcelService.isNewTrack(number, storeId));
+    }
+
+    @Test
+    void isNewTrack_Existing_ReturnsFalse() {
+        String number = "RR124";
+        Long storeId = 11L;
+        TrackParcel parcel = new TrackParcel();
+
+        when(trackParcelRepository.findByNumberAndStoreId(number, storeId)).thenReturn(parcel);
+
+        assertFalse(trackParcelService.isNewTrack(number, storeId));
+    }
+
+    @Test
+    void isNewTrack_NullStoreId_ReturnsTrue() {
+        String number = "RR125";
+
+        assertTrue(trackParcelService.isNewTrack(number, null));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure TrackingNumberServiceXLS checks new tracks using storeId
- add unit tests for `isNewTrack` in TrackParcelService

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5393b504832d92652e43c9527ee7