### PR TITLE
Fix default store handling in profile

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -233,11 +233,19 @@ public class ProfileController {
     }
 
     /**
-     * Получает список магазинов пользователя.
+     * Возвращает список магазинов пользователя.
+     * <p>
+     * Перед отправкой данных вызывается сервис {@link StoreService#getDefaultStoreId(Long)},
+     * чтобы установить магазин по умолчанию, если у пользователя только один магазин.
+     * </p>
+     *
+     * @param user текущий пользователь
+     * @return список магазинов пользователя
      */
     @GetMapping("/stores")
     @ResponseBody
     public List<Store> getUserStores(@AuthenticationPrincipal User user) {
+        storeService.getDefaultStoreId(user.getId());
         return storeService.getUserStores(user.getId());
     }
 

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -429,18 +429,16 @@ async function loadStores() {
     }
 
     tableBody.innerHTML = "";
-    const isMultipleStores = stores.length > 1; // Проверяем, можно ли менять магазин по умолчанию
 
     stores.forEach(store => {
         const row = document.createElement("tr");
         row.innerHTML = `
             <td class="d-flex align-items-center">
-                <input type="radio" name="defaultStore" 
-                       class="default-store-radio me-2" 
-                       data-store-id="${store.id}" 
-                       ${store.default ? "checked" : ""} 
-                       ${!isMultipleStores ? "disabled" : ""} 
-                       data-bs-toggle="tooltip" 
+                <input type="radio" name="defaultStore"
+                       class="default-store-radio me-2"
+                       data-store-id="${store.id}"
+                       ${store.default ? "checked" : ""}
+                       data-bs-toggle="tooltip"
                        title="Магазин по умолчанию">
                 <input type="text" class="form-control store-name-input" value="${store.name}" id="store-name-${store.id}" disabled>
             </td>


### PR DESCRIPTION
## Summary
- ensure default store is initialized when listing stores
- always enable store radio buttons in the UI

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684deb50b9cc832d804918daf0ed949b