### PR TITLE
Add telegram notification flag in subscription plans

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
@@ -18,4 +18,5 @@ public class SubscriptionPlanDTO {
     private Integer maxTrackUpdates;
     private boolean allowBulkUpdate;
     private Integer maxStores;
+    private boolean allowTelegramNotifications;
 }

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -38,4 +38,7 @@ public class SubscriptionPlan {
 
     @Column(nullable = false)
     private Integer maxStores;
+
+    @Column(name = "allow_telegram_notifications", nullable = false)
+    private Boolean allowTelegramNotifications = false;
 }

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -179,6 +179,23 @@ public class SubscriptionService {
     }
 
     /**
+     * Проверяет, разрешены ли Telegram-уведомления для пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если тарифный план пользователя позволяет Telegram-уведомления
+     */
+    public boolean canUseTelegramNotifications(Long userId) {
+        SubscriptionCode code = userSubscriptionRepository.getSubscriptionPlanCode(userId);
+        if (code == null) {
+            log.warn("Пользователь {} не имеет активной подписки. Telegram недоступен.", userId);
+            return false;
+        }
+        return subscriptionPlanRepository.findByCode(code)
+                .map(SubscriptionPlan::getAllowTelegramNotifications)
+                .orElse(false);
+    }
+
+    /**
      * Проверяет наличие подписки PREMIUM у пользователя.
      *
      * @param userId идентификатор пользователя

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -42,6 +42,7 @@ public class SubscriptionPlanService {
         plan.setMaxTrackUpdates(dto.getMaxTrackUpdates());
         plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
         plan.setMaxStores(dto.getMaxStores());
+        plan.setAllowTelegramNotifications(dto.isAllowTelegramNotifications());
         log.info("Создан тарифный план {}", dto.getCode());
         return planRepository.save(plan);
     }
@@ -62,6 +63,7 @@ public class SubscriptionPlanService {
         plan.setMaxTrackUpdates(dto.getMaxTrackUpdates());
         plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
         plan.setMaxStores(dto.getMaxStores());
+        plan.setAllowTelegramNotifications(dto.isAllowTelegramNotifications());
         log.info("Обновлен тарифный план {}", id);
         return planRepository.save(plan);
     }

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -600,8 +600,8 @@ public class DeliveryHistoryService {
         }
 
         Long ownerId = parcel.getStore().getOwner().getId();
-        boolean premium = subscriptionService.isUserPremium(ownerId);
-        if (!premium) {
+        boolean allowed = subscriptionService.canUseTelegramNotifications(ownerId);
+        if (!allowed) {
             return false;
         }
 

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -39,8 +39,8 @@ public class StoreTelegramSettingsService {
     public void update(Store store, StoreTelegramSettingsDTO dto, Long userId) {
         boolean enableRequested = dto.isEnabled();
 
-        if (enableRequested && !subscriptionService.isUserPremium(userId)) {
-            String msg = "Telegram-уведомления доступны только для подписки PREMIUM.";
+        if (enableRequested && !subscriptionService.canUseTelegramNotifications(userId)) {
+            String msg = "Telegram-уведомления доступны только на выбранном тарифе.";
             webSocketController.sendUpdateStatus(userId, msg, false);
             log.warn("⛔ Попытка включить Telegram-уведомления магазином ID={} без премиум-подписки", store.getId());
             throw new IllegalStateException(msg);

--- a/src/main/resources/db/migration/V20__add_allow_telegram_notifications.sql
+++ b/src/main/resources/db/migration/V20__add_allow_telegram_notifications.sql
@@ -1,0 +1,4 @@
+ALTER TABLE subscription_plans
+    ADD COLUMN allow_telegram_notifications BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE subscription_plans SET allow_telegram_notifications = TRUE WHERE code = 'PREMIUM';

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -17,6 +17,7 @@
             <th>Обновлений в день</th>
             <th>Магазинов</th>
             <th>Массовое обновление</th>
+            <th>Telegram-уведомления</th>
             <th>Действия</th>
         </tr>
         </thead>
@@ -30,6 +31,7 @@
                 <td><input type="number" name="maxTrackUpdates" class="form-control" th:value="${plan.maxTrackUpdates}" /></td>
                 <td><input type="number" name="maxStores" class="form-control" th:value="${plan.maxStores}" /></td>
                 <td class="text-center"><input type="checkbox" name="allowBulkUpdate" th:checked="${plan.allowBulkUpdate}" /></td>
+                <td class="text-center"><input type="checkbox" name="allowTelegramNotifications" th:checked="${plan.allowTelegramNotifications}" /></td>
                 <td><button type="submit" class="btn btn-success btn-sm">Сохранить</button></td>
             </form>
         </tr>
@@ -49,6 +51,7 @@
         <div class="col-md-2"><input type="number" name="maxTrackUpdates" class="form-control" /></div>
         <div class="col-md-2"><input type="number" name="maxStores" class="form-control" /></div>
         <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowBulkUpdate" class="form-check-input" /></div>
+        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowTelegramNotifications" class="form-check-input" /></div>
         <div class="col-md-1"><button type="submit" class="btn btn-primary">Создать</button></div>
     </form>
 </main>

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -40,6 +40,7 @@
             <th>Обновлений в день</th>
             <th>Магазинов</th>
             <th>Массовое обновление</th>
+            <th>Telegram-уведомления</th>
         </tr>
         </thead>
         <tbody>
@@ -50,6 +51,7 @@
             <td th:text="${plan.maxTrackUpdates != null ? plan.maxTrackUpdates : '∞'}"></td>
             <td th:text="${plan.maxStores}"></td>
             <td th:text="${plan.allowBulkUpdate}"></td>
+            <td th:text="${plan.allowTelegramNotifications}"></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- allow enabling telegram notifications per subscription plan
- expose allowTelegramNotifications property via DTO and admin UI
- support new flag in SubscriptionPlanService
- add method to check telegram access in SubscriptionService
- use new check in StoreTelegramSettingsService and DeliveryHistoryService
- add Flyway migration for allow_telegram_notifications column

## Testing
- `./mvnw -q test` *(fails: cannot open .mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685558587ad0832d83cecbb4e742dea8