### PR TITLE
Normalize transaction annotation

### DIFF
--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -8,7 +8,7 @@ import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.repository.SubscriptionPlanRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -6,7 +6,7 @@ import com.project.tracking_system.repository.PasswordResetTokenRepository;
 import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.service.email.EmailService;
 import com.project.tracking_system.utils.EmailUtils;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -16,7 +16,7 @@ import com.project.tracking_system.utils.EncryptionUtils;
 import com.project.tracking_system.utils.EmailUtils;
 import com.project.tracking_system.utils.UserCredentialsResolver;
 import java.math.BigDecimal;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;


### PR DESCRIPTION
## Summary
- use the Spring `@Transactional` annotation in service classes

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6856e12ce3b0832d8ae16f5389519fee