### PR TITLE
Fix telegram registration confirmation logic

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -89,13 +89,20 @@ public class BuyerTelegramBot extends TelegramLongPollingBot {
         String rawPhone = update.getMessage().getContact().getPhoneNumber();
         String phone = PhoneUtils.normalizePhone(rawPhone);
         Long chatId = update.getMessage().getChatId();
-        registrationService.linkTelegramToCustomer(chatId, phone);
-
-        SendMessage confirm = new SendMessage(chatId.toString(), "Номер сохранён. Спасибо!");
         try {
-            execute(confirm);
-        } catch (TelegramApiException e) {
-            log.error("Не удалось отправить подтверждение", e);
+            // Пытаемся привязать чат к покупателю
+            registrationService.linkTelegramToCustomer(chatId, phone);
+
+            // Отправляем подтверждение только при успешной привязке
+            SendMessage confirm = new SendMessage(chatId.toString(), "Номер сохранён. Спасибо!");
+            try {
+                execute(confirm);
+            } catch (TelegramApiException e) {
+                log.error("Не удалось отправить подтверждение", e);
+            }
+        } catch (Exception e) {
+            // Если регистрация не удалась, сообщение не отправляем
+            log.error("Ошибка привязки телефона {} к чату {}", phone, chatId, e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- send confirmation to Telegram buyer only after registration link succeeds

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685080ac9584832da5a3a87ea928da4a