### PR TITLE
feat: dynamic telegram settings blocks

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.security.Principal;
 
 
 /**
@@ -305,6 +306,21 @@ public class ProfileController {
             log.error("Ошибка установки магазина по умолчанию: {}", e.getMessage());
             return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         }
+    }
+
+    /**
+     * Возвращает HTML-фрагмент блока магазина с Telegram-настройками.
+     *
+     * @param id        идентификатор магазина
+     * @param model     модель представления
+     * @param principal текущий пользователь
+     * @return фрагмент HTML магазина
+     */
+    @GetMapping("/stores/fragment/{id}")
+    public String getStoreFragment(@PathVariable Long id, Model model, Principal principal) {
+        Store store = storeService.findOwnedByUser(id, principal);
+        model.addAttribute("store", store);
+        return "fragments/store :: storeBlock";
     }
 
 

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -669,9 +669,11 @@ async function saveNewStore(event) {
     });
 
     if (response.ok) {
+        const newStore = await response.json();
         loadStores(); // Обновляем список магазинов
         updateStoreLimit();
         loadAnalyticsButtons();
+        appendTelegramBlock(newStore.id);
     } else {
         console.warn("Ошибка при создании магазина: ", await response.text());
         return;
@@ -703,6 +705,10 @@ async function deleteStore() {
         loadStores();
         updateStoreLimit();
         loadAnalyticsButtons();
+        const storeElement = document.querySelector(`#store-block-${storeToDelete}`);
+        if (storeElement) {
+            storeElement.remove();
+        }
     } else {
         alert("Ошибка при удалении: " + await response.text());
     }
@@ -733,6 +739,26 @@ async function updateStoreLimit() {
         }
     } catch (error) {
         console.error("Ошибка при обновлении лимита магазинов:", error);
+    }
+}
+
+async function appendTelegramBlock(storeId) {
+    try {
+        const response = await fetch(`/profile/stores/fragment/${storeId}`);
+        if (!response.ok) {
+            console.error('Ошибка загрузки блока магазина:', await response.text());
+            return;
+        }
+        const html = await response.text();
+        const container = document.getElementById('telegram-management');
+        if (container) {
+            const wrapper = document.createElement('div');
+            wrapper.innerHTML = html.trim();
+            const element = wrapper.firstElementChild;
+            if (element) container.appendChild(element);
+        }
+    } catch (e) {
+        console.error('Ошибка при получении фрагмента магазина:', e);
     }
 }
 

--- a/src/main/resources/templates/fragments/store.html
+++ b/src/main/resources/templates/fragments/store.html
@@ -1,0 +1,29 @@
+<th:block th:fragment="storeBlock">
+    <div th:id="'store-block-' + ${store.id}" class="mt-3 border p-3 rounded bg-light-subtle">
+        <h6 th:text="${store.name}" class="mb-2"></h6>
+        <form th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <div class="form-check form-switch mb-2">
+                <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
+                       th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
+                <label class="form-check-label" th:for="'tg-enable-' + ${store.id}">Включить уведомления</label>
+            </div>
+            <div class="mb-2">
+                <label class="form-label" th:for="'tg-start-' + ${store.id}">Первое напоминание (через дней)</label>
+                <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
+                       th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
+            </div>
+            <div class="mb-2">
+                <label class="form-label" th:for="'tg-repeat-' + ${store.id}">Интервал повторных напоминаний (в днях)</label>
+                <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
+                       th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
+            </div>
+            <div class="mb-2">
+                <label class="form-label" th:for="'tg-sign-' + ${store.id}">Подпись к уведомлению (необязательно)</label>
+                <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}" name="customSignature"
+                       th:value="${store.telegramSettings?.customSignature}" maxlength="200">
+            </div>
+            <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
+        </form>
+    </div>
+</th:block>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -119,37 +119,7 @@
 
                     <div id="telegram-management" class="mt-4">
                         <h5 class="mb-3">Настройки Telegram</h5>
-                        <div th:each="store : ${stores}" class="mt-3 border p-3 rounded bg-light-subtle" th:id="'store-' + ${store.id}">
-                            <h6 th:text="${store.name}" class="mb-2"></h6>
-                            <form th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
-                                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                                <div class="form-check form-switch mb-2">
-                                    <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
-                                           th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
-                                    <label class="form-check-label" th:for="'tg-enable-' + ${store.id}">Включить уведомления</label>
-                                </div>
-
-                                <div class="mb-2">
-                                    <label class="form-label" th:for="'tg-start-' + ${store.id}">Первое напоминание (через дней)</label>
-                                    <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
-                                           th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
-                                </div>
-
-                                <div class="mb-2">
-                                    <label class="form-label" th:for="'tg-repeat-' + ${store.id}">Интервал повторных напоминаний (в днях)</label>
-                                    <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
-                                           th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
-                                </div>
-
-                                <div class="mb-2">
-                                    <label class="form-label" th:for="'tg-sign-' + ${store.id}">Подпись к уведомлению (необязательно)</label>
-                                    <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}" name="customSignature"
-                                           th:value="${store.telegramSettings?.customSignature}" maxlength="200">
-                                </div>
-
-                                <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
-                            </form>
-                        </div>
+                        <div th:each="store : ${stores}" th:replace="~{fragments/store :: storeBlock}"></div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- extract telegram settings block to a new reusable fragment
- serve store fragment with telegram settings for dynamic updates
- update profile page to use the fragment
- add JS helpers to insert/remove telegram blocks on store changes

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850acbdc8d4832daea5bc21894633d7