### PR TITLE
Add JavaDoc for security filter chain

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -44,6 +44,17 @@ public class SecurityConfiguration {
     private final AuthenticationProviderConfig authenticationProviderConfig;
     private final LoginAttemptService loginAttemptService;
 
+    /**
+     * Формирует настройки безопасности приложения.
+     * <p>
+     * Метод конфигурирует фильтры и основные параметры Spring Security.
+     * </p>
+     *
+     * @param http           объект {@link HttpSecurity} для настройки безопасности
+     * @param cspNonceFilter фильтр добавления nonce для CSP
+     * @return цепочка фильтров {@link SecurityFilterChain}
+     * @throws Exception при ошибках конфигурации
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, CspNonceFilter cspNonceFilter) throws Exception {
         http


### PR DESCRIPTION
## Summary
- document `securityFilterChain` method in `SecurityConfiguration`

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685290baa960832db91b1118881f993d