### PR TITLE
Fix mobile input rounding

### DIFF
--- a/src/main/resources/assets/scss/components/_forms.scss
+++ b/src/main/resources/assets/scss/components/_forms.scss
@@ -74,4 +74,24 @@
   .btn {
     border-radius: 0 ui.$border-radius ui.$border-radius 0;
   }
+
+  @include ui.respond-to(sm) {
+    flex-direction: column;
+    align-items: stretch;
+
+    input,
+    .btn {
+      border-radius: ui.$border-radius !important;
+      width: 100%;
+    }
+
+    input {
+      margin-bottom: 0.5rem;
+    }
+  }
+}
+
+// Округление поля ввода телефона
+#phone {
+  border-radius: ui.$border-radius !important;
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -524,6 +524,24 @@ button:hover {
   .btn-equal {
     width: 100%;
   }
+  /* Перемещённая под поле кнопка и само поле имеют скруглённые углы */
+  .input-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+.input-group input,
+.input-group .btn {
+    border-radius: 8px !important;
+    width: 100%;
+}
+.input-group input {
+    margin-bottom: 0.5rem;
+}
+}
+
+/* Отдельное поле ввода телефона с округлением справа */
+#phone {
+  border-radius: 8px !important;
 }
 
 .auth-form {


### PR DESCRIPTION
## Summary
- adjust input group style on small screens so input and button corners are rounded when stacked
- add rounding to phone input field
- update SCSS sources to match CSS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685584b29f88832d90f5cde38e0bd477