### PR TITLE
Adjust tariff card grid layout

### DIFF
--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -23,7 +23,7 @@
 
         <div class="row justify-content-center g-4">
 
-            <div class="col-md-6 col-lg-5" th:each="plan : ${plans}">
+            <div class="col-12 col-sm-6 col-md-4 col-lg-3" th:each="plan : ${plans}">
                 <div class="card h-100 shadow-sm border-0 rounded-4 d-flex flex-column">
 
                     <!-- Название -->


### PR DESCRIPTION
## Summary
- narrow tariff cards to fit 4 columns on large screens

## Testing
- `npm run build:css` *(fails: sass not found)*
- `./mvnw -q test` *(fails: wrapper not present)*

------
https://chatgpt.com/codex/tasks/task_e_68573affa230832d8ad23ef75b1e4cba