### PR TITLE
Handle missing store stats in final status registration

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -199,8 +199,14 @@ public class DeliveryHistoryService {
         }
 
         Store store = history.getStore();
+        // Получаем статистику магазина или создаём новую запись
         StoreStatistics stats = storeAnalyticsRepository.findByStoreId(store.getId())
-                .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
+                .orElseGet(() -> {
+                    StoreStatistics s = new StoreStatistics();
+                    s.setStore(store);
+                    // Сохраняем запись, чтобы атомарные инкременты прошли успешно
+                    return storeAnalyticsRepository.save(s);
+                });
         PostalServiceStatistics psStats = getOrCreateServiceStats(store, history.getPostalService());
 
         BigDecimal deliveryDays = null;


### PR DESCRIPTION
## Summary
- create `StoreStatistics` row on-demand in `registerFinalStatus`

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684dcfe3b614832db8c335f8595f7960