### PR TITLE
Fix unique notification containers in profile

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -300,6 +300,16 @@ function notifyUser(message, type = "info") {
 
 // Уведомления
 function showAlert(message, type) {
+    // Находим контейнер уведомлений на странице
+    const notificationContainer = document.querySelector('#storeNotificationContainer')
+        || document.querySelector('#evropostNotificationContainer')
+        || document.querySelector('#notificationContainer');
+
+    if (!notificationContainer) {
+        console.warn("❌ Не найден контейнер для уведомлений!");
+        return;
+    }
+
     let existingAlert = document.querySelector(".notification"); // Берём только первый найденный alert
 
     // ❌ Игнорируем "Обновление запущено...", так как оно временное

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -84,7 +84,7 @@
                 <div class="tab-pane fade card p-4 shadow-sm rounded-4" id="v-pills-stores" role="tabpanel">
 
                     <!-- Контейнер для уведомлений -->
-                    <div id="notificationContainer"></div>
+                    <div id="storeNotificationContainer"></div>
 
                     <h5 class="mb-3">
                         Мои магазины
@@ -184,7 +184,7 @@
                      role="tabpanel">
 
                     <!-- Контейнер для уведомлений -->
-                    <div id="notificationContainer"></div>
+                    <div id="evropostNotificationContainer"></div>
 
                     <div id="evropost-content" th:fragment="evropostFragment">
 


### PR DESCRIPTION
## Summary
- rename each profile notification container to have unique IDs
- update JS alert helper to find the correct notification container

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68528b3666b8832d8639c5f2c7597857