### PR TITLE
Fix Russian typo in lock message

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AuthenticationProviderConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/AuthenticationProviderConfig.java
@@ -50,7 +50,7 @@ public class AuthenticationProviderConfig {
             public Authentication authenticate(Authentication authentication) throws AuthenticationException {
                 String email = authentication.getName();
                 if (loginAttemptService.isEmailBlocked(email)){
-                    throw new LockedException("Аккант временно заблокирован");
+                    throw new LockedException("Аккаунт временно заблокирован");
                 }
                 return super.authenticate(authentication);
             }


### PR DESCRIPTION
## Summary
- correct typo in account lock message in authentication provider

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529127972c832da0cf653baac2b5ef