### PR TITLE
Fix profile card rendering

### DIFF
--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -11,18 +11,22 @@
 
     <div class="row mb-4">
         <div class="col-md-6">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center">Всего покупателей</h5>
                     <p class="card-text text-center" th:text="${totalCustomers}"></p>
                 </div>
+                </div>
             </div>
         </div>
         <div class="col-md-6">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center">Процент ненадёжных</h5>
                     <p class="card-text text-center" th:text="${unreliablePercent} + '%'"></p>
+                </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -19,50 +19,62 @@
     <div class="row">
         <!-- Карточки с данными -->
         <div class="col-md-4">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-primary text-white')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card bg-primary text-white')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-people metric-icon"></i>Общее количество пользователей</h5>
                     <p class="card-text text-center" th:text="${totalUsers}">100</p>
                 </div>
+                </div>
             </div>
         </div>
         <div class="col-md-4">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-success text-white')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card bg-success text-white')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-cash-stack metric-icon"></i>Платных пользователей</h5>
                     <p class="card-text text-center" th:text="${paidUsers}">50</p>
                 </div>
+                </div>
             </div>
         </div>
         <div class="col-md-4">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-warning text-dark')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card bg-warning text-dark')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-box-seam metric-icon"></i>Количество посылок в системе</h5>
                     <p class="card-text text-center" th:text="${totalParcels}">200</p>
                 </div>
+                </div>
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-info text-white')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card bg-info text-white')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-people-fill metric-icon"></i>Всего покупателей</h5>
                     <p class="card-text text-center" th:text="${totalCustomers}"></p>
                 </div>
-            </div>
-        </div>
-        <div class="col-md-4 mt-3">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-secondary text-white')}">
-                <div class="card-body">
-                    <h5 class="card-title text-center"><i class="bi bi-telegram metric-icon"></i>Telegram привязок</h5>
-                    <p class="card-text text-center" th:text="${telegramBound}"></p>
                 </div>
             </div>
         </div>
         <div class="col-md-4 mt-3">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card bg-danger text-white')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card bg-secondary text-white')}">
+                <div th:fragment="content">
+                <div class="card-body">
+                    <h5 class="card-title text-center"><i class="bi bi-telegram metric-icon"></i>Telegram привязок</h5>
+                    <p class="card-text text-center" th:text="${telegramBound}"></p>
+                </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mt-3">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card bg-danger text-white')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center"><i class="bi bi-shop metric-icon"></i>Всего магазинов</h5>
                     <p class="card-text text-center" th:text="${storesCount}"></p>
+                </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -11,20 +11,24 @@
 
     <div class="row mb-4">
         <div class="col-md-6">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center">Версия приложения</h5>
                     <p class="card-text text-center" th:text="${appVersion}">-</p>
                 </div>
+                </div>
             </div>
         </div>
         <div class="col-md-6">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center">Webhook Telegram</h5>
                     <p class="card-text text-center">
                         <span th:text="${webhookEnabled} ? 'Включен' : 'Выключен'"></span>
                     </p>
+                </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -11,18 +11,22 @@
 
     <div class="row mb-4">
         <div class="col-md-6">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center">Покупателей с Telegram</h5>
                     <p class="card-text text-center" th:text="${boundCustomers}"></p>
                 </div>
+                </div>
             </div>
         </div>
         <div class="col-md-6">
-            <div th:replace="~{partials/card :: card(~{::content}, 'custom-card')}">
+            <div th:replace="~{partials/card :: card(~{this.content}, 'custom-card')}">
+                <div th:fragment="content">
                 <div class="card-body">
                     <h5 class="card-title text-center">Магазинов с напоминаниями</h5>
                     <p class="card-text text-center" th:text="${remindersEnabled}"></p>
+                </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/analytics/dashboard.html
+++ b/src/main/resources/templates/analytics/dashboard.html
@@ -94,7 +94,8 @@
             <!-- Графики -->
             <div class="row mt-5">
                 <div class="col-md-6 mb-4">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'chart-wrapper')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'chart-wrapper')}">
+                        <div th:fragment="content">
                         <h5>Статусы отправлений</h5>
                         <div class="chart-container position-relative">
                             <canvas id="statusPieChart"></canvas>
