### PR TITLE
Add subscription plan management

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.dto.TrackParcelAdminInfoDTO;
 import com.project.tracking_system.dto.UserDetailsAdminInfoDTO;
 import com.project.tracking_system.dto.UserListAdminInfoDTO;
 import com.project.tracking_system.dto.BreadcrumbItemDTO;
+import com.project.tracking_system.dto.SubscriptionPlanDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.StoreRepository;
 import com.project.tracking_system.service.SubscriptionService;
@@ -511,6 +512,50 @@ public class AdminController {
         );
         model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/settings";
+    }
+
+    /**
+     * Отображает список тарифных планов и форму их редактирования.
+     *
+     * @param model модель для передачи данных
+     * @return имя шаблона управления тарифами
+     */
+    @GetMapping("/plans")
+    public String plans(Model model) {
+        model.addAttribute("plans", adminService.getPlans());
+        model.addAttribute("codes", SubscriptionCode.values());
+
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Тарифы", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
+        return "admin/plans";
+    }
+
+    /**
+     * Создаёт новый тарифный план.
+     *
+     * @param dto параметры плана
+     * @return редирект на страницу тарифов
+     */
+    @PostMapping("/plans")
+    public String createPlan(SubscriptionPlanDTO dto) {
+        adminService.createPlan(dto);
+        return "redirect:/admin/plans";
+    }
+
+    /**
+     * Обновляет существующий тарифный план.
+     *
+     * @param id  идентификатор плана
+     * @param dto новые параметры
+     * @return редирект на страницу тарифов
+     */
+    @PostMapping("/plans/{id}")
+    public String updatePlan(@PathVariable Long id, SubscriptionPlanDTO dto) {
+        adminService.updatePlan(id, dto);
+        return "redirect:/admin/plans";
     }
 
 }

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
@@ -1,0 +1,21 @@
+package com.project.tracking_system.dto;
+
+import com.project.tracking_system.entity.SubscriptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO для работы с тарифными планами.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionPlanDTO {
+    private SubscriptionCode code;
+    private Integer maxTracksPerFile;
+    private Integer maxSavedTracks;
+    private Integer maxTrackUpdates;
+    private boolean allowBulkUpdate;
+    private Integer maxStores;
+}

--- a/src/main/java/com/project/tracking_system/service/admin/AdminService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminService.java
@@ -3,8 +3,10 @@ package com.project.tracking_system.service.admin;
 import com.project.tracking_system.dto.StoreAdminInfoDTO;
 import com.project.tracking_system.dto.TrackParcelAdminInfoDTO;
 import com.project.tracking_system.dto.UserListAdminInfoDTO;
