### PR TITLE
Add MapStruct mapper for admin user list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,17 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -198,6 +209,22 @@
                             <artifactId>lombok</artifactId>
                         </exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -12,6 +12,7 @@ import com.project.tracking_system.service.analytics.StatsAggregationService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.admin.AdminService;
+import com.project.tracking_system.mapper.UserAdminMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,7 +23,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +46,7 @@ public class AdminController {
     private final StoreRepository storeRepository;
     private final StatsAggregationService statsAggregationService;
     private final AdminService adminService;
+    private final UserAdminMapper userAdminMapper;
 
     /**
      * Отображает дашборд администратора.
@@ -86,23 +87,9 @@ public class AdminController {
     @GetMapping("/users")
     public String getAllUsers(Model model) {
         List<User> users = userService.findAll();
-        List<UserListAdminInfoDTO> userListAdminInfoDTOS = new ArrayList<>();
-
-        for (User user : users) {
-            // Получаем подписку пользователя (если есть)
-            String subscriptionName = user.getSubscription() != null
-                    ? user.getSubscription().getSubscriptionPlan().getName()
-                    : "NONE"; // Если подписки нет, ставим "NONE" или "FREE"
-
-            UserListAdminInfoDTO userListAdminInfoDTO = new UserListAdminInfoDTO(
-                    user.getId(),
-                    user.getEmail(),
-                    user.getRole(),
-                    subscriptionName
-            );
-
-            userListAdminInfoDTOS.add(userListAdminInfoDTO);
-        }
+        List<UserListAdminInfoDTO> userListAdminInfoDTOS = users.stream()
+                .map(userAdminMapper::toAdminListDto)
+                .toList();
 
         model.addAttribute("users", userListAdminInfoDTOS);
 

--- a/src/main/java/com/project/tracking_system/mapper/UserAdminMapper.java
+++ b/src/main/java/com/project/tracking_system/mapper/UserAdminMapper.java
@@ -1,0 +1,23 @@
+package com.project.tracking_system.mapper;
+
+import com.project.tracking_system.dto.UserListAdminInfoDTO;
+import com.project.tracking_system.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Маппер пользователей для административного интерфейса.
+ */
+@Mapper(componentModel = "spring")
+public interface UserAdminMapper {
+
+    /**
+     * Преобразует пользователя в DTO для списка администрирования.
+     *
+     * @param user сущность пользователя
+     * @return DTO с краткой информацией
+     */
+    @Mapping(target = "subscriptionPlanName",
+            expression = "java(user.getSubscription() != null ? user.getSubscription().getSubscriptionPlan().getName() : \"NONE\")")
+    UserListAdminInfoDTO toAdminListDto(User user);
+}

--- a/src/test/java/com/project/tracking_system/mapper/UserAdminMapperTest.java
+++ b/src/test/java/com/project/tracking_system/mapper/UserAdminMapperTest.java
@@ -1,0 +1,51 @@
+package com.project.tracking_system.mapper;
+
+import com.project.tracking_system.dto.UserListAdminInfoDTO;
+import com.project.tracking_system.entity.Role;
+import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.entity.UserSubscription;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты для {@link UserAdminMapper}.
+ */
+class UserAdminMapperTest {
+
+    private final UserAdminMapper mapper = Mappers.getMapper(UserAdminMapper.class);
+
+    @Test
+    void mapsUserWithSubscription() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("admin@example.com");
+        user.setRole(Role.ROLE_ADMIN);
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setName("PREMIUM");
+        UserSubscription subscription = new UserSubscription();
+        subscription.setSubscriptionPlan(plan);
+        user.setSubscription(subscription);
+
+        UserListAdminInfoDTO dto = mapper.toAdminListDto(user);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("admin@example.com", dto.getEmail());
+        assertEquals(Role.ROLE_ADMIN, dto.getRole());
+        assertEquals("PREMIUM", dto.getSubscriptionPlanName());
+    }
+
+    @Test
+    void mapsUserWithoutSubscription() {
+        User user = new User();
+        user.setId(2L);
+        user.setEmail("user@example.com");
+        user.setRole(Role.ROLE_USER);
+
+        UserListAdminInfoDTO dto = mapper.toAdminListDto(user);
+
+        assertEquals("NONE", dto.getSubscriptionPlanName());
+    }
+}


### PR DESCRIPTION
## Summary
- add MapStruct dependencies
- implement `UserAdminMapper` to map `User` to `UserListAdminInfoDTO`
- refactor `AdminController#getAllUsers` to use new mapper
- add unit tests for mapper

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853383da52c832d9e4a81955085d7c8