### PR TITLE
Add migration for subscription plan fields

### DIFF
--- a/src/main/resources/db/migration/V26__add_name_and_description_to_plans.sql
+++ b/src/main/resources/db/migration/V26__add_name_and_description_to_plans.sql
@@ -1,0 +1,9 @@
+ALTER TABLE subscription_plans
+    ADD COLUMN IF NOT EXISTS name VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS description VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS price DECIMAL(10,2) NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS duration_days INT,
+    ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Заполняем поле name на основе существующих кодов
+UPDATE subscription_plans SET name = code WHERE name IS NULL;


### PR DESCRIPTION
## Summary
- add migration to reintroduce name/description and related fields for `subscription_plans`
- ensure entity and DTO already support the columns

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b15903c0832d91c555f05db3fc3a