### PR TITLE
Add JavaDoc for toViewDto

### DIFF
--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -51,6 +51,12 @@ public class TariffService {
         subscriptionService.upgradeOrExtendSubscription(userId, months);
     }
 
+    /**
+     * Преобразует сущность тарифного плана в DTO для отображения.
+     *
+     * @param plan сущность тарифного плана
+     * @return объект с информацией для клиента
+     */
     public SubscriptionPlanViewDTO toViewDto(SubscriptionPlan plan) {
         BigDecimal monthly = plan.getMonthlyPrice();
         BigDecimal annual = plan.getAnnualPrice();


### PR DESCRIPTION
## Summary
- add JavaDoc to the `toViewDto` method of `TariffService`

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6856dd0ecdc4832d94dc4b894dd318d5