### PR TITLE
UI/UX tweaks

### DIFF
--- a/src/main/resources/assets/scss/components/_nav.scss
+++ b/src/main/resources/assets/scss/components/_nav.scss
@@ -37,6 +37,7 @@
   &.active {
     opacity: 1;
     transform: translateY(0);
+    background-color: #f9f9f9;
   }
 }
 

--- a/src/main/resources/assets/scss/layouts/_sidebar.scss
+++ b/src/main/resources/assets/scss/layouts/_sidebar.scss
@@ -40,3 +40,10 @@
     display: none;
   }
 }
+
+@media (min-width: 768px) {
+  .sticky-sidebar {
+    position: sticky;
+    top: 1rem;
+  }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -488,6 +488,7 @@ header .mobile-nav.active {
 .tab-pane.active {
   opacity: 1;
   transform: translateY(0);
+  background-color: #f9f9f9;
 }
 
 @media (max-width: 768px) {
@@ -1381,6 +1382,13 @@ body.loading {
   transform: translate(-50%, -50%);
   text-align: center;
   opacity: 0.6;
+}
+
+@media (min-width: 768px) {
+  .sticky-sidebar {
+    position: sticky;
+    top: 1rem;
+  }
 }
 
 /*# sourceMappingURL=style.css.map */

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1236,6 +1236,28 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
+    // Запоминание активной вкладки и анимация при переключении
+    const tabKey = "profileActiveTab";
+    const tabLinks = document.querySelectorAll('#v-pills-tab a');
+    const savedTab = localStorage.getItem(tabKey);
+    if (savedTab) {
+        const triggerEl = document.querySelector(`[href="${savedTab}"]`);
+        if (triggerEl) new bootstrap.Tab(triggerEl).show();
+    }
+    tabLinks.forEach(link => {
+        link.addEventListener('shown.bs.tab', e => {
+            const href = e.target.getAttribute('href');
+            localStorage.setItem(tabKey, href);
+            const pane = document.querySelector(href);
+            if (pane) {
+                pane.classList.add('animate__animated', 'animate__fadeIn');
+                pane.addEventListener('animationend', () => {
+                    pane.classList.remove('animate__animated', 'animate__fadeIn');
+                }, { once: true });
+            }
+        });
+    });
+
     // Логика показа/скрытия пароля
     document.querySelectorAll(".toggle-password").forEach(button => {
         button.addEventListener("click", function () {

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -13,7 +13,7 @@
 </div>
 
 <main layout:fragment="content">
-    <h1 class="mt-4 text-center">Добро пожаловать в админ панель</h1>
+    <h1 class="mt-4 text-center mb-1">Добро пожаловать в админ панель</h1>
     <p class="text-center mb-4">Здесь вы можете управлять пользователями, посылками и другими ресурсами.</p>
 
     <div class="row">

--- a/src/main/resources/templates/admin/parcel-details.html
+++ b/src/main/resources/templates/admin/parcel-details.html
@@ -11,7 +11,7 @@
     <a href="/admin/parcels" class="btn btn-primary mb-4">Посылки</a>
 
     <div class="container mt-4">
-        <h1 class="mb-4">Информация о посылке</h1>
+        <h1 class="mb-1">Информация о посылке</h1>
         <div class="card mb-4">
             <div class="card-body">
                 <p><strong>ID:</strong> <span th:text="${parcel.id}"></span></p>

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -15,7 +15,7 @@
 <main layout:fragment="content">
 
 <div class="container mt-4">
-    <h1 class="mb-4">Информация о пользователе</h1>
+    <h1 class="mb-1">Информация о пользователе</h1>
 
     <div class="card mb-4">
         <div class="card-body">

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -15,7 +15,7 @@
 <main layout:fragment="content">
 
 <div class="container mt-4">
-    <h1 class="mb-4">Список пользователей</h1>
+    <h1 class="mb-1">Список пользователей</h1>
 
     <a th:href="@{/admin/users/new}" class="btn btn-primary mb-4">Добавить пользователя</a>
 

--- a/src/main/resources/templates/admin/user-new.html
+++ b/src/main/resources/templates/admin/user-new.html
@@ -10,7 +10,7 @@
 <main layout:fragment="content">
 
     <div class="container mt-4">
-        <h1 class="mb-4">Новый пользователь</h1>
+        <h1 class="mb-1">Новый пользователь</h1>
 
         <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
 

--- a/src/main/resources/templates/analytics/dashboard.html
+++ b/src/main/resources/templates/analytics/dashboard.html
@@ -12,7 +12,7 @@
         <div class="row justify-content-center">
             <div class="col-lg-10 col-md-10 col-12">
 
-                <h1>Аналитика магазинов</h1>
+                <h1 class="mb-1">Аналитика магазинов</h1>
 
         <!-- Контейнер для уведомлений -->
         <div id="notificationContainer"></div>

--- a/src/main/resources/templates/departures.html
+++ b/src/main/resources/templates/departures.html
@@ -16,7 +16,7 @@
 
                     <!-- Заголовок с кнопкой обновления -->
                     <div class="d-flex justify-content-center align-items-center mb-4 gap-2">
-                        <h1 class="mb-0 fs-2">Информация о посылках</h1>
+                        <h1 class="mb-1 fs-2">Информация о посылках</h1>
                         <button type="button"
                                 id="refreshAllBtn"
                                 class="history-refresh-btn ms-2"

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -15,7 +15,7 @@
             <div class="col-lg-10 col-md-10 col-12">
 
                 <!-- Заголовок страницы -->
-                <h1>Отслеживание посылок</h1>
+                <h1 class="mb-1">Отслеживание посылок</h1>
 
                 <!-- Ошибки -->
                 <div th:if="${customError}" class="alert alert-danger mb-4">

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -18,6 +18,8 @@
     <link rel="stylesheet" th:href="@{/bootstrap/bootstrap-icons.css}">
     <!-- Подключаем основной CSS вашего проекта -->
     <link rel="stylesheet" th:href="@{/css/style.css}">
+    <!-- Анимации -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
 
     <!-- Пример, как подставлять динамически заголовок, если нужно -->
     <title layout:fragment="title">Default Title</title>

--- a/src/main/resources/templates/privacy-policy.html
+++ b/src/main/resources/templates/privacy-policy.html
@@ -9,7 +9,7 @@
 </head>
 
 <main layout:fragment="content" class="legal-container container py-4">
-    <h1 class="legal-title">Политика конфиденциальности</h1>
+    <h1 class="legal-title mb-1">Политика конфиденциальности</h1>
     <p class="legal-date">Дата последнего обновления: 01.02.2025</p>
 
     <!-- 1. Общие положения -->

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -13,8 +13,8 @@
         <div class="row">
 
             <!-- Плавающая кнопка вызова меню (мобильная версия) -->
-            <button class="menu-toggle d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#settingsSidebar">
-                <i class="bi bi-gear"></i>
+            <button class="menu-toggle d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#settingsSidebar" title="Меню настроек">
+                <i class="bi bi-gear" title="Меню"></i>
             </button>
 
             <!-- Offcanvas боковая панель -->
@@ -26,22 +26,22 @@
                 <div class="offcanvas-body">
                     <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill" href="#v-pills-home" role="tab">
-                            <i class="bi bi-person me-2"></i> Об аккаунте
+                            <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте
                         </a>
                         <a class="nav-link d-flex align-items-center" id="stores-settings-link" data-bs-toggle="pill" href="#v-pills-stores" role="tab">
-                            <i class="bi bi-shop me-2"></i> Мои магазины
+                            <i class="bi bi-shop me-2" title="Мои магазины"></i> Мои магазины
                         </a>
                         <a class="nav-link d-flex align-items-center" id="password-settings-link" data-bs-toggle="pill" href="#v-pills-profile" role="tab">
-                            <i class="bi bi-key me-2"></i> Изменить пароль
+                            <i class="bi bi-key me-2" title="Изменить пароль"></i> Изменить пароль
                         </a>
                         <a class="nav-link d-flex align-items-center" id="evropost-settings-link" data-bs-toggle="pill" href="#v-pills-evropost" role="tab">
-                            <i class="bi bi-truck me-2"></i> Европочта
+                            <i class="bi bi-truck me-2" title="Европочта"></i> Европочта
                         </a>
                         <a class="nav-link d-flex align-items-center" id="belpost-settings-link" data-bs-toggle="pill" href="#v-pills-belpost" role="tab">
-                            <i class="bi bi-envelope me-2"></i> Белпочта
+                            <i class="bi bi-envelope me-2" title="Белпочта"></i> Белпочта
                         </a>
                         <a class="nav-link d-flex align-items-center text-danger" id="v-pills-messages-tab" data-bs-toggle="pill" href="#v-pills-messages" role="tab">
-                            <i class="bi bi-trash me-2"></i> Удалить аккаунт
+                            <i class="bi bi-trash me-2" title="Удалить аккаунт"></i> Удалить аккаунт
                         </a>
                     </div>
                 </div>
@@ -49,26 +49,26 @@
 
             <!-- Боковое меню (для ПК и планшетов) -->
             <div class="col-lg-3 col-md-4 d-none d-md-block">
-                <div class="card shadow-sm p-3 rounded-4">
+                <div class="card shadow-sm p-4 rounded-4 sticky-sidebar">
                     <h5 class="mb-3 text-center">Меню</h5>
                     <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill" href="#v-pills-home" role="tab">
-                            <i class="bi bi-person me-2"></i> Об аккаунте
+                            <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте
                         </a>
                         <a class="nav-link d-flex align-items-center" id="stores-settings-link" data-bs-toggle="pill" href="#v-pills-stores" role="tab">
-                            <i class="bi bi-shop me-2"></i> Мои магазины
+                            <i class="bi bi-shop me-2" title="Мои магазины"></i> Мои магазины
                         </a>
                         <a class="nav-link d-flex align-items-center" id="password-settings-link" data-bs-toggle="pill" href="#v-pills-profile" role="tab">
-                            <i class="bi bi-key me-2"></i> Изменить пароль
+                            <i class="bi bi-key me-2" title="Изменить пароль"></i> Изменить пароль
                         </a>
                         <a class="nav-link d-flex align-items-center" id="evropost-settings-link" data-bs-toggle="pill" href="#v-pills-evropost" role="tab">
-                            <i class="bi bi-truck me-2"></i> Европочта
+                            <i class="bi bi-truck me-2" title="Европочта"></i> Европочта
                         </a>
                         <a class="nav-link d-flex align-items-center" id="belpost-settings-link" data-bs-toggle="pill" href="#v-pills-belpost" role="tab">
-                            <i class="bi bi-envelope me-2"></i> Белпочта
+                            <i class="bi bi-envelope me-2" title="Белпочта"></i> Белпочта
                         </a>
                         <a class="nav-link d-flex align-items-center text-danger" id="v-pills-messages-tab" data-bs-toggle="pill" href="#v-pills-messages" role="tab">
-                            <i class="bi bi-trash me-2"></i> Удалить аккаунт
+                            <i class="bi bi-trash me-2" title="Удалить аккаунт"></i> Удалить аккаунт
                         </a>
                     </div>
                 </div>
@@ -85,7 +85,10 @@
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-4 text-muted">Тариф</div>
-                        <div class="col-sm-8" th:text="${userProfile.subscriptionPlan}"></div>
+                        <div class="col-sm-8">
+                            <span th:if="${userProfile.subscriptionPlan == 'PREMIUM'}" class="badge bg-success">PREMIUM</span>
+                            <span th:if="${userProfile.subscriptionPlan == 'FREE'}" class="badge bg-secondary">FREE</span>
+                        </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-4 text-muted">Оплачено до</div>
@@ -245,7 +248,7 @@
                                     <div th:errors="*{serviceNumber}" class="text-danger"></div>
                                 </div>
 
-                                <button class="btn btn-primary w-100 py-2" type="submit">Сохранить данные</button>
+                                <button class="btn btn-primary btn-sm w-100" type="submit">Сохранить данные</button>
                             </div>
                         </form>
                     </div>
@@ -364,7 +367,7 @@
                     <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}" name="customSignature"
                            th:value="${store.telegramSettings?.customSignature}" maxlength="200">
                 </div>
-                <button type="submit" class="btn btn-sm btn-primary">Сохранить</button>
+                <button type="submit" class="btn btn-sm btn-primary w-100">Сохранить</button>
             </form>
         </div>
     </div>

--- a/src/main/resources/templates/terms-of-use.html
+++ b/src/main/resources/templates/terms-of-use.html
@@ -9,7 +9,7 @@
 </head>
 
 <main layout:fragment="content" class="legal-container container py-4">
-    <h1 class="legal-title">Пользовательское соглашение</h1>
+    <h1 class="legal-title mb-1">Пользовательское соглашение</h1>
     <p class="legal-date">Дата последнего обновления: 01.02.2025</p>
 
     <section class="legal-section">


### PR DESCRIPTION
## Summary
- add animate.css to enable animations
- highlight active tab and remember active profile section
- make profile menu sticky on desktop
- style subscription plan label and buttons
- unify header spacing across pages
- move tab and sidebar styles to SCSS

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854424e5cf4832d951edc29e1baa40f