### PR TITLE
Send Telegram updates after initial binding

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -73,4 +73,13 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
         """)
     List<TrackParcel> findWaitingForPickupBefore(@Param("status") GlobalStatus status,
                                                  @Param("threshold") java.time.ZonedDateTime threshold);
+
+    /**
+     * Найти все активные посылки покупателя в указанных статусах.
+     *
+     * @param customerId идентификатор покупателя
+     * @param statuses    список статусов
+     * @return список подходящих посылок
+     */
+    List<TrackParcel> findByCustomerIdAndStatusIn(Long customerId, List<GlobalStatus> statuses);
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -110,6 +110,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 SendMessage confirm = new SendMessage(chatId.toString(), "✅ Номер сохранён. Спасибо!");
                 telegramClient.execute(confirm);
                 telegramService.confirmTelegram(customer);
+                telegramService.notifyActualStatuses(customer);
             }
         } catch (Exception e) {
             log.error("❌ Ошибка регистрации телефона {} для чата {}", phone, chatId, e);


### PR DESCRIPTION
## Summary
- notify buyers about all active parcels when Telegram is linked
- fetch active parcels for a customer
- send updates from the bot on first confirmation

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532618a720832d89c84045dc40492d