### PR TITLE
Implement tariff purchase flow

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -71,4 +71,27 @@ public class TariffController {
         tariffService.upgradeUser(userId, months);
         return "redirect:/profile";
     }
+
+    /**
+     * Покупает выбранный тарифный план для пользователя.
+     *
+     * @param planCode       код плана
+     * @param months         срок в месяцах
+     * @param authentication текущая аутентификация
+     * @return редирект на страницу профиля
+     */
+    @PostMapping("/buy")
+    public String buy(@RequestParam("plan") String planCode,
+                      @RequestParam(value = "months", defaultValue = "1") int months,
+                      Authentication authentication) {
+        Long userId = userService.extractUserId(authentication);
+        if (userId == null) {
+            return "redirect:/login";
+        }
+        if (months <= 0) {
+            months = 1;
+        }
+        tariffService.buyPlan(userId, planCode, months);
+        return "redirect:/profile";
+    }
 }

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -51,6 +51,21 @@ public class TariffService {
     }
 
     /**
+     * Покупает указанный тарифный план для пользователя.
+     * <p>
+     * Валидация срока подписки выполняется на уровне сервиса подписок.
+     * </p>
+     *
+     * @param userId   идентификатор пользователя
+     * @param planCode код тарифа
+     * @param months   количество месяцев действия тарифа
+     */
+    @Transactional
+    public void buyPlan(Long userId, String planCode, int months) {
+        subscriptionService.changeSubscription(userId, planCode, months);
+    }
+
+    /**
      * Преобразует сущность тарифного плана в DTO для отображения.
      *
      * @param plan сущность тарифного плана

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -91,11 +91,13 @@
                             <button th:if="${authenticatedUser != null}" class="btn btn-outline-secondary w-100" disabled th:text="'Ваш тариф'"></button>
                         </div>
 
-                        <!-- ✅ PREMIUM: переход или продление -->
-                        <form th:if="${plan.code == 'PREMIUM' && (userProfile == null || userProfile.subscriptionCode != plan.code)}" th:action="@{/tariffs/upgrade}" method="post" class="mt-auto">
+                        <!-- ✅ Покупка платного плана -->
+                        <form th:if="${plan.code != 'FREE' && (userProfile == null || userProfile.subscriptionCode != plan.code)}"
+                              th:action="@{/tariffs/buy}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
-                            <button type="submit" class="btn btn-primary w-100" th:text="'Перейти на Premium'"></button>
+                            <input type="hidden" name="plan" th:value="${plan.code}"/>
+                            <button type="submit" class="btn btn-primary w-100" th:text="'Купить'"></button>
                         </form>
 
                     </div>


### PR DESCRIPTION
## Summary
- add ability to buy any tariff via `/tariffs/buy`
- implement service method to change subscription
- hide purchase button for free tariff and show it for paid plans

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68573b18604c832d818c6f0aa465d048