### PR TITLE
Add SubscriptionFeature entity and feature migration

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/SubscriptionFeature.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionFeature.java
@@ -1,0 +1,37 @@
+package com.project.tracking_system.entity;
+
+import com.project.tracking_system.model.subscription.FeatureKey;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Запись о доступной функции тарифного плана.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "subscription_features", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"subscription_plan_id", "feature_key"})
+})
+public class SubscriptionFeature {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "feature_key", nullable = false)
+    private FeatureKey featureKey;
+
+    @Column(nullable = false)
+    private boolean enabled = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subscription_plan_id", nullable = false)
+    private SubscriptionPlan subscriptionPlan;
+}

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionLimits.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionLimits.java
@@ -32,11 +32,5 @@ public class SubscriptionLimits {
     private Integer maxTrackUpdates;
 
     @Column(nullable = false)
-    private boolean allowBulkUpdate;
-
-    @Column(nullable = false)
     private Integer maxStores;
-
-    @Column(name = "allow_telegram_notifications", nullable = false)
-    private Boolean allowTelegramNotifications = false;
 }

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import com.project.tracking_system.model.subscription.FeatureKey;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Dmitriy Anisimov
@@ -43,6 +45,9 @@ public class SubscriptionPlan {
     @OneToOne(mappedBy = "subscriptionPlan", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private SubscriptionLimits limits;
 
+    @OneToMany(mappedBy = "subscriptionPlan", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<SubscriptionFeature> features = new ArrayList<>();
+
     @Column(name = "monthly_price", nullable = false)
     private java.math.BigDecimal monthlyPrice = java.math.BigDecimal.ZERO;
 
@@ -56,13 +61,13 @@ public class SubscriptionPlan {
      * @return {@code true}, если возможность включена
      */
     public boolean isFeatureEnabled(FeatureKey key) {
-        if (limits == null || key == null) {
+        if (key == null || features == null) {
             return false;
         }
-        return switch (key) {
-            case TELEGRAM_NOTIFICATIONS -> Boolean.TRUE.equals(limits.getAllowTelegramNotifications());
-            case BULK_UPDATE -> limits.isAllowBulkUpdate();
-        };
+
+        // ищем соответствующую настройку в списке функций
+        return features.stream()
+                .anyMatch(f -> key.equals(f.getFeatureKey()) && f.isEnabled());
     }
 
 }

--- a/src/main/java/com/project/tracking_system/repository/SubscriptionPlanRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/SubscriptionPlanRepository.java
@@ -2,6 +2,8 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.SubscriptionPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.math.BigDecimal;
 
 import java.util.Optional;
@@ -13,7 +15,8 @@ import java.util.Optional;
 
 public interface SubscriptionPlanRepository extends JpaRepository<SubscriptionPlan, Long> {
 
-    Optional<SubscriptionPlan> findByCode(String code);
+    @Query("SELECT sp FROM SubscriptionPlan sp LEFT JOIN FETCH sp.features WHERE sp.code = :code")
+    Optional<SubscriptionPlan> findByCode(@Param("code") String code);
 
     /**
      * Найти первый план с указанной ценой.

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.dto.SubscriptionPlanDTO;
 import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
 import com.project.tracking_system.entity.SubscriptionPlan;
 import com.project.tracking_system.entity.SubscriptionLimits;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.repository.SubscriptionPlanRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
@@ -86,9 +87,9 @@ public class TariffService {
                 limits.getMaxTracksPerFile(),
                 limits.getMaxSavedTracks(),
                 limits.getMaxTrackUpdates(),
-                limits.isAllowBulkUpdate(),
+                plan.isFeatureEnabled(FeatureKey.BULK_UPDATE),
                 limits.getMaxStores(),
-                limits.getAllowTelegramNotifications(),
+                plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
                 monthlyLabel,
                 annualLabel,
                 fullAnnualPriceLabel,

--- a/src/main/resources/db/migration/V28__create_subscription_features_table.sql
+++ b/src/main/resources/db/migration/V28__create_subscription_features_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE subscription_features (
+    id SERIAL PRIMARY KEY,
+    subscription_plan_id BIGINT NOT NULL REFERENCES subscription_plans(id),
+    feature_key VARCHAR(50) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT uk_plan_feature UNIQUE (subscription_plan_id, feature_key)
+);
+
+INSERT INTO subscription_features (subscription_plan_id, feature_key, enabled)
+SELECT subscription_plan_id, 'BULK_UPDATE', allow_bulk_update
+FROM subscription_limits;
+
+INSERT INTO subscription_features (subscription_plan_id, feature_key, enabled)
+SELECT subscription_plan_id, 'TELEGRAM_NOTIFICATIONS', allow_telegram_notifications
+FROM subscription_limits;
+
+ALTER TABLE subscription_limits
+    DROP COLUMN IF EXISTS allow_bulk_update,
+    DROP COLUMN IF EXISTS allow_telegram_notifications;

--- a/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
@@ -2,6 +2,8 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.SubscriptionPlan;
 import com.project.tracking_system.entity.SubscriptionLimits;
+import com.project.tracking_system.entity.SubscriptionFeature;
+import com.project.tracking_system.model.subscription.FeatureKey;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -32,10 +34,14 @@ class SubscriptionPlanRepositoryTest {
         limits.setMaxTracksPerFile(1);
         limits.setMaxSavedTracks(1);
         limits.setMaxTrackUpdates(1);
-        limits.setAllowBulkUpdate(true);
         limits.setMaxStores(1);
-        limits.setAllowTelegramNotifications(false);
         plan.setLimits(limits);
+
+        SubscriptionFeature feature = new SubscriptionFeature();
+        feature.setFeatureKey(FeatureKey.BULK_UPDATE);
+        feature.setEnabled(true);
+        feature.setSubscriptionPlan(plan);
+        plan.setFeatures(java.util.List.of(feature));
 
         plan.setMonthlyPrice(new BigDecimal("9.99"));
         plan.setAnnualPrice(new BigDecimal("99.99"));
@@ -60,10 +66,14 @@ class SubscriptionPlanRepositoryTest {
         limits.setMaxTracksPerFile(1);
         limits.setMaxSavedTracks(1);
         limits.setMaxTrackUpdates(1);
-        limits.setAllowBulkUpdate(false);
         limits.setMaxStores(1);
-        limits.setAllowTelegramNotifications(false);
         plan.setLimits(limits);
+
+        SubscriptionFeature feature = new SubscriptionFeature();
+        feature.setFeatureKey(FeatureKey.BULK_UPDATE);
+        feature.setEnabled(false);
+        feature.setSubscriptionPlan(plan);
+        plan.setFeatures(java.util.List.of(feature));
 
         repository.save(plan);
 


### PR DESCRIPTION
## Summary
- add `SubscriptionFeature` entity to store plan features
- drop feature booleans from `SubscriptionLimits`
- update `SubscriptionPlan` with feature list and check method
- adapt services and repository to new feature storage
- migrate data in new `V28__create_subscription_features_table.sql`
- adjust repository test

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856d8fbe448832da5f47d7a88d3407e