### PR TITLE
Add customer assignment flow

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/CustomerController.java
+++ b/src/main/java/com/project/tracking_system/controller/CustomerController.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * Контроллер для получения информации о покупателях.
@@ -33,6 +35,26 @@ public class CustomerController {
         CustomerInfoDTO dto = customerService.getCustomerInfoByParcelId(parcelId);
         model.addAttribute("customerInfo", dto);
         model.addAttribute("notFound", dto == null);
+        model.addAttribute("trackId", parcelId);
+        return "partials/customer-info";
+    }
+
+    /**
+     * Привязывает покупателя к посылке по номеру телефона.
+     *
+     * @param trackId идентификатор посылки
+     * @param phone   номер телефона покупателя
+     * @param model   модель для передачи данных во фрагмент
+     * @return HTML-фрагмент с обновлённой информацией о покупателе
+     */
+    @PostMapping("/assign")
+    public String assignCustomer(@RequestParam Long trackId,
+                                 @RequestParam String phone,
+                                 Model model) {
+        CustomerInfoDTO dto = customerService.assignCustomerToParcel(trackId, phone);
+        model.addAttribute("customerInfo", dto);
+        model.addAttribute("notFound", dto == null);
+        model.addAttribute("trackId", trackId);
         return "partials/customer-info";
     }
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -111,6 +111,24 @@ public class CustomerService {
                 .orElse(null);
     }
 
+    /**
+     * Привязать покупателя к посылке по телефону.
+     *
+     * @param parcelId идентификатор посылки
+     * @param rawPhone телефон покупателя
+     * @return обновлённая информация о покупателе
+     */
+    @Transactional
+    public CustomerInfoDTO assignCustomerToParcel(Long parcelId, String rawPhone) {
+        Customer customer = registerOrGetByPhone(rawPhone);
+        TrackParcel parcel = trackParcelRepository.findById(parcelId)
+                .orElseThrow(() -> new IllegalArgumentException("Посылка не найдена"));
+        parcel.setCustomer(customer);
+        trackParcelRepository.save(parcel);
+        updateStatsOnTrackAdd(parcel);
+        return toInfoDto(customer);
+    }
+
     private CustomerInfoDTO toInfoDto(Customer customer) {
         if (customer == null) {
             return null;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -167,6 +167,11 @@ function initializePhoneToggle() {
     }
 }
 
+// Инициализация формы привязки покупателя к посылке
+function initAssignCustomerFormHandler() {
+    ajaxSubmitForm('assign-customer-form', 'customerInfoContainer', [initAssignCustomerFormHandler]);
+}
+
 // Показать или скрыть поля
 function toggleFieldsVisibility(checkbox, fieldsContainer) {
     if (checkbox.checked) {
@@ -897,6 +902,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initEvropostFormHandler();
     initializeCustomCredentialsCheckbox();
     initializePhoneToggle();
+    initAssignCustomerFormHandler();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие
     const addStoreBtn = document.getElementById("addStoreBtn");

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -1,6 +1,14 @@
-<div>
+<div id="customerInfoContainer">
     <div th:if="${notFound}">
         <p>Покупатель не найден</p>
+        <form id="assign-customer-form" th:action="@{/customers/assign}" method="post" class="mt-3">
+            <input type="hidden" name="trackId" th:value="${trackId}">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <div class="input-group mb-2">
+                <input type="text" name="phone" class="form-control" placeholder="375XXXXXXXXX" required>
+                <button type="submit" class="btn btn-primary">Сохранить</button>
+            </div>
+        </form>
     </div>
     <div th:unless="${notFound}">
         <ul class="list-group">


### PR DESCRIPTION
## Summary
- enhance customer info partial with form to assign phone
- add endpoint for assigning customer to a parcel
- link parcel and customer in service layer
- submit assignment via AJAX

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f572e3830832d8b1ec28e4f359159