### PR TITLE
Update tariff card price placeholders

### DIFF
--- a/src/main/resources/assets/scss/components/_cards.scss
+++ b/src/main/resources/assets/scss/components/_cards.scss
@@ -14,3 +14,7 @@
 .table-container {
   @include card-style;
 }
+
+.price-placeholder {
+  visibility: hidden;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -627,6 +627,10 @@ button:hover {
   padding: 20px;
 }
 
+.price-placeholder {
+  visibility: hidden;
+}
+
 .modal {
   display: none;
 }

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -30,10 +30,14 @@
                         <h4 class="mb-0 fw-bold" th:text="${plan.code.displayName}">Премиум</h4>
                         <p class="mb-0 mt-2 fw-semibold text-primary price-monthly"
                            th:if="${plan.monthlyPrice != null and plan.monthlyPrice > 0}"
-                           th:text="'от ' + plan.monthlyPrice + ' BYN/мес'"></p>
+                           th:text="'от ' + #numbers.formatDecimal(plan.monthlyPrice, 2, 2) + ' BYN/мес'"></p>
+                        <p class="mb-0 mt-2 fw-semibold price-placeholder price-monthly"
+                           th:unless="${plan.monthlyPrice != null and plan.monthlyPrice > 0}">0</p>
                         <p class="mb-0 mt-2 fw-semibold text-primary price-yearly d-none"
                            th:if="${plan.annualPrice != null and plan.annualPrice > 0}"
-                           th:text="'от ' + plan.annualPrice + ' BYN/год'"></p>
+                           th:text="'от ' + #numbers.formatDecimal(plan.annualPrice, 2, 2) + ' BYN/год'"></p>
+                        <p class="mb-0 mt-2 fw-semibold price-placeholder price-yearly d-none"
+                           th:unless="${plan.annualPrice != null and plan.annualPrice > 0}">0</p>
                     </div>
 
                     <div class="card-body px-4 d-flex flex-column">


### PR DESCRIPTION
## Summary
- format tariff prices via `#numbers.formatDecimal`
- add hidden price placeholders in tariffs template
- style `.price-placeholder` in SCSS and CSS

## Testing
- `mvnw test` *(fails: `.mvn/wrapper` missing)*
- `npm run build:css` *(fails: `sass: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855de6982d0832db1e9d769cbc27847