### PR TITLE
Add AJAX submission for Telegram settings

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -182,26 +182,23 @@ function initTelegramForms() {
             event.preventDefault();
 
             const formData = new FormData(form);
-            const payload = Object.fromEntries(formData.entries());
+            const csrfToken = form.querySelector('input[name="_csrf"]')?.value || '';
 
             try {
                 const response = await fetch(form.action, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        [window.csrfHeader]: window.csrfToken
-                    },
-                    body: JSON.stringify(payload)
+                    headers: { 'X-CSRF-TOKEN': csrfToken },
+                    body: formData
                 });
 
                 if (response.ok) {
-                    notifyUser('Настройки Telegram сохранены.', 'success');
+                    showInlineNotification(form, 'Настройки сохранены', 'success');
                 } else {
                     const errorText = await response.text();
-                    notifyUser(errorText || 'Ошибка при сохранении.', 'danger');
+                    showInlineNotification(form, errorText || 'Ошибка при сохранении', 'danger');
                 }
             } catch (e) {
-                notifyUser('Ошибка сети при сохранении.', 'danger');
+                showInlineNotification(form, 'Ошибка сети при сохранении', 'danger');
             }
         });
     });
@@ -347,6 +344,16 @@ function showAlert(message, type) {
             setTimeout(() => notification.remove(), 500);
         }
     }, 5000);
+}
+
+// Показ уведомления прямо под формой
+function showInlineNotification(form, message, type = 'info') {
+    form.nextElementSibling?.classList.contains('form-notification') && form.nextElementSibling.remove();
+    const div = document.createElement('div');
+    div.className = `alert alert-${type} mt-2 form-notification`;
+    div.textContent = message;
+    form.insertAdjacentElement('afterend', div);
+    setTimeout(() => div.remove(), 4000);
 }
 
 // Функция для показа Toast (если пользователь ушёл или уже в модальном окне)


### PR DESCRIPTION
## Summary
- handle Telegram settings form submission with multipart via AJAX
- show inline form notifications on success or failure
- support new POST endpoint for AJAX form submissions

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685292308bc4832d9faba7b2ab1c2914