### PR TITLE
Add executor shutdown on destroy

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
@@ -8,6 +8,7 @@ import com.project.tracking_system.service.store.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
+import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -236,6 +237,18 @@ public class TrackingNumberServiceXLS {
             log.error("Ошибка обработки {}: {}", trackingNumber, e.getMessage(), e);
             return new TrackingResultAdd(trackingNumber, "Ошибка обработки");
         }
+    }
+
+    /**
+     * Завершает пул потоков при остановке приложения.
+     * <p>
+     * Метод вызывается контейнером Spring перед уничтожением бина
+     * для корректного завершения всех задач в очереди.
+     * </p>
+     */
+    @PreDestroy
+    public void shutdownExecutor() {
+        executor.shutdown();
     }
 
 }

--- a/src/test/java/TrackingNumberServiceXLSTest.java
+++ b/src/test/java/TrackingNumberServiceXLSTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.io.ByteArrayOutputStream;
 
@@ -99,5 +100,17 @@ public class TrackingNumberServiceXLSTest {
         ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
         verify(trackParcelService).processTrack(eq("RR123"), captor.capture(), eq(userId), eq(true));
         assertEquals(defaultStore, captor.getValue());
+    }
+
+    @Test
+    void shutdownExecutor_CalledOnContextClose() {
+        TrackingNumberServiceXLS spyService = Mockito.spy(new TrackingNumberServiceXLS(trackParcelService, subscriptionService, storeService));
+
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.registerBean(TrackingNumberServiceXLS.class, () -> spyService);
+            context.refresh();
+        }
+
+        Mockito.verify(spyService).shutdownExecutor();
     }
 }


### PR DESCRIPTION
## Summary
- ensure TrackingNumberServiceXLS thread pool is shutdown with `@PreDestroy`
- test that PreDestroy method is invoked when Spring context closes

## Testing
- `./mvnw test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684b56089b34832db935b13652c5a862