### PR TITLE
Improve customer reputation display

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
@@ -17,4 +17,22 @@ public class CustomerInfoDTO {
     private int pickedUpCount;
     private double pickupPercentage;
     private BuyerReputation reputation;
+
+    /**
+     * Получить отображаемое название репутации покупателя.
+     *
+     * @return строковое представление репутации
+     */
+    public String getReputationDisplayName() {
+        return reputation.getDisplayName();
+    }
+
+    /**
+     * Получить CSS-класс для отображения репутации.
+     *
+     * @return название класса для разметки
+     */
+    public String getColorClass() {
+        return reputation.getColorClass();
+    }
 }

--- a/src/main/java/com/project/tracking_system/entity/BuyerReputation.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerReputation.java
@@ -4,7 +4,36 @@ package com.project.tracking_system.entity;
  * Репутация покупателя в системе.
  */
 public enum BuyerReputation {
-    RELIABLE,
-    NEUTRAL,
-    UNRELIABLE
+    /** Надёжный покупатель. */
+    RELIABLE("Надёжный", "reputation-reliable"),
+    /** Нейтральный покупатель. */
+    NEUTRAL("Нейтральный", "reputation-neutral"),
+    /** Ненадёжный покупатель. */
+    UNRELIABLE("Ненадёжный", "reputation-unreliable");
+
+    private final String displayName;
+    private final String colorClass;
+
+    BuyerReputation(String displayName, String colorClass) {
+        this.displayName = displayName;
+        this.colorClass = colorClass;
+    }
+
+    /**
+     * Возвращает отображаемое название репутации.
+     *
+     * @return русскоязычное название репутации
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Возвращает CSS-класс для отображения репутации.
+     *
+     * @return имя CSS-класса
+     */
+    public String getColorClass() {
+        return colorClass;
+    }
 }

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -18,8 +18,8 @@
             <li class="list-group-item"><strong>Процент выкупа:</strong> <span th:text="${customerInfo.pickupPercentage}"></span>%</li>
             <li class="list-group-item">
                 <strong>Репутация:</strong>
-                <span th:text="${customerInfo.reputation}"
-                      th:class="${customerInfo.reputation == T(com.project.tracking_system.entity.BuyerReputation).RELIABLE ? 'reputation-reliable' : (customerInfo.reputation == T(com.project.tracking_system.entity.BuyerReputation).UNRELIABLE ? 'reputation-unreliable' : 'reputation-neutral')}"></span>
+                <span th:text="${customerInfo.reputationDisplayName}"
+                      th:class="${customerInfo.colorClass}"></span>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Summary
- add display name and CSS class fields to `BuyerReputation`
- expose helper methods in `CustomerInfoDTO`
- render display name and class in `customer-info.html`

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684f593091cc832d99dad06ae731a4c8