### PR TITLE
Implement selective JWT token refresh

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/UserRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/UserRepository.java
@@ -63,4 +63,24 @@ public interface UserRepository extends JpaRepository <User, Long> {
                              @Param("role") Role role,
                              @Param("subscription") String subscription);
 
+    /**
+     * Найти пользователей с просроченным JWT токеном Европочты.
+     * <p>
+     * Пользователь должен иметь учётные данные Европочты и использовать
+     * собственные данные для подключения к API. Метод выбирает только тех
+     * пользователей, у кого токен отсутствует или создан раньше указанной
+     * даты.
+     * </p>
+     *
+     * @param expiryDate дата, раньше которой токен считается просроченным
+     * @return список пользователей с истекшим токеном
+     */
+    @Query("""
+        SELECT u FROM User u
+        JOIN u.evropostServiceCredential esc
+        WHERE esc.useCustomCredentials = true
+          AND (esc.tokenCreatedAt IS NULL OR esc.tokenCreatedAt < :expiryDate)
+        """)
+    List<User> findUsersForTokenRefresh(@Param("expiryDate") java.time.ZonedDateTime expiryDate);
+
 }

--- a/src/main/java/com/project/tracking_system/service/jsonEvropostService/JwtTokenManager.java
+++ b/src/main/java/com/project/tracking_system/service/jsonEvropostService/JwtTokenManager.java
@@ -164,11 +164,10 @@ public class JwtTokenManager {
         try {
             refreshSystemTokenIfExpired();
 
-            List<User> users = userRepository.findAll().stream()
-                    .filter(user -> user.getEvropostServiceCredential() != null)
-                    .filter(user -> user.getEvropostServiceCredential().getUseCustomCredentials()) // Только пользователи с пользовательскими кредами
-                    .filter(this::isUserTokenExpired)      // Проверяем, истёк ли токен
-                    .toList();
+            java.time.ZonedDateTime threshold = java.time.ZonedDateTime
+                    .now(java.time.ZoneOffset.UTC)
+                    .minusDays(TOKEN_LIFETIME_DAYS);
+            List<User> users = userRepository.findUsersForTokenRefresh(threshold);
 
             for (User user : users) {
                 log.info("Обновление токена для пользователя: {}", user.getEmail());

--- a/src/test/java/com/project/tracking_system/repository/UserRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/UserRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.EvropostServiceCredential;
+import com.project.tracking_system.entity.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты для {@link UserRepository}.
+ */
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager entityManager;
+
+    @Test
+    void findUsersForTokenRefresh_ReturnsOnlyExpired() {
+        User expired = new User();
+        expired.setEmail("expired@example.com");
+        expired.setPassword("pass");
+        expired.setTimeZone("UTC");
+        EvropostServiceCredential credExpired = new EvropostServiceCredential();
+        credExpired.setUser(expired);
+        credExpired.setUseCustomCredentials(true);
+        credExpired.setTokenCreatedAt(ZonedDateTime.now(ZoneOffset.UTC).minusDays(30));
+        expired.setEvropostServiceCredential(credExpired);
+        entityManager.persist(expired);
+
+        User valid = new User();
+        valid.setEmail("valid@example.com");
+        valid.setPassword("pass");
+        valid.setTimeZone("UTC");
+        EvropostServiceCredential credValid = new EvropostServiceCredential();
+        credValid.setUser(valid);
+        credValid.setUseCustomCredentials(true);
+        credValid.setTokenCreatedAt(ZonedDateTime.now(ZoneOffset.UTC).minusDays(10));
+        valid.setEvropostServiceCredential(credValid);
+        entityManager.persist(valid);
+
+        entityManager.flush();
+
+        ZonedDateTime threshold = ZonedDateTime.now(ZoneOffset.UTC).minusDays(29);
+        List<User> result = userRepository.findUsersForTokenRefresh(threshold);
+
+        assertEquals(1, result.size());
+        assertEquals("expired@example.com", result.get(0).getEmail());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/jsonEvropostService/JwtTokenManagerTest.java
+++ b/src/test/java/com/project/tracking_system/service/jsonEvropostService/JwtTokenManagerTest.java
@@ -1,0 +1,63 @@
+package com.project.tracking_system.service.jsonEvropostService;
+
+import com.project.tracking_system.entity.EvropostServiceCredential;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.utils.EncryptionUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link JwtTokenManager}.
+ */
+@ExtendWith(MockitoExtension.class)
+class JwtTokenManagerTest {
+
+    @Mock
+    private EncryptionUtils encryptionUtils;
+    @Mock
+    private GetJwtTokenService getJwtTokenService;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private JwtTokenManager tokenManager;
+
+    @Test
+    void scheduledTokenRefresh_UsesRepositoryMethod() {
+        User user = new User();
+        EvropostServiceCredential cred = new EvropostServiceCredential();
+        cred.setUsername("login");
+        cred.setPassword("encPass");
+        cred.setServiceNumber("encSrv");
+        cred.setUseCustomCredentials(true);
+        cred.setTokenCreatedAt(ZonedDateTime.now(ZoneOffset.UTC).minusDays(30));
+        user.setEvropostServiceCredential(cred);
+
+        when(userRepository.findUsersForTokenRefresh(any())).thenReturn(List.of(user));
+        when(encryptionUtils.decrypt("encPass")).thenReturn("pass");
+        when(encryptionUtils.decrypt("encSrv")).thenReturn("srv");
+        when(getJwtTokenService.getUserTokenFromApi("login", "pass", "srv")).thenReturn("new");
+
+        tokenManager.scheduledTokenRefresh();
+
+        ArgumentCaptor<ZonedDateTime> captor = ArgumentCaptor.forClass(ZonedDateTime.class);
+        verify(userRepository).findUsersForTokenRefresh(captor.capture());
+        verify(userRepository).save(user);
+        assertEquals("new", cred.getJwtToken());
+        // Пороговая дата должна быть раньше текущего момента
+        assertTrue(captor.getValue().isBefore(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- filter users with expired JWT tokens in repository
- call new repository method in JWT token manager
- cover token refresh query with repository and service tests

## Testing
- `./mvnw test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6859ab197524832d9ea5fc75ae885090