### PR TITLE
Mask email addresses in logs

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -96,7 +96,7 @@ public class SecurityConfiguration {
                             if (loginAttemptService.checkAndRedirect(request, response, email, ip)) return;
 
                             loginAttemptService.loginFailed(email, ip);
-                            log.info("Неудачная попытка входа: email={}, IP={}", email, ip);
+                            log.info("Неудачная попытка входа: email={}, IP={}", com.project.tracking_system.utils.EmailUtils.maskEmail(email), ip);
                             response.sendRedirect("/login?error=true");
                         })
                 )

--- a/src/main/java/com/project/tracking_system/service/email/EmailService.java
+++ b/src/main/java/com/project/tracking_system/service/email/EmailService.java
@@ -10,6 +10,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import com.project.tracking_system.utils.EmailUtils;
 
 import java.util.Map;
 
@@ -41,10 +42,10 @@ public class EmailService {
      * @param confirmationCode Код подтверждения.
      */
     public void sendConfirmationEmail(String to, String confirmationCode) {
-        log.info("📨 Генерация email для: {} с кодом {}", to, confirmationCode);
+        log.info("📨 Генерация email для: {} с кодом {}", EmailUtils.maskEmail(to), confirmationCode);
 
         if (!isValidEmail(to)) {
-            log.warn("⚠ Неверный формат email: {}", to);
+            log.warn("⚠ Неверный формат email: {}", EmailUtils.maskEmail(to));
             return;
         }
 
@@ -67,7 +68,7 @@ public class EmailService {
      */
     public void sendPasswordResetEmail(String to, String resetLink) {
         if (!isValidEmail(to)) {
-            log.warn("⚠ Неверный формат email: {}", to);
+            log.warn("⚠ Неверный формат email: {}", EmailUtils.maskEmail(to));
             return;
         }
 
@@ -90,12 +91,12 @@ public class EmailService {
      */
     @Async
     public void sendHtmlEmailAsync(String to, String subject, String content) {
-        log.info("📧 Начинаем отправку email на {}", to);
+        log.info("📧 Начинаем отправку email на {}", EmailUtils.maskEmail(to));
 
         try {
             MimeMessage message = createMimeMessage(to, subject, content);
             emailSender.send(message);
-            log.info("✅ Email успешно отправлен на {}", to);
+            log.info("✅ Email успешно отправлен на {}", EmailUtils.maskEmail(to));
         } catch (MessagingException e) {
             log.error("❌ Ошибка при отправке email: {}", e.getMessage(), e);
         }

--- a/src/main/java/com/project/tracking_system/service/user/LoginAttemptService.java
+++ b/src/main/java/com/project/tracking_system/service/user/LoginAttemptService.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.entity.LoginAttempt;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.LoginAttemptRepository;
 import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.utils.EmailUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +66,7 @@ public class LoginAttemptService {
         ipAttempts.remove(ip);
         blockedIPs.remove(ip);
 
-        log.info("Пользователь {} успешно вошел. IP {} разблокирован.", email, ip);
+        log.info("Пользователь {} успешно вошел. IP {} разблокирован.", EmailUtils.maskEmail(email), ip);
     }
 
     public boolean isIPBlocked(String ip) {
@@ -209,7 +210,7 @@ public class LoginAttemptService {
         }
 
         if (email != null && isEmailBlocked(email)) {
-            log.warn("Блокировка по email: {} (Попытка входа заблокирована)", email);
+            log.warn("Блокировка по email: {} (Попытка входа заблокирована)", EmailUtils.maskEmail(email));
             response.sendRedirect("/login?blocked=true");
             return true;
         }

--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.PasswordResetTokenRepository;
 import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.service.email.EmailService;
+import com.project.tracking_system.utils.EmailUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,26 +51,26 @@ public class PasswordResetService {
      */
     @Transactional
     public void createPasswordResetToken(String email) {
-        log.info("Начало процесса генерации токена сброса пароля для {}", email);
+        log.info("Начало процесса генерации токена сброса пароля для {}", EmailUtils.maskEmail(email));
 
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> {
-                    log.warn("❌ Пользователь с email {} не найден", email);
+                    log.warn("❌ Пользователь с email {} не найден", EmailUtils.maskEmail(email));
                     return new UsernameNotFoundException("Пользователь с email " + email + " не найден");
                 });
 
-        log.info("✅ Пользователь {} найден. Генерируем токен...", user.getEmail());
+        log.info("✅ Пользователь {} найден. Генерируем токен...", EmailUtils.maskEmail(user.getEmail()));
 
         String token = randomStringGenerator.generateConfirmCodRegistration();
         String resetLink = LINK + token;
 
-        log.debug("🔑 Сгенерирован токен: {} для email {}", token, email);
+        log.debug("🔑 Сгенерирован токен: {} для email {}", token, EmailUtils.maskEmail(email));
 
         saveOrUpdatePasswordResetToken(email, token);
 
-        log.info("📧 Отправка email для сброса пароля пользователю {}", email);
+        log.info("📧 Отправка email для сброса пароля пользователю {}", EmailUtils.maskEmail(email));
         emailService.sendPasswordResetEmail(email, resetLink);
-        log.info("Процесс генерации токена для {} успешно завершён", email);
+        log.info("Процесс генерации токена для {} успешно завершён", EmailUtils.maskEmail(email));
     }
 
     /**
@@ -79,13 +80,13 @@ public class PasswordResetService {
         tokenRepository.findByEmail(email)
                 .ifPresentOrElse(
                         existingToken -> {
-                            log.info("♻️ Обновление существующего токена для email {}", email);
+                            log.info("♻️ Обновление существующего токена для email {}", EmailUtils.maskEmail(email));
                             existingToken.setToken(token);
                             existingToken.setExpirationDate(ZonedDateTime.now(ZoneOffset.UTC).plusHours(1));
                             tokenRepository.save(existingToken);
                         },
                         () -> {
-                            log.info("🆕 Создание нового токена для email {}", email);
+                            log.info("🆕 Создание нового токена для email {}", EmailUtils.maskEmail(email));
                             PasswordResetToken newToken = new PasswordResetToken(email, token);
                             tokenRepository.save(newToken);
                         }
@@ -122,7 +123,7 @@ public class PasswordResetService {
         userRepository.save(user);
         tokenRepository.deleteByToken(token);
 
-        log.info("Пароль для пользователя {} успешно сброшен", email);
+        log.info("Пароль для пользователя {} успешно сброшен", EmailUtils.maskEmail(email));
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/user/RegistrationService.java
+++ b/src/main/java/com/project/tracking_system/service/user/RegistrationService.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.service.user;
 
 import com.project.tracking_system.dto.UserRegistrationDTO;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
+import com.project.tracking_system.utils.EmailUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class RegistrationService {
     public boolean isInitialStep(UserRegistrationDTO userDTO) {
         boolean initial = userDTO.getConfirmCodRegistration() == null
                 || userDTO.getConfirmCodRegistration().isEmpty();
-        log.debug("Проверка первого шага регистрации для {}: {}", userDTO.getEmail(), initial);
+        log.debug("Проверка первого шага регистрации для {}: {}", EmailUtils.maskEmail(userDTO.getEmail()), initial);
         return initial;
     }
 
@@ -43,21 +44,21 @@ public class RegistrationService {
      */
     public boolean handleInitialStep(UserRegistrationDTO userDTO, BindingResult result)
             throws UserAlreadyExistsException {
-        log.info("Старт первичной регистрации пользователя: {}", userDTO.getEmail());
+        log.info("Старт первичной регистрации пользователя: {}", EmailUtils.maskEmail(userDTO.getEmail()));
 
         if (result.hasFieldErrors("email") || result.hasFieldErrors("password")
                 || result.hasFieldErrors("confirmPassword") || result.hasFieldErrors("agreeToTerms")) {
-            log.debug("Ошибки валидации формы регистрации для {}", userDTO.getEmail());
+            log.debug("Ошибки валидации формы регистрации для {}", EmailUtils.maskEmail(userDTO.getEmail()));
             return false;
         }
         if (!userDTO.getPassword().equals(userDTO.getConfirmPassword())) {
-            log.warn("Пароли не совпадают для {}", userDTO.getEmail());
+            log.warn("Пароли не совпадают для {}", EmailUtils.maskEmail(userDTO.getEmail()));
             result.rejectValue("confirmPassword", "password.mismatch", "Пароли не совпадают");
             return false;
         }
 
         userService.sendConfirmationCode(userDTO);
-        log.info("Код подтверждения отправлен пользователю {}", userDTO.getEmail());
+        log.info("Код подтверждения отправлен пользователю {}", EmailUtils.maskEmail(userDTO.getEmail()));
         return true;
     }
 
@@ -67,7 +68,7 @@ public class RegistrationService {
      * @param userDTO данные пользователя с кодом подтверждения
      */
     public void confirm(UserRegistrationDTO userDTO) {
-        log.info("Подтверждение регистрации для {}", userDTO.getEmail());
+        log.info("Подтверждение регистрации для {}", EmailUtils.maskEmail(userDTO.getEmail()));
         userService.confirmRegistration(userDTO);
     }
 }

--- a/src/main/java/com/project/tracking_system/utils/EmailUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/EmailUtils.java
@@ -1,0 +1,28 @@
+package com.project.tracking_system.utils;
+
+/**
+ * Утилиты для работы с email.
+ */
+public final class EmailUtils {
+
+    private EmailUtils() {
+    }
+
+    /**
+     * Маскирует email, оставляя первые четыре символа и скрывая остальную часть локальной части.
+     *
+     * @param email исходный email
+     * @return маскированный email, либо исходную строку, если email некорректен
+     */
+    public static String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return email;
+        }
+
+        String[] parts = email.split("@", 2);
+        String local = parts[0];
+        String domain = parts[1];
+        String visible = local.length() <= 4 ? local : local.substring(0, 4);
+        return visible + "***@" + domain;
+    }
+}


### PR DESCRIPTION
## Summary
- create `EmailUtils` with helper to mask addresses
- apply masking to email logging in user-related services
- mask email in login failure log

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684edde337cc832da612d4ac8468e1be