### PR TITLE
Implement customer linkage for parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackFacade.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackFacade.java
@@ -38,6 +38,24 @@ public class TrackFacade {
     }
 
     /**
+     * Обрабатывает трек-номер с привязкой покупателя.
+     *
+     * @param number  номер трека
+     * @param storeId идентификатор магазина
+     * @param userId  идентификатор пользователя
+     * @param canSave признак возможности сохранения
+     * @param phone   телефон покупателя
+     * @return информация о треке
+     */
+    public TrackInfoListDTO processTrack(String number,
+                                         Long storeId,
+                                         Long userId,
+                                         boolean canSave,
+                                         String phone) {
+        return trackProcessingService.processTrack(number, storeId, userId, canSave, phone);
+    }
+
+    /**
      * Запускает обновление всех треков пользователя.
      *
      * @param userId идентификатор пользователя


### PR DESCRIPTION
## Summary
- link parcels to customers in `TrackProcessingService`
- expose new overloads for processing tracks with customer phone
- update delivery history logic to register customer stats on delivery
- roll back customer counters when non-final parcel is deleted

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4304b014832da5bfc676f5c0b00e