### PR TITLE
Add admin management pages

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/StoreAdminInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreAdminInfoDTO.java
@@ -1,0 +1,20 @@
+package com.project.tracking_system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Информация о магазине для административной панели.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreAdminInfoDTO {
+    private Long id;
+    private String name;
+    private String ownerEmail;
+    private boolean telegramEnabled;
+    private boolean remindersEnabled;
+    private String subscriptionPlan;
+}

--- a/src/main/java/com/project/tracking_system/repository/CustomerNotificationLogRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerNotificationLogRepository.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.entity.CustomerNotificationLog;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 /**
  * Репозиторий для работы с логом уведомлений покупателей.
@@ -26,5 +27,12 @@ public interface CustomerNotificationLogRepository extends JpaRepository<Custome
      * Найти последнее напоминание для посылки.
      */
     CustomerNotificationLog findTopByParcelIdAndNotificationTypeOrderBySentAtDesc(Long parcelId,
-                                                                                   NotificationType type);
+                                           NotificationType type);
+
+    /**
+     * Получить последние десять записей журнала уведомлений.
+     *
+     * @return список из десяти последних уведомлений
+     */
+    List<CustomerNotificationLog> findTop10ByOrderBySentAtDesc();
 }

--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -1,6 +1,8 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.BuyerReputation;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -73,4 +75,27 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
         WHERE c.id = :id
         """)
     int incrementReturnedCount(@Param("id") Long id);
+
+    /**
+     * Подсчитать количество покупателей с указанной репутацией.
+     *
+     * @param reputation репутация покупателя
+     * @return число покупателей
+     */
+    long countByReputation(BuyerReputation reputation);
+
+    /**
+     * Получить покупателей по репутации.
+     *
+     * @param reputation уровень доверия покупателя
+     * @return список покупателей
+     */
+    List<Customer> findByReputation(BuyerReputation reputation);
+
+    /**
+     * Подсчитать количество покупателей, привязавших Telegram.
+     *
+     * @return число покупателей с Telegram
+     */
+    long countByTelegramChatIdNotNull();
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreRepository.java
@@ -68,4 +68,16 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query("SELECT s FROM Store s LEFT JOIN FETCH s.telegramSettings WHERE s.owner.id = :ownerId")
     List<Store> findByOwnerIdFetchSettings(@Param("ownerId") Long ownerId);
 
+    /**
+     * Получить все магазины с Telegram-настройками и подпиской владельца.
+     *
+     * @return список магазинов
+     */
+    @Query("SELECT s FROM Store s " +
+           "LEFT JOIN FETCH s.telegramSettings " +
+           "LEFT JOIN FETCH s.owner o " +
+           "LEFT JOIN FETCH o.subscription us " +
+           "LEFT JOIN FETCH us.subscriptionPlan")
+    List<Store> findAllWithSettingsAndSubscription();
+
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreTelegramSettingsRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreTelegramSettingsRepository.java
@@ -15,4 +15,11 @@ public interface StoreTelegramSettingsRepository extends JpaRepository<StoreTele
      * @return настройки или {@code null}, если не найдены
      */
     StoreTelegramSettings findByStoreId(Long storeId);
+
+    /**
+     * Подсчитать количество магазинов с включёнными напоминаниями.
+     *
+     * @return число магазинов
+     */
+    long countByRemindersEnabledTrue();
 }

--- a/src/main/java/com/project/tracking_system/repository/UserSubscriptionRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/UserSubscriptionRepository.java
@@ -72,4 +72,12 @@ public interface UserSubscriptionRepository extends JpaRepository<UserSubscripti
        """)
     void resetUpdateCount(@Param("userId") Long userId, @Param("resetDate") LocalDate resetDate);
 
+    /**
+     * Получить все подписки вместе с пользователем и планом.
+     *
+     * @return список подписок
+     */
+    @Query("SELECT s FROM UserSubscription s JOIN FETCH s.user u JOIN FETCH s.subscriptionPlan sp")
+    List<UserSubscription> findAllWithUserAndPlan();
+
 }

