### PR TITLE
Improve filter layout for small screens

### DIFF
--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -366,6 +366,18 @@
     }
   }
 
+  .history-controls {
+    .filter-group {
+      flex-direction: column;
+      align-items: stretch;
+
+      button,
+      select {
+        width: 100%;
+      }
+    }
+  }
+
   .table-responsive {
     overflow-x: auto;
   }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1197,6 +1197,14 @@ button:hover {
     padding: 5px 10px;
     max-width: 120px;
   }
+  .history-controls .filter-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .history-controls .filter-group button,
+  .history-controls .filter-group select {
+    width: 100%;
+  }
   .table-responsive {
     overflow-x: auto;
   }

--- a/src/main/resources/templates/departures.html
+++ b/src/main/resources/templates/departures.html
@@ -42,7 +42,7 @@
                     <div class="history-controls d-flex flex-wrap align-items-center gap-3 justify-content-between">
 
                         <!-- Действие + кнопка "Применить" -->
-                        <div class="filter-group d-flex align-items-center gap-2">
+                        <div class="filter-group d-flex flex-column flex-sm-row align-items-sm-center gap-2">
                             <div class="filter-item d-flex align-items-center">
                                 <label for="actionSelect" class="form-label m-0 me-2">Действие:</label>
                                 <select id="actionSelect" class="form-select w-auto">
@@ -55,7 +55,7 @@
                         </div>
 
                         <!-- Фильтр по магазину (показываем только если магазинов больше 1) -->
-                        <div class="filter-group d-flex align-items-center gap-2"
+                        <div class="filter-group d-flex flex-column flex-sm-row align-items-sm-center gap-2"
                              th:if="${stores != null and #lists.size(stores) > 1}">
                             <label for="storeId" class="form-label m-0 me-2">Магазин:</label>
                             <select id="storeId" name="storeId" class="form-select w-auto">
@@ -69,7 +69,7 @@
                         </div>
 
                         <!-- Фильтр по статусу -->
-                        <div class="filter-group d-flex align-items-center gap-2">
+                        <div class="filter-group d-flex flex-column flex-sm-row align-items-sm-center gap-2">
                             <label for="status" class="form-label m-0 me-2">Статус:</label>
                             <select id="status" name="status" class="form-select w-auto">
                                 <!-- Всегда выводим опцию "Все статусы" -->
@@ -84,7 +84,7 @@
                         </div>
 
                         <!-- Количество элементов на странице -->
-                        <div class="filter-group size-controls d-flex align-items-center gap-2">
+                        <div class="filter-group size-controls d-flex flex-column flex-sm-row align-items-sm-center gap-2">
                             <button type="button" class="btn btn-outline-secondary size-btn" data-size="20"
                                     th:classappend="${size == 20} ? 'active'">20</button>
                             <button type="button" class="btn btn-outline-secondary size-btn" data-size="50"


### PR DESCRIPTION
## Summary
- add responsive flex classes in `departures.html`
- allow filter groups to stack on small screens in `_history.scss`
- update compiled CSS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855295f1d7c832d9516d6533433b753