### PR TITLE
Implement FeatureKey enum and refactor feature checks

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import java.math.BigDecimal;
 
 /**
@@ -51,17 +52,16 @@ public class SubscriptionPlan {
     /**
      * Проверяет, доступна ли указанная возможность в тарифе.
      *
-     * @param key ключ функции (bulkUpdate, telegramNotifications и т.д.)
+     * @param key ключ функции
      * @return {@code true}, если возможность включена
      */
-    public boolean isFeatureEnabled(String key) {
-        if (limits == null) {
+    public boolean isFeatureEnabled(FeatureKey key) {
+        if (limits == null || key == null) {
             return false;
         }
         return switch (key) {
-            case "telegramNotifications" -> Boolean.TRUE.equals(limits.getAllowTelegramNotifications());
-            case "bulkUpdate" -> limits.isAllowBulkUpdate();
-            default -> false;
+            case TELEGRAM_NOTIFICATIONS -> Boolean.TRUE.equals(limits.getAllowTelegramNotifications());
+            case BULK_UPDATE -> limits.isAllowBulkUpdate();
         };
     }
 

--- a/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
+++ b/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
@@ -1,0 +1,32 @@
+package com.project.tracking_system.model.subscription;
+
+/**
+ * Перечисление ключей доступных функций тарифных планов.
+ */
+public enum FeatureKey {
+
+    /**
+     * Массовое обновление треков.
+     */
+    BULK_UPDATE("bulkUpdate"),
+
+    /**
+     * Отправка Telegram-уведомлений.
+     */
+    TELEGRAM_NOTIFICATIONS("telegramNotifications");
+
+    private final String key;
+
+    FeatureKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Возвращает строковое представление ключа.
+     *
+     * @return ключ функции
+     */
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.entity.SubscriptionPlan;
 import com.project.tracking_system.entity.SubscriptionLimits;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.UserSubscription;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.repository.SubscriptionPlanRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
@@ -167,7 +168,7 @@ public class SubscriptionService {
      * @return {@code true}, если тарифный план позволяет массовое обновление
      */
     public boolean canUseBulkUpdate(Long userId) {
-        boolean allowed = isFeatureEnabled(userId, "bulkUpdate");
+        boolean allowed = isFeatureEnabled(userId, FeatureKey.BULK_UPDATE);
         log.debug("Пользователь {} пытается использовать массовое обновление. Доступ: {}", userId, allowed);
         return allowed;
     }
@@ -179,7 +180,7 @@ public class SubscriptionService {
      * @return {@code true}, если тарифный план пользователя позволяет Telegram-уведомления
      */
     public boolean canUseTelegramNotifications(Long userId) {
-        boolean allowed = isFeatureEnabled(userId, "telegramNotifications");
+        boolean allowed = isFeatureEnabled(userId, FeatureKey.TELEGRAM_NOTIFICATIONS);
         if (!allowed) {
             log.warn("Пользователь {} не имеет активной подписки или функция Telegram недоступна.", userId);
         }
@@ -193,7 +194,7 @@ public class SubscriptionService {
      * @param key    ключ функции
      * @return {@code true}, если функция доступна
      */
-    public boolean isFeatureEnabled(Long userId, String key) {
+    public boolean isFeatureEnabled(Long userId, FeatureKey key) {
         String code = userSubscriptionRepository.getSubscriptionPlanCode(userId);
         if (code == null) {
             return false;

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -16,6 +16,7 @@ import com.project.tracking_system.service.customer.CustomerService;
 import com.project.tracking_system.service.customer.CustomerStatsService;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.repository.CustomerNotificationLogRepository;
 import com.project.tracking_system.entity.CustomerNotificationLog;
 import com.project.tracking_system.entity.NotificationType;
@@ -600,7 +601,7 @@ public class DeliveryHistoryService {
         }
 
         Long ownerId = parcel.getStore().getOwner().getId();
-        boolean allowed = subscriptionService.isFeatureEnabled(ownerId, "telegramNotifications");
+        boolean allowed = subscriptionService.isFeatureEnabled(ownerId, FeatureKey.TELEGRAM_NOTIFICATIONS);
         if (!allowed) {
             return false;
         }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.dto.CustomerInfoDTO;
 import com.project.tracking_system.repository.CustomerRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.utils.PhoneUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -221,7 +222,7 @@ public class CustomerService {
                 .map(User::getId)
                 .orElse(null);
 
-        return ownerId != null && subscriptionService.isFeatureEnabled(ownerId, "telegramNotifications");
+        return ownerId != null && subscriptionService.isFeatureEnabled(ownerId, FeatureKey.TELEGRAM_NOTIFICATIONS);
     }
 
     private CustomerInfoDTO toInfoDto(Customer customer) {

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.StoreTelegramSettings;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,7 +40,7 @@ public class StoreTelegramSettingsService {
     public void update(Store store, StoreTelegramSettingsDTO dto, Long userId) {
         boolean enableRequested = dto.isEnabled();
 
-        if (enableRequested && !subscriptionService.isFeatureEnabled(userId, "telegramNotifications")) {
+        if (enableRequested && !subscriptionService.isFeatureEnabled(userId, FeatureKey.TELEGRAM_NOTIFICATIONS)) {
             String msg = "Telegram-уведомления недоступны на вашем тарифе.";
             webSocketController.sendUpdateStatus(userId, msg, false);
             log.warn("⛔ Попытка включить Telegram-уведомления магазином ID={} без премиум-подписки", store.getId());

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.dto.TrackParcelDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
@@ -60,7 +61,7 @@ public class TrackUpdateService {
      */
     @Transactional
     public UpdateResult updateAllParcels(Long userId) {
-        if (!subscriptionService.isFeatureEnabled(userId, "bulkUpdate")) {
+        if (!subscriptionService.isFeatureEnabled(userId, FeatureKey.BULK_UPDATE)) {
             String msg = "Обновление всех треков доступно только в премиум-версии.";
             log.warn("Отказано в доступе для пользователя ID: {}", userId);
 


### PR DESCRIPTION
## Summary
- add `FeatureKey` enum with available feature keys
- refactor feature checks to use `FeatureKey` instead of raw strings

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6856d2107918832da78a4222f12e736a