### PR TITLE
Add Telegram settings block

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -65,9 +65,13 @@ public class ProfileController {
 
         String storeLimit = userService.getUserStoreLimit(userId);
 
+        // Загружаем магазины с настройками Telegram
+        List<Store> stores = storeService.getUserStoresWithSettings(userId);
+
         // Добавляем данные профиля в модель
         model.addAttribute("username", user.getEmail());
         model.addAttribute("storeLimit", storeLimit);
+        model.addAttribute("stores", stores);
         log.debug("Данные профиля добавлены в модель для пользователя с ID: {}", userId);
 
         // Добавляем настройки и другие данные пользователя в модель

--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.StoreTelegramSettings;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import com.project.tracking_system.utils.ResponseBuilder;
 import com.project.tracking_system.utils.AuthUtils;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import java.security.Principal;
 
 /**
  * Управление Telegram-настройками магазина.
@@ -26,6 +29,7 @@ public class StoreTelegramSettingsController {
 
     private final StoreService storeService;
     private final StoreTelegramSettingsRepository settingsRepository;
+    private final StoreTelegramSettingsService telegramSettingsService;
 
     /**
      * Получить текущие настройки магазина.
@@ -42,7 +46,7 @@ public class StoreTelegramSettingsController {
     /**
      * Обновить настройки магазина.
      */
-    @PostMapping
+    @PostMapping(consumes = org.springframework.http.MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<?> updateSettings(@PathVariable Long storeId,
                                             @RequestBody StoreTelegramSettingsDTO dto,
@@ -62,5 +66,19 @@ public class StoreTelegramSettingsController {
             log.error("Ошибка обновления настроек Telegram", e);
             return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         }
+    }
+
+    /**
+     * Обновить настройки через форму профиля.
+     */
+    @PostMapping(consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public String updateSettingsForm(@PathVariable("storeId") Long storeId,
+                                     @ModelAttribute StoreTelegramSettingsDTO dto,
+                                     Principal principal,
+                                     RedirectAttributes redirectAttributes) {
+        Store store = storeService.findOwnedByUser(storeId, principal);
+        telegramSettingsService.update(store, dto);
+        redirectAttributes.addFlashAttribute("successMessage", "Настройки Telegram сохранены.");
+        return "redirect:/profile#store-" + storeId;
     }
 }

--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -1,5 +1,8 @@
 package com.project.tracking_system.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +13,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StoreTelegramSettingsDTO {
     private boolean enabled = true;
+    @Min(1)
+    @Max(14)
     private int reminderStartAfterDays = 3;
+
+    @Min(1)
+    @Max(14)
     private int reminderRepeatIntervalDays = 2;
+
+    @Size(max = 200)
     private String customSignature;
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreRepository.java
@@ -59,4 +59,13 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("SELECT s.id FROM Store s WHERE s.owner.id = :ownerId")
     List<Long> findStoreIdsByOwnerId(@Param("ownerId") Long ownerId);
 
+    /**
+     * Получить магазины пользователя вместе с Telegram-настройками.
+     *
+     * @param ownerId идентификатор владельца
+     * @return список магазинов с инициализированными настройками
+     */
+    @Query("SELECT s FROM Store s LEFT JOIN FETCH s.telegramSettings WHERE s.owner.id = :ownerId")
+    List<Store> findByOwnerIdFetchSettings(@Param("ownerId") Long ownerId);
+
 }

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -55,6 +56,21 @@ public class StoreService {
     }
 
     /**
+     * Найти магазин по Id и проверить принадлежность текущему пользователю.
+     *
+     * @param storeId   идентификатор магазина
+     * @param principal текущий пользователь
+     * @return найденный магазин
+     */
+    public Store findOwnedByUser(Long storeId, Principal principal) {
+        String email = principal.getName();
+        Long userId = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден"))
+                .getId();
+        return getStore(storeId, userId);
+    }
+
+    /**
      * Возвращает список магазинов, принадлежащих пользователю.
      *
      * @param userId идентификатор пользователя
@@ -62,6 +78,16 @@ public class StoreService {
      */
     public List<Store> getUserStores(Long userId) {
         return storeRepository.findByOwnerId(userId);
+    }
+
+    /**
+     * Возвращает магазины пользователя вместе с Telegram-настройками.
+     *
+     * @param userId идентификатор пользователя
+     * @return список магазинов с настройками
+     */
+    public List<Store> getUserStoresWithSettings(Long userId) {
+        return storeRepository.findByOwnerIdFetchSettings(userId);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -1,0 +1,43 @@
+package com.project.tracking_system.service.store;
+
+import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис управления Telegram-настройками магазина.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreTelegramSettingsService {
+
+    private final StoreTelegramSettingsRepository settingsRepository;
+
+    /**
+     * Создать или обновить настройки Telegram магазина.
+     *
+     * @param store магазин, к которому относятся настройки
+     * @param dto   данные настроек
+     */
+    @Transactional
+    public void update(Store store, StoreTelegramSettingsDTO dto) {
+        StoreTelegramSettings settings = settingsRepository.findByStoreId(store.getId());
+        if (settings == null) {
+            settings = new StoreTelegramSettings();
+            settings.setStore(store);
+        }
+        settings.setEnabled(dto.isEnabled());
+        settings.setReminderStartAfterDays(dto.getReminderStartAfterDays());
+        settings.setReminderRepeatIntervalDays(dto.getReminderRepeatIntervalDays());
+        settings.setCustomSignature(dto.getCustomSignature());
+        settingsRepository.save(settings);
+        store.setTelegramSettings(settings);
+        log.info("Настройки Telegram для магазина ID={} обновлены", store.getId());
+    }
+}

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -493,9 +493,6 @@ async function loadStores() {
                 <button class="btn btn-sm btn-outline-danger delete-store-btn" data-store-id="${store.id}">
                     <i class="bi bi-trash"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-secondary telegram-settings-btn" data-store-id="${store.id}">
-                    <i class="bi bi-telegram"></i>
-                </button>
             </td>
         `;
         tableBody.appendChild(row);
@@ -992,9 +989,6 @@ document.addEventListener("DOMContentLoaded", function () {
             }
             if (button.classList.contains("remove-new-store-btn")) {
                 removeNewStoreRow(button);
-            }
-            if (button.classList.contains("telegram-settings-btn")) {
-                openTelegramSettings(storeId);
             }
         });
     }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -116,6 +116,41 @@
                             <i class="bi bi-trash me-2"></i> Удалить всю аналитику
                         </button>
                     </div>
+
+                    <div th:each="store : ${stores}" class="mt-3" th:id="'store-' + ${store.id}">
+                        <h6 th:text="${store.name}" class="mb-2"></h6>
+                        <div class="mt-3 border p-3 rounded bg-light-subtle">
+                            <h6>Настройки Telegram-уведомлений</h6>
+
+                            <form th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
+                                <div class="form-check mb-2">
+                                    <input class="form-check-input" type="checkbox" name="enabled"
+                                           th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
+                                    <label class="form-check-label">Включить уведомления</label>
+                                </div>
+
+                                <div class="mb-2">
+                                    <label class="form-label">Первое напоминание (через дней)</label>
+                                    <input type="number" class="form-control form-control-sm" name="reminderStartAfterDays"
+                                           th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
+                                </div>
+
+                                <div class="mb-2">
+                                    <label class="form-label">Интервал повторных напоминаний (в днях)</label>
+                                    <input type="number" class="form-control form-control-sm" name="reminderRepeatIntervalDays"
+                                           th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
+                                </div>
+
+                                <div class="mb-2">
+                                    <label class="form-label">Подпись к уведомлению (необязательно)</label>
+                                    <input type="text" class="form-control form-control-sm" name="customSignature"
+                                           th:value="${store.telegramSettings?.customSignature}">
+                                </div>
+
+                                <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
+                            </form>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="tab-pane fade card p-4 shadow-sm rounded-4"


### PR DESCRIPTION
## Summary
- load user stores with telegram settings in profile controller
- extend store repository/service for telegram settings access
- add service to manage telegram settings
- support profile form submission for store telegram settings
- show telegram settings block on profile page
- remove obsolete telegram icon and event handler
- add validation for settings DTO

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a3806608832d95ca0128f92049c2