@@ -103,10 +104,12 @@
                                 <p class="text-muted mt-2">Нет данных для отображения</p>
                             </div>
                         </div>
+                        </div>
                     </div>
                 </div>
                 <div class="col-md-6 mb-4">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'chart-wrapper')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'chart-wrapper')}">
+                        <div th:fragment="content">
                         <h5 id="periodChartTitle">Динамика отправлений по неделям</h5>
                         <div class="chart-container position-relative">
                             <canvas id="periodBarChart"></canvas>
@@ -114,6 +117,7 @@
                                 <img src="/images/no-data.png" alt="Нет данных" class="img-fluid" style="max-height: 180px;">
                                 <p class="text-muted mt-2">Нет данных для отображения</p>
                             </div>
+                        </div>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -49,7 +49,8 @@
 
             <!-- Боковое меню (для ПК и планшетов) -->
             <div class="col-lg-3 col-md-4 d-none d-md-block">
-                <div th:replace="~{partials/card :: card(~{::content}, 'p-3')}">
+                <div th:replace="~{partials/card :: card(~{this.content}, 'p-3')}">
+                    <div th:fragment="content">
                     <h5 class="mb-3 text-center">Меню</h5>
                     <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill" href="#v-pills-home" role="tab">
@@ -71,20 +72,24 @@
                             <i class="bi bi-trash me-2"></i> Удалить аккаунт
                         </a>
                     </div>
+                    </div>
                 </div>
             </div>
 
             <!-- Контент вкладок -->
             <div class="col-lg-9 col-md-8 tab-content" id="v-pills-tabContent">
                 <div class="tab-pane fade show active" id="v-pills-home" role="tabpanel">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'p-4')}">
+                        <div th:fragment="content">
                         <h5 class="mb-3">Об аккаунте</h5>
                         <p>Тут просто информация.</p>
+                        </div>
                     </div>
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-stores" role="tabpanel">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'p-4')}">
+                        <div th:fragment="content">
 
                     <!-- Контейнер для уведомлений -->
                     <div id="storeNotificationContainer"></div>
@@ -118,6 +123,7 @@
                         <button type="button" class="btn btn-danger w-100 d-flex align-items-center" id="resetAllAnalyticsBtn">
                             <i class="bi bi-trash me-2"></i> Удалить всю аналитику
                         </button>
+                        </div>
                     </div>
 
                     <div id="telegram-management" class="mt-4">
@@ -132,7 +138,8 @@
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-profile" role="tabpanel">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'p-4')}">
+                        <div th:fragment="content">
 
                     <div id="password-content" th:fragment="passwordFragment">
 
@@ -182,7 +189,8 @@
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-evropost" role="tabpanel">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'p-4')}">
+                        <div th:fragment="content">
 
                     <!-- Контейнер для уведомлений -->
                     <div id="evropostNotificationContainer"></div>
@@ -233,11 +241,13 @@
                                 <button class="btn btn-primary w-100 py-2" type="submit">Сохранить данные</button>
                             </div>
                         </form>
+                        </div>
                     </div>
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-belpost" role="tabpanel">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'p-4')}">
+                        <div th:fragment="content">
 
                     <h5 class="mb-3">Белпочта</h5>
                     <p>Если у вас есть договор на API Белпочты, свяжитесь со мной для реализации интеграции.</p>
@@ -246,11 +256,13 @@
                     <p>
                         📧 <a href="mailto:info@belivery.by" class="text-decoration-none">info@belivery.by</a>
                     </p>
+                        </div>
                     </div>
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-messages" role="tabpanel">
-                    <div th:replace="~{partials/card :: card(~{::content}, 'p-4')}">
+                    <div th:replace="~{partials/card :: card(~{this.content}, 'p-4')}">
+                    <div th:fragment="content">
                     <h5 class="mb-3">Удаление аккаунта</h5>
                     <p class="fw-semibold">
                         <strong>Вы уверены, что хотите удалить аккаунт?</strong>
@@ -284,6 +296,7 @@
                     <button class="btn btn-danger w-50 py-2" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
                         <i class="bi bi-trash"></i> Удалить аккаунт
                     </button>
+                    </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- fix usage of card fragment in profile.html
- wrap dashboard/admin templates with `th:fragment="content"`
- ensure analytics dashboard uses card fragment correctly

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f481d17c832da27b8f075f4a3225