### PR TITLE
Add ordered subscription plans with move controls

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -642,4 +642,28 @@ public class AdminController {
         return "redirect:/admin/plans";
     }
 
+    /**
+     * Переместить тариф вверх в списке.
+     *
+     * @param id идентификатор плана
+     * @return редирект на страницу тарифов
+     */
+    @PostMapping("/plans/{id}/move-up")
+    public String movePlanUp(@PathVariable Long id) {
+        subscriptionPlanService.movePlanUp(id);
+        return "redirect:/admin/plans";
+    }
+
+    /**
+     * Переместить тариф вниз в списке.
+     *
+     * @param id идентификатор плана
+     * @return редирект на страницу тарифов
+     */
+    @PostMapping("/plans/{id}/move-down")
+    public String movePlanDown(@PathVariable Long id) {
+        subscriptionPlanService.movePlanDown(id);
+        return "redirect:/admin/plans";
+    }
+
 }

--- a/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
+++ b/src/main/java/com/project/tracking_system/entity/SubscriptionPlan.java
@@ -50,6 +50,12 @@ public class SubscriptionPlan {
     private java.math.BigDecimal annualPrice = java.math.BigDecimal.ZERO;
 
     /**
+     * Позиция плана в отсортированном списке.
+     */
+    @Column(nullable = false)
+    private int position;
+
+    /**
      * Проверяет, доступна ли указанная возможность в тарифе.
      *
      * @param key ключ функции

--- a/src/main/java/com/project/tracking_system/repository/SubscriptionPlanRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/SubscriptionPlanRepository.java
@@ -27,6 +27,21 @@ public interface SubscriptionPlanRepository extends JpaRepository<SubscriptionPl
     Optional<SubscriptionPlan> findFirstByPrice(BigDecimal price);
 
     /**
+     * Получить все тарифы, отсортированные по позиции.
+     *
+     * @return список тарифных планов
+     */
+    List<SubscriptionPlan> findAllByOrderByPositionAsc();
+
+    /**
+     * Найти максимальную позицию среди тарифных планов.
+     *
+     * @return максимальная позиция или {@code Optional.empty()}
+     */
+    @Query("SELECT MAX(sp.position) FROM SubscriptionPlan sp")
+    Optional<Integer> findMaxPosition();
+
+    /**
      * Найти первый план с ценой выше указанной.
      *
      * @param price минимальная цена плана

--- a/src/main/java/com/project/tracking_system/service/admin/AppInfoService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AppInfoService.java
@@ -44,6 +44,6 @@ public class AppInfoService {
      * @return список тарифных планов
      */
     public List<SubscriptionPlan> getPlans() {
-        return planRepository.findAll();
+        return planRepository.findAllByOrderByPositionAsc();
     }
 }

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -33,7 +33,7 @@ public class TariffService {
      * @return список планов в виде DTO
      */
     public List<SubscriptionPlanViewDTO> getAllPlans() {
-        return planRepository.findAll()
+        return planRepository.findAllByOrderByPositionAsc()
                 .stream()
                 .map(this::toViewDto)
                 .collect(Collectors.toList());

--- a/src/main/resources/db/migration/V30__add_position_to_subscription_plans.sql
+++ b/src/main/resources/db/migration/V30__add_position_to_subscription_plans.sql
@@ -1,0 +1,11 @@
+ALTER TABLE subscription_plans ADD COLUMN position INT NOT NULL DEFAULT 0;
+
+-- заполняем позиции для существующих записей
+WITH ordered AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn
+    FROM subscription_plans
+)
+UPDATE subscription_plans sp
+SET position = o.rn
+FROM ordered o
+WHERE sp.id = o.id;

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -42,6 +42,8 @@
                 <td class="text-center"><input type="checkbox" name="active" th:checked="${plan.active}" /></td>
                 <td>
                     <button type="submit" class="btn btn-success btn-sm me-1">Сохранить</button>
+                    <button type="submit" class="btn btn-secondary btn-sm me-1" th:formaction="@{/admin/plans/{id}/move-up(id=${plan.id})}" formmethod="post">⬆️</button>
+                    <button type="submit" class="btn btn-secondary btn-sm me-1" th:formaction="@{/admin/plans/{id}/move-down(id=${plan.id})}" formmethod="post">⬇️</button>
                     <button type="submit" class="btn btn-danger btn-sm" th:formaction="@{/admin/plans/{id}/delete(id=${plan.id})}" formmethod="post">Удалить</button>
                 </td>
             </form>

--- a/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/SubscriptionPlanRepositoryTest.java
@@ -80,4 +80,29 @@ class SubscriptionPlanRepositoryTest {
         SubscriptionPlan found = repository.findByCode("FREE").orElseThrow();
         assertEquals("FREE", found.getCode());
     }
+
+    /**
+     * Проверяет сортировку планов по позиции.
+     */
+    @Test
+    void findAllByOrderByPositionAsc_ReturnsSorted() {
+        SubscriptionPlan first = new SubscriptionPlan();
+        first.setCode("A");
+        first.setPosition(2);
+        first.setLimits(new SubscriptionLimits());
+
+        SubscriptionPlan second = new SubscriptionPlan();
+        second.setCode("B");
+        second.setPosition(1);
+        second.setLimits(new SubscriptionLimits());
+
+        repository.save(first);
+        repository.save(second);
+
+        java.util.List<SubscriptionPlan> plans = repository.findAllByOrderByPositionAsc();
+
+        assertEquals(2, plans.size());
+        assertEquals("B", plans.get(0).getCode());
+        assertEquals("A", plans.get(1).getCode());
+    }
 }

