### PR TITLE
Refactor RandomlyGeneratedString to use shared SecureRandom

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/RandomlyGeneratedString.java
+++ b/src/main/java/com/project/tracking_system/service/user/RandomlyGeneratedString.java
@@ -24,6 +24,9 @@ public class RandomlyGeneratedString {
     /** Длина случайной строки */
     private static final int LENGTH = 10;
 
+    /** Источник случайных чисел */
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     /**
      * Генерирует код подтверждения.
      * <p>
@@ -33,10 +36,9 @@ public class RandomlyGeneratedString {
      * @return случайно сгенерированная строка
      */
     public String generateConfirmationCode() {
-        SecureRandom secureRandom = new SecureRandom();
         StringBuilder sb = new StringBuilder(LENGTH);
         for (int i = 0; i < LENGTH; i++) {
-            int index = secureRandom.nextInt(CHARACTERS.length());
+            int index = RANDOM.nextInt(CHARACTERS.length());
             sb.append(CHARACTERS.charAt(index));
         }
         return sb.toString();


### PR DESCRIPTION
## Summary
- centralize SecureRandom instance in `RandomlyGeneratedString`
- use the shared instance when generating confirmation codes

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: cannot open ./mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6853499d4258832d8aab43ab8ec60e88