### PR TITLE
Add subscription limits entity

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/SubscriptionLimits.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionLimits.java
@@ -1,0 +1,42 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Лимиты тарифного плана.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "subscription_limits")
+public class SubscriptionLimits {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "subscription_plan_id", nullable = false, unique = true)
+    private SubscriptionPlan subscriptionPlan;
+
+    private Integer maxTracksPerFile;
+
+    private Integer maxSavedTracks;
+
+    private Integer maxTrackUpdates;
+
+    @Column(nullable = false)
+    private boolean allowBulkUpdate;
+
+    @Column(nullable = false)
+    private Integer maxStores;
+
+    @Column(name = "allow_telegram_notifications", nullable = false)
+    private Boolean allowTelegramNotifications = false;
+}

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -39,23 +39,8 @@ public class SubscriptionPlan {
     private Boolean active = true;
 
 
-    @Column(nullable = false)
-    private Integer maxTracksPerFile;
-
-    @Column(nullable = false)
-    private Integer maxSavedTracks;
-
-    @Column(nullable = false)
-    private Integer maxTrackUpdates;
-
-    @Column(nullable = false)
-    private boolean allowBulkUpdate;
-
-    @Column(nullable = false)
-    private Integer maxStores;
-
-    @Column(name = "allow_telegram_notifications", nullable = false)
-    private Boolean allowTelegramNotifications = false;
+    @OneToOne(mappedBy = "subscriptionPlan", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private SubscriptionLimits limits;
 
     @Column(name = "monthly_price", nullable = false)
     private java.math.BigDecimal monthlyPrice = java.math.BigDecimal.ZERO;

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.service;
 
 import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.entity.SubscriptionLimits;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.UserSubscription;
 import com.project.tracking_system.repository.SubscriptionPlanRepository;
@@ -50,9 +51,10 @@ public class SubscriptionService {
 
         UserSubscription subscription = optionalSubscription.get();
         SubscriptionPlan plan = subscription.getSubscriptionPlan();
+        SubscriptionLimits limits = (plan != null) ? plan.getLimits() : null;
 
         // Получаем лимит треков на файл
-        Integer maxTracksPerFile = (plan != null) ? plan.getMaxTracksPerFile() : null;
+        Integer maxTracksPerFile = (limits != null) ? limits.getMaxTracksPerFile() : null;
         if (maxTracksPerFile == null) {
             return Integer.MAX_VALUE; // Безлимитный план
         }
@@ -80,8 +82,9 @@ public class SubscriptionService {
 
         UserSubscription subscription = optionalSubscription.get();
         SubscriptionPlan plan = subscription.getSubscriptionPlan();
+        SubscriptionLimits limits = (plan != null) ? plan.getLimits() : null;
 
-        Integer maxSavedTracks = (plan != null) ? plan.getMaxSavedTracks() : null;
+        Integer maxSavedTracks = (limits != null) ? limits.getMaxSavedTracks() : null;
         if (maxSavedTracks == null) {
             log.info("✅ У пользователя {} безлимитный план. Можно сохранить {} треков.", userId, tracksCountToSave);
             return tracksCountToSave; // Безлимитный план позволяет сохранить все запрошенные треки
@@ -121,7 +124,8 @@ public class SubscriptionService {
         }
 
         SubscriptionPlan plan = subscription.getSubscriptionPlan();
-        Integer maxUpdates = (plan != null) ? plan.getMaxTrackUpdates() : null;
+        SubscriptionLimits limits = (plan != null) ? plan.getLimits() : null;
+        Integer maxUpdates = (limits != null) ? limits.getMaxTrackUpdates() : null;
         if (maxUpdates == null) {
             log.info("✅ У пользователя {} безлимитный план. Разрешено {} обновлений.", userId, updatesRequested);
             return updatesRequested; // Безлимитный план
@@ -172,7 +176,8 @@ public class SubscriptionService {
         }
 
         SubscriptionPlan plan = subscription.getSubscriptionPlan();
-        boolean allowed = plan != null && plan.isAllowBulkUpdate();
+        SubscriptionLimits limits = (plan != null) ? plan.getLimits() : null;
+        boolean allowed = limits != null && limits.isAllowBulkUpdate();
 
         log.debug("Пользователь {} пытается использовать массовое обновление. Доступ: {}", userId, allowed);
         return allowed;
@@ -191,7 +196,8 @@ public class SubscriptionService {
             return false;
         }
         return subscriptionPlanRepository.findByCode(code)
-                .map(p -> Boolean.TRUE.equals(p.getAllowTelegramNotifications()))
+                .map(SubscriptionPlan::getLimits)
+                .map(l -> Boolean.TRUE.equals(l.getAllowTelegramNotifications()))
                 .orElse(false);
     }
 

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.service.admin;
 
 import com.project.tracking_system.dto.SubscriptionPlanDTO;
 import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.entity.SubscriptionLimits;
 import com.project.tracking_system.repository.SubscriptionPlanRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,12 +45,19 @@ public class SubscriptionPlanService {
         plan.setPrice(dto.getPrice());
         plan.setDurationDays(dto.getDurationDays());
         plan.setActive(dto.getActive());
-        plan.setMaxTracksPerFile(dto.getMaxTracksPerFile());
-        plan.setMaxSavedTracks(dto.getMaxSavedTracks());
-        plan.setMaxTrackUpdates(dto.getMaxTrackUpdates());
-        plan.setAllowBulkUpdate(dto.isAllowBulkUpdate());
-        plan.setMaxStores(dto.getMaxStores());
-        plan.setAllowTelegramNotifications(dto.isAllowTelegramNotifications());
+
+        SubscriptionLimits limits = plan.getLimits();
+        if (limits == null) {
+            limits = new SubscriptionLimits();
+            limits.setSubscriptionPlan(plan);
+            plan.setLimits(limits);
+        }
+        limits.setMaxTracksPerFile(dto.getMaxTracksPerFile());
+        limits.setMaxSavedTracks(dto.getMaxSavedTracks());
+        limits.setMaxTrackUpdates(dto.getMaxTrackUpdates());
+        limits.setAllowBulkUpdate(dto.isAllowBulkUpdate());
+        limits.setMaxStores(dto.getMaxStores());
+        limits.setAllowTelegramNotifications(dto.isAllowTelegramNotifications());
 
         BigDecimal monthly = dto.getMonthlyPrice();
         if (monthly == null || monthly.compareTo(BigDecimal.ZERO) < 0) {

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -117,7 +117,7 @@ public class StoreService {
                 .map(UserSubscription::getSubscriptionPlan)
                 .orElseThrow(() -> new IllegalStateException("У пользователя нет активной подписки"));
 
-        int maxStores = subscriptionPlan.getMaxStores(); // Получаем лимит магазинов
+        int maxStores = subscriptionPlan.getLimits().getMaxStores(); // Получаем лимит магазинов
 
         if (userStoreCount >= maxStores) {
             String message = "Вы достигли лимита магазинов (" + maxStores + ")";

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.tariff;
 import com.project.tracking_system.dto.SubscriptionPlanDTO;
 import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
 import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.entity.SubscriptionLimits;
 import com.project.tracking_system.repository.SubscriptionPlanRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
@@ -78,14 +79,16 @@ public class TariffService {
             }
         }
 
+        SubscriptionLimits limits = plan.getLimits();
+
         return new SubscriptionPlanViewDTO(
                 plan.getCode(),
-                plan.getMaxTracksPerFile(),
-                plan.getMaxSavedTracks(),
-                plan.getMaxTrackUpdates(),
-                plan.isAllowBulkUpdate(),
-                plan.getMaxStores(),
-                plan.getAllowTelegramNotifications(),
+                limits.getMaxTracksPerFile(),
+                limits.getMaxSavedTracks(),
+                limits.getMaxTrackUpdates(),
+                limits.isAllowBulkUpdate(),
+                limits.getMaxStores(),
+                limits.getAllowTelegramNotifications(),
                 monthlyLabel,
                 annualLabel,
                 fullAnnualPriceLabel,

--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -475,7 +475,8 @@ public class UserService {
         int storeCount = user.getStores().size(); // Получаем количество магазинов
         int maxStores = Optional.ofNullable(user.getSubscription())
                 .map(UserSubscription::getSubscriptionPlan)
-                .map(SubscriptionPlan::getMaxStores)
+                .map(SubscriptionPlan::getLimits)
+                .map(SubscriptionLimits::getMaxStores)
                 .orElse(1); // По умолчанию 1
 
         return storeCount + "/" + maxStores;

--- a/src/main/resources/db/migration/V27__create_subscription_limits_table.sql
+++ b/src/main/resources/db/migration/V27__create_subscription_limits_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE subscription_limits (
+    id SERIAL PRIMARY KEY,
+    subscription_plan_id BIGINT NOT NULL UNIQUE REFERENCES subscription_plans(id),
+    max_tracks_per_file INT,
+    max_saved_tracks INT,
+    max_track_updates INT,
+    allow_bulk_update BOOLEAN NOT NULL DEFAULT FALSE,
+    max_stores INT NOT NULL DEFAULT 1,
+    allow_telegram_notifications BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+INSERT INTO subscription_limits (subscription_plan_id, max_tracks_per_file, max_saved_tracks, max_track_updates, allow_bulk_update, max_stores, allow_telegram_notifications)
+SELECT id, max_tracks_per_file, max_saved_tracks, max_track_updates, allow_bulk_update, max_stores, allow_telegram_notifications
+FROM subscription_plans;
+
+ALTER TABLE subscription_plans
+    DROP COLUMN IF EXISTS max_tracks_per_file,
+    DROP COLUMN IF EXISTS max_saved_tracks,
+    DROP COLUMN IF EXISTS max_track_updates,
+    DROP COLUMN IF EXISTS allow_bulk_update,
+    DROP COLUMN IF EXISTS max_stores,
+    DROP COLUMN IF EXISTS allow_telegram_notifications;

--- a/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.entity.SubscriptionLimits;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -25,12 +26,17 @@ class SubscriptionPlanRepositoryTest {
     void createAndFindWithPrices() {
         SubscriptionPlan plan = new SubscriptionPlan();
         plan.setCode("PREMIUM");
-        plan.setMaxTracksPerFile(1);
-        plan.setMaxSavedTracks(1);
-        plan.setMaxTrackUpdates(1);
-        plan.setAllowBulkUpdate(true);
-        plan.setMaxStores(1);
-        plan.setAllowTelegramNotifications(false);
+
+        SubscriptionLimits limits = new SubscriptionLimits();
+        limits.setSubscriptionPlan(plan);
+        limits.setMaxTracksPerFile(1);
+        limits.setMaxSavedTracks(1);
+        limits.setMaxTrackUpdates(1);
+        limits.setAllowBulkUpdate(true);
+        limits.setMaxStores(1);
+        limits.setAllowTelegramNotifications(false);
+        plan.setLimits(limits);
+
         plan.setMonthlyPrice(new BigDecimal("9.99"));
         plan.setAnnualPrice(new BigDecimal("99.99"));
 


### PR DESCRIPTION
## Summary
- add `SubscriptionLimits` entity
- move limit fields from `SubscriptionPlan` to `SubscriptionLimits`
- refactor services and tests to use new limits entity
- create flyway migration for subscription limits table

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b35f4aa4832db8f08a7a101778e9