### PR TITLE
Fix phone toggle on mobile

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -161,9 +161,10 @@ function initializePhoneToggle() {
         // Первичное состояние
         toggleFieldsVisibility(toggle, phoneField);
 
-        toggle.addEventListener('change', function () {
-            toggleFieldsVisibility(toggle, phoneField);
-        });
+        // Единый обработчик для переключения и касания на мобилках
+        const handler = () => toggleFieldsVisibility(toggle, phoneField);
+        toggle.addEventListener('change', handler);
+        toggle.addEventListener('touchstart', handler);
     }
 }
 


### PR DESCRIPTION
## Summary
- handle `touchstart` event in `initializePhoneToggle` so phone field toggles on mobile

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855021cb8dc832db9113e0cea242c8a