### PR TITLE
Implement Telegram settings async save

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -172,6 +172,41 @@ function initAssignCustomerFormHandler() {
     ajaxSubmitForm('assign-customer-form', 'customerInfoContainer', [initAssignCustomerFormHandler]);
 }
 
+// Инициализация форм настроек Telegram
+function initTelegramForms() {
+    document.querySelectorAll('.telegram-settings-form').forEach(form => {
+        if (form.dataset.initialized) return;
+        form.dataset.initialized = 'true';
+
+        form.addEventListener('submit', async function (event) {
+            event.preventDefault();
+
+            const formData = new FormData(form);
+            const payload = Object.fromEntries(formData.entries());
+
+            try {
+                const response = await fetch(form.action, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        [window.csrfHeader]: window.csrfToken
+                    },
+                    body: JSON.stringify(payload)
+                });
+
+                if (response.ok) {
+                    notifyUser('Настройки Telegram сохранены.', 'success');
+                } else {
+                    const errorText = await response.text();
+                    notifyUser(errorText || 'Ошибка при сохранении.', 'danger');
+                }
+            } catch (e) {
+                notifyUser('Ошибка сети при сохранении.', 'danger');
+            }
+        });
+    });
+}
+
 // Показать или скрыть поля
 function toggleFieldsVisibility(checkbox, fieldsContainer) {
     if (checkbox.checked) {
@@ -674,6 +709,7 @@ async function saveNewStore(event) {
         updateStoreLimit();
         loadAnalyticsButtons();
         appendTelegramBlock(newStore.id);
+        initTelegramForms();
     } else {
         console.warn("Ошибка при создании магазина: ", await response.text());
         return;
@@ -910,6 +946,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initializeCustomCredentialsCheckbox();
     initializePhoneToggle();
     initAssignCustomerFormHandler();
+    initTelegramForms();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие
     const addStoreBtn = document.getElementById("addStoreBtn");

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -122,7 +122,7 @@
                         <th:block th:each="store : ${stores}">
                             <div th:id="'store-block-' + ${store.id}" class="mt-3 border p-3 rounded bg-light-subtle">
                                 <h6 th:text="${store.name}" class="mb-2"></h6>
-                                <form th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
+                                <form class="telegram-settings-form" th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
                                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                                     <div class="form-check form-switch mb-2">
                                         <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"


### PR DESCRIPTION
## Summary
- mark Telegram settings form with class for JS targeting
- add JS helper to submit Telegram settings via fetch
- initialize Telegram forms on page load and when adding stores

## Testing
- `./mvnw test -q` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6851ea61f924832daa769e0aff7baf08