### PR TITLE
Add admin parcels listing

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -273,6 +273,18 @@ public class AdminController {
     }
 
     /**
+     * Отображает список всех посылок в системе.
+     *
+     * @param model модель для передачи данных о посылках
+     * @return имя шаблона со списком посылок
+     */
+    @GetMapping("/parcels")
+    public String parcels(Model model) {
+        model.addAttribute("parcels", adminService.getAllParcels());
+        return "admin/parcels";
+    }
+
+    /**
      * Управление подписками пользователей.
      */
     @GetMapping("/subscriptions")

--- a/src/main/java/com/project/tracking_system/dto/TrackParcelAdminInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackParcelAdminInfoDTO.java
@@ -1,0 +1,20 @@
+package com.project.tracking_system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Детальная информация о посылке для административной панели.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrackParcelAdminInfoDTO {
+    private Long id;
+    private String number;
+    private String status;
+    private String storeName;
+    private String userEmail;
+    private String data;
+}

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -86,4 +86,12 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     List<TrackParcel> findActiveByCustomerId(@Param("customerId") Long customerId,
                                              @Param("finalStatuses") List<GlobalStatus> finalStatuses);
 
+    /**
+     * Получить все посылки с загруженными пользователем и магазином.
+     *
+     * @return список посылок
+     */
+    @Query("SELECT t FROM TrackParcel t JOIN FETCH t.store JOIN FETCH t.user")
+    List<TrackParcel> findAllWithStoreAndUser();
+
 }

--- a/src/main/java/com/project/tracking_system/service/admin/AdminService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminService.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.service.admin;
 
 import com.project.tracking_system.dto.StoreAdminInfoDTO;
+import com.project.tracking_system.dto.TrackParcelAdminInfoDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class AdminService {
     private final StoreTelegramSettingsRepository storeTelegramSettingsRepository;
     private final UserSubscriptionRepository userSubscriptionRepository;
     private final SubscriptionPlanRepository subscriptionPlanRepository;
+    private final TrackParcelRepository trackParcelRepository;
 
     /**
      * Подсчитать общее количество покупателей.
@@ -123,5 +125,25 @@ public class AdminService {
      */
     public long countStores() {
         return storeRepository.count();
+    }
+
+    /**
+     * Получить список всех посылок системы с информацией о владельце и магазине.
+     *
+     * @return список посылок для отображения в админ-панели
+     */
+    public List<TrackParcelAdminInfoDTO> getAllParcels() {
+        return trackParcelRepository.findAllWithStoreAndUser().stream()
+                .map(p -> new TrackParcelAdminInfoDTO(
+                        p.getId(),
+                        p.getNumber(),
+                        p.getStatus().getDescription(),
+                        p.getStore().getName(),
+                        p.getUser().getEmail(),
+                        java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss")
+                                .withZone(java.time.ZoneId.systemDefault())
+                                .format(p.getData())
+                ))
+                .collect(java.util.stream.Collectors.toList());
     }
 }

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Посылки</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Номер</th>
+            <th>Магазин</th>
+            <th>Пользователь</th>
+            <th>Статус</th>
+            <th>Дата</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="p : ${parcels}">
+            <td th:text="${p.id}"></td>
+            <td th:text="${p.number}"></td>
+            <td th:text="${p.storeName}"></td>
+            <td th:text="${p.userEmail}"></td>
+            <td th:text="${p.status}"></td>
+            <td th:text="${p.data}"></td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- add `TrackParcelAdminInfoDTO` for admin parcel info
- add repository method `findAllWithStoreAndUser`
- implement admin service `getAllParcels`
- expose `/admin/parcels` in `AdminController`
- create `parcels.html` admin template

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68533d3c29b0832d95d4a5180240e7b1