### PR TITLE
Improve tariffs page UI

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -40,6 +40,7 @@ public class TariffController {
         Long userId = userService.extractUserId(authentication);
         if (userId != null) {
             model.addAttribute("authenticatedUser", userId);
+            model.addAttribute("userProfile", userService.getUserProfile(userId));
         }
         List<SubscriptionPlanViewDTO> plans = tariffService.getAllPlans();
         model.addAttribute("plans", plans);

--- a/src/main/resources/assets/scss/main.scss
+++ b/src/main/resources/assets/scss/main.scss
@@ -27,5 +27,6 @@
 @use 'pages/legal';
 @use 'pages/dashboard';
 @use 'pages/analytics';
+@use 'pages/tariffs';
 
 

--- a/src/main/resources/assets/scss/pages/_tariffs.scss
+++ b/src/main/resources/assets/scss/pages/_tariffs.scss
@@ -1,0 +1,13 @@
+.tariff-features li {
+  margin-bottom: 0.75rem;
+}
+
+.price-yearly {
+  color: ui.$danger;
+}
+
+.discount-label {
+  color: ui.$danger;
+  font-size: 0.875rem;
+  margin-left: 0.25rem;
+}

--- a/src/main/resources/static/js/tariffs.js
+++ b/src/main/resources/static/js/tariffs.js
@@ -13,6 +13,7 @@
     btnYearly.classList.replace('btn-primary', 'btn-outline-secondary');
     document.querySelectorAll('.price-monthly').forEach(el => el.classList.remove('d-none'));
     document.querySelectorAll('.price-yearly').forEach(el => el.classList.add('d-none'));
+    document.querySelectorAll('.discount-label').forEach(el => el.classList.add('d-none'));
     if (subscribeBtn) {
         subscribeBtn.textContent = 'Перейти';
     }
@@ -26,6 +27,7 @@
     btnYearly.classList.replace('btn-outline-secondary', 'btn-primary');
     document.querySelectorAll('.price-monthly').forEach(el => el.classList.add('d-none'));
     document.querySelectorAll('.price-yearly').forEach(el => el.classList.remove('d-none'));
+    document.querySelectorAll('.discount-label').forEach(el => el.classList.remove('d-none'));
     if (subscribeBtn) {
         subscribeBtn.textContent = 'Перейти ';
     }

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -35,15 +35,17 @@
                     <p class="mb-0 mt-2 fw-semibold price-placeholder price-monthly"
                        th:unless="${plan.monthlyPriceLabel != null}">0</p>
 
-                    <p class="mb-0 mt-2 fw-semibold text-primary price-yearly d-none"
-                       th:if="${plan.annualPriceLabel != null}"
-                       th:text="${plan.annualPriceLabel}">150 BYN/год</p>
+                    <p class="mb-0 mt-2 fw-semibold price-yearly d-none"
+                       th:if="${plan.annualPriceLabel != null}">
+                        <span th:text="${plan.annualPriceLabel}">150 BYN/год</span>
+                        <span class="discount-label">Скидка 16%</span>
+                    </p>
 
                     <p class="mb-0 mt-2 fw-semibold price-placeholder price-yearly d-none"
                        th:unless="${plan.annualPriceLabel != null}">0</p>
 
                     <div class="card-body px-4 d-flex flex-column">
-                        <ul class="list-unstyled mb-4 flex-grow-1">
+                        <ul class="tariff-features list-unstyled mb-4 flex-grow-1">
                             <li>📥 Треков в файле:
                                 <strong th:text="${plan.maxTracksPerFile != null ? plan.maxTracksPerFile : 'Без лимита'}"></strong>
                             </li>
@@ -66,13 +68,17 @@
                             </li>
                         </ul>
 
-                        <form th:if="${plan.code.name() == 'PREMIUM'}" th:action="@{/tariffs/upgrade}" method="post" class="mt-auto">
+                        <form th:if="${plan.code.name() == 'PREMIUM' && (userProfile == null || userProfile.subscriptionCode.name() != 'PREMIUM')}" th:action="@{/tariffs/upgrade}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <button type="submit" id="subscribeBtn" class="btn btn-primary w-100">
                                 Перейти на Premium
                             </button>
                         </form>
+                        <div th:if="${plan.code.name() == 'PREMIUM' && userProfile != null && userProfile.subscriptionCode.name() == 'PREMIUM'}" class="mt-auto">
+                            <button class="btn btn-outline-success w-100" disabled
+                                    th:text="'Ваш тариф до ' + ${userProfile.subscriptionEndDate}"></button>
+                        </div>
 
                         <div th:if="${plan.code.name() == 'FREE'}" class="mt-auto">
                             <button class="btn btn-outline-secondary w-100" disabled>Вы используете</button>


### PR DESCRIPTION
## Summary
- show subscription details when user has premium
- highlight annual price with discount
- add new SCSS styles for tariffs page
- toggle discount label in tariffs.js

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e757f8d8832d91955a35bc9f9c5e