### PR TITLE
Update subscription plan loading

### DIFF
--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -337,7 +337,8 @@ public class SubscriptionService {
      * @return новая подписка пользователя
      */
     public UserSubscription createDefaultSubscriptionForUser(User user) {
-        SubscriptionPlan defaultPlan = subscriptionPlanRepository.findFirstByPrice(BigDecimal.ZERO)
+        SubscriptionPlan defaultPlan = subscriptionPlanRepository
+                .findByCode("FREE")
                 .orElseThrow(() -> new IllegalStateException("Бесплатный план не найден"));
 
         UserSubscription subscription = new UserSubscription();


### PR DESCRIPTION
## Summary
- lookup default subscription plan by code instead of by price

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_68574458ddb8832dbdc0b7a4309bff91