### PR TITLE
Refine reputation enum

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
@@ -15,6 +15,7 @@ public class CustomerInfoDTO {
     private String phone;
     private int sentCount;
     private int pickedUpCount;
+    private int returnedCount;
     private double pickupPercentage;
     private BuyerReputation reputation;
 

--- a/src/main/java/com/project/tracking_system/entity/BuyerReputation.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerReputation.java
@@ -4,6 +4,8 @@ package com.project.tracking_system.entity;
  * Репутация покупателя в системе.
  */
 public enum BuyerReputation {
+    /** Репутация формируется. Недостаточно завершённых заказов. */
+    NEW("Формируется репутация", "reputation-new"),
     /** Надёжный покупатель. */
     RELIABLE("Надёжный", "reputation-reliable"),
     /** Нейтральный покупатель. */

--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -30,26 +30,34 @@ public class Customer {
     @Column(name = "picked_up_count", nullable = false)
     private int pickedUpCount = 0;
 
+    @Column(name = "returned_count", nullable = false)
+    private int returnedCount = 0;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "reputation", nullable = false)
-    private BuyerReputation reputation = BuyerReputation.NEUTRAL;
+    private BuyerReputation reputation = BuyerReputation.NEW;
 
     /**
-     * Пересчитать репутацию покупателя на основе количества отправленных
-     * и забранных им посылок.
+     * Пересчитать репутацию покупателя на основе завершённых заказов.
+     * <p>
+     * Репутация "Формируется" присваивается, если суммарно обработано
+     * меньше трёх посылок. Далее оценивается доля забранных заказов
+     * относительно всех завершённых (забранных + возвращённых).
+     * </p>
      */
     public void recalculateReputation() {
-        if (sentCount == 0) {
-            reputation = BuyerReputation.NEUTRAL;
+        int finished = pickedUpCount + returnedCount;
+        if (finished < 3) {
+            this.reputation = BuyerReputation.NEW;
             return;
         }
-        double rate = (double) pickedUpCount / sentCount;
-        if (rate >= 0.8) {
-            reputation = BuyerReputation.RELIABLE;
-        } else if (rate <= 0.3) {
-            reputation = BuyerReputation.UNRELIABLE;
+        double ratio = (double) pickedUpCount / finished;
+        if (ratio >= 0.8) {
+            this.reputation = BuyerReputation.RELIABLE;
+        } else if (ratio >= 0.5) {
+            this.reputation = BuyerReputation.NEUTRAL;
         } else {
-            reputation = BuyerReputation.NEUTRAL;
+            this.reputation = BuyerReputation.UNRELIABLE;
         }
     }
 }

--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -50,4 +50,19 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
         WHERE c.id = :id
         """)
     int incrementPickedUpCount(@Param("id") Long id);
+
+    /**
+     * Атомарно увеличить счётчик возвращённых посылок.
+     *
+     * @param id идентификатор покупателя
+     * @return количество обновлённых записей
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE Customer c
+        SET c.returnedCount = c.returnedCount + 1
+        WHERE c.id = :id
+        """)
+    int incrementReturnedCount(@Param("id") Long id);
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -331,6 +331,8 @@ public class DeliveryHistoryService {
 
         if (status == GlobalStatus.DELIVERED && trackParcel.getCustomer() != null) {
             customerStatsService.incrementPickedUp(trackParcel.getCustomer());
+        } else if (status == GlobalStatus.RETURNED && trackParcel.getCustomer() != null) {
+            customerStatsService.incrementReturned(trackParcel.getCustomer());
         }
 
         // флаг включён, дальнейшее обновление записей не требуется

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -194,6 +194,7 @@ public class CustomerService {
                 customer.getPhone(),
                 customer.getSentCount(),
                 customer.getPickedUpCount(),
+                customer.getReturnedCount(),
                 Math.round(percentage * 100.0) / 100.0,
                 customer.getReputation()
         );

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerStatsService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerStatsService.java
@@ -83,4 +83,34 @@ public class CustomerStatsService {
             customerRepository.save(customer);
         }
     }
+
+    /**
+     * Увеличить счётчик возвращённых посылок покупателя.
+     *
+     * @param customer покупатель
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementReturned(Customer customer) {
+        if (customer == null) {
+            return;
+        }
+        log.debug("🔄 Попытка атомарного увеличения возвратов для customerId={}", customer.getId());
+        int updated = customerRepository.incrementReturnedCount(customer.getId());
+        if (updated == 0) {
+            log.warn("⚠️ Не удалось атомарно обновить возвраты для customerId={}, переключаемся на ручной режим", customer.getId());
+            Customer fresh = customerRepository.findById(customer.getId())
+                    .orElseThrow(() -> new IllegalStateException("Покупатель не найден"));
+            fresh.setReturnedCount(fresh.getReturnedCount() + 1);
+            fresh.recalculateReputation();
+            customerRepository.save(fresh);
+            customer.setReturnedCount(fresh.getReturnedCount());
+            customer.setReputation(fresh.getReputation());
+            log.debug("✅ Счётчик возвратов вручную увеличен для customerId={}", customer.getId());
+        } else {
+            log.debug("✅ Атомарное увеличение возвратов успешно для customerId={}", customer.getId());
+            customer.setReturnedCount(customer.getReturnedCount() + 1);
+            customer.recalculateReputation();
+            customerRepository.save(customer);
+        }
+    }
 }

--- a/src/main/resources/db/migration/V13__add_returned_count_to_customers.sql
+++ b/src/main/resources/db/migration/V13__add_returned_count_to_customers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tb_customers ADD COLUMN returned_count INTEGER NOT NULL DEFAULT 0;

--- a/src/test/java/com/project/tracking_system/customer/CustomerReputationTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerReputationTest.java
@@ -1,0 +1,31 @@
+package com.project.tracking_system.customer;
+
+import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.Customer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Проверка расчёта репутации покупателя.
+ */
+class CustomerReputationTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "0,0,NEW",
+            "2,0,NEW",
+            "2,1,NEUTRAL",
+            "4,1,RELIABLE",
+            "2,2,NEUTRAL",
+            "1,3,UNRELIABLE"
+    })
+    void reputationCalculatedCorrectly(int pickedUp, int returned, BuyerReputation expected) {
+        Customer customer = new Customer();
+        customer.setPickedUpCount(pickedUp);
+        customer.setReturnedCount(returned);
+        customer.recalculateReputation();
+        assertEquals(expected, customer.getReputation());
+    }
+}

