### PR TITLE
Implement Customer stats service

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -2,6 +2,10 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 /**
@@ -16,4 +20,34 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
      * @return найденный покупатель или {@link java.util.Optional#empty()}
      */
     Optional<Customer> findByPhone(String phone);
+
+    /**
+     * Атомарно увеличить счётчик отправленных посылок.
+     *
+     * @param id идентификатор покупателя
+     * @return количество обновлённых записей
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE Customer c
+        SET c.sentCount = c.sentCount + 1
+        WHERE c.id = :id
+        """)
+    int incrementSentCount(@Param("id") Long id);
+
+    /**
+     * Атомарно увеличить счётчик забранных посылок.
+     *
+     * @param id идентификатор покупателя
+     * @return количество обновлённых записей
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE Customer c
+        SET c.pickedUpCount = c.pickedUpCount + 1
+        WHERE c.id = :id
+        """)
+    int incrementPickedUpCount(@Param("id") Long id);
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.repository.PostalServiceDailyStatisticsReposi
 import com.project.tracking_system.service.track.StatusTrackService;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.customer.CustomerService;
+import com.project.tracking_system.service.customer.CustomerStatsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,7 @@ public class DeliveryHistoryService {
     private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
     private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
     private final CustomerService customerService;
+    private final CustomerStatsService customerStatsService;
 
     /**
      * Обновляет или создаёт запись {@link DeliveryHistory}, когда меняется статус посылки.
@@ -327,7 +329,9 @@ public class DeliveryHistoryService {
             updateDailyStats(store, history.getPostalService(), eventDate, status, deliveryDays, pickupDays);
         }
 
-        customerService.updateStatsOnTrackDelivered(trackParcel);
+        if (status == GlobalStatus.DELIVERED && trackParcel.getCustomer() != null) {
+            customerStatsService.incrementPickedUp(trackParcel.getCustomer());
+        }
 
         // флаг включён, дальнейшее обновление записей не требуется
 

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -26,6 +26,7 @@ public class CustomerService {
     private final CustomerRepository customerRepository;
     private final TrackParcelRepository trackParcelRepository;
     private final CustomerTransactionalService transactionalService;
+    private final CustomerStatsService customerStatsService;
 
     /**
      * Зарегистрировать нового покупателя или получить существующего по телефону.
@@ -68,10 +69,7 @@ public class CustomerService {
         if (track == null || track.getCustomer() == null) {
             return;
         }
-        Customer customer = track.getCustomer();
-        customer.setSentCount(customer.getSentCount() + 1);
-        customer.recalculateReputation();
-        customerRepository.save(customer);
+        customerStatsService.incrementSent(track.getCustomer());
     }
 
     /**
@@ -84,10 +82,7 @@ public class CustomerService {
         if (track == null || track.getCustomer() == null) {
             return;
         }
-        Customer customer = track.getCustomer();
-        customer.setPickedUpCount(customer.getPickedUpCount() + 1);
-        customer.recalculateReputation();
-        customerRepository.save(customer);
+        customerStatsService.incrementPickedUp(track.getCustomer());
     }
 
     /**
@@ -155,7 +150,7 @@ public class CustomerService {
         trackParcelRepository.save(parcel);
 
         // Статистику увеличиваем только при фактическом добавлении нового покупателя
-        updateStatsOnTrackAdd(parcel);
+        customerStatsService.incrementSent(newCustomer);
         return toInfoDto(newCustomer);
     }
 

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerStatsService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerStatsService.java
@@ -1,0 +1,76 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис для обновления статистики покупателя.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerStatsService {
+
+    private final CustomerRepository customerRepository;
+
+    /**
+     * Увеличить счётчик отправленных посылок покупателя.
+     *
+     * @param customer покупатель
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementSent(Customer customer) {
+        if (customer == null) {
+            return;
+        }
+        // Пытаемся атомарно увеличить счётчик
+        int updated = customerRepository.incrementSentCount(customer.getId());
+        if (updated == 0) {
+            // При неудаче загружаем сущность и обновляем вручную
+            Customer fresh = customerRepository.findById(customer.getId())
+                    .orElseThrow(() -> new IllegalStateException("Покупатель не найден"));
+            fresh.setSentCount(fresh.getSentCount() + 1);
+            fresh.recalculateReputation();
+            customerRepository.save(fresh);
+            // Синхронизируем переданный объект
+            customer.setSentCount(fresh.getSentCount());
+            customer.setReputation(fresh.getReputation());
+        } else {
+            customer.setSentCount(customer.getSentCount() + 1);
+            customer.recalculateReputation();
+        }
+    }
+
+    /**
+     * Увеличить счётчик забранных посылок покупателя.
+     *
+     * @param customer покупатель
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementPickedUp(Customer customer) {
+        if (customer == null) {
+            return;
+        }
+        // Атомарное обновление счётчика
+        int updated = customerRepository.incrementPickedUpCount(customer.getId());
+        if (updated == 0) {
+            // При неудаче читаем и обновляем вручную
+            Customer fresh = customerRepository.findById(customer.getId())
+                    .orElseThrow(() -> new IllegalStateException("Покупатель не найден"));
+            fresh.setPickedUpCount(fresh.getPickedUpCount() + 1);
+            fresh.recalculateReputation();
+            customerRepository.save(fresh);
+            // Обновляем переданный экземпляр
+            customer.setPickedUpCount(fresh.getPickedUpCount());
+            customer.setReputation(fresh.getReputation());
+        } else {
+            customer.setPickedUpCount(customer.getPickedUpCount() + 1);
+            customer.recalculateReputation();
+        }
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.repository.*;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.analytics.DeliveryHistoryService;
 import com.project.tracking_system.service.customer.CustomerService;
+import com.project.tracking_system.service.customer.CustomerStatsService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.utils.DateParserUtils;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class TrackProcessingService {
     private final SubscriptionService subscriptionService;
     private final DeliveryHistoryService deliveryHistoryService;
     private final CustomerService customerService;
+    private final CustomerStatsService customerStatsService;
     private final UserService userService;
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
@@ -194,8 +196,8 @@ public class TrackProcessingService {
 
         trackParcelRepository.save(trackParcel);
 
-        if (isNewParcel) {
-            customerService.updateStatsOnTrackAdd(trackParcel);
+        if (isNewParcel && customer != null) {
+            customerStatsService.incrementSent(customer);
         }
 
         boolean storeChanged = !isNewParcel && previousStoreId != null && !previousStoreId.equals(storeId);

--- a/src/test/java/com/project/tracking_system/customer/CustomerServiceTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerServiceTest.java
@@ -13,6 +13,8 @@ import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.StoreRepository;
 import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.service.customer.CustomerService;
+import com.project.tracking_system.service.customer.CustomerStatsService;
+import com.project.tracking_system.service.customer.CustomerTransactionalService;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Интеграционные тесты для {@link CustomerService}.
  */
 @DataJpaTest
