### PR TITLE
Sync profile tabs in duplicate menus

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -30,6 +30,16 @@ function toggleAllCheckboxes(checked) {
     updateApplyButtonState();
 }
 
+/**
+ * Устанавливает активную вкладку профиля во всех меню.
+ * @param {string} href - Идентификатор вкладки (href вида '#v-pills-home').
+ */
+function setActiveProfileTab(href) {
+    document.querySelectorAll('.profile-tab-menu a').forEach(link => {
+        link.classList.toggle('active', link.getAttribute('href') === href);
+    });
+}
+
 // Обновляем кнопку при изменении чекбоксов
 document.body.addEventListener("change", function (event) {
     if (event.target.classList.contains("selectCheckbox")) {
@@ -1243,15 +1253,19 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Запоминание активной вкладки и анимация при переключении
     const tabKey = "profileActiveTab";
-    const tabLinks = document.querySelectorAll('#v-pills-tab a');
+    const tabLinks = document.querySelectorAll('.profile-tab-menu a');
     const savedTab = localStorage.getItem(tabKey);
     if (savedTab) {
-        const triggerEl = document.querySelector(`[href="${savedTab}"]`);
-        if (triggerEl) new bootstrap.Tab(triggerEl).show();
+        const links = document.querySelectorAll(`.profile-tab-menu a[href="${savedTab}"]`);
+        if (links.length > 0) {
+            bootstrap.Tab.getOrCreateInstance(links[0]).show();
+            setActiveProfileTab(savedTab);
+        }
     }
     tabLinks.forEach(link => {
         link.addEventListener('shown.bs.tab', e => {
             const href = e.target.getAttribute('href');
+            setActiveProfileTab(href);
             localStorage.setItem(tabKey, href);
             const pane = document.querySelector(href);
             if (pane) {

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -26,7 +26,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Закрыть"></button>
                 </div>
                 <div class="offcanvas-body">
-                    <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+                    <div class="nav flex-column nav-pills profile-tab-menu" id="v-pills-tab" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill"
                            href="#v-pills-home" role="tab">
                             <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте
@@ -59,7 +59,7 @@
             <div class="col-lg-3 col-md-4 d-none d-md-block">
                 <div class="card shadow-sm p-4 rounded-4 sticky-sidebar">
                     <h5 class="mb-3 text-center">Меню</h5>
-                    <div class="nav flex-column nav-pills" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+                    <div class="nav flex-column nav-pills profile-tab-menu" id="v-pills-tab" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill"
                            href="#v-pills-home" role="tab">
                             <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте


### PR DESCRIPTION
## Summary
- sync tab selection across duplicate menus
- update selector in JS to use `.profile-tab-menu`

## Testing
- `./mvnw test -q` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68553252e394832da667d024f48a7773