### PR TITLE
Update plan display logic

### DIFF
--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -27,7 +27,7 @@
         <tr th:each="plan : ${plans}">
             <form th:action="@{/admin/plans/{id}(id=${plan.id})}" method="post" class="align-middle">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-                <td th:text="${plan.code.name()}"></td>
+                <td th:text="${plan.code}"></td>
                 <td><input type="number" name="maxTracksPerFile" class="form-control" th:value="${plan.maxTracksPerFile}" /></td>
                 <td><input type="number" name="maxSavedTracks" class="form-control" th:value="${plan.maxSavedTracks}" /></td>
                 <td><input type="number" name="maxTrackUpdates" class="form-control" th:value="${plan.maxTrackUpdates}" /></td>
@@ -47,7 +47,7 @@
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <div class="col-md-2">
             <select name="code" class="form-select">
-                <option th:each="c : ${codes}" th:value="${c.name()}" th:text="${c.displayName}"></option>
+                <option th:each="c : ${codes}" th:value="${c}" th:text="${c}"></option>
             </select>
         </div>
         <div class="col-md-2"><input type="number" name="maxTracksPerFile" class="form-control" /></div>

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -45,7 +45,7 @@
         </thead>
         <tbody>
         <tr th:each="plan : ${plans}">
-            <td th:text="${plan.code.displayName}"></td>
+            <td th:text="${plan.name}"></td>
             <td th:text="${plan.maxTracksPerFile != null ? plan.maxTracksPerFile : '∞'}"></td>
             <td th:text="${plan.maxSavedTracks != null ? plan.maxSavedTracks : '∞'}"></td>
             <td th:text="${plan.maxTrackUpdates != null ? plan.maxTrackUpdates : '∞'}"></td>

--- a/src/main/resources/templates/admin/subscriptions.html
+++ b/src/main/resources/templates/admin/subscriptions.html
@@ -20,15 +20,15 @@
         <tbody>
         <tr th:each="s : ${subscriptions}">
             <td th:text="${s.user.email}"></td>
-            <td th:text="${s.subscriptionPlan.getCode().getDisplayName()}"></td>
+            <td th:text="${s.subscriptionPlan.name}"></td>
             <td th:text="${s.subscriptionEndDate}"></td>
             <td>
                 <form th:action="@{/admin/users/{id}/change-subscription(id=${s.user.id})}" method="post" class="d-flex">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                     <select name="subscriptionPlan" class="form-select form-select-sm me-2">
                         <option th:each="p : ${plans}"
-                                th:value="${p.code.name()}"
-                                th:text="${p.code.displayName}"
+                                th:value="${p.code}"
+                                th:text="${p.name}"
                                 th:selected="${p.code == s.subscriptionPlan.code}">
                         </option>
                     </select>

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -23,7 +23,7 @@
             <p><strong>Email:</strong> <span th:text="${user.email}"></span></p>
             <p><strong>Роль:</strong> <span th:text="${user.role}"></span></p>
             <p><strong>Текущий план подписки:</strong>
-                <span th:text="${user.subscriptionPlanCode != null ? user.subscriptionPlanCode.displayName : 'Нет подписки'}"></span>
+                <span th:text="${user.subscriptionPlanCode != null ? user.subscriptionPlanCode : 'Нет подписки'}"></span>
             </p>
             <p><strong>Дата окончания подписки:</strong>
                 <span th:text="${user.subscriptionEndDate}"></span>

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -33,9 +33,9 @@
             <select class="form-select" name="subscription">
                 <option value="">Все подписки</option>
                 <option th:each="p : ${plans}"
-                        th:value="${p.code.name()}"
-                        th:text="${p.code.displayName}"
-                        th:selected="${selectedSubscription?.name() == p.code.name()}">
+                        th:value="${p.code}"
+                        th:text="${p.name}"
+                        th:selected="${selectedSubscription == p.code}">
                 </option>
             </select>
         </div>
@@ -59,7 +59,7 @@
             <td th:text="${user.id}"></td>
             <td th:text="${user.email}"></td>
             <td th:text="${user.role}"></td>
