### PR TITLE
Add CSRF tokens to admin POST forms

### DIFF
--- a/src/main/resources/templates/admin/subscriptions.html
+++ b/src/main/resources/templates/admin/subscriptions.html
@@ -21,6 +21,7 @@
             <td th:text="${s.subscriptionEndDate}"></td>
             <td>
                 <form th:action="@{/admin/users/{id}/change-subscription(id=${s.user.id})}" method="post" class="d-flex">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                     <select name="subscriptionPlan" class="form-select form-select-sm me-2">
                         <option th:each="p : ${plans}" th:value="${p.name}" th:text="${p.name}" th:selected="${p.name == s.subscriptionPlan.name}"></option>
                     </select>

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -32,6 +32,7 @@
 
     <h4>Сменить роль</h4>
     <form th:action="@{/admin/users/{userId}/role-update(userId=${user.id})}" method="post" class="mb-4">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
         <div class="d-flex">
             <div class="mb-3 me-2">
                 <label for="role" class="form-label">Новая роль:</label>
@@ -46,6 +47,7 @@
 
     <h4>Изменить план подписки</h4>
     <form th:action="@{/admin/users/{userId}/change-subscription(userId=${user.id})}" method="post" class="mb-4">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
         <div class="d-flex">
             <div class="mb-3 me-2">
                 <label for="subscriptionPlan" class="form-label">Новый план:</label>


### PR DESCRIPTION
## Summary
- include hidden CSRF inputs in admin user details and subscriptions pages
- verified other admin POST forms already contain the token

## Testing
- `./mvnw test -q` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685349688cf8832d931409811e1973bc