### PR TITLE
Replace direct prints with structured logging

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPost.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPost.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class WebBelPost {
 
     private final WebDriverFactory webDriverFactory;
@@ -100,7 +102,7 @@ public class WebBelPost {
                 trackInfoListDTO.addTrackInfo(trackInfoDTO);
             }
         } catch (Exception e) {
-            System.err.println("Error: " + e.getMessage());
+            log.error("Ошибка веб-автоматизации BelPost: {}", e.getMessage(), e);
         } finally {
             if (driver != null) {
                 driver.quit();

--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -142,7 +142,7 @@ public class PasswordResetService {
             ZonedDateTime expiration = tokenEntity.getExpirationDate();
             return expiration.isAfter(now);
         }
-        System.out.println("Токен не найден");
+        log.warn("Токен не найден в базе данных");
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- log a warning when token is absent
- log BelPost automation errors instead of printing

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eaaf38bb0832d9b9e8ff2c310812b