-            <td th:text="${user.getSubscriptionPlanCode().getDisplayName()}"></td>
+            <td th:text="${user.subscriptionPlanCode}"></td>
             <td>
                 <a th:href="@{/admin/users/{userId}(userId=${user.id})}" class="btn btn-info btn-sm me-1">Подробнее</a>
                 <form th:action="@{/admin/users/{id}/delete(id=${user.id})}" method="post" class="d-inline">

--- a/src/main/resources/templates/admin/user-new.html
+++ b/src/main/resources/templates/admin/user-new.html
@@ -34,7 +34,7 @@
             <div class="mb-3">
                 <label for="subscriptionPlan" class="form-label">Статус аккаунта</label>
                 <select id="subscriptionPlan" name="subscriptionPlan" class="form-select">
-                    <option th:each="p : ${plans}" th:value="${p.code.name()}" th:text="${p.code.getDisplayName()}"></option>
+                    <option th:each="p : ${plans}" th:value="${p.code}" th:text="${p.name}"></option>
                 </select>
             </div>
             <button type="submit" class="btn btn-success">Создать</button>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -105,7 +105,7 @@
                     <div class="row mb-2">
                         <div class="col-sm-4 text-muted">Тариф</div>
                         <div class="col-sm-8">
-                            <span th:class="'badge ' + (${userProfile.subscriptionCode.name() == 'PREMIUM'} ? 'bg-success' : 'bg-secondary')"
+                            <span th:class="'badge ' + (${userProfile.subscriptionCode == 'PREMIUM'} ? 'bg-success' : 'bg-secondary')"
                                   th:text="${userProfile.subscriptionDisplayName}">
                             </span>
                         </div>

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -27,7 +27,7 @@
                 <div class="card h-100 shadow-sm border-0 rounded-4 d-flex flex-column">
 
                     <!-- Название -->
-                    <h3 class="text-center fw-bold fs-3 mt-3 mb-1" th:text="${plan.code.displayName}">Premium</h3>
+                    <h3 class="text-center fw-bold fs-3 mt-3 mb-1" th:text="${plan.name}">Premium</h3>
 
                     <!-- Цена (ежемесячно) -->
                     <p class="text-center mb-2 mt-2 fw-semibold fs-5 price-monthly text-dark"
@@ -79,18 +79,18 @@
 
 
                         <!-- 🔒 FREE: если у пользователя PREMIUM → отключена -->
-                        <div th:if="${plan.code.name() == 'FREE'}" class="mt-auto">
+                        <div th:if="${plan.code == 'FREE'}" class="mt-auto">
                             <button class="btn btn-outline-secondary w-100" disabled
-                                    th:text="${userProfile != null && userProfile.subscriptionCode.name() == 'PREMIUM' ? 'У вас активен платный тариф' : 'Ваш тариф'}">
+                                    th:text="${userProfile != null && userProfile.subscriptionCode == 'PREMIUM' ? 'У вас активен платный тариф' : 'Ваш тариф'}">
                             </button>
                         </div>
 
                         <!-- ✅ PREMIUM: если уже активен → продление -->
-                        <form th:if="${plan.code.name() == 'PREMIUM'}" th:action="@{/tariffs/upgrade}" method="post" class="mt-auto">
+                        <form th:if="${plan.code == 'PREMIUM'}" th:action="@{/tariffs/upgrade}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <button type="submit" class="btn btn-primary w-100"
-                                    th:text="${userProfile != null && userProfile.subscriptionCode.name() == 'PREMIUM' ? 'Ваш тариф активен до ' + userProfile.subscriptionEndDate : 'Перейти на Premium'}">
+                                    th:text="${userProfile != null && userProfile.subscriptionCode == 'PREMIUM' ? 'Ваш тариф активен до ' + userProfile.subscriptionEndDate : 'Перейти на Premium'}">
                             </button>
                         </form>
 


### PR DESCRIPTION
## Summary
- update plan bindings in tariffs and admin templates
- show subscription codes directly
- simplify subscription comparison logic

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856af4e71ac832d892c09aca7efaf20