### PR TITLE
Add admin user creation

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -110,6 +110,46 @@ public class AdminController {
     }
 
     /**
+     * Отображает форму создания нового пользователя.
+     *
+     * Загружает список доступных тарифов в модель.
+     *
+     * @param model модель для передачи тарифных планов
+     * @return имя шаблона формы
+     */
+    @GetMapping("/users/new")
+    public String newUserForm(Model model) {
+        model.addAttribute("plans", adminService.getPlans());
+        return "admin/user-new";
+    }
+
+    /**
+     * Создаёт нового пользователя по введённым данным.
+     *
+     * @param email    адрес почты
+     * @param password пароль пользователя
+     * @param role     роль пользователя
+     * @param subscriptionPlan начальный тариф
+     * @param model    модель для передачи сообщений
+     * @return редирект на список пользователей или форма с ошибкой
+     */
+    @PostMapping("/users/new")
+    public String createUser(@RequestParam String email,
+                             @RequestParam String password,
+                             @RequestParam String role,
+                             @RequestParam("subscriptionPlan") String subscriptionPlan,
+                             Model model) {
+        try {
+            userService.createUserByAdmin(email, password, role, subscriptionPlan);
+            return "redirect:/admin/users";
+        } catch (Exception e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("plans", adminService.getPlans());
+            return "admin/user-new";
+        }
+    }
+
+    /**
      * Отображает детальную информацию о выбранном пользователе.
      *
      * Загружает в модель список магазинов пользователя и связанные посылки.

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -15,7 +15,7 @@
 <div class="container mt-4">
     <h1 class="mb-4">Список пользователей</h1>
 
-    <a href="/admin/users/new" class="btn btn-primary mb-4">Добавить пользователя</a>
+    <a th:href="@{/admin/users/new}" class="btn btn-primary mb-4">Добавить пользователя</a>
 
     <table class="table table-bordered table-striped">
         <thead class="thead-dark">

--- a/src/main/resources/templates/admin/user-new.html
+++ b/src/main/resources/templates/admin/user-new.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Создание пользователя</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+    <a href="/admin/users" class="btn btn-primary mb-4">Пользователи</a>
+
+    <div class="container mt-4">
+        <h1 class="mb-4">Новый пользователь</h1>
+
+        <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+        <form th:action="@{/admin/users/new}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" name="email" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Пароль</label>
+                <input type="password" class="form-control" id="password" name="password" required>
+            </div>
+            <div class="mb-3">
+                <label for="role" class="form-label">Роль</label>
+                <select id="role" name="role" class="form-select">
+                    <option value="ROLE_USER">ROLE_USER</option>
+                    <option value="ROLE_ADMIN">ROLE_ADMIN</option>
+                </select>
+            </div>
+            <div class="mb-3">
+                <label for="subscriptionPlan" class="form-label">Статус аккаунта</label>
+                <select id="subscriptionPlan" name="subscriptionPlan" class="form-select">
+                    <option th:each="p : ${plans}" th:value="${p.name}" th:text="${p.name}"></option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-success">Создать</button>
+        </form>
+    </div>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- enable admins to create users
- link to user creation form from users list
- bootstrap form template for new user
- allow admin to pick subscription plan at creation

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6853418376ac832da92cdb43e051b2e1