### PR TITLE
Handle absent limits in TariffService

### DIFF
--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -102,14 +102,27 @@ public class TariffService {
 
         SubscriptionLimits limits = plan.getLimits();
 
+        // при отсутствии лимитов возвращаем значения по умолчанию
+        Integer maxTracksPerFile = null;
+        Integer maxSavedTracks = null;
+        Integer maxTrackUpdates = null;
+        Integer maxStores = null;
+
+        if (limits != null) {
+            maxTracksPerFile = limits.getMaxTracksPerFile();
+            maxSavedTracks = limits.getMaxSavedTracks();
+            maxTrackUpdates = limits.getMaxTrackUpdates();
+            maxStores = limits.getMaxStores();
+        }
+
         return new SubscriptionPlanViewDTO(
                 plan.getCode(),
                 plan.getName(),
-                limits.getMaxTracksPerFile(),
-                limits.getMaxSavedTracks(),
-                limits.getMaxTrackUpdates(),
+                maxTracksPerFile,
+                maxSavedTracks,
+                maxTrackUpdates,
                 plan.isFeatureEnabled(FeatureKey.BULK_UPDATE),
-                limits.getMaxStores(),
+                maxStores,
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
                 monthlyLabel,
                 annualLabel,

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -104,4 +104,18 @@ class TariffServiceTest {
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
         assertEquals("выгода −17%", dto.getAnnualDiscountLabel());
     }
+
+    @Test
+    void toViewDto_LimitsNull_ReturnsDtoWithDefaultValues() {
+        plan.setLimits(null);
+
+        SubscriptionPlanViewDTO dto = tariffService.toViewDto(plan);
+
+        assertNull(dto.getMaxTracksPerFile());
+        assertNull(dto.getMaxSavedTracks());
+        assertNull(dto.getMaxTrackUpdates());
+        assertNull(dto.getMaxStores());
+        assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
+        assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
+    }
 }


### PR DESCRIPTION
## Summary
- handle missing limits in `TariffService.toViewDto`
- add unit test for plans without limits

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594d57aa24832da0e3308c1608a56e