### PR TITLE
Remove outdated plan fields

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanDTO.java
@@ -19,9 +19,7 @@ public class SubscriptionPlanDTO {
     private Long id;
     private String code;
     private String name;
-    private String description;
     private BigDecimal price;
-    private Integer durationDays;
     private Boolean active;
     private BigDecimal monthlyPrice;
     private BigDecimal annualPrice;

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 public class SubscriptionPlanViewDTO {
     private String code;
     private String name;
-    private String description;
     private Integer maxTracksPerFile;
     private Integer maxSavedTracks;
     private Integer maxTrackUpdates;

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -30,13 +30,8 @@ public class SubscriptionPlan {
     @Column(nullable = false)
     private String name;
 
-    private String description;
-
     @Column(nullable = false)
     private BigDecimal price = BigDecimal.ZERO;
-
-    @Column(name = "duration_days")
-    private Integer durationDays;
 
     @Column(nullable = false)
     private Boolean active = true;

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -60,9 +60,7 @@ public class SubscriptionPlanService {
         dto.setId(plan.getId());
         dto.setCode(plan.getCode());
         dto.setName(plan.getName());
-        dto.setDescription(plan.getDescription());
         dto.setPrice(plan.getPrice());
-        dto.setDurationDays(plan.getDurationDays());
         dto.setActive(plan.getActive());
         dto.setMonthlyPrice(plan.getMonthlyPrice());
         dto.setAnnualPrice(plan.getAnnualPrice());
@@ -79,9 +77,7 @@ public class SubscriptionPlanService {
     private void fillFromDto(SubscriptionPlan plan, SubscriptionPlanDTO dto) {
         plan.setCode(dto.getCode());
         plan.setName(dto.getName());
-        plan.setDescription(dto.getDescription());
         plan.setPrice(dto.getPrice());
-        plan.setDurationDays(dto.getDurationDays());
         plan.setActive(dto.getActive());
 
         SubscriptionLimits limits = plan.getLimits();

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -90,7 +90,6 @@ public class TariffService {
         return new SubscriptionPlanViewDTO(
                 plan.getCode(),
                 plan.getName(),
-                plan.getDescription(),
                 limits.getMaxTracksPerFile(),
                 limits.getMaxSavedTracks(),
                 limits.getMaxTrackUpdates(),

--- a/src/main/resources/db/migration/V29__remove_description_and_duration.sql
+++ b/src/main/resources/db/migration/V29__remove_description_and_duration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE subscription_plans
+    DROP COLUMN IF EXISTS description,
+    DROP COLUMN IF EXISTS duration_days;

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -28,7 +28,6 @@
 
                     <!-- Название -->
                     <h3 class="text-center fw-bold fs-3 mt-3 mb-1" th:text="${plan.name}">Premium</h3>
-                    <p class="text-center text-muted mb-2" th:text="${plan.description}"></p>
 
                     <!-- Цена (ежемесячно) -->
                     <p class="text-center mb-2 mt-2 fw-semibold fs-5 price-monthly text-dark"

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -40,7 +40,6 @@ class TariffServiceTest {
         plan = new SubscriptionPlan();
         plan.setCode("PREMIUM");
         plan.setName("Premium");
-        plan.setDescription("Premium plan");
         plan.setMonthlyPrice(new BigDecimal("15"));
         plan.setAnnualPrice(new BigDecimal("150"));
 
@@ -72,7 +71,6 @@ class TariffServiceTest {
         assertEquals(1, dtos.size());
         SubscriptionPlanViewDTO dto = dtos.get(0);
         assertEquals("Premium", dto.getName());
-        assertEquals("Premium plan", dto.getDescription());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
@@ -85,7 +83,6 @@ class TariffServiceTest {
 
         assertEquals("PREMIUM", dto.getCode());
         assertEquals("Premium", dto.getName());
-        assertEquals("Premium plan", dto.getDescription());
         assertEquals(5, dto.getMaxTracksPerFile());
         assertEquals(100, dto.getMaxSavedTracks());
         assertTrue(dto.isAllowBulkUpdate());


### PR DESCRIPTION
## Summary
- drop `description` and `duration_days` columns
- remove fields from `SubscriptionPlan` entity and DTOs
- adjust services and templates for removed columns
- update tests

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857248ea534832d89aa3f7fe0eb0360