### PR TITLE
Move breadcrumb data to controllers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.dto.TrackParcelDTO;
 import com.project.tracking_system.dto.TrackParcelAdminInfoDTO;
 import com.project.tracking_system.dto.UserDetailsAdminInfoDTO;
 import com.project.tracking_system.dto.UserListAdminInfoDTO;
+import com.project.tracking_system.dto.BreadcrumbItemDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.UserSubscription;
@@ -77,6 +78,12 @@ public class AdminController {
         model.addAttribute("telegramBound", telegramBound);
         model.addAttribute("storesCount", storesCount);
 
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
+
         return "admin/dashboard";
     }
 
@@ -101,6 +108,13 @@ public class AdminController {
         model.addAttribute("search", search);
         model.addAttribute("selectedRole", role);
         model.addAttribute("selectedSubscription", subscription);
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Пользователи", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/user-list";
     }
 
@@ -115,6 +129,14 @@ public class AdminController {
     @GetMapping("/users/new")
     public String newUserForm(Model model) {
         model.addAttribute("plans", adminService.getPlans());
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Пользователи", "/admin/users"),
+                new BreadcrumbItemDTO("Новый пользователь", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/user-new";
     }
 
@@ -190,6 +212,14 @@ public class AdminController {
         model.addAttribute("user", adminInfoDTO);
         model.addAttribute("stores", stores); // Передаём магазины
         model.addAttribute("storeParcels", storeParcels); // Передаём посылки по магазинам
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Пользователи", "/admin/users"),
+                new BreadcrumbItemDTO("Информация о пользователе", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/user-details";
     }
 
@@ -278,6 +308,13 @@ public class AdminController {
         model.addAttribute("totalCustomers", total);
         model.addAttribute("unreliablePercent", String.format("%.2f", percent));
         model.addAttribute("riskCustomers", adminService.getUnreliableCustomers());
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Покупатели", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/customers";
     }
 
@@ -303,6 +340,13 @@ public class AdminController {
         model.addAttribute("boundCustomers", adminService.countTelegramBoundCustomers());
         model.addAttribute("remindersEnabled", adminService.countStoresWithReminders());
         model.addAttribute("logs", adminService.getRecentLogs());
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Telegram", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/telegram";
     }
 
@@ -315,6 +359,13 @@ public class AdminController {
     @GetMapping("/stores")
     public String stores(Model model) {
         model.addAttribute("stores", adminService.getStoresInfo());
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Магазины", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/stores";
     }
 
@@ -335,6 +386,13 @@ public class AdminController {
         model.addAttribute("currentPage", parcelPage.getNumber());
         model.addAttribute("totalPages", parcelPage.getTotalPages());
         model.addAttribute("size", size);
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Посылки", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
 
         return "admin/parcels";
     }
@@ -364,6 +422,14 @@ public class AdminController {
     @GetMapping("/parcels/{id}")
     public String parcelDetails(@PathVariable Long id, Model model) {
         model.addAttribute("parcel", adminService.getParcelById(id));
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Посылки", "/admin/parcels"),
+                new BreadcrumbItemDTO("Детали посылки", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/parcel-details";
     }
 
@@ -401,6 +467,13 @@ public class AdminController {
     public String subscriptions(Model model) {
         model.addAttribute("subscriptions", adminService.getAllUserSubscriptions());
         model.addAttribute("plans", adminService.getPlans());
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Подписки", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/subscriptions";
     }
 
@@ -414,6 +487,13 @@ public class AdminController {
         model.addAttribute("appVersion", appInfoService.getApplicationVersion());
         model.addAttribute("webhookEnabled", appInfoService.isTelegramWebhookEnabled());
         model.addAttribute("plans", appInfoService.getPlans());
+
+        // Хлебные крошки
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Настройки", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/settings";
     }
 

--- a/src/main/java/com/project/tracking_system/dto/BreadcrumbItemDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/BreadcrumbItemDTO.java
@@ -1,0 +1,16 @@
+package com.project.tracking_system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Элемент навигационных хлебных крошек.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BreadcrumbItemDTO {
+    private String label;
+    private String url;
+}

--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -3,10 +3,8 @@
 <head>
     <title layout:fragment="title">Покупатели</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Покупатели'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -8,9 +8,8 @@
     <title layout:fragment="title">Админ Панель</title>
 </head>
 
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','', 'label','Админ Панель'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/parcel-details.html
+++ b/src/main/resources/templates/admin/parcel-details.html
@@ -3,11 +3,8 @@
 <head>
     <title layout:fragment="title">Детали посылки</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','/admin/parcels','label','Посылки'),
-                                            #maps.map('url','', 'label','Детали посылки'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -3,10 +3,8 @@
 <head>
     <title layout:fragment="title">Посылки</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Посылки'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -3,10 +3,8 @@
 <head>
     <title layout:fragment="title">Настройки</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Настройки'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/stores.html
+++ b/src/main/resources/templates/admin/stores.html
@@ -3,10 +3,8 @@
 <head>
     <title layout:fragment="title">Магазины</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Магазины'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/subscriptions.html
+++ b/src/main/resources/templates/admin/subscriptions.html
@@ -3,10 +3,8 @@
 <head>
     <title layout:fragment="title">Подписки</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Подписки'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -3,10 +3,8 @@
 <head>
     <title layout:fragment="title">Telegram</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Telegram'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -8,11 +8,8 @@
     <title layout:fragment="title">Информация о пользователе</title>
 </head>
 
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','/admin/users','label','Пользователи'),
-                                            #maps.map('url','', 'label','Информация о пользователе'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -8,10 +8,8 @@
     <title layout:fragment="title">Список пользователей</title>
 </head>
 
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','', 'label','Пользователи'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">

--- a/src/main/resources/templates/admin/user-new.html
+++ b/src/main/resources/templates/admin/user-new.html
@@ -3,11 +3,8 @@
 <head>
     <title layout:fragment="title">Создание пользователя</title>
 </head>
-<div layout:fragment="afterHeader"
-     th:with="items=${#lists.list(#maps.map('url','/admin','label','Админ Панель'),
-                                            #maps.map('url','/admin/users','label','Пользователи'),
-                                            #maps.map('url','', 'label','Новый пользователь'))}">
-    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${items})}"></div>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
 </div>
 
 <main layout:fragment="content">


### PR DESCRIPTION
## Summary
- introduce `BreadcrumbItemDTO`
- populate breadcrumbs in admin controller methods
- simplify admin templates to accept breadcrumbs from model

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b2cdea6c832db4081ce044713a23