### PR TITLE
Fix plan name rendering

### DIFF
--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -44,7 +44,7 @@
         </thead>
         <tbody>
         <tr th:each="plan : ${plans}">
-            <td th:text="${plan.name}"></td>
+            <td th:text="${plan.code.displayName}"></td>
             <td th:text="${plan.maxTracksPerFile != null ? plan.maxTracksPerFile : '∞'}"></td>
             <td th:text="${plan.maxSavedTracks != null ? plan.maxSavedTracks : '∞'}"></td>
             <td th:text="${plan.maxTrackUpdates != null ? plan.maxTrackUpdates : '∞'}"></td>


### PR DESCRIPTION
## Summary
- fix plan name in admin settings table to use plan code display name

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_6854a589cb6c832d905a447d0e296284