### PR TITLE
Add Telegram linking service

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -1,0 +1,66 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.utils.PhoneUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис привязки Telegram-чатов к покупателям.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerTelegramService {
+
+    private final CustomerRepository customerRepository;
+
+    /**
+     * Привязать чат Telegram к покупателю по номеру телефона.
+     * <p>
+     * Номер телефона нормализуется до формата 375XXXXXXXXX. Если покупатель с
+     * таким номером существует и не имеет привязанного чата, чат будет сохранён.
+     * При отсутствии покупателя создаётся новая запись с нейтральной репутацией.
+     * Повторная привязка уже связанного покупателя игнорируется.
+     * </p>
+     *
+     * @param phone  номер телефона в произвольном формате
+     * @param chatId идентификатор чата Telegram
+     * @return сущность покупателя после обновления
+     */
+    @Transactional
+    public Customer linkTelegramToCustomer(String phone, Long chatId) {
+        String normalized = PhoneUtils.normalizePhone(phone);
+        log.info("🔗 Попытка привязки телефона {} к чату {}", normalized, chatId);
+
+        Customer customer = customerRepository.findByPhone(normalized).orElse(null);
+
+        if (customer != null) {
+            // Проверяем, не привязан ли уже чат к покупателю
+            if (customer.getTelegramChatId() != null) {
+                log.warn("⚠️ Покупатель {} уже привязан к чату {}", customer.getId(), customer.getTelegramChatId());
+                return customer;
+            }
+            customer.setTelegramChatId(chatId);
+            Customer saved = customerRepository.save(customer);
+            log.info("✅ Чат {} привязан к покупателю {}", chatId, saved.getId());
+            return saved;
+        }
+
+        // Создаём нового покупателя с начальными значениями
+        Customer newCustomer = new Customer();
+        newCustomer.setPhone(normalized);
+        newCustomer.setTelegramChatId(chatId);
+        newCustomer.setSentCount(0);
+        newCustomer.setPickedUpCount(0);
+        newCustomer.setReputation(BuyerReputation.NEUTRAL);
+
+        Customer saved = customerRepository.save(newCustomer);
+        log.info("🆕 Создан покупатель {} и привязан чат {}", saved.getId(), chatId);
+        return saved;
+    }
+}

--- a/src/test/java/com/project/tracking_system/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerTelegramServiceTest.java
@@ -1,0 +1,62 @@
+package com.project.tracking_system.customer;
+
+import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.service.customer.CustomerTelegramService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Интеграционные тесты для {@link CustomerTelegramService}.
+ */
+@DataJpaTest
+@Import(CustomerTelegramService.class)
+class CustomerTelegramServiceTest {
+
+    @Autowired
+    private CustomerTelegramService telegramService;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void createsNewCustomerWhenNotExists() {
+        Customer customer = telegramService.linkTelegramToCustomer("29 123-45-67", 111L);
+        assertNotNull(customer.getId());
+        assertEquals("375291234567", customer.getPhone());
+        assertEquals(0, customer.getSentCount());
+        assertEquals(0, customer.getPickedUpCount());
+        assertEquals(BuyerReputation.NEUTRAL, customer.getReputation());
+        Customer fromDb = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(111L, fromDb.getTelegramChatId());
+    }
+
+    @Test
+    void attachesChatToExistingCustomer() {
+        Customer existing = new Customer();
+        existing.setPhone("375291234567");
+        customerRepository.save(existing);
+
+        Customer customer = telegramService.linkTelegramToCustomer("291234567", 222L);
+        assertEquals(existing.getId(), customer.getId());
+        assertEquals(222L, customerRepository.findById(existing.getId()).orElseThrow().getTelegramChatId());
+    }
+
+    @Test
+    void repeatedLinkDoesNothing() {
+        Customer existing = new Customer();
+        existing.setPhone("375291234567");
+        existing.setTelegramChatId(333L);
+        customerRepository.save(existing);
+
+        Customer customer = telegramService.linkTelegramToCustomer("291234567", 444L);
+        assertEquals(existing.getId(), customer.getId());
+        Customer fromDb = customerRepository.findById(existing.getId()).orElseThrow();
+        assertEquals(333L, fromDb.getTelegramChatId());
+    }
+}


### PR DESCRIPTION
## Summary
- add `CustomerTelegramService` to link Telegram chats with customers
- integrate new service with phone normalization, validation and logging
- create integration tests for linking chats

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_68507f7068e4832da359e2e0efa9f3b0