### PR TITLE
Add dedicated executor for track updates

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 
 import java.util.concurrent.Executor;
 
@@ -37,6 +38,26 @@ public class AsyncConfig {
         executor.setMaxPoolSize(10); // максимальное количество потоков
         executor.setQueueCapacity(100); // размер очереди задач
         executor.setThreadNamePrefix("Post"); // префикс для имен потоков
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Создаёт пул потоков для {@link com.project.tracking_system.service.track.TrackUpdateService}.
+     * <p>
+     * Используется только для обновления треков, чтобы разграничить нагрузку от других
+     * асинхронных задач.
+     * </p>
+     *
+     * @return настроенный {@link TaskExecutor} для сервиса обновления треков
+     */
+    @Bean(name = "trackExecutor")
+    public TaskExecutor trackExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5); // минимальное количество потоков
+        executor.setMaxPoolSize(10); // максимальное количество потоков
+        executor.setQueueCapacity(100); // размер очереди задач
+        executor.setThreadNamePrefix("TrackUpdate-"); // префикс для имен потоков
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -22,6 +22,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Сервис обновления треков пользователей.
+ * <p>
+ * Для асинхронной обработки используется отдельный пул {@code trackExecutor},
+ * что разгружает общий исполнитель задач и повышает масштабируемость.
+ * </p>
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -35,7 +39,8 @@ public class TrackUpdateService {
     private final TrackParcelRepository trackParcelRepository;
     private final TrackParcelService trackParcelService;
     private final UserService userService;
-    @Qualifier("Post")
+    /** Исполнитель задач для обновления треков */
+    @Qualifier("trackExecutor")
     private final TaskExecutor taskExecutor;
 
     /**
@@ -81,7 +86,7 @@ public class TrackUpdateService {
     /**
      * Асинхронно обновляет все треки пользователя.
      */
-    @Async("Post")
+    @Async("trackExecutor")
     @Transactional
     public void processAllTrackUpdatesAsync(Long userId, List<TrackParcelDTO> parcelsToUpdate) {
         try {
@@ -184,7 +189,7 @@ public class TrackUpdateService {
     /**
      * Асинхронно обновляет выбранный список посылок пользователя.
      */
-    @Async("Post")
+    @Async("trackExecutor")
     @Transactional
     public void processTrackUpdatesAsync(Long userId, List<TrackParcel> parcelsToUpdate, int totalRequested, int nonUpdatableCount) {
         try {


### PR DESCRIPTION
## Summary
- provide trackExecutor bean for TrackUpdateService
- inject trackExecutor into TrackUpdateService
- document new executor
- use trackExecutor for async track update methods

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2b7fc544832da986b38351ebfd6a