### PR TITLE
Fix custom signature in Telegram notifications

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -26,6 +26,10 @@ public class TelegramNotificationService {
 
     /**
      * Отправить уведомление о смене статуса посылки.
+     * <p>
+     * Если в профиле магазина указана подпись, она будет добавлена
+     * в конец сообщения.
+     * </p>
      *
      * @param parcel посылка
      * @param status новый статус
@@ -50,6 +54,11 @@ public class TelegramNotificationService {
 
         Long chatId = getChatId(parcel);
         String text = buyerStatus.formatMessage(parcel.getNumber(), parcel.getStore().getName());
+
+        if (settings != null && settings.getCustomSignature() != null && !settings.getCustomSignature().isBlank()) {
+            text += "\n\n" + settings.getCustomSignature();
+        }
+
         SendMessage message = new SendMessage(chatId.toString(), text);
 
         try {


### PR DESCRIPTION
## Summary
- append custom signature from store settings to Telegram status update messages
- document the behavior in JavaDoc

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68590c18aa38832da100667ee0c03408