### PR TITLE
Fix breadcrumbs rendering for empty URLs

### DIFF
--- a/src/main/resources/templates/partials/breadcrumbs.html
+++ b/src/main/resources/templates/partials/breadcrumbs.html
@@ -2,8 +2,8 @@
     <ol class="breadcrumb my-3">
         <li class="breadcrumb-item" th:each="item, iterStat : ${items}"
             th:classappend="${iterStat.last} ? 'active'" th:attr="aria-current=${iterStat.last}? 'page'">
-            <a th:if="${!iterStat.last and item.url != ''}" th:href="${item.url}" th:text="${item.label}"></a>
-            <span th:if="${iterStat.last or item.url == ''}" th:text="${item.label}"></span>
+            <a th:if="${item.url != ''}" th:href="${item.url}" th:text="${item.label}"></a>
+            <span th:if="${item.url == ''}" th:text="${item.label}"></span>
         </li>
     </ol>
 </nav>


### PR DESCRIPTION
## Summary
- show breadcrumb links only when `item.url` is not empty

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6853b22c1e10832d8cff3f251393e05c