### PR TITLE
Fix tariffs data flow

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -4,7 +4,6 @@ import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
 import com.project.tracking_system.dto.UserProfileDTO;
 import com.project.tracking_system.service.tariff.TariffService;
 import com.project.tracking_system.service.user.UserService;
-import com.project.tracking_system.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -28,7 +27,6 @@ public class TariffController {
 
     private final TariffService tariffService;
     private final UserService userService;
-    private final SubscriptionService subscriptionService;
 
     /**
      * Отображает страницу с тарифными планами.
@@ -44,11 +42,9 @@ public class TariffController {
             // пользователь авторизован
             model.addAttribute("authenticatedUser", userId);
 
-            // проверяем, активен ли премиум-план, чтобы избежать ошибок вывода
-            if (subscriptionService.isUserPremium(userId)) {
-                UserProfileDTO profile = userService.getUserProfile(userId);
-                model.addAttribute("userProfile", profile);
-            }
+            // загружаем профиль пользователя для отображения тарифа
+            UserProfileDTO profile = userService.getUserProfile(userId);
+            model.addAttribute("userProfile", profile);
         }
         List<SubscriptionPlanViewDTO> plans = tariffService.getAllPlans();
         model.addAttribute("plans", plans);

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SubscriptionPlanViewDTO {
     private String code;
+    private String name;
+    private String description;
     private Integer maxTracksPerFile;
     private Integer maxSavedTracks;
     private Integer maxTrackUpdates;

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -89,6 +89,8 @@ public class TariffService {
 
         return new SubscriptionPlanViewDTO(
                 plan.getCode(),
+                plan.getName(),
+                plan.getDescription(),
                 limits.getMaxTracksPerFile(),
                 limits.getMaxSavedTracks(),
                 limits.getMaxTrackUpdates(),

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -28,6 +28,7 @@
 
                     <!-- Название -->
                     <h3 class="text-center fw-bold fs-3 mt-3 mb-1" th:text="${plan.name}">Premium</h3>
+                    <p class="text-center text-muted mb-2" th:text="${plan.description}"></p>
 
                     <!-- Цена (ежемесячно) -->
                     <p class="text-center mb-2 mt-2 fw-semibold fs-5 price-monthly text-dark"

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -39,6 +39,8 @@ class TariffServiceTest {
     void initPlan() {
         plan = new SubscriptionPlan();
         plan.setCode("PREMIUM");
+        plan.setName("Premium");
+        plan.setDescription("Premium plan");
         plan.setMonthlyPrice(new BigDecimal("15"));
         plan.setAnnualPrice(new BigDecimal("150"));
 
@@ -69,6 +71,8 @@ class TariffServiceTest {
 
         assertEquals(1, dtos.size());
         SubscriptionPlanViewDTO dto = dtos.get(0);
+        assertEquals("Premium", dto.getName());
+        assertEquals("Premium plan", dto.getDescription());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
@@ -80,6 +84,8 @@ class TariffServiceTest {
         SubscriptionPlanViewDTO dto = tariffService.toViewDto(plan);
 
         assertEquals("PREMIUM", dto.getCode());
+        assertEquals("Premium", dto.getName());
+        assertEquals("Premium plan", dto.getDescription());
         assertEquals(5, dto.getMaxTracksPerFile());
         assertEquals(100, dto.getMaxSavedTracks());
         assertTrue(dto.isAllowBulkUpdate());


### PR DESCRIPTION
## Summary
- send user profile always in `TariffController`
- add `name` and `description` fields to `SubscriptionPlanViewDTO`
- map new fields in `TariffService`
- show plan description on tariffs page
- update unit tests

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685706cc8f34832db08f554c302f2843