### PR TITLE
fix: make subscription constants static

### DIFF
--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -28,8 +28,8 @@ public class SubscriptionService {
     private final UserSubscriptionRepository userSubscriptionRepository;
     private final SubscriptionPlanRepository subscriptionPlanRepository;
 
-    private final String PREMIUM_PLAN = "PREMIUM";
-    private final String FREE_PLAN = "FREE";
+    private static final String PREMIUM_PLAN = "PREMIUM";
+    private static final String FREE_PLAN = "FREE";
 
     /**
      * Рассчитывает, сколько треков можно загрузить в одном файле.


### PR DESCRIPTION
## Summary
- make subscription type constants `static final` in `SubscriptionService`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854442aeeec832db62a70ec68b5e4d6