### PR TITLE
Enhance admin dashboard visuals

### DIFF
--- a/src/main/resources/assets/scss/pages/_dashboard.scss
+++ b/src/main/resources/assets/scss/pages/_dashboard.scss
@@ -26,6 +26,12 @@
     font-weight: 600;
     color: vars.$dark;
     text-align: center;
+
+    .metric-icon {
+      margin-right: 8px;
+      font-size: 1.3rem;
+      color: inherit;
+    }
   }
 
   .card-text {
@@ -33,6 +39,23 @@
     font-weight: 700;
     color: vars.$primary;
     text-align: center;
+  }
+
+  &.bg-primary,
+  &.bg-success,
+  &.bg-warning,
+  &.bg-info,
+  &.bg-secondary,
+  &.bg-dark,
+  &.bg-danger {
+    .card-title,
+    .card-text {
+      color: vars.$white;
+    }
+
+    i {
+      color: vars.$white;
+    }
   }
 }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1236,11 +1236,41 @@ button:hover {
   color: #343a40;
   text-align: center;
 }
+.custom-card .card-title .metric-icon {
+  margin-right: 8px;
+  font-size: 1.3rem;
+  color: inherit;
+}
 .custom-card .card-text {
   font-size: 1.5rem;
   font-weight: 700;
   color: #007bff;
   text-align: center;
+}
+.custom-card.bg-primary .card-title,
+.custom-card.bg-success .card-title,
+.custom-card.bg-warning .card-title,
+.custom-card.bg-info .card-title,
+.custom-card.bg-secondary .card-title,
+.custom-card.bg-dark .card-title,
+.custom-card.bg-danger .card-title,
+.custom-card.bg-primary .card-text,
+.custom-card.bg-success .card-text,
+.custom-card.bg-warning .card-text,
+.custom-card.bg-info .card-text,
+.custom-card.bg-secondary .card-text,
+.custom-card.bg-dark .card-text,
+.custom-card.bg-danger .card-text {
+  color: #ffffff;
+}
+.custom-card.bg-primary i,
+.custom-card.bg-success i,
+.custom-card.bg-warning i,
+.custom-card.bg-info i,
+.custom-card.bg-secondary i,
+.custom-card.bg-dark i,
+.custom-card.bg-danger i {
+  color: #ffffff;
 }
 
 /* Стили для элементов списка */

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -15,49 +15,49 @@
     <div class="row">
         <!-- Карточки с данными -->
         <div class="col-md-4">
-            <div class="card shadow-sm custom-card">
+            <div class="card shadow-sm custom-card bg-primary text-white">
                 <div class="card-body">
-                    <h5 class="card-title text-center">Общее количество пользователей</h5>
+                    <h5 class="card-title text-center"><i class="bi bi-people metric-icon"></i>Общее количество пользователей</h5>
                     <p class="card-text text-center" th:text="${totalUsers}">100</p>
                 </div>
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card shadow-sm custom-card">
+            <div class="card shadow-sm custom-card bg-success text-white">
                 <div class="card-body">
-                    <h5 class="card-title text-center">Платных пользователей</h5>
+                    <h5 class="card-title text-center"><i class="bi bi-cash-stack metric-icon"></i>Платных пользователей</h5>
                     <p class="card-text text-center" th:text="${paidUsers}">50</p>
                 </div>
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card shadow-sm custom-card">
+            <div class="card shadow-sm custom-card bg-warning text-dark">
                 <div class="card-body">
-                    <h5 class="card-title text-center">Количество посылок в системе</h5>
+                    <h5 class="card-title text-center"><i class="bi bi-box-seam metric-icon"></i>Количество посылок в системе</h5>
                     <p class="card-text text-center" th:text="${totalParcels}">200</p>
                 </div>
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div class="card shadow-sm custom-card">
+            <div class="card shadow-sm custom-card bg-info text-white">
                 <div class="card-body">
-                    <h5 class="card-title text-center">Всего покупателей</h5>
+                    <h5 class="card-title text-center"><i class="bi bi-people-fill metric-icon"></i>Всего покупателей</h5>
                     <p class="card-text text-center" th:text="${totalCustomers}"></p>
                 </div>
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div class="card shadow-sm custom-card">
+            <div class="card shadow-sm custom-card bg-secondary text-white">
                 <div class="card-body">
-                    <h5 class="card-title text-center">Telegram привязок</h5>
+                    <h5 class="card-title text-center"><i class="bi bi-telegram metric-icon"></i>Telegram привязок</h5>
                     <p class="card-text text-center" th:text="${telegramBound}"></p>
                 </div>
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div class="card shadow-sm custom-card">
+            <div class="card shadow-sm custom-card bg-danger text-white">
                 <div class="card-body">
-                    <h5 class="card-title text-center">Всего магазинов</h5>
+                    <h5 class="card-title text-center"><i class="bi bi-shop metric-icon"></i>Всего магазинов</h5>
                     <p class="card-text text-center" th:text="${storesCount}"></p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add Bootstrap icons and colors to metric cards
- support colored cards and icons in dashboard SCSS
- generate matching CSS styles

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ab7e11a0832d8eb0a113ba5c980e