### PR TITLE
Add table mappings to security tokens

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/ConfirmationToken.java
+++ b/src/main/java/com/project/tracking_system/entity/ConfirmationToken.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.entity;
 
 import jakarta.persistence.*;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.time.ZonedDateTime;
 
 @Data
 @Entity
+@Table(name = "confirmation_token")
 @AllArgsConstructor
 @NoArgsConstructor
 public class ConfirmationToken {

--- a/src/main/java/com/project/tracking_system/entity/LoginAttempt.java
+++ b/src/main/java/com/project/tracking_system/entity/LoginAttempt.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.entity;
 
 import jakarta.persistence.*;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.Objects;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Table(name = "login_attempt")
 public class LoginAttempt {
 
     @Id

--- a/src/main/java/com/project/tracking_system/entity/PasswordResetToken.java
+++ b/src/main/java/com/project/tracking_system/entity/PasswordResetToken.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.entity;
 
 import jakarta.persistence.*;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 @Entity
+@Table(name = "password_reset_token")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor


### PR DESCRIPTION
## Summary
- map ConfirmationToken entity to `confirmation_token` table
- map PasswordResetToken entity to `password_reset_token` table
- map LoginAttempt entity to `login_attempt` table
- explicitly import `jakarta.persistence.Table`

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5a72ac0832d9a113ee8df84e1eb