### PR TITLE
Add pricing info to subscription plans

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
@@ -19,4 +19,6 @@ public class SubscriptionPlanDTO {
     private boolean allowBulkUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
+    private java.math.BigDecimal monthlyPrice;
+    private java.math.BigDecimal annualPrice;
 }

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -41,4 +41,10 @@ public class SubscriptionPlan {
 
     @Column(name = "allow_telegram_notifications", nullable = false)
     private Boolean allowTelegramNotifications = false;
+
+    @Column(name = "monthly_price", nullable = false)
+    private java.math.BigDecimal monthlyPrice = java.math.BigDecimal.ZERO;
+
+    @Column(name = "annual_price", nullable = false)
+    private java.math.BigDecimal annualPrice = java.math.BigDecimal.ZERO;
 }

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -43,6 +43,8 @@ public class SubscriptionPlanService {
         plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
         plan.setMaxStores(dto.getMaxStores());
         plan.setAllowTelegramNotifications(dto.isAllowTelegramNotifications());
+        plan.setMonthlyPrice(dto.getMonthlyPrice());
+        plan.setAnnualPrice(dto.getAnnualPrice());
         log.info("Создан тарифный план {}", dto.getCode());
         return planRepository.save(plan);
     }
@@ -64,6 +66,8 @@ public class SubscriptionPlanService {
         plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
         plan.setMaxStores(dto.getMaxStores());
         plan.setAllowTelegramNotifications(dto.isAllowTelegramNotifications());
+        plan.setMonthlyPrice(dto.getMonthlyPrice());
+        plan.setAnnualPrice(dto.getAnnualPrice());
         log.info("Обновлен тарифный план {}", id);
         return planRepository.save(plan);
     }

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -54,6 +54,8 @@ public class TariffService {
         dto.setAllowBulkUpdate(plan.isAllowBulkUpdate());
         dto.setMaxStores(plan.getMaxStores());
         dto.setAllowTelegramNotifications(Boolean.TRUE.equals(plan.getAllowTelegramNotifications()));
+        dto.setMonthlyPrice(plan.getMonthlyPrice());
+        dto.setAnnualPrice(plan.getAnnualPrice());
         return dto;
     }
 }

--- a/src/main/resources/db/migration/V25__add_price_columns_to_subscription_plans.sql
+++ b/src/main/resources/db/migration/V25__add_price_columns_to_subscription_plans.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subscription_plans
+    ADD COLUMN monthly_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+    ADD COLUMN annual_price DECIMAL(10,2) NOT NULL DEFAULT 0;

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -16,6 +16,8 @@
             <th>Сохранённых треков</th>
             <th>Обновлений в день</th>
             <th>Магазинов</th>
+            <th>Цена в месяц</th>
+            <th>Цена в год</th>
             <th>Массовое обновление</th>
             <th>Telegram-уведомления</th>
             <th>Действия</th>
@@ -30,6 +32,8 @@
                 <td><input type="number" name="maxSavedTracks" class="form-control" th:value="${plan.maxSavedTracks}" /></td>
                 <td><input type="number" name="maxTrackUpdates" class="form-control" th:value="${plan.maxTrackUpdates}" /></td>
                 <td><input type="number" name="maxStores" class="form-control" th:value="${plan.maxStores}" /></td>
+                <td><input type="number" step="0.01" name="monthlyPrice" class="form-control" th:value="${plan.monthlyPrice}" /></td>
+                <td><input type="number" step="0.01" name="annualPrice" class="form-control" th:value="${plan.annualPrice}" /></td>
                 <td class="text-center"><input type="checkbox" name="allowBulkUpdate" th:checked="${plan.allowBulkUpdate}" /></td>
                 <td class="text-center"><input type="checkbox" name="allowTelegramNotifications" th:checked="${plan.allowTelegramNotifications}" /></td>
                 <td><button type="submit" class="btn btn-success btn-sm">Сохранить</button></td>
@@ -50,6 +54,8 @@
         <div class="col-md-2"><input type="number" name="maxSavedTracks" class="form-control" /></div>
         <div class="col-md-2"><input type="number" name="maxTrackUpdates" class="form-control" /></div>
         <div class="col-md-2"><input type="number" name="maxStores" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" step="0.01" name="monthlyPrice" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" step="0.01" name="annualPrice" class="form-control" /></div>
         <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowBulkUpdate" class="form-check-input" /></div>
         <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowTelegramNotifications" class="form-check-input" /></div>
         <div class="col-md-1"><button type="submit" class="btn btn-primary">Создать</button></div>

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -21,6 +21,8 @@
                             <li>Сохранённых треков: <span th:text="${plan.maxSavedTracks != null ? plan.maxSavedTracks : 'Без лимита'}"></span></li>
                             <li>Обновлений в день: <span th:text="${plan.maxTrackUpdates != null ? plan.maxTrackUpdates : 'Без лимита'}"></span></li>
                             <li>Количество магазинов: <span th:text="${plan.maxStores}"></span></li>
+                            <li>Цена за месяц: <span th:text="${plan.monthlyPrice}"></span></li>
+                            <li>Цена за год: <span th:text="${plan.annualPrice}"></span></li>
                             <li th:if="${plan.allowBulkUpdate}">Массовое обновление доступно</li>
                             <li th:if="${plan.allowTelegramNotifications}">Telegram-уведомления</li>
                         </ul>

--- a/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.SubscriptionCode;
+import com.project.tracking_system.entity.SubscriptionPlan;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тестирование репозитория тарифных планов.
+ */
+@DataJpaTest
+class SubscriptionPlanRepositoryTest {
+
+    @Autowired
+    private SubscriptionPlanRepository repository;
+
+    /**
+     * Проверяет сохранение и получение плана с ценами.
+     */
+    @Test
+    void createAndFindWithPrices() {
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setCode(SubscriptionCode.PREMIUM);
+        plan.setMaxTracksPerFile(1);
+        plan.setMaxSavedTracks(1);
+        plan.setMaxTrackUpdates(1);
+        plan.setAllowBulkUpdate(true);
+        plan.setMaxStores(1);
+        plan.setAllowTelegramNotifications(false);
+        plan.setMonthlyPrice(new BigDecimal("9.99"));
+        plan.setAnnualPrice(new BigDecimal("99.99"));
+
+        SubscriptionPlan saved = repository.save(plan);
+        SubscriptionPlan found = repository.findById(saved.getId()).orElseThrow();
+
+        assertEquals(new BigDecimal("9.99"), found.getMonthlyPrice());
+        assertEquals(new BigDecimal("99.99"), found.getAnnualPrice());
+    }
+}


### PR DESCRIPTION
## Summary
- extend `SubscriptionPlan` with monthly and annual price
- map price fields in DTOs and services
- show prices on admin and public tariff pages
- add Flyway migration for new price columns
- cover repository with test for price fields

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6855d41ffb30832d8b7157c0ca54b08f