### PR TITLE
Add filters to admin user list

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.dto.UserListAdminInfoDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.UserSubscription;
+import com.project.tracking_system.entity.Role;
 import com.project.tracking_system.repository.StoreRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.analytics.StatsAggregationService;
@@ -23,7 +24,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,34 +79,26 @@ public class AdminController {
     }
 
     /**
-     * Отображает список всех пользователей системы.
+     * Отображает список всех пользователей системы с возможностью фильтрации.
      *
-     * @param model модель для передачи данных о пользователях
+     * @param search       строка поиска по email
+     * @param role         фильтр по роли
+     * @param subscription фильтр по подписке
+     * @param model        модель для передачи данных
      * @return имя шаблона со списком пользователей
      */
     @GetMapping("/users")
-    public String getAllUsers(Model model) {
-        List<User> users = userService.findAll();
-        List<UserListAdminInfoDTO> userListAdminInfoDTOS = new ArrayList<>();
-
-        for (User user : users) {
-            // Получаем подписку пользователя (если есть)
-            String subscriptionName = user.getSubscription() != null
-                    ? user.getSubscription().getSubscriptionPlan().getName()
-                    : "NONE"; // Если подписки нет, ставим "NONE" или "FREE"
-
-            UserListAdminInfoDTO userListAdminInfoDTO = new UserListAdminInfoDTO(
-                    user.getId(),
-                    user.getEmail(),
-                    user.getRole(),
-                    subscriptionName
-            );
-
-            userListAdminInfoDTOS.add(userListAdminInfoDTO);
-        }
-
-        model.addAttribute("users", userListAdminInfoDTOS);
-
+    public String getAllUsers(@RequestParam(value = "search", required = false) String search,
+                              @RequestParam(value = "role", required = false) String role,
+                              @RequestParam(value = "subscription", required = false) String subscription,
+                              Model model) {
+        List<UserListAdminInfoDTO> users = adminService.getUsers(search, role, subscription);
+        model.addAttribute("users", users);
+        model.addAttribute("roles", Role.values());
+        model.addAttribute("plans", adminService.getPlans());
+        model.addAttribute("search", search);
+        model.addAttribute("selectedRole", role);
+        model.addAttribute("selectedSubscription", subscription);
         return "admin/user-list";
     }
 

--- a/src/main/java/com/project/tracking_system/repository/UserRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.repository;
 
+import com.project.tracking_system.entity.Role;
 import com.project.tracking_system.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -33,4 +34,24 @@ public interface UserRepository extends JpaRepository <User, Long> {
      */
     @Query("SELECT COUNT(u) FROM User u JOIN u.subscription s JOIN s.subscriptionPlan sp WHERE sp.name = :planName")
     long countUsersBySubscriptionPlan(@Param("planName") String planName);
+
+    /**
+     * Найти пользователей по фильтрам email, роли и названию подписки.
+     *
+     * @param search       часть email пользователя
+     * @param role         роль пользователя
+     * @param subscription название подписки
+     * @return список подходящих пользователей
+     */
+    @Query("""
+        SELECT u FROM User u
+        LEFT JOIN u.subscription us
+        LEFT JOIN us.subscriptionPlan sp
+        WHERE (:search IS NULL OR LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%')))
+          AND (:role IS NULL OR u.role = :role)
+          AND (:subscription IS NULL OR sp.name = :subscription)
+        """)
+    java.util.List<User> findByFilters(@Param("search") String search,
+                                       @Param("role") Role role,
+                                       @Param("subscription") String subscription);
 }

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -17,6 +17,27 @@
 
     <a th:href="@{/admin/users/new}" class="btn btn-primary mb-4">Добавить пользователя</a>
 
+    <form method="get" th:action="@{/admin/users}" class="row row-cols-lg-auto g-2 mb-3">
+        <div class="col-12">
+            <input type="text" class="form-control" name="search" placeholder="Поиск по email" th:value="${search}">
+        </div>
+        <div class="col-12">
+            <select class="form-select" name="role">
+                <option value="">Все роли</option>
+                <option th:each="r : ${roles}" th:value="${r}" th:text="${r}" th:selected="${selectedRole == r}"></option>
+            </select>
+        </div>
+        <div class="col-12">
+            <select class="form-select" name="subscription">
+                <option value="">Все подписки</option>
+                <option th:each="p : ${plans}" th:value="${p.name}" th:text="${p.name}" th:selected="${selectedSubscription == p.name}"></option>
+            </select>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-secondary">Найти</button>
+        </div>
+    </form>
+
     <table class="table table-bordered table-striped">
         <thead class="thead-dark">
         <tr>


### PR DESCRIPTION
## Summary
- filter users by email, role and subscription
- support filtering in AdminService and UserRepository
- add search bar and dropdown filters in admin UI

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685349a418b0832d8dee2693ca60d859