### PR TITLE
Implement automatic track update service

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
@@ -17,6 +17,7 @@ public class SubscriptionLimitsDTO {
     private Integer maxSavedTracks;
     private Integer maxTrackUpdates;
     private boolean allowBulkUpdate;
+    private boolean allowAutoUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
 }

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -20,6 +20,7 @@ public class SubscriptionPlanViewDTO {
     private Integer maxSavedTracks;
     private Integer maxTrackUpdates;
     private boolean allowBulkUpdate;
+    private boolean allowAutoUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
     private String monthlyPriceLabel;

--- a/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
+++ b/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
@@ -13,7 +13,12 @@ public enum FeatureKey {
     /**
      * Отправка Telegram-уведомлений.
      */
-    TELEGRAM_NOTIFICATIONS("telegramNotifications");
+    TELEGRAM_NOTIFICATIONS("telegramNotifications"),
+
+    /**
+     * Автоматическое обновление треков.
+     */
+    AUTO_UPDATE("autoUpdate");
 
     private final String key;
 

--- a/src/main/java/com/project/tracking_system/repository/UserSubscriptionRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/UserSubscriptionRepository.java
@@ -83,4 +83,18 @@ public interface UserSubscriptionRepository extends JpaRepository<UserSubscripti
     @Query("SELECT s FROM UserSubscription s JOIN FETCH s.user u JOIN FETCH s.subscriptionPlan sp")
     List<UserSubscription> findAllWithUserAndPlan();
 
+    /**
+     * Найти идентификаторы пользователей, у которых включена указанная функция.
+     *
+     * @param key ключ функции
+     * @return список идентификаторов пользователей
+     */
+    @Query("""
+        SELECT us.user.id FROM UserSubscription us
+        JOIN us.subscriptionPlan sp
+        JOIN sp.features f
+        WHERE f.featureKey = :key AND f.enabled = true
+        """)
+    List<Long> findUserIdsByFeature(@Param("key") com.project.tracking_system.model.subscription.FeatureKey key);
+
 }

--- a/src/main/java/com/project/tracking_system/service/SchedulerInitializer.java
+++ b/src/main/java/com/project/tracking_system/service/SchedulerInitializer.java
@@ -21,6 +21,7 @@ public class SchedulerInitializer {
     public static final long JWT_REFRESH_ID = 3L;
     public static final long SUBSCRIPTION_CHECK_ID = 4L;
     public static final long TOKEN_CLEANUP_ID = 5L;
+    public static final long AUTO_UPDATE_ID = 6L;
 
     private final DynamicSchedulerService schedulerService;
     private final StatsAggregationService statsAggregationService;
@@ -28,6 +29,7 @@ public class SchedulerInitializer {
     private final JwtTokenManager jwtTokenManager;
     private final SubscriptionExpirationScheduler subscriptionExpirationScheduler;
     private final TokenCleanupService tokenCleanupService;
+    private final com.project.tracking_system.service.track.TrackAutoUpdateScheduler trackAutoUpdateScheduler;
 
     /**
      * Регистрирует все задачи в динамическом планировщике.
@@ -39,5 +41,6 @@ public class SchedulerInitializer {
         schedulerService.registerTask(JWT_REFRESH_ID, jwtTokenManager::scheduledTokenRefresh);
         schedulerService.registerTask(SUBSCRIPTION_CHECK_ID, subscriptionExpirationScheduler::checkExpiredSubscriptions);
         schedulerService.registerTask(TOKEN_CLEANUP_ID, tokenCleanupService::cleanupExpiredTokens);
+        schedulerService.registerTask(AUTO_UPDATE_ID, trackAutoUpdateScheduler::updateAllUsersTracks);
     }
 }

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -174,6 +174,16 @@ public class SubscriptionService {
     }
 
     /**
+     * Проверяет, разрешено ли автообновление треков для пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если функция включена в тарифе
+     */
+    public boolean canUseAutoUpdate(Long userId) {
+        return isFeatureEnabled(userId, FeatureKey.AUTO_UPDATE);
+    }
+
+    /**
      * Проверяет, разрешены ли Telegram-уведомления для пользователя.
      *
      * @param userId идентификатор пользователя

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -54,6 +54,7 @@ public class SubscriptionPlanService {
         }
         // флаги функций определяем через список features
         limitsDto.setAllowBulkUpdate(plan.isFeatureEnabled(FeatureKey.BULK_UPDATE));
+        limitsDto.setAllowAutoUpdate(plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE));
         limitsDto.setAllowTelegramNotifications(plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS));
 
         SubscriptionPlanDTO dto = new SubscriptionPlanDTO();
@@ -94,6 +95,7 @@ public class SubscriptionPlanService {
 
             // обновляем признаки доступности функций
             setFeature(plan, FeatureKey.BULK_UPDATE, l.isAllowBulkUpdate());
+            setFeature(plan, FeatureKey.AUTO_UPDATE, l.isAllowAutoUpdate());
             setFeature(plan, FeatureKey.TELEGRAM_NOTIFICATIONS, l.isAllowTelegramNotifications());
         }
 

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -109,6 +109,7 @@ public class TariffService {
                 limits.getMaxSavedTracks(),
                 limits.getMaxTrackUpdates(),
                 plan.isFeatureEnabled(FeatureKey.BULK_UPDATE),
+                plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE),
                 limits.getMaxStores(),
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
                 monthlyLabel,

--- a/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
@@ -1,0 +1,88 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.model.subscription.FeatureKey;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.UserSubscriptionRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.service.track.TrackProcessingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Планировщик автоматического обновления треков.
+ * <p>
+ * Выполняет обход пользователей, для которых в тарифе
+ * разрешено автоматическое обновление, и обновляет их активные треки.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrackAutoUpdateScheduler {
+
+    private final UserSubscriptionRepository userSubscriptionRepository;
+    private final TrackParcelRepository trackParcelRepository;
+    private final TrackProcessingService trackProcessingService;
+    private final SubscriptionService subscriptionService;
+
+    /**
+     * Запускает автообновление треков для всех подходящих пользователей.
+     */
+    @Transactional
+    public void updateAllUsersTracks() {
+        List<Long> userIds = userSubscriptionRepository.findUserIdsByFeature(FeatureKey.AUTO_UPDATE);
+        if (userIds.isEmpty()) {
+            log.info("Нет пользователей с автообновлением треков");
+            return;
+        }
+
+        for (Long userId : userIds) {
+            updateUserTracks(userId);
+        }
+    }
+
+    private void updateUserTracks(Long userId) {
+        List<TrackParcel> parcels = trackParcelRepository.findByUserId(userId);
+        List<TrackParcel> toUpdate = parcels.stream()
+                .filter(p -> !p.getStatus().isFinal())
+                .toList();
+
+        if (toUpdate.isEmpty()) {
+            return;
+        }
+
+        int allowed = subscriptionService.canUpdateTracks(userId, toUpdate.size());
+        if (allowed <= 0) {
+            log.debug("Лимит автообновлений исчерпан для userId={}", userId);
+            return;
+        }
+
+        int updated = 0;
+        for (int i = 0; i < Math.min(allowed, toUpdate.size()); i++) {
+            TrackParcel parcel = toUpdate.get(i);
+            try {
+                TrackInfoListDTO info = trackProcessingService.processTrack(
+                        parcel.getNumber(),
+                        parcel.getStore().getId(),
+                        userId,
+                        true
+                );
+                if (info != null && !info.getList().isEmpty()) {
+                    updated++;
+                }
+            } catch (Exception e) {
+                log.error("Ошибка автообновления трека {}: {}", parcel.getNumber(), e.getMessage());
+            }
+        }
+
+        if (updated > 0) {
+            log.info("♻️ Автообновление: {} из {} треков обновлено для userId={}", updated, toUpdate.size(), userId);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V32__add_auto_update_feature.sql
+++ b/src/main/resources/db/migration/V32__add_auto_update_feature.sql
@@ -1,0 +1,7 @@
+-- Добавление функции автоматического обновления треков
+INSERT INTO subscription_features (subscription_plan_id, feature_key, enabled)
+SELECT id, 'AUTO_UPDATE', false FROM subscription_plans;
+
+-- Планировщик автоматического обновления треков
+INSERT INTO tb_scheduled_task_config(id, description, cron, zone)
+VALUES (6, 'Автообновление треков', '0 0 6 * * *', 'UTC');

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -20,6 +20,7 @@
             <th>Цена в месяц</th>
             <th>Цена в год</th>
             <th>Массовое обновление</th>
+            <th>Автообновление</th>
             <th>Telegram-уведомления</th>
             <th>Активный</th>
             <th>Действия</th>
@@ -38,6 +39,7 @@
                 <td><input type="number" step="0.01" name="monthlyPrice" class="form-control" th:value="${plan.monthlyPrice}" /></td>
                 <td><input type="number" step="0.01" name="annualPrice" class="form-control" th:value="${plan.annualPrice}" /></td>
                 <td class="text-center"><input type="checkbox" name="limits.allowBulkUpdate" th:checked="${plan.limits.allowBulkUpdate}" /></td>
+                <td class="text-center"><input type="checkbox" name="limits.allowAutoUpdate" th:checked="${plan.limits.allowAutoUpdate}" /></td>
                 <td class="text-center"><input type="checkbox" name="limits.allowTelegramNotifications" th:checked="${plan.limits.allowTelegramNotifications}" /></td>
                 <td class="text-center"><input type="checkbox" name="active" th:checked="${plan.active}" /></td>
                 <td>
@@ -90,6 +92,12 @@
             <div class="form-check">
                 <input id="plan-bulk-update" type="checkbox" name="limits.allowBulkUpdate" class="form-check-input" />
                 <label class="form-check-label" for="plan-bulk-update">Массовое обновление</label>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <div class="form-check">
+                <input id="plan-auto-update" type="checkbox" name="limits.allowAutoUpdate" class="form-check-input" />
+                <label class="form-check-label" for="plan-auto-update">Автообновление</label>
             </div>
         </div>
         <div class="col-md-1">

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -72,6 +72,10 @@
                                 <span th:unless="${plan.allowBulkUpdate}" class="text-muted">❌ Массовое обновление</span>
                             </li>
                             <li>
+                                <span th:if="${plan.allowAutoUpdate}">♻️ Автообновление треков</span>
+                                <span th:unless="${plan.allowAutoUpdate}" class="text-muted">❌ Автообновление треков</span>
+                            </li>
+                            <li>
                                 <span th:if="${plan.allowTelegramNotifications}">📨 Telegram-уведомления</span>
                                 <span th:unless="${plan.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
                             </li>

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -56,11 +56,15 @@ class TariffServiceTest {
         bulk.setFeatureKey(FeatureKey.BULK_UPDATE);
         bulk.setEnabled(true);
         bulk.setSubscriptionPlan(plan);
+        SubscriptionFeature auto = new SubscriptionFeature();
+        auto.setFeatureKey(FeatureKey.AUTO_UPDATE);
+        auto.setEnabled(true);
+        auto.setSubscriptionPlan(plan);
         SubscriptionFeature telegram = new SubscriptionFeature();
         telegram.setFeatureKey(FeatureKey.TELEGRAM_NOTIFICATIONS);
         telegram.setEnabled(true);
         telegram.setSubscriptionPlan(plan);
-        plan.setFeatures(List.of(bulk, telegram));
+        plan.setFeatures(List.of(bulk, auto, telegram));
     }
 
     @Test
@@ -98,6 +102,7 @@ class TariffServiceTest {
         assertEquals(5, dto.getMaxTracksPerFile());
         assertEquals(100, dto.getMaxSavedTracks());
         assertTrue(dto.isAllowBulkUpdate());
+        assertTrue(dto.isAllowAutoUpdate());
         assertTrue(dto.isAllowTelegramNotifications());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());


### PR DESCRIPTION
## Summary
- add AUTO_UPDATE subscription feature
- expose feature in DTOs and tariffs pages
- support editing auto update in admin plans
- add scheduler service to update tracks automatically
- register new scheduled task and migration

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592fca2cd4832d80364ad82e0a05e0