### PR TITLE
Add collapsed style

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -11,6 +11,7 @@
     opacity: 0;
     padding: 0 !important;
     margin: 0 !important;
+    display: none; // Полностью скрываем блок при сворачивании
   }
 
   &.expanded {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1163,6 +1163,7 @@ button:hover {
   opacity: 0;
   padding: 0 !important;
   margin: 0 !important;
+  display: none;
 }
 .tg-settings-content.expanded {
   max-height: 1000px;


### PR DESCRIPTION
## Summary
- hide telegram settings block when collapsed

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528cd987fc832db4aecc4dfa3e8092