### PR TITLE
Add customer tracking service

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -2,9 +2,18 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 /**
  * Репозиторий для работы с сущностью {@link Customer}.
  */
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+    /**
+     * Найти покупателя по номеру телефона.
+     *
+     * @param phone номер телефона в формате 375XXXXXXXXX
+     * @return найденный покупатель или {@link java.util.Optional#empty()}
+     */
+    Optional<Customer> findByPhone(String phone);
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -1,0 +1,96 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.utils.PhoneUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Сервис управления покупателями.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerService {
+
+    private final CustomerRepository customerRepository;
+
+    /**
+     * Зарегистрировать нового покупателя или получить существующего по телефону.
+     *
+     * @param rawPhone телефон в произвольном формате
+     * @return сущность покупателя
+     */
+    @Transactional
+    public Customer registerOrGetByPhone(String rawPhone) {
+        String phone = PhoneUtils.normalizePhone(rawPhone);
+        Optional<Customer> existing = customerRepository.findByPhone(phone);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+        Customer customer = new Customer();
+        customer.setPhone(phone);
+        Customer saved = customerRepository.save(customer);
+        log.info("Создан новый покупатель с номером {}", phone);
+        return saved;
+    }
+
+    /**
+     * Увеличить счётчик отправленных посылок для покупателя.
+     *
+     * @param track посылка, связанная с покупателем
+     */
+    @Transactional
+    public void updateStatsOnTrackAdd(TrackParcel track) {
+        if (track == null || track.getCustomer() == null) {
+            return;
+        }
+        Customer customer = track.getCustomer();
+        customer.setSentCount(customer.getSentCount() + 1);
+        customer.recalculateReputation();
+        customerRepository.save(customer);
+    }
+
+    /**
+     * Увеличить счётчик забранных посылок при доставке.
+     *
+     * @param track посылка, связанная с покупателем
+     */
+    @Transactional
+    public void updateStatsOnTrackDelivered(TrackParcel track) {
+        if (track == null || track.getCustomer() == null) {
+            return;
+        }
+        Customer customer = track.getCustomer();
+        customer.setPickedUpCount(customer.getPickedUpCount() + 1);
+        customer.recalculateReputation();
+        customerRepository.save(customer);
+    }
+
+    /**
+     * Откатить статистику при удалении посылки.
+     *
+     * @param track удаляемая посылка
+     */
+    @Transactional
+    public void rollbackStatsOnTrackDelete(TrackParcel track) {
+        if (track == null || track.getCustomer() == null) {
+            return;
+        }
+        Customer customer = track.getCustomer();
+        if (customer.getSentCount() > 0) {
+            customer.setSentCount(customer.getSentCount() - 1);
+        }
+        if (track.getStatus() != null && track.getStatus().isFinal() && customer.getPickedUpCount() > 0) {
+            customer.setPickedUpCount(customer.getPickedUpCount() - 1);
+        }
+        customer.recalculateReputation();
+        customerRepository.save(customer);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `CustomerRepository` with phone lookup
- add `CustomerService` with methods for customer registration and stats updates

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f42032878832d9a3b65cf49ce622d