### PR TITLE
Implement admin system info

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -14,6 +14,7 @@ import com.project.tracking_system.service.analytics.StatsAggregationService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.admin.AdminService;
+import com.project.tracking_system.service.admin.AppInfoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -47,6 +48,7 @@ public class AdminController {
     private final StoreRepository storeRepository;
     private final StatsAggregationService statsAggregationService;
     private final AdminService adminService;
+    private final AppInfoService appInfoService;
 
     /**
      * Отображает дашборд администратора.
@@ -356,7 +358,10 @@ public class AdminController {
      * @return имя шаблона настроек
      */
     @GetMapping("/settings")
-    public String settings() {
+    public String settings(Model model) {
+        model.addAttribute("appVersion", appInfoService.getApplicationVersion());
+        model.addAttribute("webhookEnabled", appInfoService.isTelegramWebhookEnabled());
+        model.addAttribute("plans", appInfoService.getPlans());
         return "admin/settings";
     }
 

--- a/src/main/java/com/project/tracking_system/service/admin/AppInfoService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AppInfoService.java
@@ -1,0 +1,65 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.repository.SubscriptionPlanRepository;
+import com.project.tracking_system.entity.SubscriptionPlan;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Сервис предоставления системной информации для админ-панели.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppInfoService {
+
+    private final SubscriptionPlanRepository planRepository;
+    private final String applicationVersion;
+    private final boolean telegramWebhookEnabled;
+
+    /**
+     * Создаёт сервис с внедрением настроек приложения.
+     *
+     * @param planRepository            репозиторий тарифов
+     * @param version                   версия приложения
+     * @param webhookEnabled            статус вебхука Telegram
+     */
+    public AppInfoService(SubscriptionPlanRepository planRepository,
+                          @Value("${application.version:unknown}") String version,
+                          @Value("${telegram.webhook.enabled:false}") boolean webhookEnabled) {
+        this.planRepository = planRepository;
+        this.applicationVersion = version;
+        this.telegramWebhookEnabled = webhookEnabled;
+    }
+
+    /**
+     * Получить версию приложения.
+     *
+     * @return строка версии
+     */
+    public String getApplicationVersion() {
+        return applicationVersion;
+    }
+
+    /**
+     * Проверить, активен ли вебхук Telegram.
+     *
+     * @return {@code true}, если вебхук включён
+     */
+    public boolean isTelegramWebhookEnabled() {
+        return telegramWebhookEnabled;
+    }
+
+    /**
+     * Получить список тарифных планов с лимитами.
+     *
+     * @return список тарифных планов
+     */
+    public List<SubscriptionPlan> getPlans() {
+        return planRepository.findAll();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,5 +33,11 @@ opencv.lib.path=/usr/lib/jni/libopencv_java4100.so
 
 tesseract.datapath=/usr/local/share/tessdata
 
+# Версия приложения для отображения в админ-панели
+application.version=0.0.1-SNAPSHOT
+
+# Использовать Telegram webhook вместо long polling
+telegram.webhook.enabled=false
+
 #telegrambots.bots[0].botUsername=Belivery_bot
 #telegrambots.bots[0].botToken=${TELEGRAM_BOT_TOKEN}

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -5,7 +5,50 @@
 </head>
 <main layout:fragment="content">
     <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
-    <h1>Страница настроек администратора</h1>
-    <p>Здесь будут настройки.</p>
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Версия приложения</h5>
+                    <p class="card-text text-center" th:text="${appVersion}">-</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm custom-card">
+                <div class="card-body">
+                    <h5 class="card-title text-center">Webhook Telegram</h5>
+                    <p class="card-text text-center">
+                        <span th:text="${webhookEnabled} ? 'Включен' : 'Выключен'"></span>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h4>Тарифные планы</h4>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>Название</th>
+            <th>Треков в файле</th>
+            <th>Сохранённых треков</th>
+            <th>Обновлений в день</th>
+            <th>Магазинов</th>
+            <th>Массовое обновление</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="plan : ${plans}">
+            <td th:text="${plan.name}"></td>
+            <td th:text="${plan.maxTracksPerFile != null ? plan.maxTracksPerFile : '∞'}"></td>
+            <td th:text="${plan.maxSavedTracks != null ? plan.maxSavedTracks : '∞'}"></td>
+            <td th:text="${plan.maxTrackUpdates != null ? plan.maxTrackUpdates : '∞'}"></td>
+            <td th:text="${plan.maxStores}"></td>
+            <td th:text="${plan.allowBulkUpdate}"></td>
+        </tr>
+        </tbody>
+    </table>
 </main>
 </html>


### PR DESCRIPTION
## Summary
- add `AppInfoService` to expose version, webhook and plan data
- populate these values in `AdminController.settings()`
- display metrics and plan limits on `admin/settings.html`
- document new properties in `application.properties`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534af426e8832d841a84dba6b77982