### PR TITLE
Implement DTO-based plan management

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -590,7 +590,6 @@ public class AdminController {
     @GetMapping("/plans")
     public String plans(Model model) {
         model.addAttribute("plans", adminService.getPlans());
-        model.addAttribute("codes", adminService.getPlans().stream().map(SubscriptionPlan::getCode).toList());
 
         List<BreadcrumbItemDTO> breadcrumbs = List.of(
                 new BreadcrumbItemDTO("Админ Панель", "/admin"),
@@ -607,7 +606,7 @@ public class AdminController {
      * @return редирект на страницу тарифов
      */
     @PostMapping("/plans")
-    public String createPlan(SubscriptionPlanDTO dto) {
+    public String createPlan(@ModelAttribute SubscriptionPlanDTO dto) {
         adminService.createPlan(dto);
         return "redirect:/admin/plans";
     }
@@ -620,8 +619,26 @@ public class AdminController {
      * @return редирект на страницу тарифов
      */
     @PostMapping("/plans/{id}")
-    public String updatePlan(@PathVariable Long id, SubscriptionPlanDTO dto) {
+    public String updatePlan(@PathVariable Long id, @ModelAttribute SubscriptionPlanDTO dto) {
         adminService.updatePlan(id, dto);
+        return "redirect:/admin/plans";
+    }
+
+    /**
+     * Отключить или включить тарифный план.
+     */
+    @PostMapping("/plans/{id}/active")
+    public String togglePlan(@PathVariable Long id, @RequestParam boolean active) {
+        adminService.setPlanActive(id, active);
+        return "redirect:/admin/plans";
+    }
+
+    /**
+     * Удалить тарифный план.
+     */
+    @PostMapping("/plans/{id}/delete")
+    public String deletePlan(@PathVariable Long id) {
+        adminService.deletePlan(id);
         return "redirect:/admin/plans";
     }
 

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
@@ -1,0 +1,20 @@
+package com.project.tracking_system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO лимитов тарифного плана.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionLimitsDTO {
+    private Integer maxTracksPerFile;
+    private Integer maxSavedTracks;
+    private Integer maxTrackUpdates;
+    private boolean allowBulkUpdate;
+    private Integer maxStores;
+    private boolean allowTelegramNotifications;
+}

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 /**
- * DTO для отображения с тарифных планов.
+ * DTO плана подписки с вложенными лимитами.
  */
 @Data
 @NoArgsConstructor
@@ -19,12 +19,7 @@ public class SubscriptionPlanDTO {
     private BigDecimal price;
     private Integer durationDays;
     private Boolean active;
-    private Integer maxTracksPerFile;
-    private Integer maxSavedTracks;
-    private Integer maxTrackUpdates;
-    private boolean allowBulkUpdate;
-    private Integer maxStores;
-    private boolean allowTelegramNotifications;
     private BigDecimal monthlyPrice;
     private BigDecimal annualPrice;
+    private SubscriptionLimitsDTO limits = new SubscriptionLimitsDTO();
 }

--- a/src/main/java/com/project/tracking_system/service/admin/AdminService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminService.java
@@ -123,7 +123,7 @@ public class AdminService {
     /**
      * Получить все планы подписки.
      */
-    public List<SubscriptionPlan> getPlans() {
+    public List<SubscriptionPlanDTO> getPlans() {
         return subscriptionPlanService.getAllPlans();
     }
 
@@ -146,6 +146,25 @@ public class AdminService {
      */
     public SubscriptionPlan updatePlan(Long id, SubscriptionPlanDTO dto) {
         return subscriptionPlanService.updatePlan(id, dto);
+    }
+
+    /**
+     * Изменить активность плана.
+     *
+     * @param id     идентификатор плана
+     * @param active новый статус
+     */
+    public void setPlanActive(Long id, boolean active) {
+        subscriptionPlanService.setPlanActive(id, active);
+    }
+
+    /**
+     * Удалить тарифный план.
+     *
+     * @param id идентификатор плана
+     */
+    public void deletePlan(Long id) {
+        subscriptionPlanService.deletePlan(id);
     }
 
     /**

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -20,23 +20,28 @@
             <th>Цена в год</th>
             <th>Массовое обновление</th>
             <th>Telegram-уведомления</th>
+            <th>Активный</th>
             <th>Действия</th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="plan : ${plans}">
-            <form th:action="@{/admin/plans/{id}(id=${plan.id})}" method="post" class="align-middle">
+            <form th:action="@{/admin/plans/{id}(id=${plan.id})}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <td th:text="${plan.code}"></td>
-                <td><input type="number" name="maxTracksPerFile" class="form-control" th:value="${plan.maxTracksPerFile}" /></td>
-                <td><input type="number" name="maxSavedTracks" class="form-control" th:value="${plan.maxSavedTracks}" /></td>
-                <td><input type="number" name="maxTrackUpdates" class="form-control" th:value="${plan.maxTrackUpdates}" /></td>
-                <td><input type="number" name="maxStores" class="form-control" th:value="${plan.maxStores}" /></td>
+                <td><input type="number" name="limits.maxTracksPerFile" class="form-control" th:value="${plan.limits.maxTracksPerFile}" /></td>
+                <td><input type="number" name="limits.maxSavedTracks" class="form-control" th:value="${plan.limits.maxSavedTracks}" /></td>
+                <td><input type="number" name="limits.maxTrackUpdates" class="form-control" th:value="${plan.limits.maxTrackUpdates}" /></td>
+                <td><input type="number" name="limits.maxStores" class="form-control" th:value="${plan.limits.maxStores}" /></td>
                 <td><input type="number" step="0.01" name="monthlyPrice" class="form-control" th:value="${plan.monthlyPrice}" /></td>
                 <td><input type="number" step="0.01" name="annualPrice" class="form-control" th:value="${plan.annualPrice}" /></td>
-                <td class="text-center"><input type="checkbox" name="allowBulkUpdate" th:checked="${plan.allowBulkUpdate}" /></td>
-                <td class="text-center"><input type="checkbox" name="allowTelegramNotifications" th:checked="${plan.allowTelegramNotifications}" /></td>
-                <td><button type="submit" class="btn btn-success btn-sm">Сохранить</button></td>
+                <td class="text-center"><input type="checkbox" name="limits.allowBulkUpdate" th:checked="${plan.limits.allowBulkUpdate}" /></td>
+                <td class="text-center"><input type="checkbox" name="limits.allowTelegramNotifications" th:checked="${plan.limits.allowTelegramNotifications}" /></td>
+                <td class="text-center"><input type="checkbox" name="active" th:checked="${plan.active}" /></td>
+                <td>
+                    <button type="submit" class="btn btn-success btn-sm me-1">Сохранить</button>
+                    <button type="submit" class="btn btn-danger btn-sm" th:formaction="@{/admin/plans/{id}/delete(id=${plan.id})}" formmethod="post">Удалить</button>
+                </td>
             </form>
         </tr>
         </tbody>
@@ -45,19 +50,16 @@
     <h4 class="mt-4">Новый план</h4>
     <form th:action="@{/admin/plans}" method="post" class="row g-2">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-        <div class="col-md-2">
-            <select name="code" class="form-select">
-                <option th:each="c : ${codes}" th:value="${c}" th:text="${c}"></option>
-            </select>
-        </div>
-        <div class="col-md-2"><input type="number" name="maxTracksPerFile" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="maxSavedTracks" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="maxTrackUpdates" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="maxStores" class="form-control" /></div>
+        <div class="col-md-2"><input type="text" name="code" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="limits.maxTracksPerFile" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="limits.maxSavedTracks" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="limits.maxTrackUpdates" class="form-control" /></div>
+        <div class="col-md-2"><input type="number" name="limits.maxStores" class="form-control" /></div>
         <div class="col-md-2"><input type="number" step="0.01" name="monthlyPrice" class="form-control" /></div>
         <div class="col-md-2"><input type="number" step="0.01" name="annualPrice" class="form-control" /></div>
-        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowBulkUpdate" class="form-check-input" /></div>
-        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="allowTelegramNotifications" class="form-check-input" /></div>
+        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="limits.allowBulkUpdate" class="form-check-input" /></div>
+        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="limits.allowTelegramNotifications" class="form-check-input" /></div>
+        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="active" class="form-check-input" checked /></div>
         <div class="col-md-1"><button type="submit" class="btn btn-primary">Создать</button></div>
     </form>
 </main>


### PR DESCRIPTION
## Summary
- add DTO for subscription limits
- refactor subscription plan DTO to include limits
- provide mapping to/from entities in service layer
- allow enabling, disabling and deleting plans
- update admin plans page to use new DTO structure

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd9fd320832d81c783c49abb39cd