### PR TITLE
Fix null stores on profile page

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -51,7 +51,7 @@ public class ProfileController {
     /**
      * Отображает страницу профиля пользователя.
      * <p>
-     * Этот метод извлекает информацию о текущем пользователе (по имени пользователя из контекста аутентификации)
+     * Этот метод извлекает информацию о текущем пользователе через объект {@link Principal}
      * и передает её в модель для отображения на странице.
      * </p>
      *
@@ -59,15 +59,17 @@ public class ProfileController {
      * @return имя представления страницы профиля
      */
     @GetMapping
-    public String profile(Model model, Authentication authentication) {
-        User user = AuthUtils.getCurrentUser(authentication);
+    public String profile(Model model, Principal principal) {
+        // Получаем пользователя по текущему Principal
+        User user = userService.findByUserEmail(principal.getName())
+                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден"));
         Long userId = user.getId();
         log.info("Получен запрос на отображение профиля для пользователя с ID: {}", userId);
 
         String storeLimit = userService.getUserStoreLimit(userId);
 
         // Загружаем магазины с настройками Telegram
-        List<Store> stores = storeService.getUserStoresWithSettings(userId);
+        List<Store> stores = storeService.findAllOwnedByUser(principal);
 
         // Добавляем данные профиля в модель
         model.addAttribute("username", user.getEmail());

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -71,6 +71,20 @@ public class StoreService {
     }
 
     /**
+     * Возвращает список магазинов текущего пользователя вместе с Telegram-настройками.
+     *
+     * @param principal текущий пользователь
+     * @return список магазинов владельца
+     */
+    public List<Store> findAllOwnedByUser(Principal principal) {
+        String email = principal.getName();
+        Long userId = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден"))
+                .getId();
+        return getUserStoresWithSettings(userId);
+    }
+
+    /**
      * Возвращает список магазинов, принадлежащих пользователю.
      *
      * @param userId идентификатор пользователя

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -119,7 +119,7 @@
 
                     <div id="telegram-management" class="mt-4">
                         <h5 class="mb-3">Настройки Telegram</h5>
-                        <div th:each="store : ${stores}" th:replace="~{partials/tg_bot_store :: storeBlock(store=${store})}"></div>
+                        <div th:if="${stores != null}" th:each="store : ${stores}" th:replace="~{partials/tg_bot_store :: storeBlock(store=${store})}"></div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- ensure stores list is loaded for profile page
- add safe null check before rendering store blocks

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6851e4348940832da94f78814084c701