### PR TITLE
Implement notification toggling in Telegram bot

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -150,4 +150,27 @@ public class CustomerTelegramService {
                 .orElse(false);
     }
 
+    /**
+     * Включить отправку Telegram-уведомлений покупателю.
+     *
+     * @param chatId идентификатор Telegram-чата
+     * @return {@code true}, если уведомления были включены
+     */
+    @Transactional
+    public boolean enableNotifications(Long chatId) {
+        if (chatId == null) {
+            return false;
+        }
+
+        return customerRepository.findByTelegramChatId(chatId)
+                .filter(c -> !c.isNotificationsEnabled())
+                .map(customer -> {
+                    customer.setNotificationsEnabled(true);
+                    customerRepository.save(customer);
+                    log.info("🔔 Уведомления включены для покупателя {}", customer.getId());
+                    return true;
+                })
+                .orElse(false);
+    }
+
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -90,6 +90,18 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                         }
                     }
                 }
+                if ("🔕 Отключить уведомления".equals(text)) {
+                    boolean disabled = telegramService.disableNotifications(message.getChatId());
+                    if (disabled) {
+                        sendNotificationsKeyboard(message.getChatId(), false);
+                    }
+                }
+                if ("🔔 Включить уведомления".equals(text)) {
+                    boolean enabled = telegramService.enableNotifications(message.getChatId());
+                    if (enabled) {
+                        sendNotificationsKeyboard(message.getChatId(), true);
+                    }
+                }
             }
 
             if (message.hasContact()) {
@@ -116,6 +128,26 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
     }
 
+    private void sendNotificationsKeyboard(Long chatId, boolean enabled) {
+        String buttonText = enabled ? "🔕 Отключить уведомления"
+                : "🔔 Включить уведомления";
+
+        KeyboardButton button = new KeyboardButton(buttonText);
+        KeyboardRow row = new KeyboardRow(List.of(button));
+        ReplyKeyboardMarkup markup = new ReplyKeyboardMarkup(List.of(row));
+        markup.setResizeKeyboard(true);
+        markup.setOneTimeKeyboard(true);
+
+        SendMessage message = new SendMessage(chatId.toString(), "🔔 Настройки уведомлений");
+        message.setReplyMarkup(markup);
+
+        try {
+            telegramClient.execute(message);
+        } catch (TelegramApiException e) {
+            log.error("❌ Ошибка отправки клавиатуры уведомлений", e);
+        }
+    }
+
     private void handleContact(Long chatId, Contact contact) {
         String rawPhone = contact.getPhoneNumber();
         String phone = PhoneUtils.normalizePhone(rawPhone);
@@ -127,6 +159,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 telegramClient.execute(confirm);
                 telegramService.confirmTelegram(customer);
                 telegramService.notifyActualStatuses(customer);
+                sendNotificationsKeyboard(chatId, true);
             }
         } catch (Exception e) {
             log.error("❌ Ошибка регистрации телефона {} для чата {}", phone, chatId, e);


### PR DESCRIPTION
## Summary
- enable notification restoration in `CustomerTelegramService`
- add a keyboard in `BuyerTelegramBot` to toggle notifications
- send keyboard after saving a contact

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac1532e8832d810b908af73c3c3a