-@Import(CustomerService.class)
+@Import({CustomerService.class, CustomerStatsService.class, CustomerTransactionalService.class})
 class CustomerServiceTest {
 
     @Autowired

--- a/src/test/java/com/project/tracking_system/customer/CustomerStatsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerStatsServiceTest.java
@@ -1,0 +1,82 @@
+package com.project.tracking_system.customer;
+
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.customer.CustomerStatsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Проверка инкрементов статистики покупателя.
+ */
+@DataJpaTest
+@Import(CustomerStatsService.class)
+class CustomerStatsServiceTest {
+
+    @Autowired
+    private CustomerStatsService customerStatsService;
+    @Autowired
+    private CustomerRepository customerRepository;
+    @Autowired
+    private TrackParcelRepository trackParcelRepository;
+    @Autowired
+    private StoreRepository storeRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void countersIncrementOncePerCall() {
+        // создаём покупателя и две посылки
+        Customer customer = new Customer();
+        customer.setPhone("375291234567");
+        customerRepository.save(customer);
+
+        User user = new User();
+        user.setEmail("stats@example.com");
+        user.setPassword("pass");
+        user.setRole(Role.ROLE_USER);
+        userRepository.save(user);
+
+        Store store = new Store();
+        store.setName("test");
+        store.setDefault(false);
+        store.setOwner(user);
+        storeRepository.save(store);
+
+        TrackParcel first = new TrackParcel();
+        first.setNumber("TR1");
+        first.setStatus(GlobalStatus.IN_TRANSIT);
+        first.setData(ZonedDateTime.now());
+        first.setStore(store);
+        first.setUser(user);
+        first.setCustomer(customer);
+        trackParcelRepository.save(first);
+
+        TrackParcel second = new TrackParcel();
+        second.setNumber("TR2");
+        second.setStatus(GlobalStatus.IN_TRANSIT);
+        second.setData(ZonedDateTime.now());
+        second.setStore(store);
+        second.setUser(user);
+        second.setCustomer(customer);
+        trackParcelRepository.save(second);
+
+        // инкрементируем отправленные два раза
+        customerStatsService.incrementSent(customer);
+        customerStatsService.incrementSent(customer);
+        Customer afterSent = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(2, afterSent.getSentCount());
+
+        // инкрементируем забранные два раза
+        customerStatsService.incrementPickedUp(customer);
+        customerStatsService.incrementPickedUp(customer);
+        Customer afterPickup = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(2, afterPickup.getPickedUpCount());
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `CustomerStatsService` to manage customer statistics
- extend `CustomerRepository` with atomic update operations
- delegate stat updates from `CustomerService`
- use `CustomerStatsService` when processing tracks and final delivery
- provide integration tests for the new service
- adjust existing tests for new dependencies

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500b793db8832d845f074b0da86885