### PR TITLE
Refactor SCSS to use new UI interface

### DIFF
--- a/src/main/resources/assets/scss/abstracts/_variables.scss
+++ b/src/main/resources/assets/scss/abstracts/_variables.scss
@@ -8,6 +8,9 @@ $info: #17a2b8;
 $light: #f8f9fa;
 $dark: #343a40;
 $white: #ffffff;
+$primary-color: #0d6efd;
+$border-radius: 8px;
+$box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 
 // === Шрифты ===
 $font-stack: 'Inter', sans-serif; // Базовый шрифт проекта

--- a/src/main/resources/assets/scss/base/_global.scss
+++ b/src/main/resources/assets/scss/base/_global.scss
@@ -1,13 +1,12 @@
-@use '../abstracts/variables' as vars;
-@use '../abstracts/mixins' as mixins;
+@use '../ui' as ui;
 
 html, body {
   height: 100%;
   margin: 0;
   display: flex;
   flex-direction: column;
-  background-color: vars.$light;
-  font-family: vars.$font-stack;
+  background-color: ui.$light;
+  font-family: ui.$font-stack;
 }
 
 .main-content {
@@ -43,7 +42,7 @@ footer {
   margin-top: auto; // Футер прижимается вниз, но не накладывается на контент
 }
 
-@include mixins.respond-to(sm) {
+@include ui.respond-to(sm) {
   .nav-link {
     padding: 8px 10px;
     font-size: 0.9rem;

--- a/src/main/resources/assets/scss/base/_typography.scss
+++ b/src/main/resources/assets/scss/base/_typography.scss
@@ -1,9 +1,8 @@
-@use '../abstracts/variables' as vars;
-@use '../abstracts/mixins' as mixins;
+@use '../ui' as ui;
 
 // Общие стили для заголовков
 h1, h3, h4, h5 {
-  color: vars.$dark;
+  color: ui.$dark;
   font-weight: bold;
   margin-bottom: 15px;
 }
@@ -18,15 +17,15 @@ h1 {
   gap: 15px;
   margin-bottom: 1.5rem;
 
-  @include mixins.respond-to(lg) {
+  @include ui.respond-to(lg) {
     font-size: 2rem;
   }
 
-  @include mixins.respond-to(md) {
+  @include ui.respond-to(md) {
     font-size: 1.75rem;
   }
 
-  @include mixins.respond-to(sm) {
+  @include ui.respond-to(sm) {
     font-size: 1.5rem;
   }
 }
@@ -47,11 +46,11 @@ h5 {
   gap: 10px;
   margin-bottom: 1rem;
 
-  @include mixins.respond-to(md) {
+  @include ui.respond-to(md) {
     font-size: 1.3rem;
   }
 
-  @include mixins.respond-to(sm) {
+  @include ui.respond-to(sm) {
     font-size: 1.2rem;
   }
 }
@@ -64,10 +63,10 @@ h5 {
 
 .text-center a.btn-link {
   font-size: 0.95rem;
-  color: vars.$secondary;
+  color: ui.$secondary;
 
   &:hover {
-    color: vars.$dark;
+    color: ui.$dark;
   }
 }
 
@@ -77,7 +76,7 @@ h5 {
   transition: color 0.3s ease-in-out, text-decoration 0.3s ease-in-out;
 
   &:hover {
-    color: vars.$dark;
+    color: ui.$dark;
     text-decoration: underline;
   }
 }

--- a/src/main/resources/assets/scss/components/_buttons.scss
+++ b/src/main/resources/assets/scss/components/_buttons.scss
@@ -1,8 +1,7 @@
-@use '../abstracts/_variables.scss' as vars;
-@use '../abstracts/_mixins.scss' as mixins;
+@use '../ui' as ui;
 
 button {
-  @include mixins.transition;
+  @include ui.transition;
 
   &:hover {
     transform: scale(1.05);
@@ -13,7 +12,7 @@ button {
   width: 150px;
   flex-shrink: 0;
 
-  @include mixins.respond-to(sm) {
+  @include ui.respond-to(sm) {
     width: 100%;
   }
 }

--- a/src/main/resources/assets/scss/components/_cards.scss
+++ b/src/main/resources/assets/scss/components/_cards.scss
@@ -1,10 +1,9 @@
-@use '../abstracts/_variables.scss' as vars;
-@use '../abstracts/_mixins.scss' as mixins;
+@use '../ui' as ui;
 
 @mixin card-style {
-  background: vars.$white;
+  background: ui.$white;
   border-radius: 10px;
-  @include mixins.box-shadow(0, 4px, 8px);
+  @include ui.box-shadow(0, 4px, 8px);
   padding: 20px;
 }
 

--- a/src/main/resources/assets/scss/components/_footer.scss
+++ b/src/main/resources/assets/scss/components/_footer.scss
@@ -1,14 +1,12 @@
-@use '../abstracts/_variables.scss' as vars;
-@use '../abstracts/_mixins.scss' as mixins;
 @use '../ui' as ui;
 
 .footer {
   width: 100%;
-  background-color: ui.$background-color;
+  background-color: ui.$white;
   box-shadow: ui.$box-shadow;
   padding: 20px 0;
   font-size: 14px;
-  color: ui.$text-color;
+  color: ui.$dark;
   position: relative;
   bottom: 0;
   z-index: 10;
@@ -78,7 +76,7 @@
         align-items: center;
         gap: 8px;
         text-decoration: none;
-        color: ui.$text-color;
+        color: ui.$dark;
         font-weight: bold;
 
         &:hover {

--- a/src/main/resources/assets/scss/components/_forms.scss
+++ b/src/main/resources/assets/scss/components/_forms.scss
@@ -1,11 +1,9 @@
-@use '../abstracts/_variables.scss' as vars;
-@use '../abstracts/_mixins.scss' as mixins;
 @use '../ui' as ui;
 
 .auth-form {
   width: 100%;
   max-width: 400px;
-  background: vars.$white;
+  background: ui.$white;
   border-radius: ui.$border-radius;
 }
 
@@ -50,7 +48,7 @@
   justify-content: center;
   cursor: pointer;
   font-size: 1.2rem;
-  color: vars.$secondary;
+  color: ui.$secondary;
   background: none;
 
   i {
@@ -61,12 +59,12 @@
   }
 
   &:hover {
-    color: vars.$dark;
+    color: ui.$dark;
   }
 }
 
 .input-group {
-  @include mixins.box-shadow(0px, 2px, 5px);
+  @include ui.box-shadow(0px, 2px, 5px);
   border-radius: ui.$border-radius;
 
   input {

--- a/src/main/resources/assets/scss/components/_header.scss
+++ b/src/main/resources/assets/scss/components/_header.scss
@@ -1,10 +1,8 @@
-@use '../abstracts/_variables.scss' as vars;
-@use '../abstracts/_mixins.scss' as mixins;
 @use '../ui' as ui;
 
 header {
-  background-color: vars.$white;
-  @include mixins.box-shadow(0, 4px, 10px);
+  background-color: ui.$white;
+  @include ui.box-shadow(0, 4px, 10px);
   height: 80px;
   display: flex;
   align-items: center;
@@ -44,22 +42,22 @@ header {
     flex-wrap: wrap;
     justify-content: center;
     gap: 15px;
-    @include mixins.transition(color);
+    @include ui.transition(color);
   }
 
   .nav-link {
     font-weight: 500;
-    color: vars.$dark;
-    @include mixins.transition(color);
+    color: ui.$dark;
+    @include ui.transition(color);
 
     &:hover {
-      color: vars.$primary;
+      color: ui.$primary;
     }
 
     &.active {
       font-weight: bold;
-      color: vars.$primary;
-      border-bottom: 3px solid vars.$primary;
+      color: ui.$primary;
+      border-bottom: 3px solid ui.$primary;
     }
   }
 
@@ -77,7 +75,7 @@ header {
       align-items: center;
       gap: 5px;
       white-space: nowrap;
-      @include mixins.hover-effect;
+      @include ui.hover-effect;
     }
 
     /* Иконки */
@@ -104,7 +102,7 @@ header {
     top: 80px;
     left: 0;
     width: 100%;
-    background: vars.$white;
+    background: ui.$white;
     box-shadow: ui.$box-shadow;
     padding: 10px 0;
     border-radius: 0 0 ui.$border-radius ui.$border-radius;
@@ -127,12 +125,12 @@ header {
           text-decoration: none;
           font-size: 1.2rem;
           font-weight: bold;
-          color: vars.$dark;
+          color: ui.$dark;
           display: block;
           padding: 10px;
           &:hover {
-            background: vars.$primary;
-            color: vars.$white;
+            background: ui.$primary;
+            color: ui.$white;
           }
         }
       }
@@ -148,7 +146,7 @@ header {
   /* ============================= */
   /* Адаптивные стили */
   /* ============================= */
-  @include mixins.respond-to(md) {
+  @include ui.respond-to(md) {
     .burger-menu {
       display: block;
       position: absolute;
@@ -184,13 +182,13 @@ header {
         height: 40px;
         border-radius: 50%;
         font-size: 1.3rem;
-        color: vars.$white;
-        background-color: vars.$primary;
+        color: ui.$white;
+        background-color: ui.$primary;
         border: none;
-        @include mixins.hover-effect;
+        @include ui.hover-effect;
 
         &.logout {
-          background-color: vars.$danger;
+          background-color: ui.$danger;
         }
       }
     }

--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -1,5 +1,3 @@
-@use "../abstracts/_mixins.scss" as mixins;
-@use "../abstracts/_variables.scss" as vars;
 @use "sass:color";
 @use '../ui' as ui;
 
@@ -63,7 +61,7 @@
     font-weight: 700;
   }
 
-  @include mixins.respond-to(md){
+  @include ui.respond-to(md){
     .modal-dialog {
       max-width: 90%;
     }
@@ -92,7 +90,7 @@
     }
   }
 
-  @include mixins.respond-to(sm) {
+  @include ui.respond-to(sm) {
     .modal-dialog {
       max-width: 95%;
     }
@@ -112,7 +110,7 @@
   bottom: 15px;
   left: 50%;
   transform: translateX(-50%);
-  background: vars.$white;
+  background: ui.$white;
   padding: 14px 20px;
   border-radius: ui.$border-radius;
   box-shadow: ui.$box-shadow;
@@ -126,11 +124,11 @@
   z-index: 1050;
   opacity: 0;
   visibility: hidden;
-  font-size: vars.$font-size-base; // Увеличиваем размер шрифта
+  font-size: ui.$font-size-base; // Увеличиваем размер шрифта
   text-align: center;
   word-wrap: break-word;
   line-height: 1.4;
-  @include mixins.transition(opacity, 0.3s, ease-in-out);
+  @include ui.transition(opacity, 0.3s, ease-in-out);
 
   &.show {
     opacity: 1;
@@ -138,17 +136,17 @@
   }
 
   p {
-    font-size: vars.$font-size-base - 1px; // Поднимаем размер шрифта
-    color: vars.$dark;
+    font-size: ui.$font-size-base - 1px; // Поднимаем размер шрифта
+    color: ui.$dark;
     margin: 0 0 12px 0; // Больше отступа снизу
     max-width: 380px; // Ограничиваем ширину текста, чтобы не растягивался
   }
 
   a {
-    color: vars.$primary;
+    color: ui.$primary;
     text-decoration: none;
     font-weight: 500;
-    @include mixins.hover-effect;
+    @include ui.hover-effect;
   }
 
   .cookie-buttons {
@@ -164,17 +162,17 @@
       width: 60%; // Немного шире
       max-width: 220px;
       text-align: center;
-      @include mixins.transition();
+      @include ui.transition();
 
       &.btn-primary {
-        @include mixins.button-style(vars.$primary);
+        @include ui.button-style(ui.$primary);
       }
     }
   }
 }
 
 // 🔹 Адаптация для мобильных устройств
-@include mixins.respond-to(sm) {
+@include ui.respond-to(sm) {
   .cookie-modal {
     width: 90%;
     max-width: 320px;

--- a/src/main/resources/assets/scss/components/_nav.scss
+++ b/src/main/resources/assets/scss/components/_nav.scss
@@ -1,5 +1,4 @@
-@use '../abstracts/variables' as vars;
-@use '../abstracts/mixins' as mixins;
+@use '../ui' as ui;
 
 .nav-pills {
   display: flex;
@@ -10,19 +9,19 @@
     font-weight: 500;
     padding: 12px 15px;
     border-radius: 8px;
-    @include mixins.transition;
+    @include ui.transition;
 
     i {
       font-size: 1.2rem;
     }
 
     &:hover {
-      background-color: rgba(vars.$light, 0.8);
+      background-color: rgba(ui.$light, 0.8);
     }
 
     &.active {
-      background-color: vars.$primary;
-      color: vars.$white;
+      background-color: ui.$primary;
+      color: ui.$white;
     }
   }
 }
@@ -32,7 +31,7 @@
   padding: 20px;
   opacity: 0;
   transform: translateY(10px);
-  //@include mixins.transition;
+  //@include ui.transition;
   transition: opacity 0.3s ease, transform 0.3s ease;
 
   &.active {
@@ -41,7 +40,7 @@
   }
 }
 
-@include mixins.respond-to(md) {
+@include ui.respond-to(md) {
   .nav-pills {
     flex-direction: row;
     justify-content: center;

--- a/src/main/resources/assets/scss/layouts/_sidebar.scss
+++ b/src/main/resources/assets/scss/layouts/_sidebar.scss
@@ -1,5 +1,4 @@
-@use '../abstracts/_variables.scss' as vars;
-@use '../abstracts/_mixins.scss' as mixins;
+@use '../ui' as ui;
 @use "sass:color";
 
 .offcanvas {
@@ -19,24 +18,24 @@
   width: 45px;
   height: 45px;
   border-radius: 0 25px 25px 0;
-  background-color: vars.$primary;
-  color: vars.$white;
+  background-color: ui.$primary;
+  color: ui.$white;
   border: none;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 1.5rem;
   z-index: 1050;
-  @include mixins.box-shadow(0, 2px, 10px, rgba(0, 0, 0, 0.2));
-  @include mixins.transition(0.3s);
+  @include ui.box-shadow(0, 2px, 10px, rgba(0, 0, 0, 0.2));
+  @include ui.transition(0.3s);
 
   &:hover {
-    background-color: color.adjust(vars.$primary, $lightness: -10%);
+    background-color: color.adjust(ui.$primary, $lightness: -10%);
     width: 50px;
   }
 }
 
-@include mixins.respond-to(md) {
+@include ui.respond-to(md) {
   .col-md-4 {
     display: none;
   }

--- a/src/main/resources/assets/scss/main.scss
+++ b/src/main/resources/assets/scss/main.scss
@@ -1,7 +1,4 @@
-// Подключаем абстрактные файлы (переменные, миксины, функции)
-@use 'abstracts/variables' as vars;
-@use 'abstracts/mixins' as mixins;
-@use 'abstracts/functions' as funcs;
+// Подключаем общий интерфейс с переменными и миксинами
 @use 'ui' as ui;
 
 // Подключаем базу
@@ -34,7 +31,4 @@
 @use 'pages/dashboard';
 @use 'pages/analytics';
 
-// Подключаем утилиты
-@use 'utilities/media';
-@use 'utilities/helpers';
 

--- a/src/main/resources/assets/scss/pages/_analytics.scss
+++ b/src/main/resources/assets/scss/pages/_analytics.scss
@@ -1,5 +1,4 @@
-@use "../abstracts/variables" as vars;
-@use "../abstracts/mixins" as mixins;
+@use '../ui' as ui;
 @use "sass:color";
 
 body.loading {

--- a/src/main/resources/assets/scss/pages/_dashboard.scss
+++ b/src/main/resources/assets/scss/pages/_dashboard.scss
@@ -1,5 +1,4 @@
-@use "../abstracts/_variables.scss" as vars;
-@use "../abstracts/_mixins.scss" as mixins;
+@use '../ui' as ui;
 @use "sass:color";
 
 /* Основные стили для всего контейнера */
@@ -12,19 +11,19 @@
 .custom-card {
   border-radius: 10px;
   padding: 20px;
-  background-color: vars.$light;
-  @include mixins.box-shadow(0, 4px, 10px, rgba(0, 0, 0, 0.1));
-  @include mixins.transition(all, 0.3s);
+  background-color: ui.$light;
+  @include ui.box-shadow(0, 4px, 10px, rgba(0, 0, 0, 0.1));
+  @include ui.transition(all, 0.3s);
 
   &:hover {
     transform: translateY(-5px);
-    @include mixins.box-shadow(0, 8px, 15px, rgba(0, 0, 0, 0.15));
+    @include ui.box-shadow(0, 8px, 15px, rgba(0, 0, 0, 0.15));
   }
 
   .card-title {
     font-size: 1.2rem;
     font-weight: 600;
-    color: vars.$dark;
+    color: ui.$dark;
     text-align: center;
 
     .metric-icon {
@@ -37,7 +36,7 @@
   .card-text {
     font-size: 1.5rem;
     font-weight: 700;
-    color: vars.$primary;
+    color: ui.$primary;
     text-align: center;
   }
 
@@ -50,11 +49,11 @@
   &.bg-danger {
     .card-title,
     .card-text {
-      color: vars.$white;
+      color: ui.$white;
     }
 
     i {
-      color: vars.$white;
+      color: ui.$white;
     }
   }
 }
@@ -64,22 +63,22 @@
   border-radius: 8px;
   margin-bottom: 10px;
   padding: 15px;
-  color: vars.$dark;
+  color: ui.$dark;
   font-size: 1.1rem;
-  @include mixins.transition(all, 0.3s);
+  @include ui.transition(all, 0.3s);
 
   &:hover {
-    background-color: vars.$light;
-    @include mixins.box-shadow(0, 4px, 10px, rgba(0, 0, 0, 0.05));
+    background-color: ui.$light;
+    @include ui.box-shadow(0, 4px, 10px, rgba(0, 0, 0, 0.05));
   }
 
   i {
     margin-right: 10px;
-    color: vars.$primary;
+    color: ui.$primary;
   }
 }
 
-@include mixins.respond-to(md) {
+@include ui.respond-to(md) {
   .custom-card {
     margin-bottom: 30px;
   }

--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -1,5 +1,3 @@
-@use "../abstracts/variables" as vars;
-@use "../abstracts/mixins" as mixins;
 @use "sass:color";
 @use '../ui' as ui;
 
@@ -9,7 +7,7 @@
   border: none;  // Без рамки
   font-size: 2rem;  // Увеличиваем размер иконки
   cursor: pointer;  // Курсор при наведении
-  color: vars.$primary;  // Цвет иконки
+  color: ui.$primary;  // Цвет иконки
   padding: 12px;  // Устанавливаем отступы, чтобы кнопка была круглая
   border-radius: 50%;  // Округляем кнопку
 
@@ -25,7 +23,7 @@
   /* Эффект при наведении */
   &:hover {
     transform: rotate(360deg) scale(1.1);  // Вращаем и увеличиваем
-    background: rgba(vars.$primary, 0.1);  // Лёгкий фон
+    background: rgba(ui.$primary, 0.1);  // Лёгкий фон
     box-shadow: ui.$box-shadow;  // Лёгкая тень
   }
 
@@ -42,10 +40,10 @@
 
 /* Фильтр и форма */
 .history-filters {
-  background: vars.$white;
+  background: ui.$white;
   border-radius: ui.$border-radius;
   padding: 15px;
-  @include mixins.box-shadow(0, 4px, 8px);
+  @include ui.box-shadow(0, 4px, 8px);
 
   .row {
     display: flex;
@@ -62,7 +60,7 @@
 
     label {
       font-weight: bold;
-      color: vars.$dark;
+      color: ui.$dark;
     }
 
     .form-select {
@@ -75,7 +73,7 @@
       font-size: 1rem;
       font-weight: bold;
       padding: 10px 15px;
-      @include mixins.hover-effect;
+      @include ui.hover-effect;
     }
   }
 }
@@ -91,28 +89,28 @@
     -moz-appearance: none;
     width: 22px; // Размер чекбокса
     height: 22px;
-    border: 2px solid vars.$primary; // Граница чекбокса
+    border: 2px solid ui.$primary; // Граница чекбокса
     border-radius: ui.$border-radius; // Немного скругляем углы
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    @include mixins.transition();
+    @include ui.transition();
 
     &:hover {
-      border-color: color.scale(vars.$primary, $lightness: -10%);
+      border-color: color.scale(ui.$primary, $lightness: -10%);
     }
 
     &:checked {
-      background: vars.$primary;
-      border-color: vars.$primary;
+      background: ui.$primary;
+      border-color: ui.$primary;
       position: relative;
 
       &::after {
         content: "\f26b"; // Галочка из Bootstrap Icons (bi-check-square)
         font-family: "bootstrap-icons";
         font-size: 18px;
-        color: vars.$white;
+        color: ui.$white;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -147,7 +145,7 @@
     align-items: center;
     justify-content: center;
     gap: 5px;
-    @include mixins.transition();
+    @include ui.transition();
 
     i {
       font-size: 1rem;
@@ -156,13 +154,13 @@
 
   /* Кнопка "Выделить все" */
   #selectAllBtn {
-    background: vars.$primary;
-    color: vars.$white;
+    background: ui.$primary;
+    color: ui.$white;
     border: none;
     font-weight: bold;
 
     &:hover {
-      background: color.scale(vars.$primary, $lightness: -10%);
+      background: color.scale(ui.$primary, $lightness: -10%);
     }
 
     &:active {
@@ -176,14 +174,14 @@
 
   /* Кнопка "Удалить выделенное" */
   #deleteSelectedBtn {
-    background: vars.$danger;
-    color: vars.$white;
+    background: ui.$danger;
+    color: ui.$white;
     border: none;
     cursor: not-allowed;
-    @include mixins.transition();
+    @include ui.transition();
 
     &:hover {
-      background: color.scale(vars.$danger, $lightness: -10%);
+      background: color.scale(ui.$danger, $lightness: -10%);
     }
 
     &:active {
@@ -200,7 +198,7 @@
       cursor: pointer;
 
       &:hover {
-        background: color.scale(vars.$danger, $lightness: -15%);
+        background: color.scale(ui.$danger, $lightness: -15%);
         transform: scale(1.05);
       }
     }
@@ -213,18 +211,18 @@
   border-spacing: 0;
 
   thead {
-    background: vars.$primary;
-    color: vars.$white;
+    background: ui.$primary;
+    color: ui.$white;
   }
 
   th, td {
     padding: 12px;
     text-align: center;
-    border-bottom: 1px solid vars.$light;
+    border-bottom: 1px solid ui.$light;
   }
 
   tbody tr:hover {
-    background: rgba(vars.$primary, 0.1);
+    background: rgba(ui.$primary, 0.1);
     cursor: pointer;
     transition: all 0.3s ease-in-out;
   }
@@ -236,13 +234,13 @@
   button {
     border: none;
     background: none;
-    color: vars.$primary;
+    color: ui.$primary;
     font-weight: 500;
-    @include mixins.transition();
+    @include ui.transition();
 
     &:hover {
       text-decoration: underline;
-      color: color.scale(vars.$primary, $lightness: -15%);
+      color: color.scale(ui.$primary, $lightness: -15%);
       transform: scale(1.1);
     }
   }
@@ -267,33 +265,33 @@
       height: 40px;
       font-size: 1rem;
       font-weight: bold;
-      color: vars.$primary;
-      background: vars.$white;
-      border: 1px solid vars.$primary;
+      color: ui.$primary;
+      background: ui.$white;
+      border: 1px solid ui.$primary;
       border-radius: 50%;
       box-shadow: ui.$box-shadow;
       transition: all 0.3s ease-in-out;
 
       &:hover {
-        background: vars.$primary;
-        color: vars.$white;
-        border-color: vars.$primary;
+        background: ui.$primary;
+        color: ui.$white;
+        border-color: ui.$primary;
         transform: scale(1.1);
       }
     }
 
     &.active .page-link {
-      background: vars.$primary;
-      color: vars.$white;
-      border-color: vars.$primary;
+      background: ui.$primary;
+      color: ui.$white;
+      border-color: ui.$primary;
       cursor: default;
       transform: scale(1);
     }
 
     &.disabled .page-link {
-      color: vars.$secondary;
-      background: vars.$light;
-      border-color: vars.$light;
+      color: ui.$secondary;
+      background: ui.$light;
+      border-color: ui.$light;
       cursor: not-allowed;
       opacity: 0.6;
       transform: none;
@@ -334,18 +332,18 @@
   min-width: 50px;
 
   &.active {
-    background-color: color.scale(vars.$primary, $lightness: 85%);
-    color: color.scale(vars.$primary, $lightness: -30%);
-    border-color: color.scale(vars.$primary, $lightness: 60%);
+    background-color: color.scale(ui.$primary, $lightness: 85%);
+    color: color.scale(ui.$primary, $lightness: -30%);
+    border-color: color.scale(ui.$primary, $lightness: 60%);
   }
 
   &:hover {
-    background-color: color.scale(vars.$primary, $lightness: 90%);
-    border-color: vars.$primary;
+    background-color: color.scale(ui.$primary, $lightness: 90%);
+    border-color: ui.$primary;
   }
 }
 
-@include mixins.respond-to(sm) {
+@include ui.respond-to(sm) {
   .history-filters {
     flex-direction: column;
     align-items: stretch;

--- a/src/main/resources/assets/scss/pages/_home.scss
+++ b/src/main/resources/assets/scss/pages/_home.scss
@@ -1,5 +1,3 @@
-@use '../abstracts/variables' as var;
-@use '../abstracts/mixins' as mixins;
 @use '../ui' as ui;
 @use "sass:color";
 
@@ -13,11 +11,11 @@
   border-radius: ui.$border-radius; // Скругленные углы
   text-align: center; // Центрирование текста
   margin-top: 15px; // Отступ сверху
-  @include mixins.transition(fadeIn, 0.5s);
+  @include ui.transition(fadeIn, 0.5s);
   box-shadow: ui.$box-shadow;
 
   // Медиа-запрос для мобильных устройств (делаем текст чуть меньше)
-  @include mixins.respond-to(md) {
+  @include ui.respond-to(md) {
     font-size: 16px;
     padding: 10px;
   }

--- a/src/main/resources/assets/scss/pages/_legal.scss
+++ b/src/main/resources/assets/scss/pages/_legal.scss
@@ -1,10 +1,9 @@
-@use '../abstracts/variables' as vars;
-@use '../abstracts/mixins' as mixins;
+@use '../ui' as ui;
 
 .legal-container {
   // Зададим базовый шрифт из переменных
-  font-family: vars.$font-stack;
-  font-size: vars.$font-size-base;
+  font-family: ui.$font-stack;
+  font-size: ui.$font-size-base;
   max-width: 800px;
   margin: 0 auto;
 
@@ -12,11 +11,11 @@
     font-size: 2rem;
     font-weight: 700;
     margin-bottom: 0.5rem;
-    color: vars.$dark; // Используем тёмный цвет
+    color: ui.$dark; // Используем тёмный цвет
   }
 
   .legal-date {
-    color: vars.$secondary; // Можно использовать второстепенный цвет
+    color: ui.$secondary; // Можно использовать второстепенный цвет
     font-size: 0.9rem;
     margin-bottom: 1.5rem;
   }
@@ -28,8 +27,8 @@
       font-size: 1.3rem;
       font-weight: 600;
       margin-bottom: 0.5rem;
-      color: vars.$dark;
-      border-left: 4px solid vars.$primary; // Линия слева с цветом primary
+      color: ui.$dark;
+      border-left: 4px solid ui.$primary; // Линия слева с цветом primary
       padding-left: 0.5rem;
     }
 
@@ -49,11 +48,11 @@
     margin-top: 2rem;
     padding: 1rem;
     font-size: 0.9rem;
-    background-color: vars.$light;
-    border-left: 4px solid vars.$warning;
+    background-color: ui.$light;
+    border-left: 4px solid ui.$warning;
 
     strong {
-      color: vars.$danger;
+      color: ui.$danger;
     }
   }
 }

--- a/src/main/resources/assets/scss/ui.scss
+++ b/src/main/resources/assets/scss/ui.scss
@@ -1,6 +1,5 @@
-$primary-color: #0d6efd;
-$secondary-color: #6c757d;
-$background-color: #ffffff;
-$text-color: #343a40;
-$border-radius: 8px;
-$box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+@forward 'abstracts/variables';
+@forward 'abstracts/mixins';
+@forward 'abstracts/functions';
+@forward 'utilities/helpers';
+@forward 'utilities/media';


### PR DESCRIPTION
## Summary
- expose variables, mixins, functions and utilities from `ui.scss`
- merge color and style variables into `_variables.scss`
- update components, pages and base styles to import only `../ui`
- clean up duplicate imports in `main.scss`

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540cab94a4832db6a2e6d403de9ef9