### PR TITLE
Check auto update availability in profile

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.service.SubscriptionService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -47,6 +48,7 @@ public class ProfileController {
     private final UserService userService;
     private final StoreService storeService;
     private final WebSocketController webSocketController;
+    private final SubscriptionService subscriptionService;
 
     /**
      * Отображает страницу профиля пользователя.
@@ -195,6 +197,11 @@ public class ProfileController {
         }
 
         try {
+            // проверяем доступность функции автообновления
+            if (!subscriptionService.canUseAutoUpdate(userId)) {
+                return ResponseBuilder.error(HttpStatus.FORBIDDEN,
+                        "Опция автообновления недоступна на текущем тарифе");
+            }
             userService.updateAutoUpdateEnabled(userId, enabled);
             return ResponseBuilder.ok("Настройки успешно обновлены.");
         } catch (Exception e) {

--- a/src/test/java/com/project/tracking_system/controller/ProfileControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ProfileControllerTest.java
@@ -1,0 +1,51 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link ProfileController}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProfileControllerTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private StoreService storeService;
+    @Mock
+    private WebSocketController webSocketController;
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @InjectMocks
+    private ProfileController controller;
+
+    @Test
+    void updateAutoUpdate_FeatureDisabled_ReturnsForbidden() {
+        Authentication authentication = mock(Authentication.class);
+        User user = new User();
+        user.setId(1L);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(user);
+        when(subscriptionService.canUseAutoUpdate(1L)).thenReturn(false);
+
+        ResponseEntity<?> response = controller.updateAutoUpdate(true, authentication);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        verify(userService, never()).updateAutoUpdateEnabled(anyLong(), anyBoolean());
+    }
+}


### PR DESCRIPTION
## Summary
- add SubscriptionService to ProfileController
- forbid auto update if plan doesn't allow it
- unit test controller when feature is disallowed

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6859b5fb66f8832d8be4b8686aa3aa5a