### PR TITLE
Add editable plan name

### DIFF
--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -12,6 +12,7 @@
         <thead>
         <tr>
             <th>Код</th>
+            <th>Название</th>
             <th>Треков в файле</th>
             <th>Сохранённых треков</th>
             <th>Обновлений в день</th>
@@ -28,7 +29,8 @@
         <tr th:each="plan : ${plans}">
             <form th:action="@{/admin/plans/{id}(id=${plan.id})}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-                <td th:text="${plan.code}"></td>
+                <td><input type="text" name="code" class="form-control" th:value="${plan.code}" /></td>
+                <td><input type="text" name="name" class="form-control" th:value="${plan.name}" /></td>
                 <td><input type="number" name="limits.maxTracksPerFile" class="form-control" th:value="${plan.limits.maxTracksPerFile}" /></td>
                 <td><input type="number" name="limits.maxSavedTracks" class="form-control" th:value="${plan.limits.maxSavedTracks}" /></td>
                 <td><input type="number" name="limits.maxTrackUpdates" class="form-control" th:value="${plan.limits.maxTrackUpdates}" /></td>
@@ -48,15 +50,16 @@
     </table>
 
     <h4 class="mt-4">Новый план</h4>
-    <form th:action="@{/admin/plans}" method="post" class="row g-2">
+    <form th:action="@{/admin/plans}" method="post" class="row row-cols-lg-auto g-2 align-items-center">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-        <div class="col-md-2"><input type="text" name="code" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="limits.maxTracksPerFile" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="limits.maxSavedTracks" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="limits.maxTrackUpdates" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" name="limits.maxStores" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" step="0.01" name="monthlyPrice" class="form-control" /></div>
-        <div class="col-md-2"><input type="number" step="0.01" name="annualPrice" class="form-control" /></div>
+        <div class="col-md-1"><input type="text" name="code" class="form-control" /></div>
+        <div class="col-md-1"><input type="text" name="name" class="form-control" /></div>
+        <div class="col-md-1"><input type="number" name="limits.maxTracksPerFile" class="form-control" /></div>
+        <div class="col-md-1"><input type="number" name="limits.maxSavedTracks" class="form-control" /></div>
+        <div class="col-md-1"><input type="number" name="limits.maxTrackUpdates" class="form-control" /></div>
+        <div class="col-md-1"><input type="number" name="limits.maxStores" class="form-control" /></div>
+        <div class="col-md-1"><input type="number" step="0.01" name="monthlyPrice" class="form-control" /></div>
+        <div class="col-md-1"><input type="number" step="0.01" name="annualPrice" class="form-control" /></div>
         <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="limits.allowBulkUpdate" class="form-check-input" /></div>
         <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="limits.allowTelegramNotifications" class="form-check-input" /></div>
         <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="active" class="form-check-input" checked /></div>


### PR DESCRIPTION
## Summary
- enable editing of plan code and name
- add plan name column and new-plan form field

## Testing
- `mvn test` *(fails: `bash: mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68570d2e89c8832d8bc2f754f9d557f2