### PR TITLE
Add customer info popup to parcels page

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/CustomerController.java
+++ b/src/main/java/com/project/tracking_system/controller/CustomerController.java
@@ -1,0 +1,38 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.CustomerInfoDTO;
+import com.project.tracking_system.service.customer.CustomerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Контроллер для получения информации о покупателях.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/customers")
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    /**
+     * Возвращает данные покупателя по идентификатору посылки.
+     *
+     * @param parcelId идентификатор посылки
+     * @param model    модель для передачи данных во фрагмент
+     * @return имя Thymeleaf-фрагмента
+     */
+    @GetMapping("/parcel/{parcelId}")
+    public String getCustomerByParcelId(@PathVariable Long parcelId, Model model) {
+        CustomerInfoDTO dto = customerService.getCustomerInfoByParcelId(parcelId);
+        model.addAttribute("customerInfo", dto);
+        model.addAttribute("notFound", dto == null);
+        return "partials/customer-info";
+    }
+}

--- a/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
@@ -1,0 +1,20 @@
+package com.project.tracking_system.dto;
+
+import com.project.tracking_system.entity.BuyerReputation;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Информация о покупателе, связанная с посылкой.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerInfoDTO {
+    private String phone;
+    private int sentCount;
+    private int pickedUpCount;
+    private double pickupPercentage;
+    private BuyerReputation reputation;
+}

--- a/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 @AllArgsConstructor
 @Data
 public class TrackParcelDTO {
+    private Long id;
     private String number;
     private String status;
     private String data;
@@ -21,6 +22,7 @@ public class TrackParcelDTO {
     private Long storeId;
 
     public TrackParcelDTO(TrackParcel trackParcel, ZoneId userZone) {
+        this.id = trackParcel.getId();
         this.number = trackParcel.getNumber();
         this.status = trackParcel.getStatus().getDescription();
         this.storeId = trackParcel.getStore().getId();

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1313,6 +1313,29 @@ body.loading {
   font-size: 2rem;
 }
 
+.customer-icon {
+  font-size: 1.2rem;
+  color: #6c757d;
+  margin-left: 0.5rem;
+  transition: color 0.3s ease-in-out;
+}
+
+.customer-icon:hover {
+  color: #0d6efd;
+}
+
+.reputation-reliable {
+  color: #198754;
+}
+
+.reputation-unreliable {
+  color: #dc3545;
+}
+
+.reputation-neutral {
+  color: #6c757d;
+}
+
 .delivered {
   color: #008000;
 }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -57,6 +57,23 @@ function loadModal(itemNumber) {
         .catch(() => notifyUser('Ошибка при загрузке данных', "danger"));
 }
 
+function loadCustomerInfo(trackId) {
+    if (!trackId) return;
+    fetch(`/customers/parcel/${trackId}`)
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Ошибка при загрузке данных');
+            }
+            return response.text();
+        })
+        .then(data => {
+            document.querySelector('#customerModal .modal-body').innerHTML = data;
+            let modal = new bootstrap.Modal(document.getElementById('customerModal'));
+            modal.show();
+        })
+        .catch(() => notifyUser('Ошибка при загрузке данных', 'danger'));
+}
+
 // Общая функция для отправки формы через AJAX
 function ajaxSubmitForm(formId, containerId, afterLoadCallbacks = []) {
     const form = document.getElementById(formId);
@@ -937,6 +954,14 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     document.body.addEventListener("click", function (event) {
+        if (event.target.closest(".customer-icon")) {
+            const icon = event.target.closest(".customer-icon");
+            const trackId = icon.getAttribute("data-trackid");
+            loadCustomerInfo(trackId);
+        }
+    });
+
+    document.body.addEventListener("click", function (event) {
         if (event.target.closest(".btn-link")) {
             const button = event.target.closest(".btn-link");
             const itemNumber = button.getAttribute("data-itemnumber");
@@ -954,6 +979,18 @@ document.addEventListener("DOMContentLoaded", function () {
             }
             document.body.classList.remove('modal-open'); // Убираем класс, если остался
             document.body.style.overflow = ''; // Восстанавливаем прокрутку
+        });
+    }
+
+    let customerModalElement = document.getElementById('customerModal');
+    if (customerModalElement) {
+        customerModalElement.addEventListener('hidden.bs.modal', function () {
+            let backdrop = document.querySelector('.modal-backdrop');
+            if (backdrop) {
+                backdrop.remove();
+            }
+            document.body.classList.remove('modal-open');
+            document.body.style.overflow = '';
         });
     }
 

--- a/src/main/resources/templates/departures.html
+++ b/src/main/resources/templates/departures.html
@@ -104,7 +104,7 @@
                                     </tr>
                                     </thead>
                                     <tbody>
-                                    <tr th:each="item : ${trackParcelDTO}" th:attr="data-track-number=${item.number}">
+                                    <tr th:each="item : ${trackParcelDTO}" th:attr="data-track-number=${item.number},data-track-id=${item.id}">
                                     <td class="checkbox-column">
                                             <input type="checkbox" class="selectCheckbox" th:value="${item.number}" name="selectedNumbers">
                                         </td>
@@ -119,6 +119,10 @@
                                                         th:data-itemnumber="${item.number}"
                                                         aria-label="Открыть детали посылки">
                                                 </button>
+                                                <span class="customer-icon" role="button"
+                                                      th:data-trackid="${item.id}" aria-label="Информация о покупателе">
+                                                    <i class="bi bi-person-circle"></i>
+                                                </span>
                                             </div>
                                         </td>
                                         <td th:text="${item.status}" class="status-text"></td>
@@ -171,6 +175,21 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="infoModalLabel">Детали посылки</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+                </div>
+                <div class="modal-body">
+                    <!-- Данные загружаются через AJAX -->
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Модальное окно покупателя -->
+    <div class="modal fade" id="customerModal" tabindex="-1" aria-labelledby="customerModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="customerModalLabel">Информация о покупателе</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
                 </div>
                 <div class="modal-body">

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -1,0 +1,18 @@
+<div>
+    <div th:if="${notFound}">
+        <p>Покупатель не найден</p>
+    </div>
+    <div th:unless="${notFound}">
+        <ul class="list-group">
+            <li class="list-group-item"><strong>Телефон:</strong> <span th:text="${customerInfo.phone}"></span></li>
+            <li class="list-group-item"><strong>Отправлено:</strong> <span th:text="${customerInfo.sentCount}"></span></li>
+            <li class="list-group-item"><strong>Забрано:</strong> <span th:text="${customerInfo.pickedUpCount}"></span></li>
+            <li class="list-group-item"><strong>Процент выкупа:</strong> <span th:text="${customerInfo.pickupPercentage}"></span>%</li>
+            <li class="list-group-item">
+                <strong>Репутация:</strong>
+                <span th:text="${customerInfo.reputation}"
+                      th:class="${customerInfo.reputation == T(com.project.tracking_system.entity.BuyerReputation).RELIABLE ? 'reputation-reliable' : (customerInfo.reputation == T(com.project.tracking_system.entity.BuyerReputation).UNRELIABLE ? 'reputation-unreliable' : 'reputation-neutral')}"></span>
+            </li>
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- extend `TrackParcelDTO` with parcel ID
- provide `CustomerInfoDTO` and a new controller for fetching customer data
- implement service logic to load customer info by parcel ID
- update departures page to show customer icon and modal
- add new Thymeleaf fragment for customer info
- enhance JS and CSS for customer modal behaviour

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4b3322ec832dbe8bc8d4c4b44174