### PR TITLE
Add registration button for unauthenticated users

### DIFF
--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -88,7 +88,8 @@
 
                         <!-- 🔒 FREE: тариф по умолчанию -->
                         <div th:if="${plan.code == 'FREE' && (userProfile == null || userProfile.subscriptionCode != plan.code)}" class="mt-auto">
-                            <button class="btn btn-outline-secondary w-100" disabled th:text="Ваш тариф">
+                            <a th:if="${authenticatedUser == null}" href="/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
+                            <button th:if="${authenticatedUser != null}" class="btn btn-outline-secondary w-100" disabled th:text="Ваш тариф">
                             </button>
                         </div>
 


### PR DESCRIPTION
## Summary
- show registration link in the FREE tariff block for guests

## Testing
- `./mvnw test -q` *(fails: cannot open maven-wrapper)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685713147b74832db5dd0793f9c8185d