### PR TITLE
Add plan details to profile

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -75,6 +75,7 @@ public class ProfileController {
         // Добавляем данные профиля в модель
         model.addAttribute("username", user.getEmail());
         model.addAttribute("userProfile", userProfile);
+        model.addAttribute("planDetails", userProfile.getPlanDetails());
         model.addAttribute("storeLimit", storeLimit);
         model.addAttribute("stores", stores);
         log.debug("Данные профиля добавлены в модель для пользователя с ID: {}", userId);

--- a/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 
+import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
+
 /**
  * @author Dmitriy Anisimov
  * @date 21.03.2025
@@ -20,6 +22,10 @@ public class UserProfileDTO {
     private String subscriptionCode;
     private String subscriptionEndDate;
     private boolean autoUpdateEnabled;
+    /**
+     * Детальная информация о текущем тарифном плане пользователя.
+     */
+    private SubscriptionPlanViewDTO planDetails;
 
     public String getSubscriptionDisplayName() {
         return subscriptionCode != null ? subscriptionCode : "Без подписки";

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -135,4 +135,19 @@ public class TariffService {
                 .orElse(-1);
     }
 
+    /**
+     * Находит тарифный план по его коду и возвращает информацию для отображения.
+     *
+     * @param code код плана
+     * @return DTO с данными плана или {@code null}, если план не найден
+     */
+    public SubscriptionPlanViewDTO getPlanInfoByCode(String code) {
+        if (code == null) {
+            return null;
+        }
+        return planRepository.findByCode(code)
+                .map(this::toViewDto)
+                .orElse(null);
+    }
+
 }

--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -9,6 +9,8 @@ import com.project.tracking_system.entity.*;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
 import com.project.tracking_system.repository.*;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.tariff.TariffService;
+import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
 import com.project.tracking_system.service.email.EmailService;
 import com.project.tracking_system.service.jsonEvropostService.JwtTokenManager;
 import com.project.tracking_system.service.store.StoreService;
@@ -58,6 +60,7 @@ public class UserService {
     private final UserCredentialsResolver userCredentialsResolver;
     private final SubscriptionService subscriptionService;
     private final StoreService storeService;
+    private final TariffService tariffService;
 
     /**
      * Отправляет код подтверждения на email для регистрации нового пользователя.
@@ -560,12 +563,15 @@ public class UserService {
                 .map(UserSubscription::isAutoUpdateEnabled)
                 .orElse(true);
 
+        SubscriptionPlanViewDTO planDetails = tariffService.getPlanInfoByCode(planCode);
+
         return new UserProfileDTO(
                 user.getEmail(),
                 user.getTimeZone(),
                 planCode,
                 formattedEndDate,
-                autoUpdate
+                autoUpdate,
+                planDetails
         );
     }
 

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -127,6 +127,36 @@
                         </div>
                         <p class="form-text ms-4">Автообновления расходуют дневной лимит обновлений.</p>
                     </form>
+
+                    <div class="mt-4">
+                        <h6 class="mb-2">Возможности тарифа</h6>
+                        <ul class="list-unstyled">
+                            <li>📥 Треков в файле:
+                                <strong th:text="${planDetails.maxTracksPerFile != null ? planDetails.maxTracksPerFile : 'Без лимита'}"></strong>
+                            </li>
+                            <li>💾 Сохранённых треков:
+                                <strong th:text="${planDetails.maxSavedTracks != null ? planDetails.maxSavedTracks : 'Без лимита'}"></strong>
+                            </li>
+                            <li>🔄 Обновлений в день:
+                                <strong th:text="${planDetails.maxTrackUpdates != null ? planDetails.maxTrackUpdates : 'Без лимита'}"></strong>
+                            </li>
+                            <li>🏬 Магазинов:
+                                <strong th:text="${planDetails.maxStores}"></strong>
+                            </li>
+                            <li>
+                                <span th:if="${planDetails.allowBulkUpdate}">✅ Массовое обновление</span>
+                                <span th:unless="${planDetails.allowBulkUpdate}" class="text-muted">❌ Массовое обновление</span>
+                            </li>
+                            <li>
+                                <span th:if="${planDetails.allowAutoUpdate}">♻️ Автообновление треков</span>
+                                <span th:unless="${planDetails.allowAutoUpdate}" class="text-muted">❌ Автообновление треков</span>
+                            </li>
+                            <li>
+                                <span th:if="${planDetails.allowTelegramNotifications}">📨 Telegram-уведомления</span>
+                                <span th:unless="${planDetails.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
 
                 <div class="tab-pane fade" id="v-pills-stores" role="tabpanel">

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -109,4 +109,23 @@ class TariffServiceTest {
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
         assertEquals("выгода −17%", dto.getAnnualDiscountLabel());
     }
+
+    @Test
+    void getPlanInfoByCode_ReturnsDto() {
+        when(planRepository.findByCode("PREMIUM")).thenReturn(java.util.Optional.of(plan));
+
+        SubscriptionPlanViewDTO dto = tariffService.getPlanInfoByCode("PREMIUM");
+
+        assertNotNull(dto);
+        assertEquals("PREMIUM", dto.getCode());
+    }
+
+    @Test
+    void getPlanInfoByCode_NotFound_ReturnsNull() {
+        when(planRepository.findByCode("NONE")).thenReturn(java.util.Optional.empty());
+
+        SubscriptionPlanViewDTO dto = tariffService.getPlanInfoByCode("NONE");
+
+        assertNull(dto);
+    }
 }

--- a/src/test/java/com/project/tracking_system/service/user/UserServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/user/UserServiceTest.java
@@ -1,0 +1,95 @@
+package com.project.tracking_system.service.user;
+
+import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
+import com.project.tracking_system.dto.UserProfileDTO;
+import com.project.tracking_system.entity.SubscriptionPlan;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.entity.UserSubscription;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.repository.EvropostServiceCredentialRepository;
+import com.project.tracking_system.repository.ConfirmationTokenRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.email.EmailService;
+import com.project.tracking_system.service.jsonEvropostService.JwtTokenManager;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.tariff.TariffService;
+import com.project.tracking_system.utils.EncryptionUtils;
+import com.project.tracking_system.utils.RandomlyGeneratedString;
+import com.project.tracking_system.utils.UserCredentialsResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link UserService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EvropostServiceCredentialRepository evropostServiceCredentialRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private RandomlyGeneratedString randomlyGeneratedString;
+    @Mock
+    private ConfirmationTokenRepository confirmationTokenRepository;
+    @Mock
+    private EncryptionUtils encryptionUtils;
+    @Mock
+    private JwtTokenManager jwtTokenManager;
+    @Mock
+    private UserCredentialsResolver userCredentialsResolver;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private StoreService storeService;
+    @Mock
+    private TariffService tariffService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void getUserProfile_FillsPlanDetails() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("user@example.com");
+        user.setTimeZone("Europe/Minsk");
+
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setCode("PREMIUM");
+        UserSubscription subscription = new UserSubscription();
+        subscription.setSubscriptionPlan(plan);
+        subscription.setAutoUpdateEnabled(false);
+        subscription.setSubscriptionEndDate(ZonedDateTime.now(ZoneOffset.UTC));
+        user.setSubscription(subscription);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        SubscriptionPlanViewDTO planDto = new SubscriptionPlanViewDTO();
+        planDto.setCode("PREMIUM");
+        when(tariffService.getPlanInfoByCode("PREMIUM")).thenReturn(planDto);
+
+        UserProfileDTO dto = userService.getUserProfile(1L);
+
+        assertEquals("user@example.com", dto.getEmail());
+        assertFalse(dto.isAutoUpdateEnabled());
+        assertNotNull(dto.getPlanDetails());
+        assertEquals("PREMIUM", dto.getPlanDetails().getCode());
+        verify(tariffService).getPlanInfoByCode("PREMIUM");
+    }
+}


### PR DESCRIPTION
## Summary
- extend `UserProfileDTO` with plan details
- provide `TariffService.getPlanInfoByCode`
- include plan info in `UserService.getUserProfile`
- expose plan info via `ProfileController`
- display tariff capabilities in `profile.html`
- test `TariffService#getPlanInfoByCode` and profile retrieval

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68594156381c832d9f1e5d93cad3b602