### PR TITLE
Remove Component annotations from DTOs

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/PasswordResetDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/PasswordResetDTO.java
@@ -6,9 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/com/project/tracking_system/dto/TrackInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackInfoDTO.java
@@ -4,9 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/com/project/tracking_system/dto/TrackInfoListDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackInfoListDTO.java
@@ -4,12 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.List;
 
-@Component
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/com/project/tracking_system/dto/TrackingResultAdd.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackingResultAdd.java
@@ -4,9 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/com/project/tracking_system/dto/UserRegistrationDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserRegistrationDTO.java
@@ -9,9 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter

--- a/src/main/java/com/project/tracking_system/dto/UserSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserSettingsDTO.java
@@ -6,9 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
-import org.springframework.stereotype.Component;
 
-@Component
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter


### PR DESCRIPTION
## Summary
- decouple DTOs from Spring container by dropping `@Component`
- keep DTO creation in controllers via `new`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b5f45248832da2651853c42f87e5