### PR TITLE
Configure Tesseract datapath

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Belpost and Evropost
 ## Конфигурация OpenCV
 
 В файле `application.properties` добавлено свойство `opencv.lib.path`, которое определяет путь к нативной библиотеке OpenCV. По умолчанию используется `/usr/lib/jni/libopencv_java4100.so`.
+
+## Конфигурация Tesseract
+
+Для работы OCR-сервиса в `application.properties` необходимо указать путь к каталогу с данными Tesseract через свойство `tesseract.datapath`. По умолчанию используется `/usr/local/share/tessdata`.

--- a/src/main/java/com/project/tracking_system/service/track/TrackNumberOcrService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackNumberOcrService.java
@@ -43,6 +43,9 @@ public class TrackNumberOcrService {
     @Value("${opencv.lib.path}")
     private String opencvLibPath;
 
+    @Value("${tesseract.datapath}")
+    private String tesseractDataPath;
+
     /**
      * Инициализация библиотеки OpenCV.
      */
@@ -109,7 +112,7 @@ public class TrackNumberOcrService {
      */
     public String recognizeText(BufferedImage image) throws TesseractException {
         Tesseract tesseract = new Tesseract();
-        tesseract.setDatapath("/usr/local/share/tessdata");
+        tesseract.setDatapath(tesseractDataPath);
         tesseract.setLanguage("rus+eng");
         tesseract.setVariable("user_defined_dpi", "300");
         tesseract.setPageSegMode(3);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,6 @@ spring.web.resources.static-locations=classpath:/static/
 
 # Путь к нативной библиотеке OpenCV
 opencv.lib.path=/usr/lib/jni/libopencv_java4100.so
+
+# Каталог с данными для Tesseract
+tesseract.datapath=/usr/local/share/tessdata


### PR DESCRIPTION
## Summary
- expose `tesseract.datapath` in properties
- inject datapath property in `TrackNumberOcrService`
- use the injected value when initializing Tesseract
- document the new configuration option in README

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684eac67ae08832d930803135e59c21c