### PR TITLE
Add auto-update setting for user tracks

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -160,6 +160,33 @@ public class ProfileController {
     }
 
     /**
+     * Изменяет настройку автообновления треков пользователя.
+     *
+     * @param enabled        новое значение флага
+     * @param authentication текущая аутентификация
+     * @return результат операции
+     */
+    @PostMapping("/settings/auto-update")
+    public ResponseEntity<?> updateAutoUpdate(
+            @RequestParam(value = "enabled", required = false) Boolean enabled,
+            Authentication authentication) {
+
+        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+
+        if (enabled == null) {
+            return ResponseBuilder.error(HttpStatus.BAD_REQUEST, "Не указан параметр enabled");
+        }
+
+        try {
+            userService.updateAutoUpdateEnabled(userId, enabled);
+            return ResponseBuilder.ok("Настройки успешно обновлены.");
+        } catch (Exception e) {
+            log.error("Ошибка обновления автообновления для пользователя {}: {}", userId, e.getMessage(), e);
+            return ResponseBuilder.error(HttpStatus.INTERNAL_SERVER_ERROR, "Ошибка при обновлении настроек.");
+        }
+    }
+
+    /**
      * Обрабатывает запросы на изменение настроек пользователя, включая смену пароля.
      * <p>
      * Этот метод выполняет валидацию нового пароля, проверку совпадения паролей и изменение пароля через сервис.

--- a/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
@@ -19,6 +19,7 @@ public class UserProfileDTO {
     private String timezone;
     private String subscriptionCode;
     private String subscriptionEndDate;
+    private boolean autoUpdateEnabled;
 
     public String getSubscriptionDisplayName() {
         return subscriptionCode != null ? subscriptionCode : "Без подписки";

--- a/src/main/java/com/project/tracking_system/entity/UserSubscription.java
+++ b/src/main/java/com/project/tracking_system/entity/UserSubscription.java
@@ -36,6 +36,9 @@ public class UserSubscription {
     @Column(name = "subscription_end_date")
     private ZonedDateTime subscriptionEndDate;
 
+    @Column(name = "auto_update_enabled", nullable = false)
+    private boolean autoUpdateEnabled = true;
+
     @Column(name = "update_count")
     private int updateCount = 0;
 

--- a/src/main/java/com/project/tracking_system/repository/UserSubscriptionRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/UserSubscriptionRepository.java
@@ -93,8 +93,33 @@ public interface UserSubscriptionRepository extends JpaRepository<UserSubscripti
         SELECT us.user.id FROM UserSubscription us
         JOIN us.subscriptionPlan sp
         JOIN sp.features f
-        WHERE f.featureKey = :key AND f.enabled = true
+        WHERE f.featureKey = :key AND f.enabled = true AND us.autoUpdateEnabled = true
         """)
     List<Long> findUserIdsByFeature(@Param("key") com.project.tracking_system.model.subscription.FeatureKey key);
+
+    /**
+     * Проверить, включено ли автообновление треков у пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если автообновление разрешено
+     */
+    @Query("SELECT us.autoUpdateEnabled FROM UserSubscription us WHERE us.user.id = :userId")
+    boolean isAutoUpdateEnabled(@Param("userId") Long userId);
+
+    /**
+     * Обновить флаг автообновления треков.
+     *
+     * @param userId идентификатор пользователя
+     * @param enabled новое значение флага
+     * @return количество обновлённых записей
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE UserSubscription us
+        SET us.autoUpdateEnabled = :enabled
+        WHERE us.user.id = :userId
+        """)
+    int updateAutoUpdateEnabled(@Param("userId") Long userId, @Param("enabled") boolean enabled);
 
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.service.track.TrackProcessingService;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class TrackAutoUpdateScheduler {
     private final TrackParcelRepository trackParcelRepository;
     private final TrackProcessingService trackProcessingService;
     private final SubscriptionService subscriptionService;
+    private final UserService userService;
 
     /**
      * Запускает автообновление треков для всех подходящих пользователей.
@@ -43,7 +45,9 @@ public class TrackAutoUpdateScheduler {
         }
 
         for (Long userId : userIds) {
-            updateUserTracks(userId);
+            if (userService.isAutoUpdateEnabled(userId)) {
+                updateUserTracks(userId);
+            }
         }
     }
 

--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -312,6 +312,27 @@ public class UserService {
     }
 
     /**
+     * Проверяет, включено ли автообновление треков у пользователя.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если автообновление разрешено
+     */
+    public boolean isAutoUpdateEnabled(Long userId) {
+        return userSubscriptionRepository.isAutoUpdateEnabled(userId);
+    }
+
+    /**
+     * Обновляет настройку автообновления треков пользователя.
+     *
+     * @param userId  идентификатор пользователя
+     * @param enabled новое значение флага
+     */
+    public void updateAutoUpdateEnabled(Long userId, boolean enabled) {
+        userSubscriptionRepository.updateAutoUpdateEnabled(userId, enabled);
+        log.info("Настройка autoUpdateEnabled обновлена для пользователя {}: {}", userId, enabled);
+    }
+
+    /**
      * Получает сохранённые учётные данные Evropost пользователя.
      *
      * @param userId идентификатор пользователя
@@ -535,11 +556,16 @@ public class UserService {
                     .format(subscription.getSubscriptionEndDate());
         }
 
+        boolean autoUpdate = Optional.ofNullable(subscription)
+                .map(UserSubscription::isAutoUpdateEnabled)
+                .orElse(true);
+
         return new UserProfileDTO(
                 user.getEmail(),
                 user.getTimeZone(),
                 planCode,
-                formattedEndDate
+                formattedEndDate,
+                autoUpdate
         );
     }
 

--- a/src/main/resources/db/migration/V33__add_auto_update_enabled_to_user_subscriptions.sql
+++ b/src/main/resources/db/migration/V33__add_auto_update_enabled_to_user_subscriptions.sql
@@ -1,0 +1,3 @@
+-- Добавление флага разрешения автообновления треков
+ALTER TABLE tb_user_subscriptions
+    ADD COLUMN auto_update_enabled BOOLEAN DEFAULT TRUE;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -172,6 +172,33 @@ function initializeCustomCredentialsCheckbox() {
     }
 }
 
+// Инициализация переключателя автообновления треков
+function initAutoUpdateToggle() {
+    const checkbox = document.getElementById("autoUpdateToggle");
+    if (!checkbox) return;
+
+    let debounceTimer;
+    checkbox.addEventListener('change', function () {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            fetch('/profile/settings/auto-update', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    [document.querySelector('meta[name="_csrf_header"]').content]: document.querySelector('meta[name="_csrf"]').content
+                },
+                body: new URLSearchParams({ enabled: checkbox.checked })
+            }).then(response => {
+                if (!response.ok) {
+                    alert('Ошибка при обновлении настройки.');
+                }
+            }).catch(() => {
+                alert('Ошибка сети при обновлении настройки.');
+            });
+        }, 300);
+    });
+}
+
 // Инициализация переключателя для ввода телефона
 function initializePhoneToggle() {
     const toggle = document.getElementById("togglePhone");
@@ -1157,6 +1184,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initPasswordFormHandler();
     initEvropostFormHandler();
     initializeCustomCredentialsCheckbox();
+    initAutoUpdateToggle();
     initializePhoneToggle();
     initAssignCustomerFormHandler();
     initTelegramForms();

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -118,6 +118,15 @@
                         <div class="col-sm-4 text-muted">Часовой пояс</div>
                         <div class="col-sm-8" th:text="${userProfile.timezone}"></div>
                     </div>
+                    <form id="auto-update-form" class="mt-3">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="autoUpdateToggle"
+                                   th:checked="${userProfile.autoUpdateEnabled}">
+                            <label class="form-check-label" for="autoUpdateToggle">Автообновление треков</label>
+                        </div>
+                        <p class="form-text ms-4">Автообновления расходуют лимит обновлений.</p>
+                    </form>
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-stores" role="tabpanel">


### PR DESCRIPTION
## Summary
- add migration for auto_update_enabled field
- store autoUpdateEnabled flag in `UserSubscription`
- extend repository with methods to check and update the flag
- expose service methods for auto-update setting
- filter scheduler with isAutoUpdateEnabled
- add endpoint and UI toggle in profile to change auto update
- handle toggle via JavaScript
- include autoUpdateEnabled in UserProfileDTO

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685936e0da98832d9782715d19707e9c