### PR TITLE
Implement Telegram bot phone registration

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -33,6 +33,9 @@ public class Customer {
     @Column(name = "returned_count", nullable = false)
     private int returnedCount = 0;
 
+    @Column(name = "telegram_chat_id")
+    private Long telegramChatId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "reputation", nullable = false)
     private BuyerReputation reputation = BuyerReputation.NEW;

--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -22,6 +22,14 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Optional<Customer> findByPhone(String phone);
 
     /**
+     * Найти покупателя по идентификатору чата Telegram.
+     *
+     * @param chatId идентификатор чата
+     * @return найденный покупатель или {@link java.util.Optional#empty()}
+     */
+    Optional<Customer> findByTelegramChatId(Long chatId);
+
+    /**
      * Атомарно увеличить счётчик отправленных посылок.
      *
      * @param id идентификатор покупателя

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerRegistrationService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerRegistrationService.java
@@ -1,0 +1,34 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис привязки Telegram чатов к покупателям.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerRegistrationService {
+
+    private final CustomerService customerService;
+    private final CustomerRepository customerRepository;
+
+    /**
+     * Связать чат Telegram с покупателем по номеру телефона.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @param phone  нормализованный номер телефона
+     */
+    @Transactional
+    public void linkTelegramToCustomer(Long chatId, String phone) {
+        Customer customer = customerService.registerOrGetByPhone(phone);
+        customer.setTelegramChatId(chatId);
+        customerRepository.save(customer);
+        log.info("Чат {} привязан к покупателю {}", chatId, customer.getId());
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1,34 +1,112 @@
 package com.project.tracking_system.service.telegram;
 
+import com.project.tracking_system.service.customer.CustomerRegistrationService;
+import com.project.tracking_system.utils.PhoneUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Contact;
 import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardRow;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+import java.util.List;
 
 /**
- * @author Dmitriy Anisimov
- * @date 16.06.2025
+ * Telegram-бот для покупателей.
  */
-//@Component
+@Component
+@RequiredArgsConstructor
+@Slf4j
 public class BuyerTelegramBot extends TelegramLongPollingBot {
 
-    @Value("${telegram.bot.token}")
-    private String botToken;
+    private final CustomerRegistrationService registrationService;
+    private final String botToken;
 
-    @Override
-    public String getBotUsername() {
-        return "YourBotName";
+    /**
+     * Создать экземпляр бота.
+     *
+     * @param registrationService сервис регистрации покупателей
+     * @param botToken            токен бота
+     */
+    public BuyerTelegramBot(CustomerRegistrationService registrationService,
+                            @Value("${telegram.bot.token}") String botToken) {
+        this.registrationService = registrationService;
+        this.botToken = botToken;
     }
 
+    /**
+     * Возвращает имя бота в Telegram.
+     *
+     * @return имя бота
+     */
+    @Override
+    public String getBotUsername() {
+        return "BuyerAssistantBot";
+    }
+
+    /**
+     * Возвращает токен для доступа к API Telegram.
+     *
+     * @return токен бота
+     */
     @Override
     public String getBotToken() {
         return botToken;
     }
 
+    /**
+     * Обрабатывает входящие обновления от Telegram.
+     *
+     * @param update объект обновления
+     */
     @Override
     public void onUpdateReceived(Update update) {
-        // обработка входящих команд (например, /start)
+        if (update.hasMessage()) {
+            if (update.getMessage().hasText() && "/start".equals(update.getMessage().getText())) {
+                sendSharePhoneKeyboard(update.getMessage().getChatId());
+                return;
+            }
+
+            Contact contact = update.getMessage().getContact();
+            if (contact != null) {
+                handleContact(update);
+            }
+        }
     }
 
+    private void sendSharePhoneKeyboard(Long chatId) {
+        KeyboardButton button = new KeyboardButton("\uD83D\uDCF1 Поделиться номером");
+        button.setRequestContact(true);
+        KeyboardRow row = new KeyboardRow(List.of(button));
+        ReplyKeyboardMarkup markup = new ReplyKeyboardMarkup(List.of(row));
+        markup.setResizeKeyboard(true);
+
+        SendMessage message = new SendMessage(chatId.toString(), "Поделитесь номером телефона");
+        message.setReplyMarkup(markup);
+        try {
+            execute(message);
+        } catch (TelegramApiException e) {
+            log.error("Не удалось отправить сообщение", e);
+        }
+    }
+
+    private void handleContact(Update update) {
+        String rawPhone = update.getMessage().getContact().getPhoneNumber();
+        String phone = PhoneUtils.normalizePhone(rawPhone);
+        Long chatId = update.getMessage().getChatId();
+        registrationService.linkTelegramToCustomer(chatId, phone);
+
+        SendMessage confirm = new SendMessage(chatId.toString(), "Номер сохранён. Спасибо!");
+        try {
+            execute(confirm);
+        } catch (TelegramApiException e) {
+            log.error("Не удалось отправить подтверждение", e);
+        }
+    }
 }

--- a/src/main/resources/db/migration/V14__add_telegram_chat_id_to_customers.sql
+++ b/src/main/resources/db/migration/V14__add_telegram_chat_id_to_customers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tb_customers ADD COLUMN telegram_chat_id BIGINT;


### PR DESCRIPTION
## Summary
- register BuyerTelegramBot as a component
- request user phone via contact button
- link Telegram chat to customer phone
- persist chat id on customer entity
- add DB migration for telegram chat id column

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507bef0388832d9bacb7cb6513414a