### PR TITLE
Fix deletion animation order

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1186,24 +1186,27 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
                 notifyUser("Выбранные посылки успешно удалены.", "success");
 
-                clearAllCheckboxes();
+                const checkedCheckboxes = Array.from(document.querySelectorAll(".selectCheckbox:checked"));
+                const rowsToRemove = checkedCheckboxes
+                    .map(cb => cb.closest("tr"))
+                    .filter(row => row);
 
                 // Анимация исчезновения удалённых строк
-                document.querySelectorAll(".selectCheckbox:checked").forEach(checkbox => {
-                    const row = checkbox.closest("tr");
-                    if (row) {
-                        row.style.transition = "opacity 0.5s";
-                        row.style.opacity = "0";
-                        setTimeout(() => row.remove(), 500);
-                    }
+                rowsToRemove.forEach(row => {
+                    row.style.transition = "opacity 0.5s";
+                    row.style.opacity = "0";
                 });
 
-                // ✅ Возвращаем кнопку в нормальное состояние
-                applyBtn.disabled = false;
-                applyBtn.innerHTML = "Применить";
+                // Удаляем строки и очищаем чекбоксы после завершения анимации
+                setTimeout(() => {
+                    rowsToRemove.forEach(row => row.remove());
+                    clearAllCheckboxes();
+                }, 500);
             })
             .catch(error => {
                 notifyUser("Ошибка при удалении: " + error.message, "danger");
+            })
+            .finally(() => {
                 applyBtn.disabled = false;
                 applyBtn.innerHTML = "Применить";
             });


### PR DESCRIPTION
## Summary
- handle row fade out before clearing checkboxes
- remove rows after animation and then clear selections
- always re-enable the action button when the request completes

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de7224e44832d9eb960732e96bee4