### PR TITLE
Handle null tracking number

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -68,8 +68,20 @@ public class TrackParcelService {
     private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
     private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
 
+    /**
+     * Обрабатывает номер посылки: получает информацию и при необходимости сохраняет её.
+     *
+     * @param number  номер посылки
+     * @param storeId идентификатор магазина
+     * @param userId  идентификатор пользователя
+     * @param canSave признак возможности сохранения
+     * @return данные о посылке
+     */
     @Transactional
     public TrackInfoListDTO processTrack(String number, Long storeId, Long userId, boolean canSave) {
+        if (number == null) {
+            throw new IllegalArgumentException("Номер посылки не может быть null");
+        }
         number = number.toUpperCase(); // Приводим к верхнему регистру
 
         log.info("Обработка трека: {} (Пользователь ID={}, Магазин ID={})", number, userId, storeId);


### PR DESCRIPTION
## Summary
- validate tracking number for `null` in `processTrack`
- document `processTrack` method in Russian

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684dc8be7b90832d8de078b5fbf4a9cb