### PR TITLE
Improve tariff labels based on user plan

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -38,6 +38,7 @@ public class TariffController {
     @GetMapping
     public String tariffs(Model model, Authentication authentication) {
         Long userId = userService.extractUserId(authentication);
+        Integer userPlanPosition = null;
         if (userId != null) {
             // пользователь авторизован
             model.addAttribute("authenticatedUser", userId);
@@ -45,9 +46,14 @@ public class TariffController {
             // загружаем профиль пользователя для отображения тарифа
             UserProfileDTO profile = userService.getUserProfile(userId);
             model.addAttribute("userProfile", profile);
+
+            if (profile.getSubscriptionCode() != null) {
+                userPlanPosition = tariffService.getPlanPositionByCode(profile.getSubscriptionCode());
+            }
         }
         List<SubscriptionPlanViewDTO> plans = tariffService.getAllPlans();
         model.addAttribute("plans", plans);
+        model.addAttribute("userPlanPosition", userPlanPosition);
         return "tariffs";
     }
 

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -28,4 +28,9 @@ public class SubscriptionPlanViewDTO {
 
     private String annualFullPriceLabel;     // "180 BYN"
     private String annualDiscountLabel;      // "выгода −16%"
+
+    /**
+     * Позиция плана в общей иерархии.
+     */
+    private int position;
 }

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -114,8 +114,24 @@ public class TariffService {
                 monthlyLabel,
                 annualLabel,
                 fullAnnualPriceLabel,
-                discountLabel
+                discountLabel,
+                plan.getPosition()
         );
+    }
+
+    /**
+     * Возвращает позицию плана по его коду.
+     *
+     * @param code код тарифного плана
+     * @return позицию плана или {@code -1}, если план не найден
+     */
+    public int getPlanPositionByCode(String code) {
+        if (code == null) {
+            return -1;
+        }
+        return planRepository.findByCode(code)
+                .map(SubscriptionPlan::getPosition)
+                .orElse(-1);
     }
 
 }

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -85,19 +85,24 @@
                             </button>
                         </div>
 
-                        <!-- 🔒 FREE: тариф по умолчанию -->
-                        <div th:if="${plan.code == 'FREE' && (userProfile == null || userProfile.subscriptionCode != plan.code)}" class="mt-auto">
-                            <a th:if="${authenticatedUser == null}" href="/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
-                            <button th:if="${authenticatedUser != null}" class="btn btn-outline-secondary w-100" disabled th:text="'Ваш тариф'"></button>
+                        <!-- ⬇ Тариф ниже текущего -->
+                        <div th:if="${authenticatedUser != null && userPlanPosition != null && plan.position < userPlanPosition}" class="mt-auto">
+                            <button class="btn btn-outline-secondary w-100" disabled>У вас выше тариф</button>
                         </div>
 
-                        <!-- ✅ Покупка платного плана -->
-                        <form th:if="${plan.code != 'FREE' && (userProfile == null || userProfile.subscriptionCode != plan.code)}"
+                        <!-- 🔒 Бесплатный тариф для незарегистрированных -->
+                        <div th:if="${plan.code == 'FREE' && authenticatedUser == null}" class="mt-auto">
+                            <a href="/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
+                        </div>
+
+                        <!-- ✅ Покупка или улучшение -->
+                        <form th:if="${plan.code != 'FREE' && (userProfile == null || userPlanPosition == null || plan.position > userPlanPosition)}"
                               th:action="@{/tariffs/buy}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <input type="hidden" name="plan" th:value="${plan.code}"/>
-                            <button type="submit" class="btn btn-primary w-100" th:text="'Купить'"></button>
+                            <button type="submit" class="btn btn-primary w-100"
+                                    th:text="${authenticatedUser != null && userPlanPosition != null && plan.position > userPlanPosition ? 'Улучшить план' : 'Купить'}"></button>
                         </form>
 
                     </div>

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -42,6 +42,7 @@ class TariffServiceTest {
         plan.setName("Premium");
         plan.setMonthlyPrice(new BigDecimal("15"));
         plan.setAnnualPrice(new BigDecimal("150"));
+        plan.setPosition(2);
 
         SubscriptionLimits limits = new SubscriptionLimits();
         limits.setMaxTracksPerFile(5);
@@ -71,10 +72,20 @@ class TariffServiceTest {
         assertEquals(1, dtos.size());
         SubscriptionPlanViewDTO dto = dtos.get(0);
         assertEquals("Premium", dto.getName());
+        assertEquals(2, dto.getPosition());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
         assertEquals("выгода −17%", dto.getAnnualDiscountLabel());
+    }
+
+    @Test
+    void getPlanPositionByCode_ReturnsPosition() {
+        when(planRepository.findByCode("PREMIUM")).thenReturn(java.util.Optional.of(plan));
+
+        int pos = tariffService.getPlanPositionByCode("PREMIUM");
+
+        assertEquals(2, pos);
     }
 
     @Test
@@ -83,6 +94,7 @@ class TariffServiceTest {
 
         assertEquals("PREMIUM", dto.getCode());
         assertEquals("Premium", dto.getName());
+        assertEquals(2, dto.getPosition());
         assertEquals(5, dto.getMaxTracksPerFile());
         assertEquals(100, dto.getMaxSavedTracks());
         assertTrue(dto.isAllowBulkUpdate());


### PR DESCRIPTION
## Summary
- include plan position in `SubscriptionPlanViewDTO`
- expose method to get plan position in `TariffService`
- store user plan position in `TariffController` and pass to view
- adjust tariffs template to show **"У вас выше тариф"** or **"Улучшить план"**
- update tests for new field and method

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573f72edac832d9ad5646caeddb2c9