### PR TITLE
Improve admin subscription management

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -205,12 +205,14 @@ public class AdminController {
         UserSubscription subscription = user.getSubscription();
 
         String code = null;
+        String planName = null;
         String subscriptionEndDate = null;
 
         if (subscription != null) {
             SubscriptionPlan plan = subscription.getSubscriptionPlan();
             if (plan != null) {
                 code = plan.getCode();
+                planName = plan.getName();
             }
 
             if (subscription.getSubscriptionEndDate() != null) {
@@ -223,6 +225,7 @@ public class AdminController {
                 user.getId(),
                 user.getEmail(),
                 user.getRole(),
+                planName,
                 code,
                 subscriptionEndDate
         );

--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -180,7 +180,8 @@ public class AdminController {
     /**
      * Отображает детальную информацию о выбранном пользователе.
      *
-     * Загружает в модель список магазинов пользователя и связанные посылки.
+     * Загружает в модель список магазинов пользователя и связанные посылки,
+     * а также список доступных тарифных планов для изменения подписки.
      *
      * @param userId идентификатор пользователя
      * @param model  модель для передачи деталей пользователя
@@ -229,6 +230,8 @@ public class AdminController {
         model.addAttribute("user", adminInfoDTO);
         model.addAttribute("stores", stores);
         model.addAttribute("storeParcels", storeParcels);
+        // Список доступных тарифов для смены подписки
+        model.addAttribute("plans", adminService.getPlans());
 
         // Хлебные крошки
         List<BreadcrumbItemDTO> breadcrumbs = List.of(
@@ -256,14 +259,15 @@ public class AdminController {
     }
 
     /**
-     * Изменяет подписку пользователя.
+     * Изменяет тарифный план пользователя.
      * <p>
-     * При выборе премиум-плана возможно продление подписки на указанное количество месяцев.
+     * При выборе платного плана можно указать срок действия в месяцах. Для бесплатных
+     * тарифов дата окончания обнуляется.
      * </p>
      *
      * @param userId           идентификатор пользователя
-     * @param subscriptionPlan название плана подписки
-     * @param months           количество месяцев продления (необязательно)
+     * @param subscriptionPlan код нового плана подписки
+     * @param months           срок действия в месяцах (для платных тарифов)
      * @return редирект на страницу деталей пользователя
      */
     @PostMapping("/users/{userId}/change-subscription")
@@ -274,10 +278,11 @@ public class AdminController {
             if (months == null || months <= 0) {
                 months = 1; // защита от некорректных значений
             }
-            subscriptionService.upgradeOrExtendSubscription(userId, months);
         } else {
-            subscriptionService.changeSubscription(userId, subscriptionPlan, null);
+            months = null; // для бесплатных тарифов срок не нужен
         }
+
+        subscriptionService.changeSubscription(userId, subscriptionPlan, months);
         return "redirect:/admin/users/" + userId;
     }
 

--- a/src/main/java/com/project/tracking_system/dto/UserDetailsAdminInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserDetailsAdminInfoDTO.java
@@ -18,6 +18,8 @@ public class UserDetailsAdminInfoDTO {
     private Long id;
     private String email;
     private Role role;
+    /** Название текущего тарифного плана */
+    private String subscriptionPlanName;
     private String subscriptionPlanCode;
     private String subscriptionEndDate;
 }

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -23,7 +23,7 @@
             <p><strong>Email:</strong> <span th:text="${user.email}"></span></p>
             <p><strong>Роль:</strong> <span th:text="${user.role}"></span></p>
             <p><strong>Текущий план подписки:</strong>
-                <span th:text="${user.subscriptionPlanCode != null ? user.subscriptionPlanCode : 'Нет подписки'}"></span>
+                <span th:text="${user.subscriptionPlanName != null ? user.subscriptionPlanName : 'Нет подписки'}"></span>
             </p>
             <p><strong>Дата окончания подписки:</strong>
                 <span th:text="${user.subscriptionEndDate}"></span>
@@ -38,8 +38,8 @@
             <div class="mb-3 me-2">
                 <label for="role" class="form-label">Новая роль:</label>
                 <select name="role" id="role" class="form-select form-select-sm">
-                    <option value="ROLE_USER" th:selected="${role == 'ROLE_USER'}">ROLE_USER</option>
-                    <option value="ROLE_ADMIN" th:selected="${role == 'ROLE_ADMIN'}">ROLE_ADMIN</option>
+                    <option value="ROLE_USER" th:selected="${user.role.name() == 'ROLE_USER'}">ROLE_USER</option>
+                    <option value="ROLE_ADMIN" th:selected="${user.role.name() == 'ROLE_ADMIN'}">ROLE_ADMIN</option>
                 </select>
             </div>
             <button type="submit" class="btn btn-primary btn-sm">Обновить роль</button>


### PR DESCRIPTION
## Summary
- expose subscription plans in user detail view
- handle paid-plan term changes correctly

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573e80d92c832da6ebb92331c9c784