### PR TITLE
Set default zone to UTC for scheduled tasks

### DIFF
--- a/src/main/resources/db/migration/V24__set_default_zone.sql
+++ b/src/main/resources/db/migration/V24__set_default_zone.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_scheduled_task_config ALTER COLUMN zone SET DEFAULT 'UTC';
+UPDATE tb_scheduled_task_config SET zone='UTC' WHERE zone IS NULL OR zone='';
+


### PR DESCRIPTION
## Summary
- add migration to set default timezone to UTC and update existing data
- revert changes to previous migration

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6855d0124ac4832d81d3d1acbf2d7243