### PR TITLE
Add admin parcel search and details

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -338,6 +338,58 @@ public class AdminController {
     }
 
     /**
+     * Поиск посылки по номеру и редирект на страницу деталей.
+     *
+     * @param number трек-номер
+     * @return редирект на страницу подробной информации
+     */
+    @GetMapping("/parcels/search")
+    public String searchParcel(@RequestParam("number") String number) {
+        TrackParcelAdminInfoDTO parcel = adminService.findParcelByNumber(number);
+        if (parcel == null) {
+            return "redirect:/admin/parcels";
+        }
+        return "redirect:/admin/parcels/" + parcel.getId();
+    }
+
+    /**
+     * Отображает подробную информацию о посылке.
+     *
+     * @param id идентификатор посылки
+     * @param model модель для передачи данных
+     * @return имя шаблона с деталями посылки
+     */
+    @GetMapping("/parcels/{id}")
+    public String parcelDetails(@PathVariable Long id, Model model) {
+        model.addAttribute("parcel", adminService.getParcelById(id));
+        return "admin/parcel-details";
+    }
+
+    /**
+     * Удаляет посылку из системы.
+     *
+     * @param id идентификатор посылки
+     * @return редирект на список посылок
+     */
+    @PostMapping("/parcels/{id}/delete")
+    public String deleteParcel(@PathVariable Long id) {
+        adminService.deleteParcel(id);
+        return "redirect:/admin/parcels";
+    }
+
+    /**
+     * Принудительно обновляет статус посылки.
+     *
+     * @param id идентификатор посылки
+     * @return редирект на страницу деталей
+     */
+    @PostMapping("/parcels/{id}/force-update")
+    public String forceUpdateParcel(@PathVariable Long id) {
+        adminService.forceUpdateParcel(id);
+        return "redirect:/admin/parcels/" + id;
+    }
+
+    /**
      * Отображает список подписок пользователей и доступных тарифов.
      *
      * @param model модель, в которую передаются сведения о подписках

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -104,4 +104,22 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
            countQuery = "SELECT count(t) FROM TrackParcel t")
     Page<TrackParcel> findAllWithStoreAndUser(Pageable pageable);
 
+    /**
+     * Найти посылку по номеру с подгруженными магазином и пользователем.
+     *
+     * @param number номер посылки
+     * @return посылка или {@code null}, если не найдена
+     */
+    @Query("SELECT t FROM TrackParcel t JOIN FETCH t.store JOIN FETCH t.user WHERE t.number = :number")
+    TrackParcel findByNumberWithStoreAndUser(@Param("number") String number);
+
+    /**
+     * Найти посылку по идентификатору с подгруженными магазином и пользователем.
+     *
+     * @param id идентификатор посылки
+     * @return посылка или {@code null}, если не найдена
+     */
+    @Query("SELECT t FROM TrackParcel t JOIN FETCH t.store JOIN FETCH t.user WHERE t.id = :id")
+    TrackParcel findByIdWithStoreAndUser(@Param("id") Long id);
+
 }

--- a/src/main/resources/templates/admin/parcel-details.html
+++ b/src/main/resources/templates/admin/parcel-details.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Детали посылки</title>
+</head>
+<main layout:fragment="content">
+    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+    <a href="/admin/parcels" class="btn btn-primary mb-4">Посылки</a>
+
+    <div class="container mt-4">
+        <h1 class="mb-4">Информация о посылке</h1>
+        <div class="card mb-4">
+            <div class="card-body">
+                <p><strong>ID:</strong> <span th:text="${parcel.id}"></span></p>
+                <p><strong>Номер:</strong> <span th:text="${parcel.number}"></span></p>
+                <p><strong>Магазин:</strong> <span th:text="${parcel.storeName}"></span></p>
+                <p><strong>Пользователь:</strong> <span th:text="${parcel.userEmail}"></span></p>
+                <p><strong>Статус:</strong> <span th:text="${parcel.status}"></span></p>
+                <p><strong>Дата:</strong> <span th:text="${parcel.data}"></span></p>
+            </div>
+        </div>
+
+        <form th:action="@{/admin/parcels/{id}/force-update(id=${parcel.id})}" method="post" class="mb-3">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <button type="submit" class="btn btn-success">Обновить статус</button>
+        </form>
+
+        <form th:action="@{/admin/parcels/{id}/delete(id=${parcel.id})}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <button type="submit" class="btn btn-danger">Удалить посылку</button>
+        </form>
+    </div>
+</main>
+</html>

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -5,6 +5,16 @@
 </head>
 <main layout:fragment="content">
     <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+
+    <form method="get" th:action="@{/admin/parcels/search}" class="row row-cols-lg-auto g-2 mb-3">
+        <div class="col-12">
+            <input type="text" class="form-control" name="number" placeholder="Поиск по номеру">
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-secondary">Найти</button>
+        </div>
+    </form>
+
     <table class="table table-bordered table-striped">
         <thead>
         <tr>
@@ -14,6 +24,7 @@
             <th>Пользователь</th>
             <th>Статус</th>
             <th>Дата</th>
+            <th>Действия</th>
         </tr>
         </thead>
         <tbody>
@@ -24,6 +35,7 @@
             <td th:text="${p.userEmail}"></td>
             <td th:text="${p.status}"></td>
             <td th:text="${p.data}"></td>
+            <td><a th:href="@{/admin/parcels/{id}(id=${p.id})}" class="btn btn-sm btn-info">Подробнее</a></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- enable searching parcels by number in AdminController
- show parcel details with actions for admin
- support parcel retrieval in AdminService
- extend TrackParcelRepository with search helpers
- enhance admin parcels view and new parcel-details page

## Testing
- `mvn test` *(fails: maven not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68534af2dca4832dae63fcb76c5490ca