### PR TITLE
Add JavaDoc for password encoder bean

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -64,6 +64,14 @@ public class AppConfiguration {
         return new ModelMapper();
     }
 
+    /**
+     * Создает бин {@link PasswordEncoder} для хеширования паролей пользователей.
+     * <p>
+     * {@link PasswordEncoder} необходим для безопасного хранения и проверки паролей в системе.
+     * </p>
+     *
+     * @return Экземпляр {@link PasswordEncoder} с алгоритмом BCrypt.
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();


### PR DESCRIPTION
## Summary
- document PasswordEncoder bean in AppConfiguration

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685291230698832db2bf22317df30e2d