### PR TITLE
Implement customer notifications

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/CustomerNotificationLogRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerNotificationLogRepository.java
@@ -1,10 +1,24 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.CustomerNotificationLog;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Репозиторий для работы с логом уведомлений покупателей.
  */
 public interface CustomerNotificationLogRepository extends JpaRepository<CustomerNotificationLog, Long> {
+
+    /**
+     * Проверить, существует ли запись уведомления с заданными параметрами.
+     *
+     * @param parcelId идентификатор посылки
+     * @param status   статус посылки
+     * @param type     тип уведомления
+     * @return {@code true}, если запись существует
+     */
+    boolean existsByParcelIdAndStatusAndNotificationType(Long parcelId,
+                                                         GlobalStatus status,
+                                                         NotificationType type);
 }

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -137,6 +137,17 @@ public class SubscriptionService {
         return hasAccess;
     }
 
+    /**
+     * Проверяет наличие подписки PREMIUM у пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если у пользователя PREMIUM-подписка
+     */
+    public boolean isUserPremium(Long userId) {
+        String planName = userSubscriptionRepository.getSubscriptionPlanName(userId);
+        return PREMIUM_PLAN.equals(planName);
+    }
+
     @Transactional
     public void upgradeOrExtendSubscription(Long userId, int months) {
         log.info("🔄 Попытка обновления подписки для пользователя с ID: {}", userId);

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -14,6 +14,11 @@ import com.project.tracking_system.service.track.StatusTrackService;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.customer.CustomerService;
 import com.project.tracking_system.service.customer.CustomerStatsService;
+import com.project.tracking_system.service.telegram.TelegramNotificationService;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.repository.CustomerNotificationLogRepository;
+import com.project.tracking_system.entity.CustomerNotificationLog;
+import com.project.tracking_system.entity.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -49,6 +54,9 @@ public class DeliveryHistoryService {
     private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
     private final CustomerService customerService;
     private final CustomerStatsService customerStatsService;
+    private final TelegramNotificationService telegramNotificationService;
+    private final CustomerNotificationLogRepository customerNotificationLogRepository;
+    private final SubscriptionService subscriptionService;
 
     /**
      * Обновляет или создаёт запись {@link DeliveryHistory}, когда меняется статус посылки.
@@ -120,6 +128,13 @@ public class DeliveryHistoryService {
         // Сохраняем историю, если что-то изменилось
         deliveryHistoryRepository.save(history);
         log.info("История доставки обновлена: {}", trackParcel.getNumber());
+
+        // Отправляем уведомление в Telegram при выполнении условий
+        if (shouldNotifyCustomer(trackParcel, newStatus)) {
+            telegramNotificationService.sendStatusUpdate(trackParcel, newStatus);
+            log.info("✅ Уведомление о статусе {} отправлено для трека {}", newStatus, trackParcel.getNumber());
+            saveNotificationLog(trackParcel, newStatus);
+        }
     }
 
     /**
@@ -575,6 +590,37 @@ public class DeliveryHistoryService {
             log.info("{}: {}", logMessage, newDate);
             setter.accept(newDate);
         }
+    }
+
+    // Проверить необходимость отправки уведомления покупателю
+    private boolean shouldNotifyCustomer(TrackParcel parcel, GlobalStatus status) {
+        Customer customer = parcel.getCustomer();
+        if (customer == null || customer.getTelegramChatId() == null) {
+            return false;
+        }
+
+        Long ownerId = parcel.getStore().getOwner().getId();
+        boolean premium = subscriptionService.isUserPremium(ownerId);
+        if (!premium) {
+            return false;
+        }
+
+        return !customerNotificationLogRepository.existsByParcelIdAndStatusAndNotificationType(
+                parcel.getId(),
+                status,
+                NotificationType.INSTANT
+        );
+    }
+
+    // Сохранить лог отправленного уведомления
+    private void saveNotificationLog(TrackParcel parcel, GlobalStatus status) {
+        CustomerNotificationLog logEntry = new CustomerNotificationLog();
+        logEntry.setCustomer(parcel.getCustomer());
+        logEntry.setParcel(parcel);
+        logEntry.setStatus(status);
+        logEntry.setNotificationType(NotificationType.INSTANT);
+        logEntry.setSentAt(ZonedDateTime.now(ZoneOffset.UTC));
+        customerNotificationLogRepository.save(logEntry);
     }
 
 


### PR DESCRIPTION
## Summary
- add repository method to detect duplicate notifications
- allow checking for PREMIUM plan
- send Telegram updates from DeliveryHistoryService

## Testing
- `./mvnw -q -DskipTests install` *(fails: `cannot open ./.mvn/wrapper/maven-wrapper.properties: No such file`)*

------
https://chatgpt.com/codex/tasks/task_e_6850914e3468832d8ebbeaa86ff86210