### PR TITLE
Add subscription info to user profile

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -66,11 +66,15 @@ public class ProfileController {
 
         String storeLimit = userService.getUserStoreLimit(userId);
 
+        // Получаем информацию о профиле пользователя
+        var userProfile = userService.getUserProfile(userId);
+
         // Загружаем магазины с настройками Telegram
         List<Store> stores = storeService.getUserStoresWithSettings(userId);
 
         // Добавляем данные профиля в модель
         model.addAttribute("username", user.getEmail());
+        model.addAttribute("userProfile", userProfile);
         model.addAttribute("storeLimit", storeLimit);
         model.addAttribute("stores", stores);
         log.debug("Данные профиля добавлены в модель для пользователя с ID: {}", userId);

--- a/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
@@ -16,5 +16,7 @@ public class UserProfileDTO {
     private String email; // отображение e-mail, но не редактируемый
     //private String fullName; // опционально, если в будущем понадобится
     private String timezone; // например, "Europe/Minsk"
+    private String subscriptionPlan; // план подписки (FREE или PREMIUM)
+    private String subscriptionEndDate; // дата окончания подписки
 
 }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -78,7 +78,22 @@
             <div class="col-lg-9 col-md-8 tab-content" id="v-pills-tabContent">
                 <div class="tab-pane fade show active card p-4 shadow-sm rounded-4" id="v-pills-home" role="tabpanel">
                     <h5 class="mb-3">Об аккаунте</h5>
-                    <p>Тут просто информация.</p>
+                    <div class="row mb-2">
+                        <div class="col-sm-4 text-muted">Email</div>
+                        <div class="col-sm-8" th:text="${userProfile.email}"></div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-sm-4 text-muted">Тариф</div>
+                        <div class="col-sm-8" th:text="${userProfile.subscriptionPlan}"></div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-sm-4 text-muted">Оплачено до</div>
+                        <div class="col-sm-8" th:text="${userProfile.subscriptionEndDate}"></div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-sm-4 text-muted">Часовой пояс</div>
+                        <div class="col-sm-8" th:text="${userProfile.timezone}"></div>
+                    </div>
                 </div>
 
                 <div class="tab-pane fade card p-4 shadow-sm rounded-4" id="v-pills-stores" role="tabpanel">


### PR DESCRIPTION
## Summary
- enrich `UserProfileDTO` with subscription details
- implement `UserService.getUserProfile` to fetch subscription data
- show profile data in `ProfileController`
- display account info on profile page using Bootstrap rows

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68543f3b6110832dad54c89bcd79bc26