### PR TITLE
Default UTC zone for scheduled tasks

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/ScheduledTaskConfig.java
+++ b/src/main/java/com/project/tracking_system/entity/ScheduledTaskConfig.java
@@ -22,4 +22,15 @@ public class ScheduledTaskConfig {
     private String cron;
 
     private String zone;
+
+    /**
+     * Устанавливает таймзону по умолчанию, если она не указана.
+     */
+    @PrePersist
+    @PreUpdate
+    private void ensureZone() {
+        if (zone == null || zone.isBlank()) {
+            zone = "UTC";
+        }
+    }
 }

--- a/src/main/java/com/project/tracking_system/service/DynamicSchedulerService.java
+++ b/src/main/java/com/project/tracking_system/service/DynamicSchedulerService.java
@@ -77,6 +77,10 @@ public class DynamicSchedulerService {
         ScheduledTaskConfig cfg = repository.findById(id)
                 .orElseThrow();
         cfg.setCron(cron);
+        // При отсутствии таймзоны проставляем значение по умолчанию
+        if (cfg.getZone() == null || cfg.getZone().isBlank()) {
+            cfg.setZone("UTC");
+        }
         repository.save(cfg);
         reschedule(cfg);
     }


### PR DESCRIPTION
## Summary
- set default zone for `ScheduledTaskConfig` with `@PrePersist`/`@PreUpdate`
- enforce default zone in `DynamicSchedulerService.updateCron`

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6855d1edb564832dafac7b7ca9fb5737