### PR TITLE
Fix logging for sensitive data

### DIFF
--- a/src/main/java/com/project/tracking_system/service/email/EmailService.java
+++ b/src/main/java/com/project/tracking_system/service/email/EmailService.java
@@ -42,7 +42,8 @@ public class EmailService {
      * @param confirmationCode Код подтверждения.
      */
     public void sendConfirmationEmail(String to, String confirmationCode) {
-        log.info("📨 Генерация email для: {} с кодом {}", EmailUtils.maskEmail(to), confirmationCode);
+        // Логируем только email без кода подтверждения
+        log.info("📨 Генерация email для: {}", EmailUtils.maskEmail(to));
 
         if (!isValidEmail(to)) {
             log.warn("⚠ Неверный формат email: {}", EmailUtils.maskEmail(to));

--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -64,7 +64,8 @@ public class PasswordResetService {
         String token = randomStringGenerator.generateConfirmCodRegistration();
         String resetLink = LINK + token;
 
-        log.debug("🔑 Сгенерирован токен: {} для email {}", token, EmailUtils.maskEmail(email));
+        // Не выводим значение токена в лог по соображениям безопасности
+        log.debug("🔑 Сгенерирован токен для email {}", EmailUtils.maskEmail(email));
 
         saveOrUpdatePasswordResetToken(email, token);
 


### PR DESCRIPTION
## Summary
- avoid logging confirmation code in `EmailService.sendConfirmationEmail`
- remove password reset token from debug logs

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684ee360a240832d99801ba8b56729e5