### PR TITLE
Add configurable WebSocket and CSP origins

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/WebSocketConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.configuration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.*;
@@ -14,13 +15,32 @@ import org.springframework.web.socket.config.annotation.*;
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    /**
+     * Список разрешённых источников для WebSocket.
+     */
+    private final String[] allowedOrigins;
+
+    public WebSocketConfig(@Value("${websocket.allowed-origins:*}") String[] allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    /**
+     * Регистрирует конечную точку STOMP для WebSocket.
+     *
+     * @param registry реестр конечных точек
+     */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("*");
+                .setAllowedOrigins(allowedOrigins);
         log.debug("✅ WebSocket endpoint /wss зарегистрирован!");
     }
 
+    /**
+     * Настраивает брокер сообщений для WebSocket.
+     *
+     * @param registry конфигурация брокера сообщений
+     */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
@@ -29,3 +49,4 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     }
 
 }
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,5 @@ tesseract.datapath=/usr/local/share/tessdata
 application.version=0.0.1-SNAPSHOT
 
 telegram.webhook.enabled=false
+websocket.allowed-origins=*
+csp.allowed-connect-origins=wss://belivery.by,ws://localhost:8080


### PR DESCRIPTION
## Summary
- add `websocket.allowed-origins` and `csp.allowed-connect-origins` properties
- use configured WebSocket origins in `WebSocketConfig`
- build `connect-src` CSP directive from configuration

## Testing
- `mvn -q test` *(fails: `bash: mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853e8bdf664832da54859848146206d