### PR TITLE
Add reusable card and modal fragments

### DIFF
--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -11,7 +11,7 @@
 
     <div class="row mb-4">
         <div class="col-md-6">
-            <div class="card shadow-sm custom-card">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
                 <div class="card-body">
                     <h5 class="card-title text-center">Всего покупателей</h5>
                     <p class="card-text text-center" th:text="${totalCustomers}"></p>
@@ -19,7 +19,7 @@
             </div>
         </div>
         <div class="col-md-6">
-            <div class="card shadow-sm custom-card">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
                 <div class="card-body">
                     <h5 class="card-title text-center">Процент ненадёжных</h5>
                     <p class="card-text text-center" th:text="${unreliablePercent} + '%'"></p>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -19,7 +19,7 @@
     <div class="row">
         <!-- Карточки с данными -->
         <div class="col-md-4">
-            <div class="card shadow-sm custom-card bg-primary text-white">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-primary text-white')}">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-people metric-icon"></i>Общее количество пользователей</h5>
                     <p class="card-text text-center" th:text="${totalUsers}">100</p>
@@ -27,7 +27,7 @@
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card shadow-sm custom-card bg-success text-white">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-success text-white')}">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-cash-stack metric-icon"></i>Платных пользователей</h5>
                     <p class="card-text text-center" th:text="${paidUsers}">50</p>
@@ -35,7 +35,7 @@
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card shadow-sm custom-card bg-warning text-dark">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-warning text-dark')}">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-box-seam metric-icon"></i>Количество посылок в системе</h5>
                     <p class="card-text text-center" th:text="${totalParcels}">200</p>
@@ -43,7 +43,7 @@
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div class="card shadow-sm custom-card bg-info text-white">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-info text-white')}">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-people-fill metric-icon"></i>Всего покупателей</h5>
                     <p class="card-text text-center" th:text="${totalCustomers}"></p>
@@ -51,7 +51,7 @@
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div class="card shadow-sm custom-card bg-secondary text-white">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-secondary text-white')}">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-telegram metric-icon"></i>Telegram привязок</h5>
                     <p class="card-text text-center" th:text="${telegramBound}"></p>
@@ -59,7 +59,7 @@
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div class="card shadow-sm custom-card bg-danger text-white">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-danger text-white')}">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-shop metric-icon"></i>Всего магазинов</h5>
                     <p class="card-text text-center" th:text="${storesCount}"></p>

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -11,7 +11,7 @@
 
     <div class="row mb-4">
         <div class="col-md-6">
-            <div class="card shadow-sm custom-card">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
                 <div class="card-body">
                     <h5 class="card-title text-center">Версия приложения</h5>
                     <p class="card-text text-center" th:text="${appVersion}">-</p>
@@ -19,7 +19,7 @@
             </div>
         </div>
         <div class="col-md-6">
-            <div class="card shadow-sm custom-card">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
                 <div class="card-body">
                     <h5 class="card-title text-center">Webhook Telegram</h5>
                     <p class="card-text text-center">

--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -11,7 +11,7 @@
 
     <div class="row mb-4">
         <div class="col-md-6">
-            <div class="card shadow-sm custom-card">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
                 <div class="card-body">
                     <h5 class="card-title text-center">Покупателей с Telegram</h5>
                     <p class="card-text text-center" th:text="${boundCustomers}"></p>
@@ -19,7 +19,7 @@
             </div>
         </div>
         <div class="col-md-6">
-            <div class="card shadow-sm custom-card">
+            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
                 <div class="card-body">
                     <h5 class="card-title text-center">Магазинов с напоминаниями</h5>
                     <p class="card-text text-center" th:text="${remindersEnabled}"></p>

--- a/src/main/resources/templates/analytics/dashboard.html
+++ b/src/main/resources/templates/analytics/dashboard.html
@@ -94,7 +94,7 @@
             <!-- Графики -->
             <div class="row mt-5">
                 <div class="col-md-6 mb-4">
-                    <div class="chart-wrapper">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'chart-wrapper')}">
                         <h5>Статусы отправлений</h5>
                         <div class="chart-container position-relative">
                             <canvas id="statusPieChart"></canvas>
@@ -106,7 +106,7 @@
                     </div>
                 </div>
                 <div class="col-md-6 mb-4">
-                    <div class="chart-wrapper">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'chart-wrapper')}">
                         <h5 id="periodChartTitle">Динамика отправлений по неделям</h5>
                         <div class="chart-container position-relative">
                             <canvas id="periodBarChart"></canvas>

--- a/src/main/resources/templates/departures.html
+++ b/src/main/resources/templates/departures.html
@@ -170,32 +170,24 @@
 
 <div layout:fragment="afterFooter">
     <!-- Модальное окно -->
