### PR TITLE
Handle unique phone conflict on customer save

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -8,6 +8,7 @@ import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.utils.PhoneUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,9 +40,14 @@ public class CustomerService {
         }
         Customer customer = new Customer();
         customer.setPhone(phone);
-        Customer saved = customerRepository.save(customer);
-        log.info("Создан новый покупатель с номером {}", phone);
-        return saved;
+        try {
+            Customer saved = customerRepository.save(customer);
+            log.info("Создан новый покупатель с номером {}", phone);
+            return saved;
+        } catch (DataIntegrityViolationException e) {
+            log.info("Покупатель с номером {} уже существует, выполняем повторный поиск", phone);
+            return customerRepository.findByPhone(phone).orElseThrow(() -> e);
+        }
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/customer/CustomerConcurrencyTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerConcurrencyTest.java
@@ -1,0 +1,56 @@
+package com.project.tracking_system.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.service.customer.CustomerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Проверка конкурентной регистрации одного и того же покупателя.
+ */
+@DataJpaTest
+@Import(CustomerService.class)
+class CustomerConcurrencyTest {
+
+    @Autowired
+    private CustomerService customerService;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void concurrentRegisterDoesNotDuplicateCustomer() throws Exception {
+        String phone = "291234567";
+        CountDownLatch latch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        Callable<Customer> task = () -> {
+            latch.await();
+            return customerService.registerOrGetByPhone(phone);
+        };
+
+        Future<Customer> first = executor.submit(task);
+        Future<Customer> second = executor.submit(task);
+        // Одновременно запускаем оба потока
+        latch.countDown();
+
+        Customer c1 = first.get(5, TimeUnit.SECONDS);
+        Customer c2 = second.get(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(c1.getId(), c2.getId());
+        assertEquals(1, customerRepository.count());
+    }
+}


### PR DESCRIPTION
## Summary
- avoid duplicate customer entries by catching `DataIntegrityViolationException`
- add integration test ensuring concurrent registration creates only one customer

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_684f59ebdd94832da68d75f9004f5d51