### PR TITLE
Fix repeated telegram confirmation

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -36,6 +36,9 @@ public class Customer {
     @Column(name = "telegram_chat_id")
     private Long telegramChatId;
 
+    @Column(name = "telegram_confirmed", nullable = false)
+    private boolean telegramConfirmed = false;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "reputation", nullable = false)
     private BuyerReputation reputation = BuyerReputation.NEW;

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -52,4 +52,23 @@ public class CustomerTelegramService {
         log.info("✅ Чат {} привязан к покупателю {}", chatId, saved.getId());
         return saved;
     }
+
+    /**
+     * Подтвердить получение уведомления о привязке Telegram.
+     *
+     * @param customer покупатель
+     * @return обновлённый покупатель
+     */
+    @Transactional
+    public Customer confirmTelegram(Customer customer) {
+        if (customer == null) {
+            throw new IllegalArgumentException("Покупатель не задан");
+        }
+        if (!customer.isTelegramConfirmed()) {
+            customer.setTelegramConfirmed(true);
+            customer = customerRepository.save(customer);
+            log.info("✅ Покупатель {} подтвердил Telegram", customer.getId());
+        }
+        return customer;
+    }
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.service.telegram;
 
+import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.service.customer.CustomerTelegramService;
 import com.project.tracking_system.utils.PhoneUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -104,10 +105,12 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         String phone = PhoneUtils.normalizePhone(rawPhone);
 
         try {
-            telegramService.linkTelegramToCustomer(phone, chatId);
-            SendMessage confirm = new SendMessage(chatId.toString(), "✅ Номер сохранён. Спасибо!");
-
-            telegramClient.execute(confirm);
+            Customer customer = telegramService.linkTelegramToCustomer(phone, chatId);
+            if (!customer.isTelegramConfirmed()) {
+                SendMessage confirm = new SendMessage(chatId.toString(), "✅ Номер сохранён. Спасибо!");
+                telegramClient.execute(confirm);
+                telegramService.confirmTelegram(customer);
+            }
         } catch (Exception e) {
             log.error("❌ Ошибка регистрации телефона {} для чата {}", phone, chatId, e);
         }

--- a/src/main/resources/db/migration/V17__add_telegram_confirmed_to_customers.sql
+++ b/src/main/resources/db/migration/V17__add_telegram_confirmed_to_customers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_customers
+    ADD COLUMN telegram_confirmed BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/project/tracking_system/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/customer/CustomerTelegramServiceTest.java
@@ -62,4 +62,15 @@ class CustomerTelegramServiceTest {
         Customer fromDb = customerRepository.findById(existing.getId()).orElseThrow();
         assertEquals(333L, fromDb.getTelegramChatId());
     }
+
+    @Test
+    void confirmTelegramSetsFlag() {
+        Customer customer = telegramService.linkTelegramToCustomer("29 123-45-67", 555L);
+        assertFalse(customer.isTelegramConfirmed());
+
+        telegramService.confirmTelegram(customer);
+
+        Customer fromDb = customerRepository.findById(customer.getId()).orElseThrow();
+        assertTrue(fromDb.isTelegramConfirmed());
+    }
 }


### PR DESCRIPTION
## Summary
- add `telegram_confirmed` flag to customer entity and database
- avoid repeated telegram confirmation message
- allow confirming telegram link in service
- test telegram confirmation logic

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685310c06b90832db51b3dfeed1334f2