### PR TITLE
Fix doc parameter name

### DIFF
--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -282,7 +282,7 @@ public class SubscriptionService {
      * </p>
      *
      * @param userId      идентификатор пользователя
-     * @param newPlanName название нового плана
+     * @param code        код нового плана
      * @param months      срок действия в месяцах (применяется для платных планов)
      * @throws IllegalArgumentException если подписка пользователя или новый план не найдены
      */


### PR DESCRIPTION
## Summary
- correct parameter description in `SubscriptionService.changeSubscription`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b161c0e0832da6d4e8d19667fb0f