### PR TITLE
Implement Telegram notification opt-out

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -39,6 +39,9 @@ public class Customer {
     @Column(name = "telegram_confirmed", nullable = false)
     private boolean telegramConfirmed = false;
 
+    @Column(name = "notifications_enabled", nullable = false)
+    private boolean notificationsEnabled = true;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "reputation", nullable = false)
     private BuyerReputation reputation = BuyerReputation.NEW;

--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -32,6 +32,22 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Optional<Customer> findByTelegramChatId(Long chatId);
 
     /**
+     * Обновить статус уведомлений для покупателя по chatId.
+     *
+     * @param chatId  идентификатор Telegram-чата
+     * @param enabled новое значение флага
+     * @return количество обновлённых записей
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE Customer c
+        SET c.notificationsEnabled = :enabled
+        WHERE c.telegramChatId = :chatId
+        """)
+    int updateNotificationsEnabled(@Param("chatId") Long chatId, @Param("enabled") boolean enabled);
+
+    /**
      * Атомарно увеличить счётчик отправленных посылок.
      *
      * @param id идентификатор покупателя

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -195,8 +195,8 @@ public class CustomerService {
     /**
      * Проверяет, можно ли отправлять уведомления покупателю.
      * <p>
-     * Уведомления разрешены, если у покупателя указан идентификатор Telegram-чатa
-     * и владелец магазина обладает подпиской PREMIUM.
+     * Уведомления разрешены, если у покупателя указан идентификатор Telegram-чатa,
+     * включены уведомления и владелец магазина обладает подпиской PREMIUM.
      * </p>
      *
      * @param customer покупатель
@@ -208,8 +208,8 @@ public class CustomerService {
             return false;
         }
 
-        // Проверяем наличие привязанного чата
-        if (customer.getTelegramChatId() == null) {
+        // Проверяем наличие привязанного чата и разрешение на уведомления
+        if (customer.getTelegramChatId() == null || !customer.isNotificationsEnabled()) {
             return false;
         }
 

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -127,4 +127,27 @@ public class CustomerTelegramService {
         }
     }
 
+    /**
+     * Отключить отправку Telegram-уведомлений покупателю.
+     *
+     * @param chatId идентификатор Telegram-чата
+     * @return {@code true}, если уведомления были отключены
+     */
+    @Transactional
+    public boolean disableNotifications(Long chatId) {
+        if (chatId == null) {
+            return false;
+        }
+
+        return customerRepository.findByTelegramChatId(chatId)
+                .filter(Customer::isNotificationsEnabled)
+                .map(customer -> {
+                    customer.setNotificationsEnabled(false);
+                    customerRepository.save(customer);
+                    log.info("🔕 Уведомления отключены для покупателя {}", customer.getId());
+                    return true;
+                })
+                .orElse(false);
+    }
+
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -71,9 +71,25 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         if (update.hasMessage()) {
             var message = update.getMessage();
 
-            if (message.hasText() && "/start".equals(message.getText())) {
-                log.info("✅ Команда /start получена от {}", message.getChatId());
-                sendSharePhoneKeyboard(message.getChatId());
+            if (message.hasText()) {
+                String text = message.getText();
+                if ("/start".equals(text)) {
+                    log.info("✅ Команда /start получена от {}", message.getChatId());
+                    sendSharePhoneKeyboard(message.getChatId());
+                }
+                if ("/stop".equals(text) || "/unsubscribe".equals(text)) {
+                    log.info("🔕 Команда {} получена от {}", text, message.getChatId());
+                    boolean disabled = telegramService.disableNotifications(message.getChatId());
+                    if (disabled) {
+                        SendMessage confirm = new SendMessage(message.getChatId().toString(),
+                                "🔕 Уведомления отключены. Чтобы возобновить их, снова отправьте /start.");
+                        try {
+                            telegramClient.execute(confirm);
+                        } catch (TelegramApiException e) {
+                            log.error("❌ Ошибка отправки подтверждения", e);
+                        }
+                    }
+                }
             }
 
             if (message.hasContact()) {


### PR DESCRIPTION
## Summary
- add a notificationsEnabled flag to `Customer`
- extend `CustomerRepository` with a method to update this flag by chat ID
- respect the flag in `CustomerService.isNotifiable`
- provide `CustomerTelegramService.disableNotifications`
- handle `/stop` and `/unsubscribe` commands in `BuyerTelegramBot`

## Testing
- `mvn -v` *(fails: command not found)*
- `./mvnw -v` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68554f3c6e4c832d8a6aea3b4b4a3f1e