### PR TITLE
Implement dynamic task scheduling

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.admin.AdminService;
 import com.project.tracking_system.service.admin.AppInfoService;
+import com.project.tracking_system.service.DynamicSchedulerService;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +49,7 @@ public class AdminController {
     private final StatsAggregationService statsAggregationService;
     private final AdminService adminService;
     private final AppInfoService appInfoService;
+    private final DynamicSchedulerService dynamicSchedulerService;
 
     /**
      * Отображает дашборд администратора.
@@ -511,6 +513,38 @@ public class AdminController {
         );
         model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/settings";
+    }
+
+    /**
+     * Просмотр расписания всех задач.
+     *
+     * @param model модель представления
+     * @return страница расписания
+     */
+    @GetMapping("/schedules")
+    public String schedules(Model model) {
+        model.addAttribute("configs", dynamicSchedulerService.getAllConfigs());
+
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("Расписание", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
+        return "admin/schedules";
+    }
+
+    /**
+     * Обновление cron выражения задачи.
+     *
+     * @param id   идентификатор задачи
+     * @param cron новое выражение cron
+     * @return редирект на список задач
+     */
+    @PostMapping("/schedules/{id}")
+    public String updateSchedule(@PathVariable Long id,
+                                 @RequestParam String cron) {
+        dynamicSchedulerService.updateCron(id, cron);
+        return "redirect:/admin/schedules";
     }
 
 }

--- a/src/main/java/com/project/tracking_system/entity/ScheduledTaskConfig.java
+++ b/src/main/java/com/project/tracking_system/entity/ScheduledTaskConfig.java
@@ -1,0 +1,25 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Конфигурация планируемой задачи.
+ */
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "tb_scheduled_task_config")
+public class ScheduledTaskConfig {
+
+    @Id
+    private Long id;
+
+    private String description;
+
+    @Column(nullable = false)
+    private String cron;
+
+    private String zone;
+}

--- a/src/main/java/com/project/tracking_system/repository/ScheduledTaskConfigRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/ScheduledTaskConfigRepository.java
@@ -1,0 +1,10 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.ScheduledTaskConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Репозиторий конфигураций планировщика задач.
+ */
+public interface ScheduledTaskConfigRepository extends JpaRepository<ScheduledTaskConfig, Long> {
+}

