### PR TITLE
Refactor track services with facade

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.service.track.StatusTrackService;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackFacade;
 import com.project.tracking_system.service.store.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,7 @@ import java.util.List;
 public class DeparturesController {
 
     private final TrackParcelService trackParcelService;
+    private final TrackFacade trackFacade;
     private final StatusTrackService statusTrackService;
     private final StoreService storeService;
     private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
@@ -186,9 +188,9 @@ public class DeparturesController {
         UpdateResult result;
         try {
             if (selectedNumbers != null && !selectedNumbers.isEmpty()) {
-                result = trackParcelService.updateSelectedParcels(userId, selectedNumbers);
+                result = trackFacade.updateSelectedParcels(userId, selectedNumbers);
             } else {
-                result = trackParcelService.updateAllParcels(userId);
+                result = trackFacade.updateAllParcels(userId);
             }
 
             // Отправляем WebSocket-уведомление
@@ -226,7 +228,7 @@ public class DeparturesController {
         }
 
         try {
-            trackParcelService.deleteByNumbersAndUserId(selectedNumbers, userId);
+            trackFacade.deleteByNumbersAndUserId(selectedNumbers, userId);
             log.info("Выбранные посылки {} удалены пользователем с ID: {}", selectedNumbers, userId);
             webSocketController.sendUpdateStatus(userId, "Выбранные посылки успешно удалены.", true);
             return ResponseBuilder.ok("Выбранные посылки успешно удалены.");

--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -4,7 +4,7 @@ import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
-import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackFacade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,7 +30,7 @@ import java.util.List;
 @RequestMapping("/")
 public class HomeController {
 
-    private final TrackParcelService trackParcelService;
+    private final TrackFacade trackFacade;
     private final StoreService storeService;
 
     /**
@@ -77,7 +77,7 @@ public class HomeController {
 
         try {
             // trackParcelService реализует логику с посылкой!
-            TrackInfoListDTO trackInfo = trackParcelService.processTrack(number, storeId, userId, canSave);
+            TrackInfoListDTO trackInfo = trackFacade.processTrack(number, storeId, userId, canSave);
 
             if (trackInfo == null || trackInfo.getList().isEmpty()) {
                 model.addAttribute("customError", "Нет данных для указанного номера посылки.");

--- a/src/main/java/com/project/tracking_system/service/track/TrackDeletionService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackDeletionService.java
@@ -1,0 +1,52 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.service.analytics.DeliveryHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Сервис удаления треков пользователя.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TrackDeletionService {
+
+    private final TrackParcelRepository trackParcelRepository;
+    private final DeliveryHistoryService deliveryHistoryService;
+
+    /**
+     * Удаляет посылки пользователя по номерам.
+     *
+     * @param numbers список номеров посылок
+     * @param userId  идентификатор пользователя
+     */
+    @Transactional
+    public void deleteByNumbersAndUserId(List<String> numbers, Long userId) {
+        List<TrackParcel> parcelsToDelete = trackParcelRepository.findByNumberInAndUserId(numbers, userId);
+
+        if (parcelsToDelete.isEmpty()) {
+            log.warn("❌ Попытка удаления несуществующих посылок. userId={}, номера={}", userId, numbers);
+            throw new RuntimeException("Нет посылок для удаления.");
+        }
+
+        // Обнуляем связь с DeliveryHistory, чтобы Hibernate не пытался сохранять зависимую сущность
+        for (TrackParcel parcel : parcelsToDelete) {
+            deliveryHistoryService.handleTrackParcelBeforeDelete(parcel);
+
+            if (parcel.getDeliveryHistory() != null) {
+                parcel.getDeliveryHistory().setTrackParcel(null);
+                parcel.setDeliveryHistory(null);
+            }
+        }
+
+        trackParcelRepository.deleteAll(parcelsToDelete);
+        log.info("✅ Удалены {} посылок пользователя ID={}", parcelsToDelete.size(), userId);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackFacade.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackFacade.java
@@ -1,0 +1,70 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.entity.UpdateResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Фасад для работы с посылками пользователя.
+ * <p>
+ * Позволяет вызывать обработку, обновление и удаление треков
+ * через единый интерфейс.
+ * </p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TrackFacade {
+
+    private final TrackProcessingService trackProcessingService;
+    private final TrackUpdateService trackUpdateService;
+    private final TrackDeletionService trackDeletionService;
+
+    /**
+     * Обрабатывает трек-номер и при необходимости сохраняет его.
+     *
+     * @param number  номер трека
+     * @param storeId идентификатор магазина
+     * @param userId  идентификатор пользователя
+     * @param canSave признак возможности сохранения
+     * @return информация о треке
+     */
+    public TrackInfoListDTO processTrack(String number, Long storeId, Long userId, boolean canSave) {
+        return trackProcessingService.processTrack(number, storeId, userId, canSave);
+    }
+
+    /**
+     * Запускает обновление всех треков пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return результат обновления
+     */
+    public UpdateResult updateAllParcels(Long userId) {
+        return trackUpdateService.updateAllParcels(userId);
+    }
+
+    /**
+     * Запускает обновление выбранных треков пользователя.
+     *
+     * @param userId          идентификатор пользователя
+     * @param selectedNumbers список номеров треков
+     * @return результат обновления
+     */
+    public UpdateResult updateSelectedParcels(Long userId, List<String> selectedNumbers) {
+        return trackUpdateService.updateSelectedParcels(userId, selectedNumbers);
+    }
+
+    /**
+     * Удаляет треки пользователя.
+     *
+     * @param numbers список номеров треков
+     * @param userId  идентификатор пользователя
+     */
+    public void deleteByNumbersAndUserId(List<String> numbers, Long userId) {
+        trackDeletionService.deleteByNumbersAndUserId(numbers, userId);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackNumberOcrService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackNumberOcrService.java
@@ -12,6 +12,7 @@ import org.opencv.core.*;
 import org.opencv.imgproc.Imgproc;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import com.project.tracking_system.service.track.TrackFacade;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -37,7 +38,7 @@ import java.util.regex.Pattern;
 @Service
 public class TrackNumberOcrService {
 
-    private final TrackParcelService trackParcelService;
+    private final TrackFacade trackFacade;
 
     @Value("${opencv.lib.path}")
     private String opencvLibPath;
@@ -150,7 +151,7 @@ public class TrackNumberOcrService {
 
                 try {
                     // Используем processTrack для комплексной работы с треком.
-                    TrackInfoListDTO trackInfo = trackParcelService.processTrack(trackNumber, storeId, userId, canSave);
+                    TrackInfoListDTO trackInfo = trackFacade.processTrack(trackNumber, storeId, userId, canSave);
 
                     if (trackInfo != null) {
                         trackInfoResult.add(new TrackingResultAdd(trackNumber, "Добавлен"));

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -1,317 +1,42 @@
 package com.project.tracking_system.service.track;
 
-import com.project.tracking_system.controller.WebSocketController;
 import com.project.tracking_system.dto.TrackParcelDTO;
-import com.project.tracking_system.dto.TrackInfoListDTO;
-import com.project.tracking_system.entity.*;
-import com.project.tracking_system.repository.StoreRepository;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.repository.TrackParcelRepository;
-import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
-import com.project.tracking_system.repository.StoreAnalyticsRepository;
-import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
-import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
-import com.project.tracking_system.repository.PostalServiceDailyStatisticsRepository;
-import com.project.tracking_system.service.SubscriptionService;
-import com.project.tracking_system.service.analytics.DeliveryHistoryService;
 import com.project.tracking_system.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.*;
-import com.project.tracking_system.utils.DateParserUtils;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.LocalDate;
+import java.util.List;
 
 /**
- * Сервис для управления посылками пользователей в системе отслеживания.
- * Этот класс отвечает за сохранение, обновление, поиск и удаление посылок пользователя, а также за управление их статусами.
- * Методы этого класса взаимодействуют с репозиторием для работы с базой данных и с другими сервисами для получения информации о посылках.
- * <p>
- * Основные функции:
- * - Сохранение или обновление информации о посылках пользователя.
- * - Поиск посылок по статусу и пользователю с поддержкой пагинации.
- * - Обновление истории отслеживания посылок асинхронно.
- * - Удаление посылок по номерам и идентификатору пользователя.
- * </p>
- * Взаимодействует с сервисами:
- * - {@link TypeDefinitionTrackPostService} для получения информации о типах посылок.
- * - {@link StatusTrackService} для обновления статусов посылок.
- *
- * @author Dmitriy Anisimov
- * @date Добавлено 07.01.2025
+ * Базовый сервис для работы с посылками пользователя.
  */
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class TrackParcelService {
 
-    private final WebSocketController webSocketController;
-    private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
-    private final StatusTrackService statusTrackService;
-    private final SubscriptionService subscriptionService;
-    private final DeliveryHistoryService deliveryHistoryService;
     private final UserService userService;
-    private final UserSubscriptionRepository userSubscriptionRepository;
-    private final StoreRepository storeRepository;
-    private final UserRepository userRepository;
     private final TrackParcelRepository trackParcelRepository;
-    private final StoreAnalyticsRepository storeAnalyticsRepository;
-    private final PostalServiceStatisticsRepository postalServiceStatisticsRepository;
-    private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
-    private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
-    @Qualifier("Post")
-    private final TaskExecutor taskExecutor;
-
-    /**
-     * Обрабатывает номер посылки: получает информацию и при необходимости сохраняет её.
-     *
-     * @param number  номер посылки
-     * @param storeId идентификатор магазина
-     * @param userId  идентификатор пользователя
-     * @param canSave признак возможности сохранения
-     * @return данные о посылке
-     */
-    @Transactional
-    public TrackInfoListDTO processTrack(String number, Long storeId, Long userId, boolean canSave) {
-        if (number == null) {
-            throw new IllegalArgumentException("Номер посылки не может быть null");
-        }
-        number = number.toUpperCase(); // Приводим к верхнему регистру
-
-        log.info("Обработка трека: {} (Пользователь ID={}, Магазин ID={})", number, userId, storeId);
-
-        // Получаем данные о треке
-        TrackInfoListDTO trackInfo = typeDefinitionTrackPostService.getTypeDefinitionTrackPostService(userId, number);
-
-        if (trackInfo == null || trackInfo.getList().isEmpty()) {
-            log.warn("Данных по треку {} не найдено", number);
-            return trackInfo;
-        }
-
-        // Сохраняем трек, если пользователь авторизован и разрешено сохранять
-        if (userId != null && canSave) {
-            save(number, trackInfo, storeId, userId);
-            log.debug("✅ Посылка сохранена: {} (UserID={}, StoreID={})", number, userId, storeId);
-        } else {
-            log.info("⏳ Трек '{}' обработан, но не сохранён.", number);
-        }
-
-        return trackInfo;
-    }
-
-    /**
-     * Сохраняет или обновляет посылку пользователя.
-     * <p>
-     * Этот метод сохраняет новую посылку или обновляет существующую, основываясь на номере посылки.
-     * Статус и дата обновляются на основе информации о посылке, полученной из {@link TrackInfoListDTO}.
-     * </p>
-     *
-     * @param number номер посылки
-     * @param trackInfoListDTO информация о посылке
-     * @param storeId идентификатор магазина
-     * @param userId  идентификатор пользователя
-     */
-    @Transactional
-    public void save(String number, TrackInfoListDTO trackInfoListDTO, Long storeId, Long userId) {
-        if (number == null || trackInfoListDTO == null) {
-            throw new IllegalArgumentException("Отсутствует посылка");
-        }
-
-        // Ищем трек по номеру и пользователю независимо от магазина
-        TrackParcel trackParcel = trackParcelRepository.findByNumberAndUserId(number, userId);
-        boolean isNewParcel = (trackParcel == null);
-        GlobalStatus oldStatus = (!isNewParcel) ? trackParcel.getStatus() : null;
-        ZonedDateTime previousDate = null; // дата отправления старого трека
-        Long previousStoreId = null;       // магазин, в котором хранился трек ранее
-
-        // Если трек новый, проверяем лимиты
-        if (isNewParcel) {
-            int remainingTracks = subscriptionService.canSaveMoreTracks(userId, 1);
-            if (remainingTracks <= 0) {
-                throw new IllegalArgumentException("Вы не можете сохранить больше посылок, так как превышен лимит сохранённых посылок.");
-            }
-
-            // Используем getReferenceById()
-            Store store = storeRepository.getReferenceById(storeId);
-            User user = userRepository.getReferenceById(userId);
-
-            // Создаём новый трек
-            trackParcel = new TrackParcel();
-            trackParcel.setNumber(number);
-            trackParcel.setStore(store);
-            trackParcel.setUser(user);
-            log.info("Создан новый трек {} для пользователя ID={}", number, userId);
-
-        } else {
-            // Запоминаем предыдущие значения для корректировки статистики
-            previousStoreId = trackParcel.getStore().getId();
-            previousDate = trackParcel.getData();
-        }
-        // Если трек уже существует, проверяем, соответствует ли магазин выбранному пользователем
-        if (!trackParcel.getStore().getId().equals(storeId)) {
-            // Загружаем новый магазин
-            Long oldStoreId = trackParcel.getStore().getId();
-            Store newStore = storeRepository.getReferenceById(storeId);
-
-            // Обновляем магазин у трека
-            trackParcel.setStore(newStore);
-            log.info("Обновление магазина для трека {}: с магазина {} на магазин {}", number, oldStoreId, storeId);
-        }
-
-        // Обновляем статус и дату трека на основе нового содержимого
-        GlobalStatus newStatus = statusTrackService.setStatus(trackInfoListDTO.getList());
-
-        trackParcel.setStatus(newStatus);
-
-        String lastDate = trackInfoListDTO.getList().get(0).getTimex();
-        ZoneId userZone = userService.getUserZone(userId);
-        ZonedDateTime zonedDateTime = DateParserUtils.parse(lastDate, userZone);
-        trackParcel.setData(zonedDateTime);
-
-        trackParcelRepository.save(trackParcel);
-
-        boolean storeChanged = !isNewParcel && previousStoreId != null && !previousStoreId.equals(storeId);
-
-        PostalServiceType serviceType = typeDefinitionTrackPostService.detectPostalService(number);
-
-        // Инкрементируем статистику нового магазина при добавлении новой посылки или смене магазина
-        if (isNewParcel || storeChanged) {
-            StoreStatistics statistics = storeAnalyticsRepository.findByStoreId(storeId)
-                    .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
-
-            // Атомарное обновление счётчика отправлений
-            int updated = storeAnalyticsRepository.incrementTotalSent(storeId, 1);
-            if (updated == 0) {
-                statistics.setTotalSent(statistics.getTotalSent() + 1);
-                statistics.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                storeAnalyticsRepository.save(statistics);
-            }
-
-            // Postal service statistics (skip UNKNOWN)
-            if (serviceType != PostalServiceType.UNKNOWN) {
-                int psUpdated = postalServiceStatisticsRepository.incrementTotalSent(storeId, serviceType, 1);
-                if (psUpdated == 0) {
-                    PostalServiceStatistics psStats = postalServiceStatisticsRepository
-                            .findByStoreIdAndPostalServiceType(storeId, serviceType)
-                            .orElseGet(() -> {
-                                PostalServiceStatistics s = new PostalServiceStatistics();
-                                s.setStore(statistics.getStore());
-                                s.setPostalServiceType(serviceType);
-                                return s;
-                            });
-                    psStats.setTotalSent(psStats.getTotalSent() + 1);
-                    psStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    postalServiceStatisticsRepository.save(psStats);
-                }
-            } else {
-                log.warn("⛔ Skipping analytics update for UNKNOWN service: {}", number);
-            }
-
-            // Ежедневная статистика магазина
-            LocalDate day = zonedDateTime.toLocalDate();
-            int dailyUpdated = storeDailyStatisticsRepository.incrementSent(storeId, day, 1);
-            if (dailyUpdated == 0) {
-                StoreDailyStatistics daily = storeDailyStatisticsRepository
-                        .findByStoreIdAndDate(storeId, day)
-                        .orElseGet(() -> {
-                            StoreDailyStatistics d = new StoreDailyStatistics();
-                            d.setStore(statistics.getStore());
-                            d.setDate(day);
-                            return d;
-                        });
-                daily.setSent(daily.getSent() + 1);
-                daily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                storeDailyStatisticsRepository.save(daily);
-            }
-
-            // Daily postal service statistics
-            if (serviceType != PostalServiceType.UNKNOWN) {
-                int psdUpdated = postalServiceDailyStatisticsRepository.incrementSent(storeId, serviceType, day, 1);
-                if (psdUpdated == 0) {
-                    PostalServiceDailyStatistics psDaily = postalServiceDailyStatisticsRepository
-                            .findByStoreIdAndPostalServiceTypeAndDate(storeId, serviceType, day)
-                            .orElseGet(() -> {
-                                PostalServiceDailyStatistics d = new PostalServiceDailyStatistics();
-                                d.setStore(statistics.getStore());
-                                d.setPostalServiceType(serviceType);
-                                d.setDate(day);
-                                return d;
-                            });
-                    psDaily.setSent(psDaily.getSent() + 1);
-                    psDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    postalServiceDailyStatisticsRepository.save(psDaily);
-                }
-            }
-        }
-
-        // Декрементируем статистику старого магазина, если посылка перенесена
-        if (storeChanged) {
-            StoreStatistics oldStats = storeAnalyticsRepository.findByStoreId(previousStoreId)
-                    .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
-            if (oldStats.getTotalSent() > 0) {
-                oldStats.setTotalSent(oldStats.getTotalSent() - 1);
-                oldStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                storeAnalyticsRepository.save(oldStats);
-            }
-
-            if (serviceType != PostalServiceType.UNKNOWN) {
-                PostalServiceStatistics oldPs = postalServiceStatisticsRepository
-                        .findByStoreIdAndPostalServiceType(previousStoreId, serviceType)
-                        .orElse(null);
-                if (oldPs != null && oldPs.getTotalSent() > 0) {
-                    oldPs.setTotalSent(oldPs.getTotalSent() - 1);
-                    oldPs.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    postalServiceStatisticsRepository.save(oldPs);
-                }
-            }
-
-            if (previousDate != null) {
-                LocalDate prevDay = previousDate.toLocalDate();
-                StoreDailyStatistics oldDaily = storeDailyStatisticsRepository
-                        .findByStoreIdAndDate(previousStoreId, prevDay)
-                        .orElse(null);
-                if (oldDaily != null && oldDaily.getSent() > 0) {
-                    oldDaily.setSent(oldDaily.getSent() - 1);
-                    oldDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    storeDailyStatisticsRepository.save(oldDaily);
-                }
-
-                if (serviceType != PostalServiceType.UNKNOWN) {
-                    PostalServiceDailyStatistics oldPsDaily = postalServiceDailyStatisticsRepository
-                            .findByStoreIdAndPostalServiceTypeAndDate(previousStoreId, serviceType, prevDay)
-                            .orElse(null);
-                    if (oldPsDaily != null && oldPsDaily.getSent() > 0) {
-                        oldPsDaily.setSent(oldPsDaily.getSent() - 1);
-                        oldPsDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                        postalServiceDailyStatisticsRepository.save(oldPsDaily);
-                    }
-                }
-            }
-        }
-
-        // Обновляем историю доставки
-        deliveryHistoryService.updateDeliveryHistory(trackParcel, oldStatus, newStatus, trackInfoListDTO);
-
-        log.info("Обновлено: userId={}, storeId={}, трек={}, новый статус={}",
-                userId, storeId, trackParcel.getNumber(), newStatus);
-    }
+    private final UserSubscriptionRepository userSubscriptionRepository;
 
     /**
      * Проверяет, принадлежит ли посылка пользователю.
      *
-     * @param itemNumber Номер посылки.
-     * @param userId     ID пользователя.
-     * @return true, если посылка принадлежит пользователю.
+     * @param itemNumber номер посылки
+     * @param userId     идентификатор пользователя
+     * @return true, если посылка принадлежит пользователю
      */
     public boolean userOwnsParcel(String itemNumber, Long userId) {
         return trackParcelRepository.existsByNumberAndUserId(itemNumber, userId);
@@ -319,12 +44,6 @@ public class TrackParcelService {
 
     /**
      * Находит посылки по магазинам с учётом пагинации.
-     *
-     * @param storeIds список идентификаторов магазинов
-     * @param page     номер страницы
-     * @param size     размер страницы
-     * @param userId   идентификатор пользователя для определения часового пояса
-     * @return страница с найденными посылками
      */
     @Transactional
     public Page<TrackParcelDTO> findByStoreTracks(List<Long> storeIds, int page, int size, Long userId) {
@@ -336,16 +55,6 @@ public class TrackParcelService {
 
     /**
      * Ищет посылки магазинов по статусу с поддержкой пагинации.
-     * <p>
-     * Возвращает страницу посылок выбранных магазинов по указанному статусу.
-     * </p>
-     *
-     * @param storeIds список идентификаторов магазинов
-     * @param status   статус посылки
-     * @param page     номер страницы
-     * @param size     размер страницы
-     * @param userId   идентификатор пользователя для определения часового пояса
-     * @return страница с посылками пользователя по статусу
      */
     @Transactional
     public Page<TrackParcelDTO> findByStoreTracksAndStatus(List<Long> storeIds, GlobalStatus status, int page, int size, Long userId) {
@@ -357,8 +66,6 @@ public class TrackParcelService {
 
     /**
      * Подсчитывает общее количество посылок в системе.
-     *
-     * @return количество всех сохранённых посылок
      */
     @Transactional
     public long countAllParcels() {
@@ -367,27 +74,18 @@ public class TrackParcelService {
 
     /**
      * Проверяет, является ли посылка новой для данного магазина.
-     *
-     * @param trackingNumber номер отслеживания
-     * @param storeId ID магазина
-     * @return true, если посылка отсутствует в магазине (новая), false, если уже существует
      */
     @Transactional
     public boolean isNewTrack(String trackingNumber, Long storeId) {
         if (storeId == null) {
-            return true; // Если магазин не указан, считаем, что посылка новая
+            return true;
         }
-
         TrackParcel existing = trackParcelRepository.findByNumberAndStoreId(trackingNumber, storeId);
         return (existing == null);
     }
 
-
     /**
      * Увеличивает счётчик обновлений треков для пользователя.
-     *
-     * @param userId идентификатор пользователя
-     * @param count  величина увеличения
      */
     @Transactional
     public void incrementUpdateCount(Long userId, int count) {
@@ -395,10 +93,7 @@ public class TrackParcelService {
     }
 
     /**
-     * Возвращает все посылки, принадлежащие конкретному магазину.
-     *
-     * @param storeId ID магазина
-     * @return список всех посылок в магазине
+     * Возвращает все посылки магазина.
      */
     @Transactional
     public List<TrackParcelDTO> findAllByStoreTracks(Long storeId, Long userId) {
@@ -410,10 +105,7 @@ public class TrackParcelService {
     }
 
     /**
-     * Возвращает все посылки, принадлежащие конкретному пользователю.
-     *
-     * @param userId ID пользователя
-     * @return список всех посылок пользователя
+     * Возвращает все посылки пользователя.
      */
     @Transactional
     public List<TrackParcelDTO> findAllByUserTracks(Long userId) {
@@ -423,279 +115,4 @@ public class TrackParcelService {
                 .map(track -> new TrackParcelDTO(track, userZone))
                 .toList();
     }
-
-    /**
-     * Обновляет историю отслеживания посылок для всех магазинов пользователя.
-     *
-     * @param userId   ID пользователя, владеющего магазинами.
-     */
-    @Transactional
-    public UpdateResult updateAllParcels(Long userId) {
-        // Проверяем подписку
-        if (!subscriptionService.canUseBulkUpdate(userId)) {
-            String msg = "Обновление всех треков доступно только в премиум-версии.";
-            log.warn("Отказано в доступе для пользователя ID: {}", userId);
-
-            webSocketController.sendUpdateStatus(userId, msg, false);
-            log.debug("📡 WebSocket отправлено: {}", msg);
-
-            return new UpdateResult(false, 0, 0, msg);
-        }
-
-        // Получаем количество магазинов пользователя
-        int count = storeRepository.countByOwnerId(userId);
-        if (count == 0) {
-            log.warn("У пользователя ID={} нет магазинов для обновления треков.", userId);
-            return new UpdateResult(false, 0, 0, "У вас нет магазинов с посылками.");
-        }
-
-        // Получаем все треки пользователя
-        List<TrackParcelDTO> allParcels = findAllByUserTracks(userId);
-
-        // Фильтруем треки, исключая финальные статусы
-        List<TrackParcelDTO> parcelsToUpdate = allParcels.stream()
-                .filter(dto -> !GlobalStatus.fromDescription(dto.getStatus()).isFinal())
-                .toList();
-
-        log.info("📦 Запущено обновление всех {} треков для userId={}", parcelsToUpdate.size(), userId);
-
-        // Отправляем уведомление о запуске
-        webSocketController.sendUpdateStatus(userId, "Обновление всех треков запущено...", true);
-
-        // Запуск асинхронного процесса
-        processAllTrackUpdatesAsync(userId, parcelsToUpdate);
-
-        return new UpdateResult(true, parcelsToUpdate.size(), allParcels.size(),
-                "Запущено обновление " + parcelsToUpdate.size() + " треков из " + allParcels.size());
-    }
-
-    /**
-     * Асинхронно обновляет все треки пользователя.
-     * <p>
-     * Метод выполняется в отдельном потоке благодаря {@link Async} и
-     * обернут в транзакцию с помощью {@link Transactional}. После запуска
-     * каждый трек обрабатывается параллельно, а по завершению формируется
-     * итоговое сообщение с количеством успешно обновлённых треков.
-     * </p>
-     *
-     * @param userId        идентификатор пользователя
-     * @param parcelsToUpdate список DTO посылок для обновления
-     */
-    @Async("Post")
-    @Transactional
-    public void processAllTrackUpdatesAsync(Long userId, List<TrackParcelDTO> parcelsToUpdate) {
-        try {
-            AtomicInteger successfulUpdates = new AtomicInteger(0);
-
-            List<CompletableFuture<Void>> futures = parcelsToUpdate.stream()
-                    .map(trackParcelDTO -> CompletableFuture.runAsync(() -> {
-                        try {
-                            // Используем `processTrack()`, он уже включает определение типа и обновление!
-                            TrackInfoListDTO trackInfo = processTrack(
-                                    trackParcelDTO.getNumber(),
-                                    trackParcelDTO.getStoreId(),
-                                    userId,
-                                    true // Позволяем обновление и сохранение
-                            );
-
-                            if (trackInfo != null && !trackInfo.getList().isEmpty()) {
-                                successfulUpdates.incrementAndGet();
-                                log.debug("Трек {} обновлён для пользователя ID={}", trackParcelDTO.getNumber(), userId);
-                            } else {
-                                log.warn("Нет данных по треку {} (userId={})", trackParcelDTO.getNumber(), userId);
-                            }
-
-                        } catch (IllegalArgumentException e) {
-                            log.warn("Ошибка обновления трека {}: {}", trackParcelDTO.getNumber(), e.getMessage());
-                        } catch (Exception e) {
-                            log.error("Ошибка обработки трека {}: {}", trackParcelDTO.getNumber(), e.getMessage(), e);
-                        }
-                    }, taskExecutor))
-                    .toList();
-
-            // Ждём завершения всех обновлений
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
-                int updatedCount = successfulUpdates.get();
-                int totalCount = parcelsToUpdate.size();
-
-                log.info("Итог обновления всех треков для userId={}: {} обновлено, {} не изменено",
-                        userId, updatedCount, totalCount - updatedCount);
-
-                // Формируем сообщение
-                String message;
-                if (updatedCount == 0) {
-                    message = "Обновление завершено, но все треки уже были в финальном статусе.";
-                } else {
-                    message = "Обновление завершено! " + updatedCount + " из " + totalCount + " треков обновлено.";
-                }
-
-                // Отправляем финальное уведомление через WebSocket
-                webSocketController.sendDetailUpdateStatus(
-                        userId,
-                        new UpdateResult(true, updatedCount, totalCount, message)
-                );
-            });
-
-        } catch (Exception e) {
-            log.error("Ошибка при обновлении всех треков для пользователя {}: {}", userId, e.getMessage());
-            webSocketController.sendUpdateStatus(userId, "Ошибка при обновлении всех треков: " + e.getMessage(), false);
-        }
-    }
-
-    /**
-     * Обновляет выбранные посылки пользователя.
-     *
-     * @param userId          ID пользователя (для проверки подписки)
-     * @param selectedNumbers список номеров посылок
-     * @return результат обновления
-     */
-    @Transactional
-    public UpdateResult updateSelectedParcels(Long userId, List<String> selectedNumbers) {
-        // Загружаем посылки по номерам, игнорируя магазины
-        List<TrackParcel> selectedParcels = trackParcelRepository.findByNumberInAndUserId(selectedNumbers, userId);
-
-        // Считаем количество финальных и обновляемых треков
-        int totalRequested = selectedParcels.size();
-        List<TrackParcel> updatableParcels = selectedParcels.stream()
-                .filter(parcel -> !parcel.getStatus().isFinal())
-                .toList();
-        int nonUpdatableCount = totalRequested - updatableParcels.size();
-
-        log.info("Фильтрация завершена: {} треков можно обновить из {}, {} уже в финальном статусе",
-                updatableParcels.size(), totalRequested, nonUpdatableCount);
-
-        if (updatableParcels.isEmpty()) {
-            String msg = "Все выбранные треки уже в финальном статусе, обновление не требуется.";
-            log.warn(msg);
-            webSocketController.sendUpdateStatus(userId, msg, true);
-            return new UpdateResult(false, 0, selectedNumbers.size(), msg);
-        }
-
-        // Проверяем лимит подписки
-        int remainingUpdates = subscriptionService.canUpdateTracks(userId, updatableParcels.size());
-
-        if (remainingUpdates <= 0) {
-            String msg = "Ваш лимит обновлений на сегодня исчерпан.";
-            log.info("Лимит обновлений исчерпан для пользователя ID: {}", userId);
-            webSocketController.sendUpdateStatus(userId, msg, true);
-            return new UpdateResult(false, 0, updatableParcels.size(), msg);
-        }
-
-        int updatesToProcess = Math.min(updatableParcels.size(), remainingUpdates);
-        List<TrackParcel> parcelsToUpdate = updatableParcels.subList(0, updatesToProcess);
-
-        log.info("Запущено обновление {} треков для пользователя ID={}", updatesToProcess, userId);
-
-        // Вызов асинхронного метода с `userId`
-        processTrackUpdatesAsync(userId, parcelsToUpdate, totalRequested, nonUpdatableCount);
-
-        return new UpdateResult(true, updatesToProcess, selectedNumbers.size(),
-                "Обновление запущено...");
-    }
-
-    /**
-     * Асинхронно обновляет выбранный список посылок пользователя.
-     * <p>
-     * Выполнение метода происходит в отдельном потоке благодаря аннотации
-     * {@link Async}. Транзакция гарантирует целостность всех операций
-     * обновления. После обработки формируется уведомление о количестве
-     * обновлённых треков и учитывается лимит подписки.
-     * </p>
-     *
-     * @param userId            идентификатор пользователя
-     * @param parcelsToUpdate   список посылок для обновления
-     * @param totalRequested    общее количество запрошенных треков
-     * @param nonUpdatableCount количество треков в финальном статусе
-     */
-    @Async("Post")
-    @Transactional
-    public void processTrackUpdatesAsync(Long userId, List<TrackParcel> parcelsToUpdate, int totalRequested, int nonUpdatableCount) {
-        try {
-            AtomicInteger successfulUpdates = new AtomicInteger(0);
-
-            log.info("Начато обновление {} треков для userId={}", parcelsToUpdate.size(), userId);
-
-            List<CompletableFuture<Void>> futures = parcelsToUpdate.stream()
-                    .map(parcel -> CompletableFuture.runAsync(() -> {
-                        try {
-                            TrackInfoListDTO trackInfo = processTrack(parcel.getNumber(), parcel.getStore().getId(), userId, true);
-                            if (trackInfo != null && !trackInfo.getList().isEmpty()) {
-                                successfulUpdates.incrementAndGet();
-                            }
-                        } catch (Exception e) {
-                            log.error("Ошибка обновления трека {}: {}", parcel.getNumber(), e.getMessage());
-                        }
-                    }, taskExecutor))
-                    .toList();
-
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
-                int updatedCount = successfulUpdates.get();
-                log.info("Итог обновления для userId={}: {} обновлено, {} в финальном статусе",
-                        userId, updatedCount, nonUpdatableCount);
-
-                // Если обновлено хотя бы 1 трек, обновляем лимит в подписке
-                if (updatedCount > 0) {
-                    log.info("Финальное обновление updateCount для userId={}, добавляем={}", userId, updatedCount);
-                    incrementUpdateCount(userId, updatedCount);
-                }
-
-                // Формируем информативное сообщение
-                String message;
-                if (updatedCount == 0 && nonUpdatableCount == 0) {
-                    message = "Все треки уже были обновлены ранее.";
-                } else if (updatedCount == 0) {
-                    message = "Обновление завершено, но все треки уже в финальном статусе.";
-                } else {
-                    message = "Обновление завершено! " + updatedCount + " из " + totalRequested + " треков обновлено.";
-                    if (nonUpdatableCount > 0) {
-                        message += " " + nonUpdatableCount + " треков уже были в финальном статусе.";
-                    }
-                }
-
-                // Отправляем уведомление через WebSocket
-                webSocketController.sendDetailUpdateStatus(
-                        userId,
-                        new UpdateResult(true, updatedCount, totalRequested, message)
-                );
-            });
-
-        } catch (Exception e) {
-            log.error("Ошибка при обновлении посылок для пользователя {}: {}", userId, e.getMessage());
-            webSocketController.sendUpdateStatus(userId, "Ошибка обновления: " + e.getMessage(), false);
-        }
-    }
-
-    /**
-     * Удаляет посылки пользователя по номерам.
-     * <p>
-     * Этот метод удаляет посылки по номерам и идентификатору пользователя.
-     * </p>
-     *
-     * @param numbers список номеров посылок
-     * @param userId  идентификатор пользователя
-     */
-    @Transactional
-    public void deleteByNumbersAndUserId(List<String> numbers, Long userId) {
-        List<TrackParcel> parcelsToDelete = trackParcelRepository.findByNumberInAndUserId(numbers, userId);
-
-        if (parcelsToDelete.isEmpty()) {
-            log.warn("❌ Попытка удаления несуществующих посылок. userId={}, номера={}", userId, numbers);
-            throw new RuntimeException("Нет посылок для удаления.");
-        }
-
-        // Обнуляем связь с DeliveryHistory, чтобы Hibernate не пытался сохранять зависимую сущность
-        for (TrackParcel parcel : parcelsToDelete) {
-            deliveryHistoryService.handleTrackParcelBeforeDelete(parcel);
-
-            if (parcel.getDeliveryHistory() != null) {
-                parcel.getDeliveryHistory().setTrackParcel(null); // Разрываем связь
-                parcel.setDeliveryHistory(null); // Обнуляем с двух сторон
-            }
-        }
-
-        // Удаляем все треки
-        trackParcelRepository.deleteAll(parcelsToDelete);
-        log.info("✅ Удалены {} посылок пользователя ID={}", parcelsToDelete.size(), userId);
-    }
-
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -1,0 +1,272 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.analytics.DeliveryHistoryService;
+import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.utils.DateParserUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+
+/**
+ * Сервис обработки треков и их сохранения.
+ * <p>
+ * Отвечает за получение информации о посылке и сохранение/обновление
+ * данных в системе.
+ * </p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TrackProcessingService {
+
+    private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+    private final StatusTrackService statusTrackService;
+    private final SubscriptionService subscriptionService;
+    private final DeliveryHistoryService deliveryHistoryService;
+    private final UserService userService;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+    private final TrackParcelRepository trackParcelRepository;
+    private final StoreAnalyticsRepository storeAnalyticsRepository;
+    private final PostalServiceStatisticsRepository postalServiceStatisticsRepository;
+    private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
+
+    /**
+     * Обрабатывает номер посылки: получает информацию и при необходимости сохраняет её.
+     *
+     * @param number  номер посылки
+     * @param storeId идентификатор магазина
+     * @param userId  идентификатор пользователя
+     * @param canSave признак возможности сохранения
+     * @return данные о посылке
+     */
+    @Transactional
+    public TrackInfoListDTO processTrack(String number, Long storeId, Long userId, boolean canSave) {
+        if (number == null) {
+            throw new IllegalArgumentException("Номер посылки не может быть null");
+        }
+        number = number.toUpperCase(); // Приводим к верхнему регистру
+
+        log.info("Обработка трека: {} (Пользователь ID={}, Магазин ID={})", number, userId, storeId);
+
+        // Получаем данные о треке
+        TrackInfoListDTO trackInfo = typeDefinitionTrackPostService.getTypeDefinitionTrackPostService(userId, number);
+
+        if (trackInfo == null || trackInfo.getList().isEmpty()) {
+            log.warn("Данных по треку {} не найдено", number);
+            return trackInfo;
+        }
+
+        // Сохраняем трек, если пользователь авторизован и разрешено сохранять
+        if (userId != null && canSave) {
+            save(number, trackInfo, storeId, userId);
+            log.debug("✅ Посылка сохранена: {} (UserID={}, StoreID={})", number, userId, storeId);
+        } else {
+            log.info("⏳ Трек '{}' обработан, но не сохранён.", number);
+        }
+
+        return trackInfo;
+    }
+
+    /**
+     * Сохраняет или обновляет посылку пользователя.
+     *
+     * @param number номер посылки
+     * @param trackInfoListDTO информация о посылке
+     * @param storeId идентификатор магазина
+     * @param userId  идентификатор пользователя
+     */
+    @Transactional
+    public void save(String number, TrackInfoListDTO trackInfoListDTO, Long storeId, Long userId) {
+        if (number == null || trackInfoListDTO == null) {
+            throw new IllegalArgumentException("Отсутствует посылка");
+        }
+
+        // Ищем трек по номеру и пользователю независимо от магазина
+        TrackParcel trackParcel = trackParcelRepository.findByNumberAndUserId(number, userId);
+        boolean isNewParcel = (trackParcel == null);
+        GlobalStatus oldStatus = (!isNewParcel) ? trackParcel.getStatus() : null;
+        ZonedDateTime previousDate = null; // дата отправления старого трека
+        Long previousStoreId = null;       // магазин, в котором хранился трек ранее
+
+        // Если трек новый, проверяем лимиты
+        if (isNewParcel) {
+            int remainingTracks = subscriptionService.canSaveMoreTracks(userId, 1);
+            if (remainingTracks <= 0) {
+                throw new IllegalArgumentException(
+                        "Вы не можете сохранить больше посылок, так как превышен лимит сохранённых посылок.");
+            }
+
+            // Используем getReferenceById()
+            Store store = storeRepository.getReferenceById(storeId);
+            User user = userRepository.getReferenceById(userId);
+
+            // Создаём новый трек
+            trackParcel = new TrackParcel();
+            trackParcel.setNumber(number);
+            trackParcel.setStore(store);
+            trackParcel.setUser(user);
+            log.info("Создан новый трек {} для пользователя ID={}", number, userId);
+
+        } else {
+            // Запоминаем предыдущие значения для корректировки статистики
+            previousStoreId = trackParcel.getStore().getId();
+            previousDate = trackParcel.getData();
+        }
+        // Если трек уже существует, проверяем, соответствует ли магазин выбранному пользователем
+        if (!trackParcel.getStore().getId().equals(storeId)) {
+            // Загружаем новый магазин
+            Long oldStoreId = trackParcel.getStore().getId();
+            Store newStore = storeRepository.getReferenceById(storeId);
+
+            // Обновляем магазин у трека
+            trackParcel.setStore(newStore);
+            log.info("Обновление магазина для трека {}: с магазина {} на магазин {}", number, oldStoreId, storeId);
+        }
+
+        // Обновляем статус и дату трека на основе нового содержимого
+        GlobalStatus newStatus = statusTrackService.setStatus(trackInfoListDTO.getList());
+
+        trackParcel.setStatus(newStatus);
+
+        String lastDate = trackInfoListDTO.getList().get(0).getTimex();
+        ZoneId userZone = userService.getUserZone(userId);
+        ZonedDateTime zonedDateTime = DateParserUtils.parse(lastDate, userZone);
+        trackParcel.setData(zonedDateTime);
+
+        trackParcelRepository.save(trackParcel);
+
+        boolean storeChanged = !isNewParcel && previousStoreId != null && !previousStoreId.equals(storeId);
+
+        PostalServiceType serviceType = typeDefinitionTrackPostService.detectPostalService(number);
+
+        // Инкрементируем статистику нового магазина при добавлении новой посылки или смене магазина
+        if (isNewParcel || storeChanged) {
+            StoreStatistics statistics = storeAnalyticsRepository.findByStoreId(storeId)
+                    .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
+
+            // Атомарное обновление счётчика отправлений
+            int updated = storeAnalyticsRepository.incrementTotalSent(storeId, 1);
+            if (updated == 0) {
+                statistics.setTotalSent(statistics.getTotalSent() + 1);
+                statistics.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                storeAnalyticsRepository.save(statistics);
+            }
+
+            // Postal service statistics (skip UNKNOWN)
+            if (serviceType != PostalServiceType.UNKNOWN) {
+                int psUpdated = postalServiceStatisticsRepository.incrementTotalSent(storeId, serviceType, 1);
+                if (psUpdated == 0) {
+                    PostalServiceStatistics psStats = postalServiceStatisticsRepository
+                            .findByStoreIdAndPostalServiceType(storeId, serviceType)
+                            .orElseGet(() -> {
+                                PostalServiceStatistics s = new PostalServiceStatistics();
+                                s.setStore(statistics.getStore());
+                                s.setPostalServiceType(serviceType);
+                                return s;
+                            });
+                    psStats.setTotalSent(psStats.getTotalSent() + 1);
+                    psStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    postalServiceStatisticsRepository.save(psStats);
+                }
+            } else {
+                log.warn("⛔ Skipping analytics update for UNKNOWN service: {}", number);
+            }
+
+            // Ежедневная статистика магазина
+            LocalDate day = zonedDateTime.toLocalDate();
+            int dailyUpdated = storeDailyStatisticsRepository.incrementSent(storeId, day, 1);
+            if (dailyUpdated == 0) {
+                StoreDailyStatistics daily = storeDailyStatisticsRepository
+                        .findByStoreIdAndDate(storeId, day)
+                        .orElseGet(() -> {
+                            StoreDailyStatistics d = new StoreDailyStatistics();
+                            d.setStore(statistics.getStore());
+                            d.setDate(day);
+                            return d;
+                        });
+                daily.setSent(daily.getSent() + 1);
+                daily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                storeDailyStatisticsRepository.save(daily);
+            }
+
+            // Daily postal service statistics
+            if (serviceType != PostalServiceType.UNKNOWN) {
+                int psdUpdated = postalServiceDailyStatisticsRepository.incrementSent(storeId, serviceType, day, 1);
+                if (psdUpdated == 0) {
+                    PostalServiceDailyStatistics psDaily = postalServiceDailyStatisticsRepository
+                            .findByStoreIdAndPostalServiceTypeAndDate(storeId, serviceType, day)
+                            .orElseGet(() -> {
+                                PostalServiceDailyStatistics d = new PostalServiceDailyStatistics();
+                                d.setStore(statistics.getStore());
+                                d.setPostalServiceType(serviceType);
+                                d.setDate(day);
+                                return d;
+                            });
+                    psDaily.setSent(psDaily.getSent() + 1);
+                    psDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    postalServiceDailyStatisticsRepository.save(psDaily);
+                }
+            }
+        }
+
+        // Декрементируем статистику старого магазина, если посылка перенесена
+        if (storeChanged) {
+            StoreStatistics oldStats = storeAnalyticsRepository.findByStoreId(previousStoreId)
+                    .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
+            if (oldStats.getTotalSent() > 0) {
+                oldStats.setTotalSent(oldStats.getTotalSent() - 1);
+                oldStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                storeAnalyticsRepository.save(oldStats);
+            }
+
+            if (serviceType != PostalServiceType.UNKNOWN) {
+                PostalServiceStatistics oldPs = postalServiceStatisticsRepository
+                        .findByStoreIdAndPostalServiceType(previousStoreId, serviceType)
+                        .orElse(null);
+                if (oldPs != null && oldPs.getTotalSent() > 0) {
+                    oldPs.setTotalSent(oldPs.getTotalSent() - 1);
+                    oldPs.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    postalServiceStatisticsRepository.save(oldPs);
+                }
+            }
+
+            if (previousDate != null) {
+                LocalDate prevDay = previousDate.toLocalDate();
+                StoreDailyStatistics oldDaily = storeDailyStatisticsRepository
+                        .findByStoreIdAndDate(previousStoreId, prevDay)
+                        .orElse(null);
+                if (oldDaily != null && oldDaily.getSent() > 0) {
+                    oldDaily.setSent(oldDaily.getSent() - 1);
+                    oldDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    storeDailyStatisticsRepository.save(oldDaily);
+                }
+
+                if (serviceType != PostalServiceType.UNKNOWN) {
+                    PostalServiceDailyStatistics oldPsDaily = postalServiceDailyStatisticsRepository
+                            .findByStoreIdAndPostalServiceTypeAndDate(previousStoreId, serviceType, prevDay)
+                            .orElse(null);
+                    if (oldPsDaily != null && oldPsDaily.getSent() > 0) {
+                        oldPsDaily.setSent(oldPsDaily.getSent() - 1);
+                        oldPsDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                        postalServiceDailyStatisticsRepository.save(oldPsDaily);
+                    }
+                }
+            }
+        }
+
+        // Обновляем историю доставки
+        deliveryHistoryService.updateDeliveryHistory(trackParcel, oldStatus, newStatus, trackInfoListDTO);
+
+        log.info("Обновлено: userId={}, storeId={}, трек={}, новый статус={}",
+                userId, storeId, trackParcel.getNumber(), newStatus);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -1,0 +1,241 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.dto.TrackParcelDTO;
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import com.project.tracking_system.service.track.TrackParcelService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Сервис обновления треков пользователей.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TrackUpdateService {
+
+    private final WebSocketController webSocketController;
+    private final TrackProcessingService trackProcessingService;
+    private final SubscriptionService subscriptionService;
+    private final StoreRepository storeRepository;
+    private final TrackParcelRepository trackParcelRepository;
+    private final TrackParcelService trackParcelService;
+    private final UserService userService;
+    @Qualifier("Post")
+    private final TaskExecutor taskExecutor;
+
+    /**
+     * Обновляет историю всех посылок пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return результат запуска обновления
+     */
+    @Transactional
+    public UpdateResult updateAllParcels(Long userId) {
+        if (!subscriptionService.canUseBulkUpdate(userId)) {
+            String msg = "Обновление всех треков доступно только в премиум-версии.";
+            log.warn("Отказано в доступе для пользователя ID: {}", userId);
+
+            webSocketController.sendUpdateStatus(userId, msg, false);
+            log.debug("📡 WebSocket отправлено: {}", msg);
+
+            return new UpdateResult(false, 0, 0, msg);
+        }
+
+        int count = storeRepository.countByOwnerId(userId);
+        if (count == 0) {
+            log.warn("У пользователя ID={} нет магазинов для обновления треков.", userId);
+            return new UpdateResult(false, 0, 0, "У вас нет магазинов с посылками.");
+        }
+
+        List<TrackParcelDTO> allParcels = trackParcelService.findAllByUserTracks(userId);
+
+        List<TrackParcelDTO> parcelsToUpdate = allParcels.stream()
+                .filter(dto -> !GlobalStatus.fromDescription(dto.getStatus()).isFinal())
+                .toList();
+
+        log.info("📦 Запущено обновление всех {} треков для userId={}", parcelsToUpdate.size(), userId);
+
+        webSocketController.sendUpdateStatus(userId, "Обновление всех треков запущено...", true);
+
+        processAllTrackUpdatesAsync(userId, parcelsToUpdate);
+
+        return new UpdateResult(true, parcelsToUpdate.size(), allParcels.size(),
+                "Запущено обновление " + parcelsToUpdate.size() + " треков из " + allParcels.size());
+    }
+
+    /**
+     * Асинхронно обновляет все треки пользователя.
+     */
+    @Async("Post")
+    @Transactional
+    public void processAllTrackUpdatesAsync(Long userId, List<TrackParcelDTO> parcelsToUpdate) {
+        try {
+            AtomicInteger successfulUpdates = new AtomicInteger(0);
+
+            List<CompletableFuture<Void>> futures = parcelsToUpdate.stream()
+                    .map(trackParcelDTO -> CompletableFuture.runAsync(() -> {
+                        try {
+                            TrackInfoListDTO trackInfo = trackProcessingService.processTrack(
+                                    trackParcelDTO.getNumber(),
+                                    trackParcelDTO.getStoreId(),
+                                    userId,
+                                    true
+                            );
+
+                            if (trackInfo != null && !trackInfo.getList().isEmpty()) {
+                                successfulUpdates.incrementAndGet();
+                                log.debug("Трек {} обновлён для пользователя ID={}", trackParcelDTO.getNumber(), userId);
+                            } else {
+                                log.warn("Нет данных по треку {} (userId={})", trackParcelDTO.getNumber(), userId);
+                            }
+
+                        } catch (IllegalArgumentException e) {
+                            log.warn("Ошибка обновления трека {}: {}", trackParcelDTO.getNumber(), e.getMessage());
+                        } catch (Exception e) {
+                            log.error("Ошибка обработки трека {}: {}", trackParcelDTO.getNumber(), e.getMessage(), e);
+                        }
+                    }, taskExecutor))
+                    .toList();
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
+                int updatedCount = successfulUpdates.get();
+                int totalCount = parcelsToUpdate.size();
+
+                log.info("Итог обновления всех треков для userId={}: {} обновлено, {} не изменено",
+                        userId, updatedCount, totalCount - updatedCount);
+
+                String message;
+                if (updatedCount == 0) {
+                    message = "Обновление завершено, но все треки уже были в финальном статусе.";
+                } else {
+                    message = "Обновление завершено! " + updatedCount + " из " + totalCount + " треков обновлено.";
+                }
+
+                webSocketController.sendDetailUpdateStatus(
+                        userId,
+                        new UpdateResult(true, updatedCount, totalCount, message)
+                );
+            });
+
+        } catch (Exception e) {
+            log.error("Ошибка при обновлении всех треков для пользователя {}: {}", userId, e.getMessage());
+            webSocketController.sendUpdateStatus(userId, "Ошибка при обновлении всех треков: " + e.getMessage(), false);
+        }
+    }
+
+    /**
+     * Обновляет выбранные посылки пользователя.
+     */
+    @Transactional
+    public UpdateResult updateSelectedParcels(Long userId, List<String> selectedNumbers) {
+        List<TrackParcel> selectedParcels = trackParcelRepository.findByNumberInAndUserId(selectedNumbers, userId);
+
+        int totalRequested = selectedParcels.size();
+        List<TrackParcel> updatableParcels = selectedParcels.stream()
+                .filter(parcel -> !parcel.getStatus().isFinal())
+                .toList();
+        int nonUpdatableCount = totalRequested - updatableParcels.size();
+
+        log.info("Фильтрация завершена: {} треков можно обновить из {}, {} уже в финальном статусе",
+                updatableParcels.size(), totalRequested, nonUpdatableCount);
+
+        if (updatableParcels.isEmpty()) {
+            String msg = "Все выбранные треки уже в финальном статусе, обновление не требуется.";
+            log.warn(msg);
+            webSocketController.sendUpdateStatus(userId, msg, true);
+            return new UpdateResult(false, 0, selectedNumbers.size(), msg);
+        }
+
+        int remainingUpdates = subscriptionService.canUpdateTracks(userId, updatableParcels.size());
+
+        if (remainingUpdates <= 0) {
+            String msg = "Ваш лимит обновлений на сегодня исчерпан.";
+            log.info("Лимит обновлений исчерпан для пользователя ID: {}", userId);
+            webSocketController.sendUpdateStatus(userId, msg, true);
+            return new UpdateResult(false, 0, updatableParcels.size(), msg);
+        }
+
+        int updatesToProcess = Math.min(updatableParcels.size(), remainingUpdates);
+        List<TrackParcel> parcelsToUpdate = updatableParcels.subList(0, updatesToProcess);
+
+        log.info("Запущено обновление {} треков для пользователя ID={}", updatesToProcess, userId);
+
+        processTrackUpdatesAsync(userId, parcelsToUpdate, totalRequested, nonUpdatableCount);
+
+        return new UpdateResult(true, updatesToProcess, selectedNumbers.size(),
+                "Обновление запущено...");
+    }
+
+    /**
+     * Асинхронно обновляет выбранный список посылок пользователя.
+     */
+    @Async("Post")
+    @Transactional
+    public void processTrackUpdatesAsync(Long userId, List<TrackParcel> parcelsToUpdate, int totalRequested, int nonUpdatableCount) {
+        try {
+            AtomicInteger successfulUpdates = new AtomicInteger(0);
+
+            log.info("Начато обновление {} треков для userId={}", parcelsToUpdate.size(), userId);
+
+            List<CompletableFuture<Void>> futures = parcelsToUpdate.stream()
+                    .map(parcel -> CompletableFuture.runAsync(() -> {
+                        try {
+                            TrackInfoListDTO trackInfo = trackProcessingService.processTrack(parcel.getNumber(), parcel.getStore().getId(), userId, true);
+                            if (trackInfo != null && !trackInfo.getList().isEmpty()) {
+                                successfulUpdates.incrementAndGet();
+                            }
+                        } catch (Exception e) {
+                            log.error("Ошибка обновления трека {}: {}", parcel.getNumber(), e.getMessage());
+                        }
+                    }, taskExecutor))
+                    .toList();
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
+                int updatedCount = successfulUpdates.get();
+                log.info("Итог обновления для userId={}: {} обновлено, {} в финальном статусе",
+                        userId, updatedCount, nonUpdatableCount);
+
+                if (updatedCount > 0) {
+                    log.info("Финальное обновление updateCount для userId={}, добавляем={}", userId, updatedCount);
+                    trackParcelService.incrementUpdateCount(userId, updatedCount);
+                }
+
+                String message;
+                if (updatedCount == 0 && nonUpdatableCount == 0) {
+                    message = "Все треки уже были обновлены ранее.";
+                } else if (updatedCount == 0) {
+                    message = "Обновление завершено, но все треки уже в финальном статусе.";
+                } else {
+                    message = "Обновление завершено! " + updatedCount + " из " + totalRequested + " треков обновлено.";
+                    if (nonUpdatableCount > 0) {
+                        message += " " + nonUpdatableCount + " треков уже были в финальном статусе.";
+                    }
+                }
+
+                webSocketController.sendDetailUpdateStatus(
+                        userId,
+                        new UpdateResult(true, updatedCount, totalRequested, message)
+                );
+            });
+
+        } catch (Exception e) {
+            log.error("Ошибка при обновлении посылок для пользователя {}: {}", userId, e.getMessage());
+            webSocketController.sendUpdateStatus(userId, "Ошибка обновления: " + e.getMessage(), false);
+        }
+    }
+

--- a/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingNumberServiceXLS.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.model.TrackingResponse;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.track.TrackFacade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 public class TrackingNumberServiceXLS {
 
     private final TrackParcelService trackParcelService;
+    private final TrackFacade trackFacade;
     private final SubscriptionService subscriptionService;
     private final StoreService storeService;
     private final ExecutorService executor = Executors.newFixedThreadPool(5);
@@ -225,7 +227,7 @@ public class TrackingNumberServiceXLS {
     private TrackingResultAdd processSingleTracking(String trackingNumber, Long storeId, Long userId, boolean canSave) {
         try {
             // Используем processTrack для получения данных и сохранения, если необходимо
-            TrackInfoListDTO trackInfo = trackParcelService.processTrack(trackingNumber, storeId, userId, canSave);
+            TrackInfoListDTO trackInfo = trackFacade.processTrack(trackingNumber, storeId, userId, canSave);
 
             String lastStatus = trackInfo.getList().get(0).getInfoTrack();
             log.debug("Трек-номер: {}, последний статус: {}", trackingNumber, lastStatus);


### PR DESCRIPTION
## Summary
- create `TrackFacade` to unify track operations
- delegate track updates and deletions through the facade
- remove duplicate methods from `TrackUpdateService`
- update controllers and OCR/XLS services to use the facade

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e946dfbd4832d9f786908fb5fd35c