### PR TITLE
Refactor Telegram block toggle

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -5,4 +5,16 @@
 .tg-settings-content {
   transition: max-height 0.3s ease, opacity 0.3s ease;
   overflow: hidden;
+
+  &.collapsed {
+    max-height: 0;
+    opacity: 0;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
+  &.expanded {
+    max-height: 1000px; // Достаточно большое значение
+    opacity: 1;
+  }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1163,6 +1163,16 @@ button:hover {
   transition: max-height 0.3s ease, opacity 0.3s ease;
   overflow: hidden;
 }
+.tg-settings-content.collapsed {
+  max-height: 0;
+  opacity: 0;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.tg-settings-content.expanded {
+  max-height: 1000px;
+  opacity: 1;
+}
 
 .legal-container {
   font-family: "Inter", sans-serif;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -261,53 +261,43 @@ function initTelegramToggle() {
 
     const collapsedStored = getCollapsedTgStores();
 
-    container.querySelectorAll('.tg-settings-content').forEach(content => {
-        if (content.dataset.collapseInit) return;
-        content.dataset.collapseInit = 'true';
-
-        const storeId = content.getAttribute('data-store-id');
+    collapsedStored.forEach(storeId => {
+        const content = container.querySelector(`.tg-settings-content[data-store-id="${storeId}"]`);
         const btn = container.querySelector(`.toggle-tg-btn[data-store-id="${storeId}"]`);
-        const link = container.querySelector(`a[data-bs-toggle="collapse"][href="#collapse-tg-${storeId}"]`);
-        const icon = btn?.querySelector('i');
-        const bsCollapse = bootstrap.Collapse.getOrCreateInstance(content, { toggle: false });
-
-        if (collapsedStored.includes(storeId)) {
-            bsCollapse.hide();
+        if (content && btn) {
+            content.classList.remove('expanded');
+            content.classList.add('collapsed');
+            const icon = btn.querySelector('i');
             icon?.classList.remove('bi-chevron-up');
             icon?.classList.add('bi-chevron-down');
-        } else {
-            bsCollapse.show();
-            icon?.classList.remove('bi-chevron-down');
-            icon?.classList.add('bi-chevron-up');
         }
+    });
 
-
-        const toggleHandler = (e) => {
+    container.querySelectorAll('.toggle-tg-btn').forEach(btn => {
+        if (btn.dataset.toggleInit) return;
+        btn.dataset.toggleInit = 'true';
+        btn.addEventListener('click', function (e) {
             e.preventDefault();
+            const storeId = this.getAttribute('data-store-id');
+            const content = container.querySelector(`.tg-settings-content[data-store-id="${storeId}"]`);
+            const icon = this.querySelector('i');
 
-            const isShown = content.classList.contains('show');
-            const ids = getCollapsedTgStores();
+            if (!content) return;
 
-            if (isShown) {
-                // Скрываем блок и запоминаем состояние
-                icon?.classList.remove('bi-chevron-up');
-                icon?.classList.add('bi-chevron-down');
+            const collapsed = content.classList.toggle('collapsed');
+            content.classList.toggle('expanded', !collapsed);
+
+            icon?.classList.toggle('bi-chevron-down', collapsed);
+            icon?.classList.toggle('bi-chevron-up', !collapsed);
+
+            let ids = getCollapsedTgStores();
+            if (collapsed) {
                 if (!ids.includes(storeId)) ids.push(storeId);
-                saveCollapsedTgStores(ids);
-                bsCollapse.hide();
             } else {
-                // Показываем блок и удаляем id из списка скрытых
-                icon?.classList.remove('bi-chevron-down');
-                icon?.classList.add('bi-chevron-up');
-                saveCollapsedTgStores(ids.filter(id => id !== storeId));
-                bsCollapse.show();
+                ids = ids.filter(id => id !== storeId);
             }
-        };
-
-        // Обработчики клика по кнопке и заголовку блока Telegram
-        btn?.addEventListener('click', toggleHandler);
-        link?.addEventListener('click', toggleHandler);
-
+            saveCollapsedTgStores(ids);
+        });
     });
 }
 

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -292,19 +292,17 @@
     <div th:id="'store-block-' + ${store.id}" class="mt-3 border p-3 rounded bg-light-subtle">
         <div class="d-flex justify-content-between align-items-center">
             <h5 class="mb-2">
-                <a class="text-decoration-none" data-bs-toggle="collapse"
-                   th:href="'#collapse-tg-' + ${store.id}" th:text="${store.name}"></a>
+                <span class="text-decoration-none" th:text="${store.name}"></span>
             </h5>
             <button type="button" class="btn btn-sm btn-outline-secondary toggle-tg-btn"
-                    th:attr="data-store-id=${store.id}" data-bs-toggle="collapse"
-                    th:data-bs-target="'#collapse-tg-' + ${store.id}">
+                    th:attr="data-store-id=${store.id}">
                 <i class="bi bi-chevron-up"></i>
             </button>
         </div>
         <div th:id="'collapse-tg-' + ${store.id}"
-             class="collapse tg-settings-content"
+             class="tg-settings-content"
              th:attr="data-store-id=${store.id}"
-             th:classappend="${first} ? ' show'">
+             th:classappend="${first} ? ' expanded' : ' collapsed'">
             <form class="telegram-settings-form" th:action="@{/stores/{id}/telegram-settings(id=${store.id})}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-check form-switch mb-2">


### PR DESCRIPTION
## Summary
- remove Bootstrap collapse usage for Telegram sections
- add collapsed/expanded classes to Telegram markup and styles
- toggle Telegram sections via manual JS logic
- extend profile page styles for new collapse behaviour

## Testing
- `npm run build:css` *(fails: `sass` not found)*
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e38eb654832d8b7de73b5a53cc8c