### PR TITLE
Improve bulk update check via subscription plan

### DIFF
--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -163,19 +163,22 @@ public class SubscriptionService {
      * Проверяет возможность массового обновления треков для пользователя.
      *
      * @param userId идентификатор пользователя
-     * @return {@code true}, если пользователь имеет премиум-подписку
+     * @return {@code true}, если тарифный план позволяет массовое обновление
      */
     public boolean canUseBulkUpdate(Long userId) {
-        SubscriptionCode code = userSubscriptionRepository.getSubscriptionPlanCode(userId);
+        UserSubscription subscription = userSubscriptionRepository.findByUserId(userId)
+                .orElse(null);
 
-        if (code == null) {
+        if (subscription == null) {
             log.warn("Пользователь {} не имеет активной подписки. Массовое обновление недоступно.", userId);
             return false;
         }
 
-        boolean hasAccess = (code == SubscriptionCode.PREMIUM);
-        log.debug("Пользователь {} пытается использовать массовое обновление. Доступ: {}", userId, hasAccess);
-        return hasAccess;
+        SubscriptionPlan plan = subscription.getSubscriptionPlan();
+        boolean allowed = plan != null && plan.isAllowBulkUpdate();
+
+        log.debug("Пользователь {} пытается использовать массовое обновление. Доступ: {}", userId, allowed);
+        return allowed;
     }
 
     /**


### PR DESCRIPTION
## Summary
- use user's SubscriptionPlan.allowBulkUpdate in `canUseBulkUpdate`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855634081d0832d90afc59bf6e387fe