### PR TITLE
Add reminder checks in telegram services

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -24,5 +24,6 @@ public class StoreTelegramSettingsDTO {
     @Size(max = 200)
     private String customSignature;
 
+
     private boolean remindersEnabled = false;
 }

--- a/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
@@ -39,6 +39,7 @@ public class StoreTelegramSettings {
     @Column(name = "custom_signature", length = 200)
     private String customSignature;
 
+
     @Column(name = "reminders_enabled", nullable = false)
     private boolean remindersEnabled = false;
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -43,6 +43,7 @@ public class TelegramNotificationService {
         Long chatId = getChatId(parcel);
         String text = buildStatusText(parcel, status);
 
+
         SendMessage message = new SendMessage(chatId.toString(), text);
 
         try {
@@ -66,7 +67,7 @@ public class TelegramNotificationService {
         }
 
         StoreTelegramSettings settings = parcel.getStore().getTelegramSettings();
-        if (settings != null && !settings.isEnabled()) {
+        if (settings != null && (!settings.isEnabled() || !settings.isRemindersEnabled())) {
             log.debug("Напоминания отключены для магазина {}", parcel.getStore().getId());
             return;
         }
@@ -82,6 +83,7 @@ public class TelegramNotificationService {
         if (settings != null && settings.getCustomSignature() != null && !settings.getCustomSignature().isBlank()) {
             text += "\n\n" + settings.getCustomSignature();
         }
+
 
         SendMessage message = new SendMessage(chatId.toString(), text);
 

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramReminderScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramReminderScheduler.java
@@ -47,7 +47,7 @@ public class TelegramReminderScheduler {
 
         for (TrackParcel parcel : parcels) {
             StoreTelegramSettings settings = parcel.getStore().getTelegramSettings();
-            if (settings == null || !settings.isEnabled()) {
+            if (settings == null || !settings.isEnabled() || !settings.isRemindersEnabled()) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- remove unused `customMessage` field and DB migration
- require both `enabled` and `remindersEnabled` to send reminders
- skip reminder scheduling for stores with reminders disabled

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_68531b694ee8832dac21a9037190dbef