### PR TITLE
Add Telegram reminder scheduler

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -57,4 +57,20 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     @Transactional
     @Query("DELETE FROM TrackParcel t WHERE t.store.id = :storeId")
     void deleteByStoreId(@Param("storeId") Long storeId);
+
+    /**
+     * Найти посылки, ожидающие покупателя дольше указанной даты.
+     *
+     * @param status    статус посылки
+     * @param threshold дата, ранее которой посылка прибыла на пункт выдачи
+     * @return список подходящих посылок
+     */
+    @Query("""
+        SELECT p FROM TrackParcel p
+        JOIN DeliveryHistory h ON h.trackParcel.id = p.id
+        WHERE p.status = :status
+          AND h.arrivedDate < :threshold
+        """)
+    List<TrackParcel> findWaitingForPickupBefore(@Param("status") GlobalStatus status,
+                                                 @Param("threshold") java.time.ZonedDateTime threshold);
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramReminderScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramReminderScheduler.java
@@ -1,0 +1,70 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.CustomerNotificationLog;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.NotificationType;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.repository.CustomerNotificationLogRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Планировщик напоминаний о невыкупленных посылках.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TelegramReminderScheduler {
+
+    private final TrackParcelRepository trackParcelRepository;
+    private final CustomerNotificationLogRepository customerNotificationLogRepository;
+    private final TelegramNotificationService telegramNotificationService;
+
+    /**
+     * Ежедневно отправляет напоминания покупателям.
+     * <p>
+     * Находит посылки в статусе {@link GlobalStatus#WAITING_FOR_CUSTOMER},
+     * прибывшие на пункт выдачи более трёх дней назад, и отправляет
+     * напоминание через Telegram.
+     * </p>
+     */
+    @Scheduled(cron = "0 0 8 * * *", zone = "UTC")
+    @Transactional
+    public void sendReminders() {
+        ZonedDateTime threshold = ZonedDateTime.now(ZoneOffset.UTC).minusDays(3);
+        List<TrackParcel> parcels = trackParcelRepository
+                .findWaitingForPickupBefore(GlobalStatus.WAITING_FOR_CUSTOMER, threshold);
+
+        for (TrackParcel parcel : parcels) {
+            boolean exists = customerNotificationLogRepository
+                    .existsByParcelIdAndStatusAndNotificationType(
+                            parcel.getId(),
+                            GlobalStatus.WAITING_FOR_CUSTOMER,
+                            NotificationType.REMINDER
+                    );
+            if (exists) {
+                log.debug("⏭ Напоминание уже отправлено для трека {}", parcel.getNumber());
+                continue;
+            }
+
+            telegramNotificationService.sendReminder(parcel);
+            log.info("📨 Напоминание отправлено для трека {}", parcel.getNumber());
+
+            CustomerNotificationLog logEntry = new CustomerNotificationLog();
+            logEntry.setCustomer(parcel.getCustomer());
+            logEntry.setParcel(parcel);
+            logEntry.setStatus(GlobalStatus.WAITING_FOR_CUSTOMER);
+            logEntry.setNotificationType(NotificationType.REMINDER);
+            logEntry.setSentAt(ZonedDateTime.now(ZoneOffset.UTC));
+            customerNotificationLogRepository.save(logEntry);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add query for overdue parcels to `TrackParcelRepository`
- implement `TelegramReminderScheduler` to send daily pickup reminders via Telegram

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685092dfe3b8832d95c94e10e85e409b