### PR TITLE
Fix DeliveryHistoryRepository key type

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/DeliveryHistoryRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
  * @author Dmitriy Anisimov
  * @date 15.03.2025
  */
-public interface DeliveryHistoryRepository extends JpaRepository<DeliveryHistory, Integer> {
+public interface DeliveryHistoryRepository extends JpaRepository<DeliveryHistory, Long> {
 
     Optional<DeliveryHistory> findByTrackParcelId(Long trackParcelId);
 }


### PR DESCRIPTION
## Summary
- correct the key type for DeliveryHistoryRepository to use `Long`

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684dc55e275c832d8977ded0d3f7f97b