### PR TITLE
Use property for remember-me key

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,6 @@ application.version=0.0.1-SNAPSHOT
 telegram.webhook.enabled=false
 websocket.allowed-origins=*
 csp.allowed-connect-origins=wss://belivery.by,ws://localhost:8080
+
+# Уникальный ключ для механизма remember-me
+security.remember-me-key=


### PR DESCRIPTION
## Summary
- inject remember-me key via `@Value`
- log warning when default key is used
- document `security.remember-me-key` property

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ab16fcdc832d96c27d0b35cbfce5