### PR TITLE
Add admin deletion features

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -282,6 +282,18 @@ public class AdminController {
     }
 
     /**
+     * Удаляет пользователя целиком.
+     *
+     * @param id идентификатор пользователя
+     * @return редирект на список пользователей
+     */
+    @PostMapping("/users/{id}/delete")
+    public String deleteUser(@PathVariable Long id) {
+        adminService.deleteUser(id);
+        return "redirect:/admin/users";
+    }
+
+    /**
      * Запускает агрегацию недельной, месячной и годовой статистики за вчерашний день.
      *
      * @return редирект на административную страницу
@@ -346,6 +358,18 @@ public class AdminController {
     }
 
     /**
+     * Удаляет покупателя и его связи.
+     *
+     * @param id идентификатор покупателя
+     * @return редирект на список покупателей
+     */
+    @PostMapping("/customers/{id}/delete")
+    public String deleteCustomer(@PathVariable Long id) {
+        adminService.deleteCustomer(id);
+        return "redirect:/admin/customers";
+    }
+
+    /**
      * Отображает статистику активности Telegram-бота.
      *
      * @param model модель, в которую передаются данные об активности
@@ -383,6 +407,18 @@ public class AdminController {
         );
         model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/stores";
+    }
+
+    /**
+     * Удаляет магазин с его данными.
+     *
+     * @param id идентификатор магазина
+     * @return редирект на список магазинов
+     */
+    @PostMapping("/stores/{id}/delete")
+    public String deleteStore(@PathVariable Long id) {
+        adminService.deleteStore(id);
+        return "redirect:/admin/stores";
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/repository/CustomerNotificationLogRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerNotificationLogRepository.java
@@ -4,6 +4,9 @@ import com.project.tracking_system.entity.CustomerNotificationLog;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 
 /**
@@ -35,4 +38,13 @@ public interface CustomerNotificationLogRepository extends JpaRepository<Custome
      * @return список из десяти последних уведомлений
      */
     List<CustomerNotificationLog> findTop10ByOrderBySentAtDesc();
+
+    /**
+     * Удалить все записи лога конкретного покупателя.
+     *
+     * @param customerId идентификатор покупателя
+     */
+    @Modifying
+    @Transactional
+    void deleteByCustomerId(Long customerId);
 }

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -122,4 +122,14 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     @Query("SELECT t FROM TrackParcel t JOIN FETCH t.store JOIN FETCH t.user WHERE t.id = :id")
     TrackParcel findByIdWithStoreAndUser(@Param("id") Long id);
 
+    /**
+     * Очистить связь покупателя у его посылок.
+     *
+     * @param customerId идентификатор покупателя
+     */
+    @Modifying
+    @Transactional
+    @Query("UPDATE TrackParcel t SET t.customer = null WHERE t.customer.id = :customerId")
+    void clearCustomer(@Param("customerId") Long customerId);
+
 }

--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -38,6 +38,7 @@
             <th>Отправлено</th>
             <th>Забрано</th>
             <th>Возвраты</th>
+            <th>Действия</th>
         </tr>
         </thead>
         <tbody>
@@ -47,6 +48,12 @@
             <td th:text="${c.sentCount}"></td>
             <td th:text="${c.pickedUpCount}"></td>
             <td th:text="${c.returnedCount}"></td>
+            <td>
+                <form th:action="@{/admin/customers/{id}/delete(id=${c.id})}" method="post" class="d-inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit" class="btn btn-danger btn-sm">Удалить</button>
+                </form>
+            </td>
         </tr>
         </tbody>
     </table>

--- a/src/main/resources/templates/admin/stores.html
+++ b/src/main/resources/templates/admin/stores.html
@@ -17,6 +17,7 @@
             <th>Telegram</th>
             <th>Напоминания</th>
             <th>Подписка</th>
+            <th>Действия</th>
         </tr>
         </thead>
         <tbody>
@@ -27,6 +28,12 @@
             <td th:text="${s.telegramEnabled}"></td>
             <td th:text="${s.remindersEnabled}"></td>
             <td th:text="${s.subscriptionPlan}"></td>
+            <td>
+                <form th:action="@{/admin/stores/{id}/delete(id=${s.id})}" method="post" class="d-inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit" class="btn btn-danger btn-sm">Удалить</button>
+                </form>
+            </td>
         </tr>
         </tbody>
     </table>

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -61,7 +61,11 @@
             <td th:text="${user.role}"></td>
             <td th:text="${user.getSubscriptionPlanCode().getDisplayName()}"></td>
             <td>
-                <a th:href="@{/admin/users/{userId}(userId=${user.id})}" class="btn btn-info btn-sm">Подробнее</a>
+                <a th:href="@{/admin/users/{userId}(userId=${user.id})}" class="btn btn-info btn-sm me-1">Подробнее</a>
+                <form th:action="@{/admin/users/{id}/delete(id=${user.id})}" method="post" class="d-inline">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit" class="btn btn-danger btn-sm">Удалить</button>
+                </form>
             </td>
         </tr>
         </tbody>


### PR DESCRIPTION
## Summary
- allow admin to delete users, stores and customers
- clear parcel links when customer is removed
- add repository helpers for customer deletion
- expose new admin routes for deletion
- show delete buttons in admin views

## Testing
- `./mvnw -q -DskipTests package` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68554f3ed810832da42f98e3cbc228df