### PR TITLE
Add telegram reminders setting

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -23,4 +23,6 @@ public class StoreTelegramSettingsDTO {
 
     @Size(max = 200)
     private String customSignature;
+
+    private boolean remindersEnabled = false;
 }

--- a/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
@@ -38,4 +38,7 @@ public class StoreTelegramSettings {
 
     @Column(name = "custom_signature", length = 200)
     private String customSignature;
+
+    @Column(name = "reminders_enabled", nullable = false)
+    private boolean remindersEnabled = false;
 }

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -395,6 +395,7 @@ public class StoreService {
         dto.setReminderStartAfterDays(settings.getReminderStartAfterDays());
         dto.setReminderRepeatIntervalDays(settings.getReminderRepeatIntervalDays());
         dto.setCustomSignature(settings.getCustomSignature());
+        dto.setRemindersEnabled(settings.isRemindersEnabled());
         return dto;
     }
 
@@ -406,6 +407,7 @@ public class StoreService {
         settings.setReminderStartAfterDays(dto.getReminderStartAfterDays());
         settings.setReminderRepeatIntervalDays(dto.getReminderRepeatIntervalDays());
         settings.setCustomSignature(dto.getCustomSignature());
+        settings.setRemindersEnabled(dto.isRemindersEnabled());
     }
 
 

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -37,6 +37,7 @@ public class StoreTelegramSettingsService {
         settings.setReminderStartAfterDays(dto.getReminderStartAfterDays());
         settings.setReminderRepeatIntervalDays(dto.getReminderRepeatIntervalDays());
         settings.setCustomSignature(dto.getCustomSignature());
+        settings.setRemindersEnabled(dto.isRemindersEnabled());
         settingsRepository.save(settings);
         store.setTelegramSettings(settings);
         log.info("Настройки Telegram для магазина ID={} обновлены", store.getId());

--- a/src/main/resources/db/migration/V18__add_reminders_enabled.sql
+++ b/src/main/resources/db/migration/V18__add_reminders_enabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_store_telegram_settings
+    ADD COLUMN reminders_enabled BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- add column reminders_enabled for telegram settings
- map remindersEnabled in service layer
- update StoreTelegramSettingsService logic
- provide Flyway migration for reminders_enabled

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68531878288c832dae1b2133f7e42296