### PR TITLE
Add TelegramClient bean JavaDoc

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/TelegramConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/TelegramConfig.java
@@ -16,6 +16,14 @@ public class TelegramConfig {
     @Value("${telegram.bot.token}")
     private String botToken;
 
+    /**
+     * Создает клиента Telegram для взаимодействия с ботом.
+     * <p>
+     * Возвращает настроенный {@link TelegramClient}, использующий токен бота.
+     * </p>
+     *
+     * @return экземпляр {@link TelegramClient}
+     */
     @Bean
     public TelegramClient telegramClient() {
         return new OkHttpTelegramClient(botToken);


### PR DESCRIPTION
## Summary
- document TelegramClient bean in TelegramConfig

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68529124e634832d9f6307b62223447b