### PR TITLE
Fix layout for size buttons on mobile

### DIFF
--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -376,6 +376,18 @@
         width: 100%;
       }
     }
+
+    /* Для группы выбора размера элементов оставляем горизонтальное
+       расположение кнопок на мобильных устройствах */
+    .size-controls {
+      flex-direction: row;
+      align-items: center;
+      flex-wrap: wrap;
+
+      button {
+        width: auto;
+      }
+    }
   }
 
   .table-responsive {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1239,6 +1239,15 @@ button:hover {
   .history-controls .filter-group select {
     width: 100%;
   }
+  /* Специальное правило для кнопок выбора количества элементов */
+  .history-controls .size-controls {
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .history-controls .size-controls button {
+    width: auto;
+  }
   .table-responsive {
     overflow-x: auto;
   }

--- a/src/main/resources/templates/departures.html
+++ b/src/main/resources/templates/departures.html
@@ -84,7 +84,7 @@
                         </div>
 
                         <!-- Количество элементов на странице -->
-                        <div class="filter-group size-controls d-flex flex-column flex-sm-row align-items-sm-center gap-2">
+                        <div class="filter-group size-controls d-flex flex-row flex-wrap align-items-center gap-2">
                             <button type="button" class="btn btn-outline-secondary size-btn" data-size="20"
                                     th:classappend="${size == 20} ? 'active'">20</button>
                             <button type="button" class="btn btn-outline-secondary size-btn" data-size="50"


### PR DESCRIPTION
## Summary
- keep size control buttons on one line for mobile
- update compiled CSS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569e7035e4832d8a55266cf7ca289e