### PR TITLE
Filter postal stats with zero shipments

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/PostalServiceStatisticsService.java
@@ -28,11 +28,13 @@ public class PostalServiceStatisticsService {
      *
      * @param storeId идентификатор магазина
      * @return список статистик по службам доставки магазина
+     *         (службы без отправлений исключаются)
      */
     public List<PostalServiceStatsDTO> getStatsByStore(Long storeId) {
         return repository.findByStoreId(storeId)
                 .stream()
                 .filter(stat -> stat.getPostalServiceType() != PostalServiceType.UNKNOWN)
+                .filter(stat -> stat.getTotalSent() > 0)
                 .map(this::mapToDto)
                 .toList();
     }
@@ -49,6 +51,7 @@ public class PostalServiceStatisticsService {
      *
      * @param storeIds список идентификаторов магазинов
      * @return агрегированная статистика по службам доставки
+     *         (службы без отправлений исключаются)
      */
     public List<PostalServiceStatsDTO> getStatsForStores(List<Long> storeIds) {
         List<PostalServiceStatistics> stats = repository.findByStoreIdIn(storeIds);
@@ -60,6 +63,7 @@ public class PostalServiceStatisticsService {
             aggregated.merge(stat.getPostalServiceType(), stat, this::mergeStats);
         }
         return aggregated.values().stream()
+                .filter(stat -> stat.getTotalSent() > 0)
                 .map(this::mapToDto)
                 .toList();
     }

--- a/src/test/java/PostalServiceStatisticsServiceTest.java
+++ b/src/test/java/PostalServiceStatisticsServiceTest.java
@@ -1,0 +1,59 @@
+import com.project.tracking_system.dto.PostalServiceStatsDTO;
+import com.project.tracking_system.entity.PostalServiceStatistics;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
+import com.project.tracking_system.service.analytics.PostalServiceStatisticsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PostalServiceStatisticsServiceTest {
+
+    @Mock
+    private PostalServiceStatisticsRepository repository;
+
+    @InjectMocks
+    private PostalServiceStatisticsService service;
+
+    @Test
+    void getStatsByStore_FiltersZeroSent() {
+        PostalServiceStatistics empty = new PostalServiceStatistics();
+        empty.setPostalServiceType(PostalServiceType.BELPOST);
+        empty.setTotalSent(0);
+
+        PostalServiceStatistics nonEmpty = new PostalServiceStatistics();
+        nonEmpty.setPostalServiceType(PostalServiceType.EVROPOST);
+        nonEmpty.setTotalSent(5);
+
+        when(repository.findByStoreId(1L)).thenReturn(List.of(empty, nonEmpty));
+
+        List<PostalServiceStatsDTO> stats = service.getStatsByStore(1L);
+        assertEquals(1, stats.size());
+        assertEquals("Европочта", stats.get(0).getPostalService());
+    }
+
+    @Test
+    void getStatsForStores_FiltersAfterAggregation() {
+        PostalServiceStatistics empty = new PostalServiceStatistics();
+        empty.setPostalServiceType(PostalServiceType.BELPOST);
+        empty.setTotalSent(0);
+
+        PostalServiceStatistics nonEmpty = new PostalServiceStatistics();
+        nonEmpty.setPostalServiceType(PostalServiceType.EVROPOST);
+        nonEmpty.setTotalSent(3);
+
+        when(repository.findByStoreIdIn(List.of(1L, 2L))).thenReturn(List.of(empty, nonEmpty));
+
+        List<PostalServiceStatsDTO> stats = service.getStatsForStores(List.of(1L, 2L));
+        assertEquals(1, stats.size());
+        assertEquals("Европочта", stats.get(0).getPostalService());
+    }
+}


### PR DESCRIPTION
## Summary
- filter out postal services with no shipments in `PostalServiceStatisticsService`
- add unit test for new filtering logic

## Testing
- `gradle -v` *(fails: there is no build file)*


------
https://chatgpt.com/codex/tasks/task_e_684de2fb0bb8832d96a21b35eb7c9567