### PR TITLE
Inject TariffService for admin settings

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -10,6 +10,7 @@ import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.admin.AdminService;
 import com.project.tracking_system.service.admin.AppInfoService;
 import com.project.tracking_system.service.admin.SubscriptionPlanService;
+import com.project.tracking_system.service.tariff.TariffService;
 import com.project.tracking_system.service.DynamicSchedulerService;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,7 @@ public class AdminController {
     private final AdminService adminService;
     private final AppInfoService appInfoService;
     private final DynamicSchedulerService dynamicSchedulerService;
+    private final TariffService tariffService;
 
     /**
      * Отображает дашборд администратора.
@@ -546,7 +548,7 @@ public class AdminController {
     public String settings(Model model) {
         model.addAttribute("appVersion", appInfoService.getApplicationVersion());
         model.addAttribute("webhookEnabled", appInfoService.isTelegramWebhookEnabled());
-        model.addAttribute("plans", appInfoService.getPlans());
+        model.addAttribute("plans", tariffService.getAllPlans());
 
         // Хлебные крошки
         List<BreadcrumbItemDTO> breadcrumbs = List.of(


### PR DESCRIPTION
## Summary
- wire TariffService into AdminController
- use tariffService to fetch plan info for settings page

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_68594c61ef60832dad766ea77bcaa432