### PR TITLE
Add integration tests for customer service

### DIFF
--- a/src/test/java/com/project/tracking_system/customer/CustomerServiceTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerServiceTest.java
@@ -1,0 +1,66 @@
+package com.project.tracking_system.customer;
+
+import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.service.customer.CustomerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Интеграционные тесты для {@link CustomerService}.
+ */
+@DataJpaTest
+@Import(CustomerService.class)
+class CustomerServiceTest {
+
+    @Autowired
+    private CustomerService customerService;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void registerOrGetByPhoneCreatesCustomer() {
+        Customer created = customerService.registerOrGetByPhone("29 123-45-67");
+        assertNotNull(created.getId());
+        assertEquals("375291234567", created.getPhone());
+        Customer fromDb = customerRepository.findById(created.getId()).orElseThrow();
+        assertEquals(created.getId(), fromDb.getId());
+    }
+
+    @Test
+    void statsUpdatedOnAddDeliverAndDelete() {
+        Customer customer = customerService.registerOrGetByPhone("291234567");
+        TrackParcel track = new TrackParcel();
+        track.setCustomer(customer);
+
+        // Добавляем посылку
+        customerService.updateStatsOnTrackAdd(track);
+        Customer afterAdd = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(1, afterAdd.getSentCount());
+        assertEquals(0, afterAdd.getPickedUpCount());
+        assertEquals(BuyerReputation.NEUTRAL, afterAdd.getReputation());
+
+        // Доставляем посылку
+        track.setStatus(GlobalStatus.DELIVERED);
+        customerService.updateStatsOnTrackDelivered(track);
+        Customer afterDeliver = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(1, afterDeliver.getSentCount());
+        assertEquals(1, afterDeliver.getPickedUpCount());
+        assertEquals(BuyerReputation.RELIABLE, afterDeliver.getReputation());
+
+        // Удаляем посылку
+        customerService.rollbackStatsOnTrackDelete(track);
+        Customer afterDelete = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(0, afterDelete.getSentCount());
+        assertEquals(0, afterDelete.getPickedUpCount());
+        assertEquals(BuyerReputation.NEUTRAL, afterDelete.getReputation());
+    }
+}

--- a/src/test/java/com/project/tracking_system/customer/PhoneNormalizationEdgeCasesTest.java
+++ b/src/test/java/com/project/tracking_system/customer/PhoneNormalizationEdgeCasesTest.java
@@ -1,0 +1,34 @@
+package com.project.tracking_system.customer;
+
+import com.project.tracking_system.utils.PhoneUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Дополнительные сценарии нормализации номера телефона.
+ */
+class PhoneNormalizationEdgeCasesTest {
+
+    @Test
+    void normalizeNumberStartingWithZero() {
+        String normalized = PhoneUtils.normalizePhone("044 123-45-67");
+        assertEquals("375441234567", normalized);
+    }
+
+    @Test
+    void normalizeNumberWithoutPrefix() {
+        String normalized = PhoneUtils.normalizePhone("291234567");
+        assertEquals("375291234567", normalized);
+    }
+
+    @Test
+    void nullNumberShouldThrow() {
+        assertThrows(IllegalArgumentException.class, () -> PhoneUtils.normalizePhone(null));
+    }
+
+    @Test
+    void blankNumberShouldThrow() {
+        assertThrows(IllegalArgumentException.class, () -> PhoneUtils.normalizePhone("   "));
+    }
+}


### PR DESCRIPTION
## Summary
- cover phone normalization edge cases
- verify customer creation via CustomerService
- test reputation and counters update on parcel events

## Testing
- `./mvnw test -q` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_684f48cdca30832d84419961e3a05544