### PR TITLE
Fix duplicate Telegram notifications

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -47,7 +47,7 @@ public class StoreTelegramSettingsController {
     }
 
     /**
-     * Обновить настройки магазина.
+     * Обновить настройки магазина (JSON).
      */
     @PostMapping(consumes = org.springframework.http.MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
@@ -72,6 +72,37 @@ public class StoreTelegramSettingsController {
             log.error("Ошибка обновления настроек Telegram", e);
             return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         }
+    }
+
+    /**
+     * Обновить настройки магазина через AJAX-форму.
+     * <p>
+     * Метод используется при отправке формы без перезагрузки страницы и
+     * отправляет уведомление через WebSocket.
+     *
+     * @param storeId        идентификатор магазина
+     * @param dto            заполненные настройки Telegram
+     * @param binding        результаты валидации формы
+     * @param authentication текущая аутентификация пользователя
+     * @return {@link ResponseEntity} с HTTP 200 или ошибкой в тексте
+     */
+    @PostMapping(consumes = org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseBody
+    public ResponseEntity<?> updateSettingsAjax(@PathVariable Long storeId,
+                                                @Valid @ModelAttribute StoreTelegramSettingsDTO dto,
+                                                BindingResult binding,
+                                                Authentication authentication) {
+        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+        if (binding.hasErrors()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(binding.getAllErrors().get(0).getDefaultMessage());
+        }
+
+        Store store = storeService.getStore(storeId, userId);
+        telegramSettingsService.update(store, dto);
+        // Отправляем уведомление через WebSocket
+        webSocketController.sendUpdateStatus(userId, "Настройки Telegram сохранены.", true);
+        return ResponseEntity.ok().build();
     }
 
     /**

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -182,20 +182,17 @@ function initTelegramForms() {
             event.preventDefault();
 
             const formData = new FormData(form);
-            const payload = Object.fromEntries(formData.entries());
+            const csrfToken = form.querySelector('input[name="_csrf"]')?.value || '';
 
             try {
                 const response = await fetch(form.action, {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        [window.csrfHeader]: window.csrfToken
-                    },
-                    body: JSON.stringify(payload)
+                    headers: { 'X-CSRF-TOKEN': csrfToken },
+                    body: formData
                 });
 
                 if (response.ok) {
-                    notifyUser('Настройки Telegram сохранены.', 'success');
+                    // Уведомление придёт через WebSocket
                 } else {
                     const errorText = await response.text();
                     notifyUser(errorText || 'Ошибка при сохранении.', 'danger');


### PR DESCRIPTION
## Summary
- avoid local inline notifications for AJAX Telegram update
- send WebSocket message after AJAX save instead

## Testing
- `./mvnw -q test` *(fails: cannot open .mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685292308bc4832d9faba7b2ab1c2914