### PR TITLE
Add breadcrumb partial to admin pages

### DIFF
--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -3,8 +3,13 @@
 <head>
     <title layout:fragment="title">Покупатели</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Покупатели'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
 
     <div class="row mb-4">
         <div class="col-md-6">

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -8,6 +8,11 @@
     <title layout:fragment="title">Админ Панель</title>
 </head>
 
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url', null, 'label','Админ Панель'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
     <h1 class="mt-4 text-center">Добро пожаловать в админ панель</h1>
     <p class="text-center mb-4">Здесь вы можете управлять пользователями, посылками и другими ресурсами.</p>

--- a/src/main/resources/templates/admin/parcel-details.html
+++ b/src/main/resources/templates/admin/parcel-details.html
@@ -3,8 +3,14 @@
 <head>
     <title layout:fragment="title">Детали посылки</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url','/admin/parcels','label','Посылки'),
+                                            T(java.util.Map).of('url', null, 'label','Детали посылки'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
     <a href="/admin/parcels" class="btn btn-primary mb-4">Посылки</a>
 
     <div class="container mt-4">

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -3,8 +3,13 @@
 <head>
     <title layout:fragment="title">Посылки</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Посылки'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
 
     <form method="get" th:action="@{/admin/parcels/search}" class="row row-cols-lg-auto g-2 mb-3">
         <div class="col-12">

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -3,8 +3,13 @@
 <head>
     <title layout:fragment="title">Настройки</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Настройки'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
 
     <div class="row mb-4">
         <div class="col-md-6">

--- a/src/main/resources/templates/admin/stores.html
+++ b/src/main/resources/templates/admin/stores.html
@@ -3,8 +3,13 @@
 <head>
     <title layout:fragment="title">Магазины</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Магазины'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
     <table class="table table-bordered table-striped">
         <thead>
         <tr>

--- a/src/main/resources/templates/admin/subscriptions.html
+++ b/src/main/resources/templates/admin/subscriptions.html
@@ -3,8 +3,13 @@
 <head>
     <title layout:fragment="title">Подписки</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Подписки'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
     <table class="table table-bordered table-striped">
         <thead>
         <tr>

--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -3,8 +3,13 @@
 <head>
     <title layout:fragment="title">Telegram</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Telegram'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
 
     <div class="row mb-4">
         <div class="col-md-6">

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -8,9 +8,15 @@
     <title layout:fragment="title">Информация о пользователе</title>
 </head>
 
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url','/admin/users','label','Пользователи'),
+                                            T(java.util.Map).of('url', null, 'label','Информация о пользователе'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
 
-<a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
 <a href="/admin/users" class="btn btn-primary mb-4">Пользователи</a>
 
 <div class="container mt-4">

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -8,9 +8,13 @@
     <title layout:fragment="title">Список пользователей</title>
 </head>
 
-<main layout:fragment="content">
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url', null, 'label','Пользователи'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
 
-<a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
+<main layout:fragment="content">
 
 <div class="container mt-4">
     <h1 class="mb-4">Список пользователей</h1>

--- a/src/main/resources/templates/admin/user-new.html
+++ b/src/main/resources/templates/admin/user-new.html
@@ -3,8 +3,14 @@
 <head>
     <title layout:fragment="title">Создание пользователя</title>
 </head>
+<div layout:fragment="afterHeader"
+     th:with="items=${T(java.util.List).of(T(java.util.Map).of('url','/admin','label','Админ Панель'),
+                                            T(java.util.Map).of('url','/admin/users','label','Пользователи'),
+                                            T(java.util.Map).of('url', null, 'label','Новый пользователь'))}">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+</div>
+
 <main layout:fragment="content">
-    <a href="/admin" class="btn btn-primary mb-4">Админ Панель</a>
     <a href="/admin/users" class="btn btn-primary mb-4">Пользователи</a>
 
     <div class="container mt-4">

--- a/src/main/resources/templates/partials/breadcrumbs.html
+++ b/src/main/resources/templates/partials/breadcrumbs.html
@@ -1,0 +1,9 @@
+<nav th:fragment="breadcrumbs(items)">
+    <ol class="breadcrumb my-3">
+        <li class="breadcrumb-item" th:each="item, iterStat : ${items}" th:classappend="${iterStat.last} ? 'active'" th:attr="aria-current=${iterStat.last}? 'page'">
+            <a th:if="${!iterStat.last}" th:href="${item.url}" th:text="${item.label}"></a>
+            <span th:if="${iterStat.last}" th:text="${item.label}"></span>
+        </li>
+    </ol>
+</nav>
+


### PR DESCRIPTION
## Summary
- add new `partials/breadcrumbs.html` fragment
- include breadcrumbs in admin pages and remove redundant back buttons

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ac94de3c832d9bcd4e132158571c