### PR TITLE
Rename confirmation code method

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -61,7 +61,7 @@ public class PasswordResetService {
 
         log.info("✅ Пользователь {} найден. Генерируем токен...", EmailUtils.maskEmail(user.getEmail()));
 
-        String token = randomStringGenerator.generateConfirmCodRegistration();
+        String token = randomStringGenerator.generateConfirmationCode();
         String resetLink = LINK + token;
 
         // Не выводим значение токена в лог по соображениям безопасности

--- a/src/main/java/com/project/tracking_system/service/user/RandomlyGeneratedString.java
+++ b/src/main/java/com/project/tracking_system/service/user/RandomlyGeneratedString.java
@@ -17,23 +17,27 @@ import java.security.SecureRandom;
 @Service
 public class RandomlyGeneratedString {
 
-    String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    int length = 10;
+    /** Доступные символы для генерации случайной строки */
+    private static final String CHARACTERS =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    /** Длина случайной строки */
+    private static final int LENGTH = 10;
 
     /**
-     * Генерирует случайную строку для подтверждения регистрации.
+     * Генерирует код подтверждения.
      * <p>
-     * Строка состоит из случайных символов (буквы и цифры) длиной {@link #length}.
+     * Строка состоит из случайных символов (буквы и цифры) длиной {@link #LENGTH}.
      * </p>
      *
      * @return случайно сгенерированная строка
      */
-    public String generateConfirmCodRegistration() {
+    public String generateConfirmationCode() {
         SecureRandom secureRandom = new SecureRandom();
-        StringBuilder sb = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            int index = secureRandom.nextInt(characters.length());
-            sb.append(characters.charAt(index));
+        StringBuilder sb = new StringBuilder(LENGTH);
+        for (int i = 0; i < LENGTH; i++) {
+            int index = secureRandom.nextInt(CHARACTERS.length());
+            sb.append(CHARACTERS.charAt(index));
         }
         return sb.toString();
     }

--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -77,7 +77,7 @@ public class UserService {
             throw new UserAlreadyExistsException("Пользователь с таким email уже существует.");
         }
 
-        String confirmationCode = randomlyGeneratedString.generateConfirmCodRegistration();
+        String confirmationCode = randomlyGeneratedString.generateConfirmationCode();
         saveOrUpdateConfirmationToken(email, confirmationCode);
 
         // Отправка email в фоне (не блокируем основной поток)


### PR DESCRIPTION
## Summary
- rename generateConfirmCodRegistration() to generateConfirmationCode()
- make `CHARACTERS` and `LENGTH` static final constants
- update password reset and user services to use the renamed method

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685345b2c94c832dbbb02b64e955da61