### PR TITLE
Add JavaDoc for subscription and user services

### DIFF
--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -317,6 +317,16 @@ public class SubscriptionService {
         log.info("✅ Подписка пользователя с ID {} изменена на {} до {}", userId, parsedCode, subscription.getSubscriptionEndDate());
     }
 
+    /**
+     * Создаёт базовую подписку для нового пользователя.
+     * <p>
+     * Пользователь автоматически привязывается к бесплатному тарифному плану
+     * со сброшенными лимитами обновлений.
+     * </p>
+     *
+     * @param user пользователь, которому создаётся подписка
+     * @return новая подписка пользователя
+     */
     public UserSubscription createDefaultSubscriptionForUser(User user) {
         SubscriptionPlan defaultPlan = subscriptionPlanRepository.findFirstByPrice(BigDecimal.ZERO)
                 .orElseThrow(() -> new IllegalStateException("Бесплатный план не найден"));
@@ -330,6 +340,12 @@ public class SubscriptionService {
         return subscription;
     }
 
+    /**
+     * Нормализует код тарифного плана.
+     *
+     * @param name исходное значение кода
+     * @return нормализованный код в верхнем регистре или {@link Optional#empty()} при пустом значении
+     */
     private Optional<String> parseCode(String name) {
         if (name == null || name.isBlank()) {
             return Optional.empty();

--- a/src/main/java/com/project/tracking_system/service/user/LoginAttemptService.java
+++ b/src/main/java/com/project/tracking_system/service/user/LoginAttemptService.java
@@ -69,6 +69,12 @@ public class LoginAttemptService {
         log.info("Пользователь {} успешно вошел. IP {} разблокирован.", EmailUtils.maskEmail(email), ip);
     }
 
+    /**
+     * Проверяет, заблокирован ли IP-адрес из-за превышения числа попыток входа.
+     *
+     * @param ip IP-адрес клиента
+     * @return {@code true}, если IP в чёрном списке, иначе {@code false}
+     */
     public boolean isIPBlocked(String ip) {
         if (blockedIPs.containsKey(ip)) {
 
@@ -201,6 +207,15 @@ public class LoginAttemptService {
         return null;
     }
 
+    /**
+     * Проверяет блокировки по IP и email, перенаправляя пользователя при необходимости.
+     *
+     * @param request  HTTP-запрос
+     * @param response HTTP-ответ
+     * @param email    email пользователя (может быть {@code null})
+     * @param ip       IP-адрес клиента
+     * @return {@code true}, если было выполнено перенаправление
+     */
     public boolean checkAndRedirect(HttpServletRequest request, HttpServletResponse response,
                                     String email, String ip) throws IOException {
         if (isIPBlocked(ip)) {

--- a/src/main/java/com/project/tracking_system/service/user/SubscriptionExpirationScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/user/SubscriptionExpirationScheduler.java
@@ -31,6 +31,13 @@ public class SubscriptionExpirationScheduler {
     private final SubscriptionPlanRepository subscriptionPlanRepository;
     private final UserSubscriptionRepository userSubscriptionRepository;
 
+    /**
+     * Проверяет истекшие подписки пользователей и переводит их на бесплатный тариф.
+     * <p>
+     * Метод запускается планировщиком и обновляет все подписки,
+     * у которых дата окончания ранее текущего момента.
+     * </p>
+     */
     public void checkExpiredSubscriptions() {
         ZonedDateTime nowUtc = ZonedDateTime.now(ZoneOffset.UTC);
 


### PR DESCRIPTION
## Summary
- document `createDefaultSubscriptionForUser` and `parseCode` in `SubscriptionService`
- add JavaDoc for IP-block checks and expired subscription scheduler

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b24f0d58832db842b74ad0852d19