### PR TITLE
Add labels to new plan form

### DIFF
--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -52,20 +52,61 @@
     </table>
 
     <h4 class="mt-4">Новый план</h4>
-    <form th:action="@{/admin/plans}" method="post" class="row row-cols-lg-auto g-2 align-items-center">
+    <form th:action="@{/admin/plans}" method="post" class="row row-cols-lg-auto g-2 align-items-end">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-        <div class="col-md-1"><input type="text" name="code" class="form-control" /></div>
-        <div class="col-md-1"><input type="text" name="name" class="form-control" /></div>
-        <div class="col-md-1"><input type="number" name="limits.maxTracksPerFile" class="form-control" /></div>
-        <div class="col-md-1"><input type="number" name="limits.maxSavedTracks" class="form-control" /></div>
-        <div class="col-md-1"><input type="number" name="limits.maxTrackUpdates" class="form-control" /></div>
-        <div class="col-md-1"><input type="number" name="limits.maxStores" class="form-control" /></div>
-        <div class="col-md-1"><input type="number" step="0.01" name="monthlyPrice" class="form-control" /></div>
-        <div class="col-md-1"><input type="number" step="0.01" name="annualPrice" class="form-control" /></div>
-        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="limits.allowBulkUpdate" class="form-check-input" /></div>
-        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="limits.allowTelegramNotifications" class="form-check-input" /></div>
-        <div class="col-md-1 d-flex align-items-center"><input type="checkbox" name="active" class="form-check-input" checked /></div>
-        <div class="col-md-1"><button type="submit" class="btn btn-primary">Создать</button></div>
+        <div class="col-md-1">
+            <label for="plan-code" class="form-label">Код</label>
+            <input id="plan-code" type="text" name="code" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-name" class="form-label">Название</label>
+            <input id="plan-name" type="text" name="name" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-max-per-file" class="form-label">Треков в файле</label>
+            <input id="plan-max-per-file" type="number" name="limits.maxTracksPerFile" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-max-saved" class="form-label">Сохранённых треков</label>
+            <input id="plan-max-saved" type="number" name="limits.maxSavedTracks" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-max-updates" class="form-label">Обновлений в день</label>
+            <input id="plan-max-updates" type="number" name="limits.maxTrackUpdates" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-max-stores" class="form-label">Магазинов</label>
+            <input id="plan-max-stores" type="number" name="limits.maxStores" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-monthly" class="form-label">Цена в месяц</label>
+            <input id="plan-monthly" type="number" step="0.01" name="monthlyPrice" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <label for="plan-annual" class="form-label">Цена в год</label>
+            <input id="plan-annual" type="number" step="0.01" name="annualPrice" class="form-control" />
+        </div>
+        <div class="col-md-1">
+            <div class="form-check">
+                <input id="plan-bulk-update" type="checkbox" name="limits.allowBulkUpdate" class="form-check-input" />
+                <label class="form-check-label" for="plan-bulk-update">Массовое обновление</label>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <div class="form-check">
+                <input id="plan-telegram" type="checkbox" name="limits.allowTelegramNotifications" class="form-check-input" />
+                <label class="form-check-label" for="plan-telegram">Telegram-уведомления</label>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <div class="form-check">
+                <input id="plan-active" type="checkbox" name="active" class="form-check-input" checked />
+                <label class="form-check-label" for="plan-active">Активный</label>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <button type="submit" class="btn btn-primary mt-4">Создать</button>
+        </div>
     </form>
 </main>
 </html>


### PR DESCRIPTION
## Summary
- add labeled inputs for new plan form to describe all fields

## Testing
- `./mvnw -q test` *(fails: cannot open Maven wrapper)*
- `npm test` *(fails: missing script & npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68573afb7ae8832dbae846b017b84cca