--- a/src/main/java/com/project/tracking_system/service/DynamicSchedulerService.java
+++ b/src/main/java/com/project/tracking_system/service/DynamicSchedulerService.java
@@ -1,0 +1,101 @@
+package com.project.tracking_system.service;
+
+import com.project.tracking_system.entity.ScheduledTaskConfig;
+import com.project.tracking_system.repository.ScheduledTaskConfigRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Сервис динамического планирования задач.
+ * <p>
+ * Позволяет регистрировать задачи в рантайме и изменять их расписание
+ * без перезапуска приложения.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DynamicSchedulerService {
+
+    private final ScheduledTaskConfigRepository repository;
+    private final TaskScheduler taskScheduler;
+
+    private final Map<Long, Runnable> tasks = new ConcurrentHashMap<>();
+    private final Map<Long, ScheduledFuture<?>> futures = new ConcurrentHashMap<>();
+
+    /**
+     * Регистрирует задачи, имеющиеся в базе данных, после старта приложения.
+     */
+    @PostConstruct
+    public void init() {
+        for (ScheduledTaskConfig cfg : repository.findAll()) {
+            schedule(cfg);
+        }
+    }
+
+    /**
+     * Регистрирует новую задачу.
+     *
+     * @param id   идентификатор конфигурации
+     * @param task исполняемый код
+     */
+    public void registerTask(Long id, Runnable task) {
+        tasks.put(id, task);
+        repository.findById(id).ifPresent(this::schedule);
+    }
+
+    /**
+     * Получить список всех конфигураций задач.
+     *
+     * @return список конфигураций
+     */
+    public List<ScheduledTaskConfig> getAllConfigs() {
+        return repository.findAll();
+    }
+
+    /**
+     * Обновить cron-выражение и пересоздать задачу.
+     *
+     * @param id   идентификатор задачи
+     * @param cron новое cron-выражение
+     */
+    @Transactional
+    public void updateCron(Long id, String cron) {
+        ScheduledTaskConfig cfg = repository.findById(id)
+                .orElseThrow();
+        cfg.setCron(cron);
+        repository.save(cfg);
+        reschedule(cfg);
+    }
+
+    private void schedule(ScheduledTaskConfig cfg) {
+        Runnable r = tasks.get(cfg.getId());
+        if (r == null) {
+            return;
+        }
+        String zone = cfg.getZone();
+        CronTrigger trigger = zone == null
+                ? new CronTrigger(cfg.getCron())
+                : new CronTrigger(cfg.getCron(), zone);
+        futures.put(cfg.getId(), taskScheduler.schedule(r, trigger));
+        log.info("Запланирована задача {} c cron {}", cfg.getDescription(), cfg.getCron());
+    }
+
+    private void reschedule(ScheduledTaskConfig cfg) {
+        ScheduledFuture<?> future = futures.get(cfg.getId());
+        if (future != null) {
+            future.cancel(false);
+        }
+        schedule(cfg);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/SchedulerInitializer.java
+++ b/src/main/java/com/project/tracking_system/service/SchedulerInitializer.java
@@ -1,0 +1,43 @@
+package com.project.tracking_system.service;
+
+import com.project.tracking_system.service.analytics.StatsAggregationService;
+import com.project.tracking_system.service.telegram.TelegramReminderScheduler;
+import com.project.tracking_system.service.jsonEvropostService.JwtTokenManager;
+import com.project.tracking_system.service.user.SubscriptionExpirationScheduler;
+import com.project.tracking_system.service.user.TokenCleanupService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Инициализирует задачи планировщика при старте приложения.
+ */
+@Service
+@RequiredArgsConstructor
+public class SchedulerInitializer {
+
+    public static final long STATS_AGGREGATION_ID = 1L;
+    public static final long TELEGRAM_REMINDER_ID = 2L;
+    public static final long JWT_REFRESH_ID = 3L;
+    public static final long SUBSCRIPTION_CHECK_ID = 4L;
+    public static final long TOKEN_CLEANUP_ID = 5L;
+
+    private final DynamicSchedulerService schedulerService;
+    private final StatsAggregationService statsAggregationService;
+    private final TelegramReminderScheduler telegramReminderScheduler;
+    private final JwtTokenManager jwtTokenManager;
+    private final SubscriptionExpirationScheduler subscriptionExpirationScheduler;
+    private final TokenCleanupService tokenCleanupService;
+
+    /**
+     * Регистрирует все задачи в динамическом планировщике.
+     */
+    @PostConstruct
+    public void register() {
+        schedulerService.registerTask(STATS_AGGREGATION_ID, statsAggregationService::aggregateYesterday);
+        schedulerService.registerTask(TELEGRAM_REMINDER_ID, telegramReminderScheduler::sendReminders);
+        schedulerService.registerTask(JWT_REFRESH_ID, jwtTokenManager::scheduledTokenRefresh);
+        schedulerService.registerTask(SUBSCRIPTION_CHECK_ID, subscriptionExpirationScheduler::checkExpiredSubscriptions);
+        schedulerService.registerTask(TOKEN_CLEANUP_ID, tokenCleanupService::cleanupExpiredTokens);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/analytics/StatsAggregationService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/StatsAggregationService.java
@@ -4,7 +4,6 @@ import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +37,6 @@ public class StatsAggregationService {
     /**
      * Агрегирует статистику за предыдущий день.
      */
-    @Scheduled(cron = "0 0 2 * * *", zone = "UTC")
     public void aggregateYesterday() {
         LocalDate yesterday = LocalDate.now(ZoneOffset.UTC).minusDays(1);
         aggregateForDate(yesterday);

--- a/src/main/java/com/project/tracking_system/service/jsonEvropostService/JwtTokenManager.java
+++ b/src/main/java/com/project/tracking_system/service/jsonEvropostService/JwtTokenManager.java
@@ -6,7 +6,6 @@ import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.utils.EncryptionUtils;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -160,7 +159,6 @@ public class JwtTokenManager {
      * @see Scheduled
      */
     @Transactional
-    @Scheduled(cron = "0 0 0 * * ?") // Обновление токена в полночь
     public void scheduledTokenRefresh() {
         log.info("Запуск планового обновления токенов в полночь.");
         try {

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramReminderScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramReminderScheduler.java
@@ -9,7 +9,6 @@ import com.project.tracking_system.repository.CustomerNotificationLogRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,7 +36,6 @@ public class TelegramReminderScheduler {
      * напоминание через Telegram.
      * </p>
      */
-    @Scheduled(cron = "0 0 8 * * *", zone = "UTC")
     @Transactional
     public void sendReminders() {
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);

--- a/src/main/java/com/project/tracking_system/service/user/SubscriptionExpirationScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/user/SubscriptionExpirationScheduler.java
@@ -7,7 +7,6 @@ import com.project.tracking_system.repository.SubscriptionPlanRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.ZoneOffset;
@@ -32,7 +31,6 @@ public class SubscriptionExpirationScheduler {
     private final SubscriptionPlanRepository subscriptionPlanRepository;
     private final UserSubscriptionRepository userSubscriptionRepository;
 
-    @Scheduled(cron = "0 0 3 * * *", zone = "UTC")
     public void checkExpiredSubscriptions() {
         ZonedDateTime nowUtc = ZonedDateTime.now(ZoneOffset.UTC);
 

--- a/src/main/java/com/project/tracking_system/service/user/TokenCleanupService.java
+++ b/src/main/java/com/project/tracking_system/service/user/TokenCleanupService.java
@@ -3,7 +3,6 @@ package com.project.tracking_system.service.user;
 import com.project.tracking_system.repository.ConfirmationTokenRepository;
 import com.project.tracking_system.repository.PasswordResetTokenRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +34,6 @@ public class TokenCleanupService {
      * </p>
      */
     @Transactional
-    @Scheduled(cron = "0 0 * * * *")
     public void cleanupExpiredTokens() {
         ZonedDateTime expiryDate = ZonedDateTime.now(ZoneOffset.UTC).minusHours(1);
 

--- a/src/main/resources/db/migration/V20__create_scheduled_task_config.sql
+++ b/src/main/resources/db/migration/V20__create_scheduled_task_config.sql
@@ -1,0 +1,13 @@
+CREATE TABLE tb_scheduled_task_config (
+    id BIGINT PRIMARY KEY,
+    description VARCHAR(255) NOT NULL,
+    cron VARCHAR(100) NOT NULL,
+    zone VARCHAR(50)
+);
+
+INSERT INTO tb_scheduled_task_config(id, description, cron, zone) VALUES
+ (1, 'Агрегация статистики', '0 0 2 * * *', 'UTC'),
+ (2, 'Напоминания Telegram', '0 0 8 * * *', 'UTC'),
+ (3, 'Обновление JWT токенов', '0 0 0 * * ?', NULL),
+ (4, 'Проверка подписок', '0 0 3 * * *', 'UTC'),
+ (5, 'Очистка токенов', '0 0 * * * *', NULL);

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -90,6 +90,9 @@
         <a href="/admin/subscriptions" class="list-group-item list-group-item-action custom-list-item">
             <i class="bi bi-bookmark-check"></i> Подписки
         </a>
+        <a href="/admin/schedules" class="list-group-item list-group-item-action custom-list-item">
+            <i class="bi bi-clock"></i> Расписание задач
+        </a>
     </div>
 </main>
 

--- a/src/main/resources/templates/admin/schedules.html
+++ b/src/main/resources/templates/admin/schedules.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Расписание задач</title>
+</head>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
+</div>
+<main layout:fragment="content">
+    <h4 class="mb-3">Расписание задач</h4>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>Описание</th>
+            <th>Cron</th>
+            <th>Часовой пояс</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="c : ${configs}">
+            <td th:text="${c.description}"></td>
+            <td>
+                <form th:action="@{/admin/schedules/{id}(id=${c.id})}" method="post" class="d-flex">
+                    <input type="text" name="cron" th:value="${c.cron}" class="form-control me-2"/>
+                    <button type="submit" class="btn btn-primary">Сохранить</button>
+                </form>
+            </td>
+            <td th:text="${c.zone}"></td>
+        </tr>
+        </tbody>
+    </table>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- add new entity `ScheduledTaskConfig` and repository
- implement `DynamicSchedulerService` with initializer
- remove `@Scheduled` annotations and use the new scheduler
- provide admin endpoints and template to manage schedules
- add default configuration migration
- update admin dashboard navigation

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855bbafabf0832da20b44c587583a0e