### PR TITLE
Add telegram block fragment

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -308,4 +308,22 @@ public class ProfileController {
         }
     }
 
+    /**
+     * Возвращает HTML-фрагмент блока настроек Telegram для магазина.
+     *
+     * @param storeId        идентификатор магазина
+     * @param authentication текущая аутентификация
+     * @param model          модель для передачи данных во фрагмент
+     * @return HTML-фрагмент блока магазина
+     */
+    @GetMapping("/stores/{storeId}/telegram-block")
+    public String getTelegramBlock(@PathVariable Long storeId,
+                                   Authentication authentication,
+                                   Model model) {
+        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+        Store store = storeService.getStore(storeId, userId);
+        model.addAttribute("store", store);
+        return "profile :: telegramStoreBlock";
+    }
+
 }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -123,49 +123,7 @@
                             Настройки уведомлений для покупателей в Telegram. Если включено, покупатели будут получать автоматические уведомления о статусах посылок (например, «отправлена», «прибыла в пункт выдачи» и др.).
                         </p>
                         <th:block th:each="store : ${stores}">
-                            <div th:id="'store-block-' + ${store.id}" class="mt-3 border p-3 rounded bg-light-subtle">
-                                <div class="d-flex justify-content-between align-items-center">
-                                    <h5 th:text="${store.name}" class="mb-2"></h5>
-                                    <button type="button" class="btn btn-sm btn-outline-secondary toggle-tg-btn"
-                                            th:attr="data-store-id=${store.id}">
-                                        <i class="bi bi-chevron-up"></i>
-                                    </button>
-                                </div>
-                                <div class="tg-settings-content expanded" th:attr="data-store-id=${store.id}">
-                                    <form class="telegram-settings-form" th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
-                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                                        <div class="form-check form-switch mb-2">
-                                            <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
-                                                   th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
-                                            <label class="form-check-label" th:for="'tg-enable-' + ${store.id}">
-                                                Отправлять уведомления покупателям этого магазина
-                                            </label>
-                                        </div>
-                                        <div class="mb-2">
-                                            <label class="form-label" th:for="'tg-start-' + ${store.id}">
-                                                Через сколько дней после прибытия посылки отправить первое напоминание
-                                            </label>
-                                            <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
-                                                   th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
-                                        </div>
-                                        <div class="mb-2">
-                                            <label class="form-label" th:for="'tg-repeat-' + ${store.id}">
-                                                Как часто повторять напоминания, если посылка не забрана (в днях)
-                                            </label>
-                                            <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
-                                                   th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
-                                        </div>
-                                        <div class="mb-2">
-                                            <label class="form-label" th:for="'tg-sign-' + ${store.id}">
-                                                Подпись к уведомлениям (отображается во всех сообщениях)
-                                            </label>
-                                            <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}" name="customSignature"
-                                                   th:value="${store.telegramSettings?.customSignature}" maxlength="200">
-                                        </div>
-                                        <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
-                                    </form>
-                                </div>
-                            </div>
+                            <div th:replace="~{profile :: telegramStoreBlock(store=${store})}"></div>
                         </th:block>
                     </div>
                 </div>
@@ -329,6 +287,52 @@
         </div>
     </div>
 </main>
+
+<th:block th:fragment="telegramStoreBlock(store)" th:remove="tag">
+    <div th:id="'store-block-' + ${store.id}" class="mt-3 border p-3 rounded bg-light-subtle">
+        <div class="d-flex justify-content-between align-items-center">
+            <h5 th:text="${store.name}" class="mb-2"></h5>
+            <button type="button" class="btn btn-sm btn-outline-secondary toggle-tg-btn"
+                    th:attr="data-store-id=${store.id}">
+                <i class="bi bi-chevron-up"></i>
+            </button>
+        </div>
+        <div class="tg-settings-content expanded" th:attr="data-store-id=${store.id}">
+            <form class="telegram-settings-form" th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <div class="form-check form-switch mb-2">
+                    <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
+                           th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
+                    <label class="form-check-label" th:for="'tg-enable-' + ${store.id}">
+                        Отправлять уведомления покупателям этого магазина
+                    </label>
+                </div>
+                <div class="mb-2">
+                    <label class="form-label" th:for="'tg-start-' + ${store.id}">
+                        Через сколько дней после прибытия посылки отправить первое напоминание
+                    </label>
+                    <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
+                           th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
+                </div>
+                <div class="mb-2">
+                    <label class="form-label" th:for="'tg-repeat-' + ${store.id}">
+                        Как часто повторять напоминания, если посылка не забрана (в днях)
+                    </label>
+                    <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
+                           th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
+                </div>
+                <div class="mb-2">
+                    <label class="form-label" th:for="'tg-sign-' + ${store.id}">
+                        Подпись к уведомлениям (отображается во всех сообщениях)
+                    </label>
+                    <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}" name="customSignature"
+                           th:value="${store.telegramSettings?.customSignature}" maxlength="200">
+                </div>
+                <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
+            </form>
+        </div>
+    </div>
+</th:block>
 
 <div layout:fragment="afterFooter">
     <!-- Модальное окно подтверждения удаления аккаунта -->


### PR DESCRIPTION
## Summary
- refactor Telegram settings block as a reusable fragment in `profile.html`
- render Telegram block via fragment on the client
- expose fragment via controller for dynamic use

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685281db23d4832d983cf364708eeac4