-    <div class="modal fade" id="infoModal" tabindex="-1" aria-labelledby="infoModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-lg modal-dialog-centered">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="infoModalLabel">Детали посылки</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
-                </div>
-                <div class="modal-body">
-                    <!-- Данные загружаются через AJAX -->
-                </div>
-            </div>
+    <div th:replace="~{partials/modal :: modal('infoModal', 'modal-lg', '')}">
+        <div class="modal-header">
+            <h5 class="modal-title" id="infoModalLabel">Детали посылки</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+        </div>
+        <div class="modal-body">
+            <!-- Данные загружаются через AJAX -->
         </div>
     </div>
 
     <!-- Модальное окно покупателя -->
-    <div class="modal fade" id="customerModal" tabindex="-1" aria-labelledby="customerModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="customerModalLabel">Информация о покупателе</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
-                </div>
-                <div class="modal-body">
-                    <!-- Данные загружаются через AJAX -->
-                </div>
-            </div>
+    <div th:replace="~{partials/modal :: modal('customerModal', '', '')}">
+        <div class="modal-header">
+            <h5 class="modal-title" id="customerModalLabel">Информация о покупателе</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+        </div>
+        <div class="modal-body">
+            <!-- Данные загружаются через AJAX -->
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/partials/card.html
+++ b/src/main/resources/templates/partials/card.html
@@ -1,0 +1,5 @@
+<div th:fragment="card(content, extraClasses)"
+     class="card rounded-4 shadow-sm p-4"
+     th:classappend="${extraClasses}">
+    <th:block th:replace="${content}"></th:block>
+</div>

--- a/src/main/resources/templates/partials/modal.html
+++ b/src/main/resources/templates/partials/modal.html
@@ -1,0 +1,8 @@
+<div th:fragment="modal(id, sizeClass, extraClasses)" class="modal fade" th:id="${id}"
+     tabindex="-1" th:attr="aria-labelledby=${id + 'Label'}" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" th:classappend="${sizeClass}">
+        <div class="modal-content p-4 rounded-4 shadow" th:classappend="${extraClasses}">
+            <th:block th:replace="~{::content}"></th:block>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -49,7 +49,7 @@
 
             <!-- Боковое меню (для ПК и планшетов) -->
             <div class="col-lg-3 col-md-4 d-none d-md-block">
-                <div class="card shadow-sm p-3 rounded-4">
+                <div th:replace="~{partials/card :: card(~{::content}, 'p-3')}">
                     <h5 class="mb-3 text-center">Меню</h5>
                     <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill" href="#v-pills-home" role="tab">
@@ -76,12 +76,15 @@
 
             <!-- Контент вкладок -->
             <div class="col-lg-9 col-md-8 tab-content" id="v-pills-tabContent">
-                <div class="tab-pane fade show active card p-4 shadow-sm rounded-4" id="v-pills-home" role="tabpanel">
-                    <h5 class="mb-3">Об аккаунте</h5>
-                    <p>Тут просто информация.</p>
+                <div class="tab-pane fade show active" id="v-pills-home" role="tabpanel">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                        <h5 class="mb-3">Об аккаунте</h5>
+                        <p>Тут просто информация.</p>
+                    </div>
                 </div>
 
-                <div class="tab-pane fade card p-4 shadow-sm rounded-4" id="v-pills-stores" role="tabpanel">
+                <div class="tab-pane fade" id="v-pills-stores" role="tabpanel">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
 
                     <!-- Контейнер для уведомлений -->
                     <div id="storeNotificationContainer"></div>
@@ -128,9 +131,8 @@
                     </div>
                 </div>
 
-                <div class="tab-pane fade card p-4 shadow-sm rounded-4"
-                     id="v-pills-profile"
-                     role="tabpanel">
+                <div class="tab-pane fade" id="v-pills-profile" role="tabpanel">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
 
                     <div id="password-content" th:fragment="passwordFragment">
 
@@ -179,9 +181,8 @@
                     </div>
                 </div>
 
-                <div class="tab-pane fade card p-4 shadow-sm rounded-4"
-                     id="v-pills-evropost"
-                     role="tabpanel">
+                <div class="tab-pane fade" id="v-pills-evropost" role="tabpanel">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
 
                     <!-- Контейнер для уведомлений -->
                     <div id="evropostNotificationContainer"></div>
@@ -235,9 +236,8 @@
                     </div>
                 </div>
 
-                <div class="tab-pane fade card p-4 shadow-sm rounded-4"
-                     id="v-pills-belpost"
-                     role="tabpanel">
+                <div class="tab-pane fade" id="v-pills-belpost" role="tabpanel">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
 
                     <h5 class="mb-3">Белпочта</h5>
                     <p>Если у вас есть договор на API Белпочты, свяжитесь со мной для реализации интеграции.</p>
@@ -246,9 +246,11 @@
                     <p>
                         📧 <a href="mailto:info@belivery.by" class="text-decoration-none">info@belivery.by</a>
                     </p>
+                    </div>
                 </div>
 
-                <div class="tab-pane fade card p-4 shadow-sm rounded-4" id="v-pills-messages" role="tabpanel">
+                <div class="tab-pane fade" id="v-pills-messages" role="tabpanel">
+                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
                     <h5 class="mb-3">Удаление аккаунта</h5>
                     <p class="fw-semibold">
                         <strong>Вы уверены, что хотите удалить аккаунт?</strong>
