### PR TITLE
Add store ownership check in XLS import

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
@@ -155,6 +155,11 @@ public class TrackingNumberServiceXLS {
                             log.warn("⚠ Неподдерживаемый тип ячейки для магазина в строке {}", rowIndex + 1);
                         }
                     }
+                    // Проверяем, принадлежит ли указанный магазин пользователю
+                    if (storeId != null && !storeService.userOwnsStore(storeId, userId)) {
+                        log.warn("⚠ Магазин ID={} не принадлежит пользователю ID={}, используем дефолтный.", storeId, userId);
+                        storeId = defaultStoreId;
+                    }
                 }
 
                 log.info("Трек={}, магазин={} (userId={})", trackingNumber, storeId, userId);

--- a/src/test/java/TrackingNumberServiceXLSTest.java
+++ b/src/test/java/TrackingNumberServiceXLSTest.java
@@ -1,0 +1,103 @@
+import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.model.TrackingResponse;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackingNumberServiceXLS;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackingNumberServiceXLSTest {
+
+    @Mock
+    private TrackParcelService trackParcelService;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private StoreService storeService;
+
+    @InjectMocks
+    private TrackingNumberServiceXLS service;
+
+    private TrackInfoListDTO sampleInfo;
+
+    @BeforeEach
+    void setup() {
+        TrackInfoDTO dto = new TrackInfoDTO("01.01.2024 00:00", "info");
+        sampleInfo = new TrackInfoListDTO(java.util.List.of(dto));
+
+        when(subscriptionService.canUploadTracks(anyLong(), anyInt())).thenReturn(1);
+        when(subscriptionService.canSaveMoreTracks(anyLong(), anyInt())).thenReturn(1);
+        when(trackParcelService.isNewTrack(anyString(), any())).thenReturn(true);
+        when(trackParcelService.processTrack(anyString(), any(), any(), anyBoolean())).thenReturn(sampleInfo);
+    }
+
+    private MockMultipartFile buildFile(Long storeId) throws Exception {
+        Workbook wb = new XSSFWorkbook();
+        var sheet = wb.createSheet();
+        var header = sheet.createRow(0);
+        header.createCell(0).setCellValue("track");
+        header.createCell(1).setCellValue("store");
+        var row = sheet.createRow(1);
+        row.createCell(0).setCellValue("RR123");
+        if (storeId != null) {
+            row.createCell(1).setCellValue(storeId);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        wb.close();
+        return new MockMultipartFile("file", "test.xlsx", "application/vnd.ms-excel", out.toByteArray());
+    }
+
+    @Test
+    void processTrackingNumber_ValidStoreId_UsesProvided() throws Exception {
+        Long userId = 1L;
+        Long defaultStore = 10L;
+        Long providedStore = 30L;
+
+        when(storeService.getDefaultStoreId(userId)).thenReturn(defaultStore);
+        when(storeService.userOwnsStore(providedStore, userId)).thenReturn(true);
+
+        MockMultipartFile file = buildFile(providedStore);
+
+        TrackingResponse resp = service.processTrackingNumber(file, userId);
+        assertNotNull(resp);
+
+        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+        verify(trackParcelService).processTrack(eq("RR123"), captor.capture(), eq(userId), eq(true));
+        assertEquals(providedStore, captor.getValue());
+    }
+
+    @Test
+    void processTrackingNumber_InvalidStoreId_FallsBackToDefault() throws Exception {
+        Long userId = 2L;
+        Long defaultStore = 11L;
+        Long providedStore = 40L;
+
+        when(storeService.getDefaultStoreId(userId)).thenReturn(defaultStore);
+        when(storeService.userOwnsStore(providedStore, userId)).thenReturn(false);
+
+        MockMultipartFile file = buildFile(providedStore);
+
+        TrackingResponse resp = service.processTrackingNumber(file, userId);
+        assertNotNull(resp);
+
+        ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+        verify(trackParcelService).processTrack(eq("RR123"), captor.capture(), eq(userId), eq(true));
+        assertEquals(defaultStore, captor.getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- verify store ownership when reading store IDs from XLS files
- fall back to default store and warn if user doesn't own specified store
- cover valid and invalid store ID cases in new tests

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b54a55e54832da354363d09a42150