### PR TITLE
Add Telegram reminder UI tweaks

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -270,6 +270,37 @@ function initTelegramToggle() {
     });
 }
 
+// Инициализация зависимых полей Telegram
+function initTelegramReminderBlocks() {
+    document.querySelectorAll('.telegram-settings-form').forEach(form => {
+        const enabledCb = form.querySelector('input[name="enabled"]');
+        const remindersBlock = form.querySelector('.reminders-container');
+        const remindersCb = form.querySelector('input[name="remindersEnabled"]');
+        const reminderFields = form.querySelector('.reminder-fields');
+
+        if (!enabledCb) return;
+
+        const updateVisibility = () => {
+            if (remindersBlock) toggleFieldsVisibility(enabledCb, remindersBlock);
+            if (reminderFields && remindersCb) {
+                if (enabledCb.checked) {
+                    toggleFieldsVisibility(remindersCb, reminderFields);
+                } else {
+                    reminderFields.classList.add('hidden');
+                }
+            }
+        };
+
+        // Первоначальное состояние
+        updateVisibility();
+
+        enabledCb.addEventListener('change', updateVisibility);
+        remindersCb?.addEventListener('change', () => {
+            if (reminderFields) toggleFieldsVisibility(remindersCb, reminderFields);
+        });
+    });
+}
+
 let lastPage = window.location.pathname; // Запоминаем текущую страницу при загрузке
 let isInitialLoad = true;
 
@@ -668,6 +699,7 @@ async function appendTelegramBlock(store) {
     // --- Инициализируем формы и collapse
     initTelegramForms();
     initTelegramToggle();
+    initTelegramReminderBlocks();
 }
 
 /**
@@ -1047,6 +1079,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initAssignCustomerFormHandler();
     initTelegramForms();
     initTelegramToggle();
+    initTelegramReminderBlocks();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие
     const addStoreBtn = document.getElementById("addStoreBtn");

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -314,20 +314,36 @@
                         Отправлять уведомления покупателям этого магазина
                     </label>
                 </div>
-                <div class="mb-2">
-                    <label class="form-label" th:for="'tg-start-' + ${store.id}">
-                        Через сколько дней после прибытия посылки отправить первое напоминание
+                <p class="form-text ms-4">
+                    Получатель увидит основные статусы посылки: «отправлена», «прибыла», «получена» и др.
+                </p>
+
+                <div th:id="'tg-reminders-block-' + ${store.id}" class="form-check form-switch mb-2 ms-3 hidden reminders-container">
+                    <input class="form-check-input" type="checkbox" th:id="'tg-reminders-' + ${store.id}" name="remindersEnabled"
+                           th:checked="${store.telegramSettings?.remindersEnabled}">
+                    <label class="form-check-label" th:for="'tg-reminders-' + ${store.id}">
+                        Отправлять напоминания, если посылка не забрана
                     </label>
-                    <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
-                           th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
                 </div>
-                <div class="mb-2">
-                    <label class="form-label" th:for="'tg-repeat-' + ${store.id}">
-                        Как часто повторять напоминания, если посылка не забрана (в днях)
-                    </label>
-                    <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
-                           th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
+
+                <div th:id="'tg-reminder-fields-' + ${store.id}" class="ms-4 hidden reminder-fields">
+                    <div class="mb-2">
+                        <label class="form-label" th:for="'tg-start-' + ${store.id}">
+                            Через сколько дней после прибытия посылки отправить первое напоминание
+                        </label>
+                        <input type="number" class="form-control form-control-sm" th:id="'tg-start-' + ${store.id}" name="reminderStartAfterDays"
+                               th:value="${store.telegramSettings?.reminderStartAfterDays ?: 3}" min="1" max="14">
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label" th:for="'tg-repeat-' + ${store.id}">
+                            Как часто повторять напоминания, если посылка не забрана (в днях)
+                        </label>
+                        <input type="number" class="form-control form-control-sm" th:id="'tg-repeat-' + ${store.id}" name="reminderRepeatIntervalDays"
+                               th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
+                    </div>
                 </div>
+
+
                 <div class="mb-2">
                     <label class="form-label" th:for="'tg-sign-' + ${store.id}">
                         Подпись к уведомлениям (отображается во всех сообщениях)


### PR DESCRIPTION
## Summary
- improve telegram settings fragment with nested reminder checkbox
- add explanatory note under notification toggle
- toggle reminder options dynamically via JS
- remove extra custom message textarea per review feedback

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: mvn not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68532001e19c832dbbc3096b80628691