### PR TITLE
Refactor subscription plan repository tests

### DIFF
--- a/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
@@ -46,4 +46,28 @@ class SubscriptionPlanRepositoryTest {
         assertEquals(new BigDecimal("9.99"), found.getMonthlyPrice());
         assertEquals(new BigDecimal("99.99"), found.getAnnualPrice());
     }
+
+    /**
+     * Проверяет поиск плана по его коду.
+     */
+    @Test
+    void findByCodeReturnsPlan() {
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setCode("FREE");
+
+        SubscriptionLimits limits = new SubscriptionLimits();
+        limits.setSubscriptionPlan(plan);
+        limits.setMaxTracksPerFile(1);
+        limits.setMaxSavedTracks(1);
+        limits.setMaxTrackUpdates(1);
+        limits.setAllowBulkUpdate(false);
+        limits.setMaxStores(1);
+        limits.setAllowTelegramNotifications(false);
+        plan.setLimits(limits);
+
+        repository.save(plan);
+
+        SubscriptionPlan found = repository.findByCode("FREE").orElseThrow();
+        assertEquals("FREE", found.getCode());
+    }
 }


### PR DESCRIPTION
## Summary
- update SubscriptionPlanRepositoryTest to ensure plan lookup by string code

## Testing
- `./mvnw test` *(fails: cannot open `.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6856d3407d38832d97e2406a4efe13ce