--- a/src/test/java/com/project/tracking_system/service/admin/SubscriptionPlanServicePositionTest.java
+++ b/src/test/java/com/project/tracking_system/service/admin/SubscriptionPlanServicePositionTest.java
@@ -1,0 +1,66 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.repository.SubscriptionPlanRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Проверка перестановки тарифных планов.
+ */
+@ExtendWith(MockitoExtension.class)
+class SubscriptionPlanServicePositionTest {
+
+    @Mock
+    private SubscriptionPlanRepository repository;
+
+    @InjectMocks
+    private SubscriptionPlanService service;
+
+    private SubscriptionPlan first;
+    private SubscriptionPlan second;
+
+    @BeforeEach
+    void setUp() {
+        first = new SubscriptionPlan();
+        first.setId(1L);
+        first.setPosition(1);
+
+        second = new SubscriptionPlan();
+        second.setId(2L);
+        second.setPosition(2);
+    }
+
+    @Test
+    void movePlanUp_SwapsWithPrevious() {
+        when(repository.findAllByOrderByPositionAsc()).thenReturn(List.of(first, second));
+
+        service.movePlanUp(2L);
+
+        assertEquals(2, first.getPosition());
+        assertEquals(1, second.getPosition());
+        verify(repository).save(first);
+        verify(repository).save(second);
+    }
+
+    @Test
+    void movePlanDown_SwapsWithNext() {
+        when(repository.findAllByOrderByPositionAsc()).thenReturn(List.of(first, second));
+
+        service.movePlanDown(1L);
+
+        assertEquals(2, first.getPosition());
+        assertEquals(1, second.getPosition());
+        verify(repository).save(first);
+        verify(repository).save(second);
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -64,7 +64,7 @@ class TariffServiceTest {
 
     @Test
     void getAllPlans_ReturnsDtosWithCalculatedLabels() {
-        when(planRepository.findAll()).thenReturn(List.of(plan));
+        when(planRepository.findAllByOrderByPositionAsc()).thenReturn(List.of(plan));
 
         List<SubscriptionPlanViewDTO> dtos = tariffService.getAllPlans();
 


### PR DESCRIPTION
## Summary
- add migration for plan position
- store position in `SubscriptionPlan`
- expose sorting methods in repository
- manage positions in `SubscriptionPlanService`
- sort plans in services and new move endpoints
- update admin template with up/down actions
- cover new logic with unit tests

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68572e59d9f0832d84a9bc8155a19cf5