### PR TITLE
Implement feature toggles in subscription services

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -48,4 +48,21 @@ public class SubscriptionPlan {
     @Column(name = "annual_price", nullable = false)
     private java.math.BigDecimal annualPrice = java.math.BigDecimal.ZERO;
 
+    /**
+     * Проверяет, доступна ли указанная возможность в тарифе.
+     *
+     * @param key ключ функции (bulkUpdate, telegramNotifications и т.д.)
+     * @return {@code true}, если возможность включена
+     */
+    public boolean isFeatureEnabled(String key) {
+        if (limits == null) {
+            return false;
+        }
+        return switch (key) {
+            case "telegramNotifications" -> Boolean.TRUE.equals(limits.getAllowTelegramNotifications());
+            case "bulkUpdate" -> limits.isAllowBulkUpdate();
+            default -> false;
+        };
+    }
+
 }

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -600,7 +600,7 @@ public class DeliveryHistoryService {
         }
 
         Long ownerId = parcel.getStore().getOwner().getId();
-        boolean allowed = subscriptionService.canUseTelegramNotifications(ownerId);
+        boolean allowed = subscriptionService.isFeatureEnabled(ownerId, "telegramNotifications");
         if (!allowed) {
             return false;
         }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -221,7 +221,7 @@ public class CustomerService {
                 .map(User::getId)
                 .orElse(null);
 
-        return ownerId != null && subscriptionService.canUseTelegramNotifications(ownerId);
+        return ownerId != null && subscriptionService.isFeatureEnabled(ownerId, "telegramNotifications");
     }
 
     private CustomerInfoDTO toInfoDto(Customer customer) {

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -39,7 +39,7 @@ public class StoreTelegramSettingsService {
     public void update(Store store, StoreTelegramSettingsDTO dto, Long userId) {
         boolean enableRequested = dto.isEnabled();
 
-        if (enableRequested && !subscriptionService.isUserPremium(userId)) {
+        if (enableRequested && !subscriptionService.isFeatureEnabled(userId, "telegramNotifications")) {
             String msg = "Telegram-уведомления недоступны на вашем тарифе.";
             webSocketController.sendUpdateStatus(userId, msg, false);
             log.warn("⛔ Попытка включить Telegram-уведомления магазином ID={} без премиум-подписки", store.getId());

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -60,7 +60,7 @@ public class TrackUpdateService {
      */
     @Transactional
     public UpdateResult updateAllParcels(Long userId) {
-        if (!subscriptionService.canUseBulkUpdate(userId)) {
+        if (!subscriptionService.isFeatureEnabled(userId, "bulkUpdate")) {
             String msg = "Обновление всех треков доступно только в премиум-версии.";
             log.warn("Отказано в доступе для пользователя ID: {}", userId);
 


### PR DESCRIPTION
## Summary
- add `isFeatureEnabled` check to `SubscriptionPlan`
- expose feature check in `SubscriptionService`
- use feature checks in telegram settings, track updates and delivery services

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5453440832db468ab74931ef1ac