### PR TITLE
Add Telegram settings block

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -65,9 +65,13 @@ public class ProfileController {
 
         String storeLimit = userService.getUserStoreLimit(userId);
 
+        // Загружаем магазины с настройками Telegram
+        List<Store> stores = storeService.getUserStoresWithSettings(userId);
+
         // Добавляем данные профиля в модель
         model.addAttribute("username", user.getEmail());
         model.addAttribute("storeLimit", storeLimit);
+        model.addAttribute("stores", stores);
         log.debug("Данные профиля добавлены в модель для пользователя с ID: {}", userId);
 
         // Добавляем настройки и другие данные пользователя в модель

--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.StoreTelegramSettings;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import com.project.tracking_system.utils.ResponseBuilder;
 import com.project.tracking_system.utils.AuthUtils;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import java.security.Principal;
 
 /**
  * Управление Telegram-настройками магазина.
@@ -26,6 +29,7 @@ public class StoreTelegramSettingsController {
 
     private final StoreService storeService;
     private final StoreTelegramSettingsRepository settingsRepository;
+    private final StoreTelegramSettingsService telegramSettingsService;
 
     /**
      * Получить текущие настройки магазина.
@@ -42,7 +46,7 @@ public class StoreTelegramSettingsController {
     /**
      * Обновить настройки магазина.
      */
-    @PostMapping
+    @PostMapping(consumes = org.springframework.http.MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<?> updateSettings(@PathVariable Long storeId,
                                             @RequestBody StoreTelegramSettingsDTO dto,
@@ -62,5 +66,25 @@ public class StoreTelegramSettingsController {
             log.error("Ошибка обновления настроек Telegram", e);
             return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         }
+    }
+
+    /**
+     * Обновляет настройки через форму профиля.
+     *
+     * @param storeId            идентификатор магазина
+     * @param dto                заполненные настройки Telegram
+     * @param principal          текущий аутентифицированный пользователь
+     * @param redirectAttributes атрибуты для передачи уведомления об успехе
+     * @return редирект на страницу профиля пользователя
+     */
+    @PostMapping(consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public String updateSettingsForm(@PathVariable("storeId") Long storeId,
+                                     @ModelAttribute StoreTelegramSettingsDTO dto,
+                                     Principal principal,
+                                     RedirectAttributes redirectAttributes) {
+        Store store = storeService.findOwnedByUser(storeId, principal);
+        telegramSettingsService.update(store, dto);
+        redirectAttributes.addFlashAttribute("successMessage", "Настройки Telegram сохранены.");
+        return "redirect:/profile#v-pills-stores";
     }
 }

--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -1,5 +1,8 @@
 package com.project.tracking_system.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +13,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StoreTelegramSettingsDTO {
     private boolean enabled = true;
+    @Min(1)
+    @Max(14)
     private int reminderStartAfterDays = 3;
+
+    @Min(1)
+    @Max(14)
     private int reminderRepeatIntervalDays = 2;
+
+    @Size(max = 200)
     private String customSignature;
 }

--- a/src/main/java/com/project/tracking_system/entity/Store.java
+++ b/src/main/java/com/project/tracking_system/entity/Store.java
@@ -42,6 +42,7 @@ public class Store {
     private List<TrackParcel> trackParcels = new ArrayList<>();
 
     @OneToOne(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JsonIgnore
     private StoreTelegramSettings telegramSettings;
 
 }

--- a/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
@@ -23,6 +23,7 @@ public class StoreTelegramSettings {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false, unique = true)
+    @JsonIgnore
     private Store store;
 
     @Column(name = "enabled", nullable = false)

--- a/src/main/java/com/project/tracking_system/repository/StoreRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreRepository.java
@@ -59,4 +59,13 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("SELECT s.id FROM Store s WHERE s.owner.id = :ownerId")
     List<Long> findStoreIdsByOwnerId(@Param("ownerId") Long ownerId);
 
+    /**
+     * Получить магазины пользователя вместе с Telegram-настройками.
+     *
+     * @param ownerId идентификатор владельца
+     * @return список магазинов с инициализированными настройками
+     */
+    @Query("SELECT s FROM Store s LEFT JOIN FETCH s.telegramSettings WHERE s.owner.id = :ownerId")
+    List<Store> findByOwnerIdFetchSettings(@Param("ownerId") Long ownerId);
+
 }

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -55,6 +56,21 @@ public class StoreService {
     }
 
     /**
+     * Найти магазин по Id и проверить принадлежность текущему пользователю.
+     *
+     * @param storeId   идентификатор магазина
+     * @param principal текущий пользователь
+     * @return найденный магазин
+     */
+    public Store findOwnedByUser(Long storeId, Principal principal) {
+        String email = principal.getName();
+        Long userId = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден"))
+                .getId();
+        return getStore(storeId, userId);
+    }
+
+    /**
      * Возвращает список магазинов, принадлежащих пользователю.
      *
      * @param userId идентификатор пользователя
@@ -62,6 +78,16 @@ public class StoreService {
      */
     public List<Store> getUserStores(Long userId) {
         return storeRepository.findByOwnerId(userId);
+    }
+
+    /**
+     * Возвращает магазины пользователя вместе с Telegram-настройками.
+     *
+     * @param userId идентификатор пользователя
+     * @return список магазинов с настройками
+     */
+    public List<Store> getUserStoresWithSettings(Long userId) {
+        return storeRepository.findByOwnerIdFetchSettings(userId);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -1,0 +1,44 @@
+package com.project.tracking_system.service.store;
+
+import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис управления Telegram-настройками магазина.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreTelegramSettingsService {
+
+    private final StoreTelegramSettingsRepository settingsRepository;
+
+    /**
+     * Создать или обновить настройки Telegram магазина.
+     *
+     * @param store магазин, к которому относятся настройки
+     * @param dto   данные настроек
+     * @return ничего не возвращает
+     */
+    @Transactional
+    public void update(Store store, StoreTelegramSettingsDTO dto) {
+        StoreTelegramSettings settings = settingsRepository.findByStoreId(store.getId());
+        if (settings == null) {
+            settings = new StoreTelegramSettings();
+            settings.setStore(store);
+        }
+        settings.setEnabled(dto.isEnabled());
+        settings.setReminderStartAfterDays(dto.getReminderStartAfterDays());
+        settings.setReminderRepeatIntervalDays(dto.getReminderRepeatIntervalDays());
+        settings.setCustomSignature(dto.getCustomSignature());
+        settingsRepository.save(settings);
+        store.setTelegramSettings(settings);
+        log.info("Настройки Telegram для магазина ID={} обновлены", store.getId());
+    }
+}

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -493,9 +493,6 @@ async function loadStores() {
                 <button class="btn btn-sm btn-outline-danger delete-store-btn" data-store-id="${store.id}">
                     <i class="bi bi-trash"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-secondary telegram-settings-btn" data-store-id="${store.id}">
-                    <i class="bi bi-telegram"></i>
-                </button>
             </td>
         `;
         tableBody.appendChild(row);
@@ -714,48 +711,6 @@ async function deleteStore() {
     bootstrap.Modal.getInstance(document.getElementById('deleteStoreModal')).hide();
 }
 
-async function openTelegramSettings(storeId) {
-    const response = await fetch(`/stores/${storeId}/telegram-settings`);
-    if (!response.ok) {
-        alert('Ошибка загрузки настроек');
-        return;
-    }
-    const data = await response.json();
-    const form = document.getElementById('telegramSettingsForm');
-    form.dataset.storeId = storeId;
-    document.getElementById('telegramEnabled').checked = data.enabled;
-    document.getElementById('reminderStartAfterDays').value = data.reminderStartAfterDays;
-    document.getElementById('reminderRepeatIntervalDays').value = data.reminderRepeatIntervalDays;
-    document.getElementById('customSignature').value = data.customSignature || '';
-    new bootstrap.Modal(document.getElementById('telegramSettingsModal')).show();
-}
-
-async function saveTelegramSettings(event) {
-    event.preventDefault();
-    const form = event.target;
-    const storeId = form.dataset.storeId;
-    const payload = {
-        enabled: document.getElementById('telegramEnabled').checked,
-        reminderStartAfterDays: parseInt(document.getElementById('reminderStartAfterDays').value),
-        reminderRepeatIntervalDays: parseInt(document.getElementById('reminderRepeatIntervalDays').value),
-        customSignature: document.getElementById('customSignature').value
-    };
-
-    const resp = await fetch(`/stores/${storeId}/telegram-settings`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            [document.querySelector('meta[name="_csrf_header"]').content]: document.querySelector('meta[name="_csrf"]').content
-        },
-        body: JSON.stringify(payload)
-    });
-    if (resp.ok) {
-        notifyUser('Настройки обновлены', 'success');
-        bootstrap.Modal.getInstance(document.getElementById('telegramSettingsModal')).hide();
-    } else {
-        notifyUser('Ошибка сохранения', 'danger');
-    }
-}
 
 /**
  * Обновляет отображение лимита магазинов
@@ -949,7 +904,6 @@ document.addEventListener("DOMContentLoaded", function () {
     initializeCustomCredentialsCheckbox();
     initializePhoneToggle();
     initAssignCustomerFormHandler();
-    document.getElementById('telegramSettingsForm')?.addEventListener('submit', saveTelegramSettings);
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие
     const addStoreBtn = document.getElementById("addStoreBtn");
@@ -992,9 +946,6 @@ document.addEventListener("DOMContentLoaded", function () {
             }
             if (button.classList.contains("remove-new-store-btn")) {
                 removeNewStoreRow(button);
-            }
-            if (button.classList.contains("telegram-settings-btn")) {
-                openTelegramSettings(storeId);
             }
         });
     }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -116,6 +116,41 @@
                             <i class="bi bi-trash me-2"></i> Удалить всю аналитику
                         </button>
                     </div>
+
+                    <div id="telegram-management" class="mt-4">
+                        <h5 class="mb-3">Настройки Telegram</h5>
+                        <div th:each="store : ${stores}" class="mt-3 border p-3 rounded bg-light-subtle" th:id="'store-' + ${store.id}">
+                            <h6 th:text="${store.name}" class="mb-2"></h6>
+                            <form th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
+                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                                <div class="form-check form-switch mb-2">
+                                    <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
+                                           th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
+                                    <label class="form-check-label" th:for="'tg-enable-' + ${store.id}">Включить уведомления</label>
+                                </div>
+
+                                <div class="mb-2">
+                                    <label class="form-label" th:for="'tg-start-' + ${store.id}">Первое напоминание (через дней)</label>
+                                    <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
+                                           th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
+                                </div>
+
+                                <div class="mb-2">
+                                    <label class="form-label" th:for="'tg-repeat-' + ${store.id}">Интервал повторных напоминаний (в днях)</label>
+                                    <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
+                                           th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
+                                </div>
+
+                                <div class="mb-2">
+                                    <label class="form-label" th:for="'tg-sign-' + ${store.id}">Подпись к уведомлению (необязательно)</label>
+                                    <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}" name="customSignature"
+                                           th:value="${store.telegramSettings?.customSignature}" maxlength="200">
+                                </div>
+
+                                <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
+                            </form>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="tab-pane fade card p-4 shadow-sm rounded-4"
@@ -350,41 +385,6 @@
         </div>
     </div>
 
-    <!-- Настройки Telegram -->
-    <div class="modal fade" id="telegramSettingsModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <form id="telegramSettingsForm">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Telegram</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="form-check form-switch mb-3">
-                            <input class="form-check-input" type="checkbox" id="telegramEnabled">
-                            <label class="form-check-label" for="telegramEnabled">Включить уведомления</label>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="reminderStartAfterDays">Начать через (дней)</label>
-                            <input type="number" min="1" max="14" class="form-control" id="reminderStartAfterDays">
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="reminderRepeatIntervalDays">Повторять каждые (дней)</label>
-                            <input type="number" min="1" max="14" class="form-control" id="reminderRepeatIntervalDays">
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="customSignature">Подпись</label>
-                            <textarea class="form-control" id="customSignature" maxlength="200"></textarea>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
-                        <button type="submit" class="btn btn-primary">Сохранить</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
 
 </div>
 


### PR DESCRIPTION
## Summary
- load user stores with telegram settings in profile controller
- extend store repository/service for telegram settings access
- add service to manage telegram settings
- support profile form submission for store telegram settings
- show telegram settings block on profile page
- remove obsolete telegram icon and event handler
- add validation for settings DTO
- visually integrate the Telegram settings block
- fix profile UI and integrate telegram settings below stores, removing modal
- fix store serialization

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850a3806608832d95ca0128f92049c2