### PR TITLE
Fix admin plans data binding

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
@@ -13,6 +13,10 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SubscriptionPlanDTO {
+    /**
+     * Идентификатор тарифного плана.
+     */
+    private Long id;
     private String code;
     private String name;
     private String description;

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -57,6 +57,7 @@ public class SubscriptionPlanService {
         limitsDto.setAllowTelegramNotifications(plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS));
 
         SubscriptionPlanDTO dto = new SubscriptionPlanDTO();
+        dto.setId(plan.getId());
         dto.setCode(plan.getCode());
         dto.setName(plan.getName());
         dto.setDescription(plan.getDescription());


### PR DESCRIPTION
## Summary
- include ID in `SubscriptionPlanDTO`
- map ID field when converting subscription plans to DTO

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: `cannot open ./.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_685708cfca9c832d824dcad18d1c44f0