+import com.project.tracking_system.dto.SubscriptionPlanDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.admin.SubscriptionPlanService;
 import com.project.tracking_system.service.track.TrackDeletionService;
 import com.project.tracking_system.service.track.TrackProcessingService;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,7 @@ public class AdminService {
     private final StoreRepository storeRepository;
     private final StoreTelegramSettingsRepository storeTelegramSettingsRepository;
     private final UserSubscriptionRepository userSubscriptionRepository;
-    private final SubscriptionPlanRepository subscriptionPlanRepository;
+    private final SubscriptionPlanService subscriptionPlanService;
     private final TrackParcelRepository trackParcelRepository;
     private final UserRepository userRepository;
     private final TrackDeletionService trackDeletionService;
@@ -125,7 +127,28 @@ public class AdminService {
      * Получить все планы подписки.
      */
     public List<SubscriptionPlan> getPlans() {
-        return subscriptionPlanRepository.findAll();
+        return subscriptionPlanService.getAllPlans();
+    }
+
+    /**
+     * Создать новый тарифный план.
+     *
+     * @param dto параметры нового плана
+     * @return созданный план
+     */
+    public SubscriptionPlan createPlan(SubscriptionPlanDTO dto) {
+        return subscriptionPlanService.createPlan(dto);
+    }
+
+    /**
+     * Обновить тарифный план.
+     *
+     * @param id  идентификатор плана
+     * @param dto новые параметры
+     * @return обновлённый план
+     */
+    public SubscriptionPlan updatePlan(Long id, SubscriptionPlanDTO dto) {
+        return subscriptionPlanService.updatePlan(id, dto);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -1,0 +1,68 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.dto.SubscriptionPlanDTO;
+import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.repository.SubscriptionPlanRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Сервис управления тарифными планами.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubscriptionPlanService {
+
+    private final SubscriptionPlanRepository planRepository;
+
+    /**
+     * Получить список всех тарифных планов.
+     *
+     * @return список планов
+     */
+    public List<SubscriptionPlan> getAllPlans() {
+        return planRepository.findAll();
+    }
+
+    /**
+     * Создать новый тарифный план.
+     *
+     * @param dto DTO с параметрами плана
+     * @return созданный план
+     */
+    public SubscriptionPlan createPlan(SubscriptionPlanDTO dto) {
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setCode(dto.getCode());
+        plan.setMaxTracksPerFile(dto.getMaxTracksPerFile());
+        plan.setMaxSavedTracks(dto.getMaxSavedTracks());
+        plan.setMaxTrackUpdates(dto.getMaxTrackUpdates());
+        plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
+        plan.setMaxStores(dto.getMaxStores());
+        log.info("Создан тарифный план {}", dto.getCode());
+        return planRepository.save(plan);
+    }
+
+    /**
+     * Обновить существующий тарифный план.
+     *
+     * @param id  идентификатор плана
+     * @param dto новые параметры
+     * @return обновлённый план
+     */
+    public SubscriptionPlan updatePlan(Long id, SubscriptionPlanDTO dto) {
+        SubscriptionPlan plan = planRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("План не найден"));
+        plan.setCode(dto.getCode());
+        plan.setMaxTracksPerFile(dto.getMaxTracksPerFile());
+        plan.setMaxSavedTracks(dto.getMaxSavedTracks());
+        plan.setMaxTrackUpdates(dto.getMaxTrackUpdates());
+        plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
+        plan.setMaxStores(dto.getMaxStores());
+        log.info("Обновлен тарифный план {}", id);
+        return planRepository.save(plan);
+    }
+}

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -90,6 +90,9 @@
         <a href="/admin/subscriptions" class="list-group-item list-group-item-action custom-list-item">
             <i class="bi bi-bookmark-check"></i> Подписки
         </a>
+        <a href="/admin/plans" class="list-group-item list-group-item-action custom-list-item">
+            <i class="bi bi-list"></i> Тарифы
+        </a>
     </div>
 </main>
 

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Тарифные планы</title>
+</head>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
+</div>
+<main layout:fragment="content">
+    <h1 class="mb-3">Тарифные планы</h1>
+    <table class="table table-bordered">
+        <thead>
+        <tr>
+            <th>Код</th>
+            <th>Треков в файле</th>
+            <th>Сохранённых треков</th>
+            <th>Обновлений в день</th>
+            <th>Магазинов</th>
+            <th>Массовое обновление</th>
+            <th>Действия</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="plan : ${plans}">
+            <form th:action="@{/admin/plans/{id}(id=${plan.id})}" method="post" class="align-middle">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <td th:text="${plan.code.name()}"></td>
+                <td><input type="number" name="maxTracksPerFile" class="form-control" th:value="${plan.maxTracksPerFile}" /></td>
+                <td><input type="number" name="maxSavedTracks" class="form-control" th:value="${plan.maxSavedTracks}" /></td>
+                <td><input type="number" name="maxTrackUpdates" class="form-control" th:value="${plan.maxTrackUpdates}" /></td>
+                <td><input type="number" name="maxStores" class="form-control" th:value="${plan.maxStores}" /></td>
+                <td class="text-center"><input type="checkbox" name="allowBulkUpdate" th:checked="${plan.allowBulkUpdate}" /></td>
+                <td><button type="submit" class="btn btn-success btn-sm">Сохранить</button></td>
+            </form>
+        </tr>
+        </tbody>
+    </table>
+
+    <h4 class="mt-4">Новый план</h4>
+    <form th:action="@{/admin/plans}" method="post" class="row g-2">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <div class="col-md-2">
+            <select name="code" class="form-select">
+                <option th:each="c : ${codes}" th:value="${c.name()}" th:text="${c.displayName}"></option>
+            </select>
+        </div>
+        <div class="col-md-2"><input type="number" name="maxTracksPerFile" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="maxSavedTracks" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="maxTrackUpdates" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="maxStores" class="form-control" /></div>
+        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowBulkUpdate" class="form-check-input" /></div>
+        <div class="col-md-1"><button type="submit" class="btn btn-primary">Создать</button></div>
+    </form>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- implement `SubscriptionPlanDTO`
- add `SubscriptionPlanService` with CRUD operations
- extend `AdminService` with plan management methods
- add plan management endpoints to `AdminController`
- create admin UI for plan editing
- link plan management from dashboard

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68554f3967f0832dbcbfef6475e85ed1