--- a/src/main/java/com/project/tracking_system/service/admin/AdminService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminService.java
@@ -1,0 +1,127 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.dto.StoreAdminInfoDTO;
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Сервис сбора административной статистики.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService {
+
+    private final CustomerRepository customerRepository;
+    private final CustomerNotificationLogRepository notificationRepository;
+    private final StoreRepository storeRepository;
+    private final StoreTelegramSettingsRepository storeTelegramSettingsRepository;
+    private final UserSubscriptionRepository userSubscriptionRepository;
+    private final SubscriptionPlanRepository subscriptionPlanRepository;
+
+    /**
+     * Подсчитать общее количество покупателей.
+     */
+    public long countCustomers() {
+        return customerRepository.count();
+    }
+
+    /**
+     * Подсчитать количество ненадёжных покупателей.
+     */
+    public long countUnreliableCustomers() {
+        return customerRepository.countByReputation(BuyerReputation.UNRELIABLE);
+    }
+
+    /**
+     * Получить список ненадёжных покупателей.
+     */
+    public List<Customer> getUnreliableCustomers() {
+        return customerRepository.findByReputation(BuyerReputation.UNRELIABLE);
+    }
+
+    /**
+     * Преобразовать список покупателей в CSV-формат.
+     */
+    public String toCsv(List<Customer> customers) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("phone,sent,picked,returned,reputation\n");
+        for (Customer c : customers) {
+            sb.append(c.getPhone()).append(',')
+              .append(c.getSentCount()).append(',')
+              .append(c.getPickedUpCount()).append(',')
+              .append(c.getReturnedCount()).append(',')
+              .append(c.getReputation()).append('\n');
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Количество покупателей с привязанным Telegram.
+     */
+    public long countTelegramBoundCustomers() {
+        return customerRepository.countByTelegramChatIdNotNull();
+    }
+
+    /**
+     * Количество магазинов с включёнными напоминаниями.
+     */
+    public long countStoresWithReminders() {
+        return storeTelegramSettingsRepository.countByRemindersEnabledTrue();
+    }
+
+    /**
+     * Получить последние уведомления.
+     */
+    public List<CustomerNotificationLog> getRecentLogs() {
+        return notificationRepository.findTop10ByOrderBySentAtDesc();
+    }
+
+    /**
+     * Список магазинов с настройками и планом подписки владельца.
+     */
+    public List<StoreAdminInfoDTO> getStoresInfo() {
+        List<Store> stores = storeRepository.findAllWithSettingsAndSubscription();
+        return stores.stream()
+                .map(s -> new StoreAdminInfoDTO(
+                        s.getId(),
+                        s.getName(),
+                        s.getOwner().getEmail(),
+                        Optional.ofNullable(s.getTelegramSettings()).map(StoreTelegramSettings::isEnabled).orElse(false),
+                        Optional.ofNullable(s.getTelegramSettings()).map(StoreTelegramSettings::isRemindersEnabled).orElse(false),
+                        Optional.ofNullable(s.getOwner().getSubscription())
+                                .map(UserSubscription::getSubscriptionPlan)
+                                .map(SubscriptionPlan::getName)
+                                .orElse("NONE")
+                ))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Список подписок пользователей.
+     */
+    public List<UserSubscription> getAllUserSubscriptions() {
+        return userSubscriptionRepository.findAllWithUserAndPlan();
+    }
+
+    /**
+     * Получить все планы подписки.
+     */
+    public List<SubscriptionPlan> getPlans() {
+        return subscriptionPlanRepository.findAll();
+    }
+
+    /**
+     * Подсчитать количество магазинов в системе.
+     */
+    public long countStores() {
+        return storeRepository.count();
+    }
+}

--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Покупатели</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Всего покупателей</h5>
+                    <p class="card-text text-center" th:text="${totalCustomers}"></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Процент ненадёжных</h5>
+                    <p class="card-text text-center" th:text="${unreliablePercent} + '%'"></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <a href="/admin/customers/export" class="btn btn-success mb-3">Экспорт CSV</a>
+
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Телефон</th>
+            <th>Отправлено</th>
+            <th>Забрано</th>
+            <th>Возвраты</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="c : ${riskCustomers}">
+            <td th:text="${c.id}"></td>
+            <td th:text="${c.phone}"></td>
+            <td th:text="${c.sentCount}"></td>
+            <td th:text="${c.pickedUpCount}"></td>
+            <td th:text="${c.returnedCount}"></td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</html>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -38,6 +38,30 @@
                 </div>
             </div>
         </div>
+        <div class="col-md-4 mt-3">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Всего покупателей</h5>
+                    <p class="card-text text-center" th:text="${totalCustomers}"></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mt-3">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Telegram привязок</h5>
+                    <p class="card-text text-center" th:text="${telegramBound}"></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mt-3">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Всего магазинов</h5>
+                    <p class="card-text text-center" th:text="${storesCount}"></p>
+                </div>
+            </div>
+        </div>
     </div>
 
     <div class="list-group mt-4">
@@ -49,6 +73,18 @@
         </a>
         <a href="/admin/settings" class="list-group-item list-group-item-action custom-list-item">
             <i class="bi bi-gear-fill"></i> Настройки
+        </a>
+        <a href="/admin/customers" class="list-group-item list-group-item-action custom-list-item">
+            <i class="bi bi-people-fill"></i> Покупатели
+        </a>
+        <a href="/admin/telegram" class="list-group-item list-group-item-action custom-list-item">
+            <i class="bi bi-telegram"></i> Telegram
+        </a>
+        <a href="/admin/stores" class="list-group-item list-group-item-action custom-list-item">
+            <i class="bi bi-shop"></i> Магазины
+        </a>
+        <a href="/admin/subscriptions" class="list-group-item list-group-item-action custom-list-item">
+            <i class="bi bi-bookmark-check"></i> Подписки
         </a>
     </div>
 </main>

--- a/src/main/resources/templates/admin/stores.html
+++ b/src/main/resources/templates/admin/stores.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Магазины</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Название</th>
+            <th>Владелец</th>
+            <th>Telegram</th>
+            <th>Напоминания</th>
+            <th>Подписка</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="s : ${stores}">
+            <td th:text="${s.id}"></td>
+            <td th:text="${s.name}"></td>
+            <td th:text="${s.ownerEmail}"></td>
+            <td th:text="${s.telegramEnabled}"></td>
+            <td th:text="${s.remindersEnabled}"></td>
+            <td th:text="${s.subscriptionPlan}"></td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</html>

--- a/src/main/resources/templates/admin/subscriptions.html
+++ b/src/main/resources/templates/admin/subscriptions.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Подписки</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>Email</th>
+            <th>План</th>
+            <th>Окончание</th>
+            <th>Изменить</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="s : ${subscriptions}">
+            <td th:text="${s.user.email}"></td>
+            <td th:text="${s.subscriptionPlan.name}"></td>
+            <td th:text="${s.subscriptionEndDate}"></td>
+            <td>
+                <form th:action="@{/admin/users/{id}/change-subscription(id=${s.user.id})}" method="post" class="d-flex">
+                    <select name="subscriptionPlan" class="form-select form-select-sm me-2">
+                        <option th:each="p : ${plans}" th:value="${p.name}" th:text="${p.name}" th:selected="${p.name == s.subscriptionPlan.name}"></option>
+                    </select>
+                    <input type="number" name="months" value="1" min="1" class="form-control form-control-sm me-2" />
+                    <button type="submit" class="btn btn-success btn-sm">Сохранить</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</html>

--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Telegram</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Покупателей с Telegram</h5>
+                    <p class="card-text text-center" th:text="${boundCustomers}"></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Магазинов с напоминаниями</h5>
+                    <p class="card-text text-center" th:text="${remindersEnabled}"></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h4>Последние уведомления</h4>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>Телефон</th>
+            <th>Трек</th>
+            <th>Тип</th>
+            <th>Дата</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="log : ${logs}">
+            <td th:text="${log.customer.phone}"></td>
+            <td th:text="${log.parcel.number}"></td>
+            <td th:text="${log.notificationType}"></td>
+            <td th:text="${#dates.format(log.sentAt,'dd.MM.yyyy HH:mm')}"></td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- extend `AdminController` with customer, telegram and store statistics
- implement `AdminService` for admin metrics
- expose repository methods for customer, store and subscription data
- add Thymeleaf templates for admin pages
- enhance dashboard with additional cards and links

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6853320ae004832db3a68783742fafdd