--- a/src/test/java/com/project/tracking_system/customer/CustomerServiceTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerServiceTest.java
@@ -65,7 +65,7 @@ class CustomerServiceTest {
         Customer afterAdd = customerRepository.findById(customer.getId()).orElseThrow();
         assertEquals(1, afterAdd.getSentCount());
         assertEquals(0, afterAdd.getPickedUpCount());
-        assertEquals(BuyerReputation.NEUTRAL, afterAdd.getReputation());
+        assertEquals(BuyerReputation.NEW, afterAdd.getReputation());
 
         // Доставляем посылку
         track.setStatus(GlobalStatus.DELIVERED);
@@ -73,14 +73,14 @@ class CustomerServiceTest {
         Customer afterDeliver = customerRepository.findById(customer.getId()).orElseThrow();
         assertEquals(1, afterDeliver.getSentCount());
         assertEquals(1, afterDeliver.getPickedUpCount());
-        assertEquals(BuyerReputation.RELIABLE, afterDeliver.getReputation());
+        assertEquals(BuyerReputation.NEW, afterDeliver.getReputation());
 
         // Удаляем посылку
         customerService.rollbackStatsOnTrackDelete(track);
         Customer afterDelete = customerRepository.findById(customer.getId()).orElseThrow();
         assertEquals(0, afterDelete.getSentCount());
         assertEquals(0, afterDelete.getPickedUpCount());
-        assertEquals(BuyerReputation.NEUTRAL, afterDelete.getReputation());
+        assertEquals(BuyerReputation.NEW, afterDelete.getReputation());
     }
 
     private TrackParcel prepareParcel() {


### PR DESCRIPTION
## Summary
- rename reputation levels to NEW, RELIABLE, NEUTRAL, and UNRELIABLE
- adjust reputation calculation thresholds
- update unit tests accordingly

## Testing
- `./mvnw -v` *(fails: cannot open maven wrapper)*
- `./mvnw test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685061a5d368832d880b941dc35638b0