### PR TITLE
Add tariffs page with upgrade option

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -74,7 +74,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/", "/login", "/logout", "/registration", "/forgot-password", "/reset-password",
                                 "/privacy-policy", "/terms-of-use", "/css/**", "/js/**", "/bootstrap/**", "/images/**",
-                                "/upload", "/ws/**", "/wss/**", "/sample/**", "/download-sample").permitAll()
+                                "/upload", "/ws/**", "/wss/**", "/sample/**", "/download-sample", "/tariffs", "/tariffs/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -1,0 +1,70 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.BreadcrumbItemDTO;
+import com.project.tracking_system.dto.SubscriptionPlanDTO;
+import com.project.tracking_system.service.tariff.TariffService;
+import com.project.tracking_system.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+/**
+ * Контроллер отображения тарифов и управления апгрейдом подписки.
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/tariffs")
+public class TariffController {
+
+    private final TariffService tariffService;
+    private final UserService userService;
+
+    /**
+     * Отображает страницу с тарифными планами.
+     *
+     * @param model          модель представления
+     * @param authentication текущая аутентификация
+     * @return имя шаблона страницы тарифов
+     */
+    @GetMapping
+    public String tariffs(Model model, Authentication authentication) {
+        Long userId = userService.extractUserId(authentication);
+        if (userId != null) {
+            model.addAttribute("authenticatedUser", userId);
+        }
+        List<SubscriptionPlanDTO> plans = tariffService.getAllPlans();
+        model.addAttribute("plans", plans);
+        model.addAttribute("breadcrumbs", List.of(new BreadcrumbItemDTO("Тарифы", "")));
+        return "tariffs";
+    }
+
+    /**
+     * Выполняет апгрейд подписки пользователя до премиум-тарифа.
+     *
+     * @param months         количество месяцев продления
+     * @param authentication текущая аутентификация
+     * @return редирект на страницу профиля
+     */
+    @PostMapping("/upgrade")
+    public String upgrade(@RequestParam(value = "months", defaultValue = "1") int months,
+                          Authentication authentication) {
+        Long userId = userService.extractUserId(authentication);
+        if (userId == null) {
+            return "redirect:/login";
+        }
+        if (months <= 0) {
+            months = 1;
+        }
+        tariffService.upgradeUser(userId, months);
+        return "redirect:/profile";
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -1,0 +1,59 @@
+package com.project.tracking_system.service.tariff;
+
+import com.project.tracking_system.dto.SubscriptionPlanDTO;
+import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.repository.SubscriptionPlanRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Сервис работы с тарифами пользователей.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TariffService {
+
+    private final SubscriptionPlanRepository planRepository;
+    private final SubscriptionService subscriptionService;
+
+    /**
+     * Возвращает список тарифных планов.
+     *
+     * @return список планов в виде DTO
+     */
+    public List<SubscriptionPlanDTO> getAllPlans() {
+        return planRepository.findAll().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Выполняет апгрейд пользователя до премиум-тарифа или продлевает его.
+     *
+     * @param userId идентификатор пользователя
+     * @param months количество месяцев продления
+     */
+    @Transactional
+    public void upgradeUser(Long userId, int months) {
+        subscriptionService.upgradeOrExtendSubscription(userId, months);
+    }
+
+    private SubscriptionPlanDTO toDto(SubscriptionPlan plan) {
+        SubscriptionPlanDTO dto = new SubscriptionPlanDTO();
+        dto.setCode(plan.getCode());
+        dto.setMaxTracksPerFile(plan.getMaxTracksPerFile());
+        dto.setMaxSavedTracks(plan.getMaxSavedTracks());
+        dto.setMaxTrackUpdates(plan.getMaxTrackUpdates());
+        dto.setAllowBulkUpdate(plan.isAllowBulkUpdate());
+        dto.setMaxStores(plan.getMaxStores());
+        dto.setAllowTelegramNotifications(Boolean.TRUE.equals(plan.getAllowTelegramNotifications()));
+        return dto;
+    }
+}

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -21,6 +21,7 @@
                     <li><a href="/departures" class="nav-link px-2" data-path="/departures">Отправления</a></li>
                     <li><a href="/profile" class="nav-link px-2" data-path="/profile">Профиль</a></li>
                     <li><a href="/analytics" class="nav-link px-2" data-path="/analytics">Аналитика</a></li>
+                    <li><a href="/tariffs" class="nav-link px-2" data-path="/tariffs">Тарифы</a></li>
                 </ul>
             </div>
 
@@ -61,6 +62,7 @@
                 <li><a href="/departures" data-path="/departures">Отправления</a></li>
                 <li><a href="/profile" data-path="/profile">Профиль</a></li>
                 <li><a href="/analytics" data-path="/analytics">Аналитика</a></li>
+                <li><a href="/tariffs" data-path="/tariffs">Тарифы</a></li>
             </ul>
         </nav>
 

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Тарифы</title>
+</head>
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
+</div>
+<main layout:fragment="content">
+    <div class="container mt-4">
+        <h1 class="mb-4">Тарифные планы</h1>
+        <div class="row" th:each="plan : ${plans}">
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header text-center">
+                        <h5 th:text="${plan.code.displayName}"></h5>
+                    </div>
+                    <div class="card-body">
+                        <ul class="list-unstyled">
+                            <li>Треков в файле: <span th:text="${plan.maxTracksPerFile != null ? plan.maxTracksPerFile : 'Без лимита'}"></span></li>
+                            <li>Сохранённых треков: <span th:text="${plan.maxSavedTracks != null ? plan.maxSavedTracks : 'Без лимита'}"></span></li>
+                            <li>Обновлений в день: <span th:text="${plan.maxTrackUpdates != null ? plan.maxTrackUpdates : 'Без лимита'}"></span></li>
+                            <li>Количество магазинов: <span th:text="${plan.maxStores}"></span></li>
+                            <li th:if="${plan.allowBulkUpdate}">Массовое обновление доступно</li>
+                            <li th:if="${plan.allowTelegramNotifications}">Telegram-уведомления</li>
+                        </ul>
+                        <form th:if="${plan.code.name() == 'PREMIUM'}" th:action="@{/tariffs/upgrade}" method="post">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                            <div class="mb-2">
+                                <label for="months" class="form-label">Месяцев:</label>
+                                <input type="number" id="months" name="months" value="1" min="1" class="form-control form-control-sm"/>
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Выбрать</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- show a list of tariff plans to users
- allow users to upgrade to the premium plan
- display new Tariffs link in navigation
- permit `/tariffs` paths in security configuration

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cf676658832da8cdae172e003258