### PR TITLE
Fix store fragment view name

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -320,7 +320,7 @@ public class ProfileController {
     public String getStoreFragment(@PathVariable Long id, Model model, Principal principal) {
         Store store = storeService.findOwnedByUser(id, principal);
         model.addAttribute("store", store);
-        return "partials/tg_bot_store :: storeBlock(store=${store})";
+        return "partials/tg_bot_store :: storeBlock";
     }
 
 


### PR DESCRIPTION
## Summary
- update `ProfileController#getStoreFragment` to return `partials/tg_bot_store :: storeBlock`

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6851db0a3118832d966abf70b6286564