### PR TITLE
Remove redundant findById method

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/SubscriptionPlanRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/SubscriptionPlanRepository.java
@@ -3,8 +3,6 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.SubscriptionCode;
 import com.project.tracking_system.entity.SubscriptionPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -14,8 +12,6 @@ import java.util.Optional;
  */
 
 public interface SubscriptionPlanRepository extends JpaRepository<SubscriptionPlan, Long> {
-
-    Optional<SubscriptionPlan> findById(Long id);
 
     Optional<SubscriptionPlan> findByCode(SubscriptionCode code);
 


### PR DESCRIPTION
## Summary
- cleanup `SubscriptionPlanRepository` to rely on `JpaRepository.findById`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855db034654832da97423103f203071