@@ -282,6 +284,7 @@
                     <button class="btn btn-danger w-50 py-2" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
                         <i class="bi bi-trash"></i> Удалить аккаунт
                     </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -356,73 +359,61 @@
 
 <div layout:fragment="afterFooter">
     <!-- Модальное окно подтверждения удаления аккаунта -->
-    <div class="modal fade" id="deleteAccountModal" tabindex="-1" aria-labelledby="deleteAccountModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered"> <!-- Добавили класс для центрирования -->
-            <div class="modal-content border-danger">
-                <div class="modal-header position-relative">
-                    <h5 class="modal-title text-danger w-100 text-center position-absolute start-50 translate-middle-x" id="deleteAccountModalLabel">
-                        Подтверждение удаления
-                    </h5>
-                    <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal" aria-label="Закрыть"></button>
-                </div>
-                <div class="modal-body">
-                    <p class="text-danger fw-semibold text-center">
-                        Вы уверены, что хотите удалить аккаунт? Это действие <span class="fw-bold text-uppercase">невозможно</span> отменить.
-                    </p>
-                </div>
-                <div class="modal-footer d-flex justify-content-between">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
-                    <form th:action="@{/profile/settings/delete}" method="post">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                        <button class="btn btn-danger">
-                            <i class="bi bi-trash-fill"></i> Да, удалить
-                        </button>
-                    </form>
-                </div>
-            </div>
+    <div th:replace="~{partials/modal :: modal('deleteAccountModal', '', 'border-danger')}">
+        <div class="modal-header position-relative">
+            <h5 class="modal-title text-danger w-100 text-center position-absolute start-50 translate-middle-x" id="deleteAccountModalLabel">
+                Подтверждение удаления
+            </h5>
+            <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+        </div>
+        <div class="modal-body">
+            <p class="text-danger fw-semibold text-center">
+                Вы уверены, что хотите удалить аккаунт? Это действие <span class="fw-bold text-uppercase">невозможно</span> отменить.
+            </p>
+        </div>
+        <div class="modal-footer d-flex justify-content-between">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+            <form th:action="@{/profile/settings/delete}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <button class="btn btn-danger">
+                    <i class="bi bi-trash-fill"></i> Да, удалить
+                </button>
+            </form>
         </div>
     </div>
 
     <!-- Модальное окно подтверждения удаления магазина-->
-    <div class="modal fade" id="deleteStoreModal" tabindex="-1" aria-labelledby="deleteStoreModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content border-danger">
-                <div class="modal-header">
-                    <h5 class="modal-title text-danger">Подтверждение удаления</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <p class="text-danger fw-semibold text-center">
-                        Вы уверены, что хотите <span class="fw-bold">удалить этот магазин</span>?
-                        Это действие <span class="fw-bold text-uppercase">невозможно</span> отменить.
-                    </p>
-                    <p class="text-muted text-center">
-                        ❗ Вместе с магазином будут удалены <br>
-                        <span class="fw-semibold">все его посылки и аналитика</span>.
-                    </p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
-                    <button class="btn btn-danger" id="confirmDeleteStore">Да, удалить</button>
-                </div>
-            </div>
+    <div th:replace="~{partials/modal :: modal('deleteStoreModal', '', 'border-danger')}">
+        <div class="modal-header">
+            <h5 class="modal-title text-danger">Подтверждение удаления</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+            <p class="text-danger fw-semibold text-center">
+                Вы уверены, что хотите <span class="fw-bold">удалить этот магазин</span>?
+                Это действие <span class="fw-bold text-uppercase">невозможно</span> отменить.
+            </p>
+            <p class="text-muted text-center">
+                ❗ Вместе с магазином будут удалены <br>
+                <span class="fw-semibold">все его посылки и аналитика</span>.
+            </p>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+            <button class="btn btn-danger" id="confirmDeleteStore">Да, удалить</button>
         </div>
     </div>
 
     <!-- Модальное окно подтверждения очистки аналитики -->
-    <div class="modal fade" id="resetAnalyticsModal" tabindex="-1" aria-labelledby="resetAnalyticsModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content border-danger">
-                <div class="modal-header">
-                    <h5 class="modal-title text-danger" id="resetAnalyticsModalLabel">Подтверждение действия</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body" id="resetAnalyticsMessage"></div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
-                    <button class="btn btn-danger" id="confirmResetAnalytics">Да, удалить</button>
-                </div>
-            </div>
+    <div th:replace="~{partials/modal :: modal('resetAnalyticsModal', '', 'border-danger')}">
+        <div class="modal-header">
+            <h5 class="modal-title text-danger" id="resetAnalyticsModalLabel">Подтверждение действия</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body" id="resetAnalyticsMessage"></div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+            <button class="btn btn-danger" id="confirmResetAnalytics">Да, удалить</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- create `card.html` and `modal.html` fragments under `partials`
- refactor `profile.html`, `departures.html`, `analytics/dashboard.html` to use new fragments
- update admin templates to use the card fragment

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f01a4620832dac30a782a9ac76ca