### PR TITLE
Implement subscription name and limit usage display

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserProfileDTO.java
@@ -20,14 +20,24 @@ public class UserProfileDTO {
     private String email;
     private String timezone;
     private String subscriptionCode;
+    private String subscriptionName;
     private String subscriptionEndDate;
     private boolean autoUpdateEnabled;
     /**
      * Детальная информация о текущем тарифном плане пользователя.
      */
     private SubscriptionPlanViewDTO planDetails;
+    /** Количество сохранённых треков пользователя. */
+    private int savedTracksUsed;
+    /** Количество обновлений треков, выполненных сегодня. */
+    private int trackUpdatesUsed;
+    /** Количество созданных магазинов пользователя. */
+    private int storesUsed;
 
     public String getSubscriptionDisplayName() {
+        if (subscriptionName != null) {
+            return subscriptionName;
+        }
         return subscriptionCode != null ? subscriptionCode : "Без подписки";
     }
 }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -135,13 +135,13 @@
                                 <strong th:text="${planDetails.maxTracksPerFile != null ? planDetails.maxTracksPerFile : 'Без лимита'}"></strong>
                             </li>
                             <li>💾 Сохранённых треков:
-                                <strong th:text="${planDetails.maxSavedTracks != null ? planDetails.maxSavedTracks : 'Без лимита'}"></strong>
+                                <strong th:text="${planDetails.maxSavedTracks != null ? userProfile.savedTracksUsed + '/' + planDetails.maxSavedTracks : userProfile.savedTracksUsed + '/∞'}"></strong>
                             </li>
                             <li>🔄 Обновлений в день:
-                                <strong th:text="${planDetails.maxTrackUpdates != null ? planDetails.maxTrackUpdates : 'Без лимита'}"></strong>
+                                <strong th:text="${planDetails.maxTrackUpdates != null ? userProfile.trackUpdatesUsed + '/' + planDetails.maxTrackUpdates : 'Без лимита'}"></strong>
                             </li>
                             <li>🏬 Магазинов:
-                                <strong th:text="${planDetails.maxStores}"></strong>
+                                <strong th:text="${userProfile.storesUsed + '/' + planDetails.maxStores}"></strong>
                             </li>
                             <li>
                                 <span th:if="${planDetails.allowBulkUpdate}">✅ Массовое обновление</span>


### PR DESCRIPTION
## Summary
- show the subscription name rather than the code
- display usage of saved tracks, daily updates and stores in profile

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685947e050b4832d8ae9d427f2c01332