### PR TITLE
Fix admin settings tariff info binding

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -10,6 +10,7 @@ import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.admin.AdminService;
 import com.project.tracking_system.service.admin.AppInfoService;
 import com.project.tracking_system.service.admin.SubscriptionPlanService;
+import com.project.tracking_system.service.tariff.TariffService;
 import com.project.tracking_system.service.DynamicSchedulerService;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,7 @@ public class AdminController {
     private final AdminService adminService;
     private final AppInfoService appInfoService;
     private final DynamicSchedulerService dynamicSchedulerService;
+    private final TariffService tariffService;
 
     /**
      * Отображает дашборд администратора.
@@ -540,13 +542,15 @@ public class AdminController {
     /**
      * Отображает страницу настроек администратора.
      *
+     * @param model модель представления для передачи параметров
      * @return имя шаблона настроек
      */
     @GetMapping("/settings")
     public String settings(Model model) {
         model.addAttribute("appVersion", appInfoService.getApplicationVersion());
         model.addAttribute("webhookEnabled", appInfoService.isTelegramWebhookEnabled());
-        model.addAttribute("plans", appInfoService.getPlans());
+        // для таблицы тарифов используем DTO с лимитами и признаками функций
+        model.addAttribute("plans", tariffService.getAllPlans());
 
         // Хлебные крошки
         List<BreadcrumbItemDTO> breadcrumbs = List.of(


### PR DESCRIPTION
## Summary
- load tariff DTOs in AdminController settings page
- inject `TariffService` for DTO creation
- document `settings` method parameter

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6859a36d04bc832da617619c5e047055