### PR TITLE
Restructure profile settings page

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -31,25 +31,21 @@
                            href="#v-pills-home" role="tab">
                             <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте
                         </a>
+                        <a class="nav-link d-flex align-items-center" id="plan-settings-link" data-bs-toggle="pill"
+                           href="#v-pills-plan" role="tab">
+                            <i class="bi bi-speedometer2 me-2" title="Тариф и лимиты"></i> Тариф и лимиты
+                        </a>
                         <a class="nav-link d-flex align-items-center" id="stores-settings-link" data-bs-toggle="pill"
                            href="#v-pills-stores" role="tab">
                             <i class="bi bi-shop me-2" title="Мои магазины"></i> Мои магазины
                         </a>
-                        <a class="nav-link d-flex align-items-center" id="password-settings-link" data-bs-toggle="pill"
-                           href="#v-pills-profile" role="tab">
-                            <i class="bi bi-key me-2" title="Изменить пароль"></i> Изменить пароль
+                        <a class="nav-link d-flex align-items-center" id="integrations-settings-link" data-bs-toggle="pill"
+                           href="#v-pills-integrations" role="tab">
+                            <i class="bi bi-link-45deg me-2" title="Интеграции (API)"></i> Интеграции (API)
                         </a>
-                        <a class="nav-link d-flex align-items-center" id="evropost-settings-link" data-bs-toggle="pill"
-                           href="#v-pills-evropost" role="tab">
-                            <i class="bi bi-truck me-2" title="Европочта"></i> Европочта
-                        </a>
-                        <a class="nav-link d-flex align-items-center" id="belpost-settings-link" data-bs-toggle="pill"
-                           href="#v-pills-belpost" role="tab">
-                            <i class="bi bi-envelope me-2" title="Белпочта"></i> Белпочта
-                        </a>
-                        <a class="nav-link d-flex align-items-center text-danger" id="v-pills-messages-tab"
-                           data-bs-toggle="pill" href="#v-pills-messages" role="tab">
-                            <i class="bi bi-trash me-2" title="Удалить аккаунт"></i> Удалить аккаунт
+                        <a class="nav-link d-flex align-items-center" id="security-settings-link" data-bs-toggle="pill"
+                           href="#v-pills-security" role="tab">
+                            <i class="bi bi-shield-lock me-2" title="Безопасность"></i> Безопасность
                         </a>
                     </div>
                 </div>
@@ -64,25 +60,21 @@
                            href="#v-pills-home" role="tab">
                             <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте
                         </a>
+                        <a class="nav-link d-flex align-items-center" id="plan-settings-link" data-bs-toggle="pill"
+                           href="#v-pills-plan" role="tab">
+                            <i class="bi bi-speedometer2 me-2" title="Тариф и лимиты"></i> Тариф и лимиты
+                        </a>
                         <a class="nav-link d-flex align-items-center" id="stores-settings-link" data-bs-toggle="pill"
                            href="#v-pills-stores" role="tab">
                             <i class="bi bi-shop me-2" title="Мои магазины"></i> Мои магазины
                         </a>
-                        <a class="nav-link d-flex align-items-center" id="password-settings-link" data-bs-toggle="pill"
-                           href="#v-pills-profile" role="tab">
-                            <i class="bi bi-key me-2" title="Изменить пароль"></i> Изменить пароль
+                        <a class="nav-link d-flex align-items-center" id="integrations-settings-link" data-bs-toggle="pill"
+                           href="#v-pills-integrations" role="tab">
+                            <i class="bi bi-link-45deg me-2" title="Интеграции (API)"></i> Интеграции (API)
                         </a>
-                        <a class="nav-link d-flex align-items-center" id="evropost-settings-link" data-bs-toggle="pill"
-                           href="#v-pills-evropost" role="tab">
-                            <i class="bi bi-truck me-2" title="Европочта"></i> Европочта
-                        </a>
-                        <a class="nav-link d-flex align-items-center" id="belpost-settings-link" data-bs-toggle="pill"
-                           href="#v-pills-belpost" role="tab">
-                            <i class="bi bi-envelope me-2" title="Белпочта"></i> Белпочта
-                        </a>
-                        <a class="nav-link d-flex align-items-center text-danger" id="v-pills-messages-tab"
-                           data-bs-toggle="pill" href="#v-pills-messages" role="tab">
-                            <i class="bi bi-trash me-2" title="Удалить аккаунт"></i> Удалить аккаунт
+                        <a class="nav-link d-flex align-items-center" id="security-settings-link" data-bs-toggle="pill"
+                           href="#v-pills-security" role="tab">
+                            <i class="bi bi-shield-lock me-2" title="Безопасность"></i> Безопасность
                         </a>
                     </div>
                 </div>
@@ -94,71 +86,73 @@
                 <!-- Контейнер для уведомлений -->
                 <div id="storeNotificationContainer"></div>
 
-                <div class="tab-pane fade show active card p-3 shadow-sm rounded-4 mb-4" id="v-pills-home"
-                     role="tabpanel">
-                    <h5 class="mb-3">Об аккаунте</h5>
-                    <hr class="my-3">
-                    <div class="row mb-2">
-                        <div class="col-sm-4 text-muted">Email</div>
-                        <div class="col-sm-8" th:text="${userProfile.email}"></div>
-                    </div>
-                    <div class="row mb-2">
-                        <div class="col-sm-4 text-muted">Тариф</div>
-                        <div class="col-sm-8">
-                            <span th:class="'badge ' + (${userProfile.subscriptionCode == 'PREMIUM'} ? 'bg-success' : 'bg-secondary')"
-                                  th:text="${userProfile.subscriptionDisplayName}">
-                            </span>
-                        </div>
-                    </div>
-                    <div class="row mb-2">
-                        <div class="col-sm-4 text-muted">Оплачено до</div>
-                        <div class="col-sm-8" th:text="${userProfile.subscriptionEndDate}"></div>
-                    </div>
-                    <div class="row mb-2">
-                        <div class="col-sm-4 text-muted">Часовой пояс</div>
-                        <div class="col-sm-8" th:text="${userProfile.timezone}"></div>
-                    </div>
-                    <form id="auto-update-form" class="mt-3">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-                        <div class="form-check form-switch">
-                            <input class="form-check-input" type="checkbox" id="autoUpdateToggle"
-                                   th:checked="${userProfile.autoUpdateEnabled}">
-                            <label class="form-check-label" for="autoUpdateToggle">Автообновление треков</label>
-                        </div>
-                        <p class="form-text ms-4">Автообновления расходуют дневной лимит обновлений.</p>
-                    </form>
+<div class="tab-pane fade show active" id="v-pills-home" role="tabpanel">
+    <div class="card p-3 shadow-sm rounded-4 mb-4">
+        <h5 class="mb-3">Об аккаунте</h5>
+        <hr class="my-3">
+        <div class="row mb-2">
+            <div class="col-sm-4 text-muted">Email</div>
+            <div class="col-sm-8" th:text="${userProfile.email}"></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-sm-4 text-muted">Тариф</div>
+            <div class="col-sm-8">
+                <span th:class="'badge ' + (${userProfile.subscriptionCode == 'PREMIUM'} ? 'bg-success' : 'bg-secondary')"
+                      th:text="${userProfile.subscriptionDisplayName}"></span>
+            </div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-sm-4 text-muted">Оплачено до</div>
+            <div class="col-sm-8" th:text="${userProfile.subscriptionEndDate}"></div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-sm-4 text-muted">Часовой пояс</div>
+            <div class="col-sm-8" th:text="${userProfile.timezone}"></div>
+        </div>
+    </div>
+    <div class="card p-3 shadow-sm rounded-4 mb-4">
+        <h5 class="mb-3">Функции и автоматизация</h5>
+        <form id="auto-update-form" class="mt-2">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="autoUpdateToggle"
+                       th:checked="${userProfile.autoUpdateEnabled}">
+                <label class="form-check-label" for="autoUpdateToggle">Автообновление треков</label>
+            </div>
+            <p class="form-text ms-4">Автообновления расходуют дневной лимит обновлений.</p>
+        </form>
+    </div>
+</div>
 
-                    <div class="mt-4">
-                        <h6 class="mb-2">Возможности тарифа</h6>
-                        <ul class="list-unstyled">
-                            <li>📥 Треков в файле:
-                                <strong th:text="${planDetails.maxTracksPerFile != null ? planDetails.maxTracksPerFile : 'Без лимита'}"></strong>
-                            </li>
-                            <li>💾 Сохранённых треков:
-                                <strong th:text="${planDetails.maxSavedTracks != null ? userProfile.savedTracksUsed + '/' + planDetails.maxSavedTracks : userProfile.savedTracksUsed + '/∞'}"></strong>
-                            </li>
-                            <li>🔄 Обновлений в день:
-                                <strong th:text="${planDetails.maxTrackUpdates != null ? userProfile.trackUpdatesUsed + '/' + planDetails.maxTrackUpdates : 'Без лимита'}"></strong>
-                            </li>
-                            <li>🏬 Магазинов:
-                                <strong th:text="${userProfile.storesUsed + '/' + planDetails.maxStores}"></strong>
-                            </li>
-                            <li>
-                                <span th:if="${planDetails.allowBulkUpdate}">✅ Массовое обновление</span>
-                                <span th:unless="${planDetails.allowBulkUpdate}" class="text-muted">❌ Массовое обновление</span>
-                            </li>
-                            <li>
-                                <span th:if="${planDetails.allowAutoUpdate}">♻️ Автообновление треков</span>
-                                <span th:unless="${planDetails.allowAutoUpdate}" class="text-muted">❌ Автообновление треков</span>
-                            </li>
-                            <li>
-                                <span th:if="${planDetails.allowTelegramNotifications}">📨 Telegram-уведомления</span>
-                                <span th:unless="${planDetails.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-
+<div class="tab-pane fade card p-3 shadow-sm rounded-4 mb-4" id="v-pills-plan" role="tabpanel">
+    <h5 class="mb-3">Тариф и лимиты</h5>
+    <ul class="list-unstyled">
+        <li>📥 Треков в файле:
+            <strong th:text="${planDetails.maxTracksPerFile != null ? planDetails.maxTracksPerFile : 'Без лимита'}"></strong>
+        </li>
+        <li>💾 Сохранённых треков:
+            <strong th:text="${planDetails.maxSavedTracks != null ? userProfile.savedTracksUsed + '/' + planDetails.maxSavedTracks : userProfile.savedTracksUsed + '/∞'}"></strong>
+        </li>
+        <li>🔄 Обновлений в день:
+            <strong th:text="${planDetails.maxTrackUpdates != null ? userProfile.trackUpdatesUsed + '/' + planDetails.maxTrackUpdates : 'Без лимита'}"></strong>
+        </li>
+        <li>🏬 Магазинов:
+            <strong th:text="${userProfile.storesUsed + '/' + planDetails.maxStores}"></strong>
+        </li>
+        <li>
+            <span th:if="${planDetails.allowBulkUpdate}">✅ Массовое обновление</span>
+            <span th:unless="${planDetails.allowBulkUpdate}" class="text-muted">❌ Массовое обновление</span>
+        </li>
+        <li>
+            <span th:if="${planDetails.allowAutoUpdate}">♻️ Автообновление треков</span>
+            <span th:unless="${planDetails.allowAutoUpdate}" class="text-muted">❌ Автообновление треков</span>
+        </li>
+        <li>
+            <span th:if="${planDetails.allowTelegramNotifications}">📨 Telegram-уведомления</span>
+            <span th:unless="${planDetails.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
+        </li>
+    </ul>
+</div>
                 <div class="tab-pane fade" id="v-pills-stores" role="tabpanel">
 
                     <div class="card p-3 shadow-sm rounded-4 mb-4">
@@ -217,172 +211,118 @@
                         </div>
                     </div>
                 </div>
-
-                <div class="tab-pane fade card p-3 shadow-sm rounded-4 mb-4"
-                     id="v-pills-profile"
-                     role="tabpanel">
-
-                    <div id="password-content" th:fragment="passwordFragment">
-
-                        <h5 class="mb-3">Изменение пароля</h5>
-                        <form id="password-settings-form" th:action="@{/profile/settings/password}"
-                              th:object="${userSettingsDTO}" method="post">
-
-                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-
-                            <div class="form-floating mb-3 position-relative">
-                                <input type="password" class="form-control password-input" id="currentPassword"
-                                       name="currentPassword"
-                                       th:field="*{currentPassword}" placeholder="Текущий пароль" autocomplete="off">
-                                <label for="currentPassword">Текущий пароль</label>
-                                <span class="toggle-password" data-target="currentPassword">
-                                    <i class="bi bi-eye"></i>
-                                </span>
-                                <div th:errors="*{currentPassword}" class="text-danger"></div>
-                            </div>
-
-                            <div class="form-floating mb-3 position-relative">
-                                <input type="password" class="form-control password-input" id="newPassword"
-                                       name="newPassword"
-                                       th:field="*{newPassword}" placeholder="Новый пароль" autocomplete="off">
-                                <label for="newPassword">Новый пароль</label>
-                                <span class="toggle-password" data-target="newPassword">
-                                    <i class="bi bi-eye"></i>
-                                </span>
-                                <div th:errors="*{newPassword}" class="text-danger"></div>
-                            </div>
-
-                            <div class="form-floating mb-3 position-relative">
-                                <input type="password" class="form-control password-input" id="confirmPassword"
-                                       name="confirmPassword"
-                                       th:field="*{confirmPassword}" placeholder="Подтвердите пароль"
-                                       autocomplete="off">
-                                <label for="confirmPassword">Подтвердите пароль</label>
-                                <span class="toggle-password" data-target="confirmPassword">
-                                    <i class="bi bi-eye"></i>
-                                </span>
-                                <div th:errors="*{confirmPassword}" class="text-danger"></div>
-                            </div>
-
-                            <div th:if="${notification}" class="mb-3">
-                                <p th:text="${notification}" class="text-success"></p>
-                            </div>
-
-                            <button class="btn btn-primary w-100 py-2" type="submit">Изменить пароль</button>
-                        </form>
+<div class="tab-pane fade" id="v-pills-integrations" role="tabpanel">
+    <div class="card p-3 shadow-sm rounded-4 mb-4">
+        <!-- Контейнер для уведомлений -->
+        <div id="evropostNotificationContainer"></div>
+        <div id="evropost-content" th:fragment="evropostFragment">
+            <h5 class="mb-3">Настройки Европочты</h5>
+            <form id="evropost-settings-form" th:action="@{/profile/settings/evropost}" th:object="${evropostCredentialsDTO}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" id="useCustomCredentials" name="useCustomCredentials" th:field="*{useCustomCredentials}">
+                    <label class="form-check-label" for="useCustomCredentials">Подключить API Европочты (договор – бесплатно)</label>
+                </div>
+                <div id="custom-credentials-fields" class="hidden">
+                    <div class="form-floating mb-3">
+                        <input type="text" class="form-control" id="evropostUsername" name="evropostUsername" th:field="*{evropostUsername}" placeholder="LoginName" autocomplete="off">
+                        <label for="evropostUsername">LoginName</label>
+                        <div th:errors="*{evropostUsername}" class="text-danger"></div>
                     </div>
-                </div>
-
-                <div class="tab-pane fade card p-3 shadow-sm rounded-4 mb-4"
-                     id="v-pills-evropost"
-                     role="tabpanel">
-
-                    <!-- Контейнер для уведомлений -->
-                    <div id="evropostNotificationContainer"></div>
-
-                    <div id="evropost-content" th:fragment="evropostFragment">
-
-                        <h5 class="mb-3">Настройки Европочты</h5>
-
-                        <form id="evropost-settings-form" th:action="@{/profile/settings/evropost}"
-                              th:object="${evropostCredentialsDTO}" method="post">
-
-                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-
-                            <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" id="useCustomCredentials"
-                                       name="useCustomCredentials"
-                                       th:field="*{useCustomCredentials}">
-                                <label class="form-check-label" for="useCustomCredentials">Подключить API Европочты
-                                    (договор – бесплатно)</label>
-                            </div>
-
-                            <div id="custom-credentials-fields" class="hidden">
-                                <div class="form-floating mb-3">
-                                    <input type="text" class="form-control" id="evropostUsername"
-                                           name="evropostUsername"
-                                           th:field="*{evropostUsername}" placeholder="LoginName" autocomplete="off">
-                                    <label for="evropostUsername">LoginName</label>
-                                    <div th:errors="*{evropostUsername}" class="text-danger"></div>
-                                </div>
-
-                                <div class="form-floating mb-3 position-relative">
-                                    <input type="password" class="form-control password-input" id="evropostPassword"
-                                           name="evropostPassword"
-                                           th:field="*{evropostPassword}" placeholder="Password" autocomplete="off">
-                                    <label for="evropostPassword">Password</label>
-                                    <span class="toggle-password" data-target="evropostPassword">
-                                        <i class="bi bi-eye"></i>
-                                    </span>
-                                    <div th:errors="*{evropostPassword}" class="text-danger"></div>
-                                </div>
-
-                                <div class="form-floating mb-3 position-relative">
-                                    <input type="password" class="form-control password-input" id="serviceNumber"
-                                           name="serviceNumber"
-                                           th:field="*{serviceNumber}" placeholder="ServiceNumber" autocomplete="off">
-                                    <label for="serviceNumber">ServiceNumber</label>
-                                    <span class="toggle-password" data-target="serviceNumber">
-                                        <i class="bi bi-eye"></i>
-                                    </span>
-                                    <div th:errors="*{serviceNumber}" class="text-danger"></div>
-                                </div>
-
-                                <button class="btn btn-primary btn-sm w-100" type="submit">Сохранить данные</button>
-                            </div>
-                        </form>
+                    <div class="form-floating mb-3 position-relative">
+                        <input type="password" class="form-control password-input" id="evropostPassword" name="evropostPassword" th:field="*{evropostPassword}" placeholder="Password" autocomplete="off">
+                        <label for="evropostPassword">Password</label>
+                        <span class="toggle-password" data-target="evropostPassword">
+                            <i class="bi bi-eye"></i>
+                        </span>
+                        <div th:errors="*{evropostPassword}" class="text-danger"></div>
                     </div>
+                    <div class="form-floating mb-3 position-relative">
+                        <input type="password" class="form-control password-input" id="serviceNumber" name="serviceNumber" th:field="*{serviceNumber}" placeholder="ServiceNumber" autocomplete="off">
+                        <label for="serviceNumber">ServiceNumber</label>
+                        <span class="toggle-password" data-target="serviceNumber">
+                            <i class="bi bi-eye"></i>
+                        </span>
+                        <div th:errors="*{serviceNumber}" class="text-danger"></div>
+                    </div>
+                    <button class="btn btn-primary btn-sm w-100" type="submit">Сохранить данные</button>
                 </div>
+            </form>
+        </div>
+    </div>
+    <div class="card p-3 shadow-sm rounded-4 mb-4">
+        <h5 class="mb-3">Белпочта</h5>
+        <p>Если у вас есть договор на API Белпочты, свяжитесь со мной для реализации интеграции.</p>
+        <p class="fw-semibold">Контакт для связи:</p>
+        <p>📧 <a href="mailto:info@belivery.by" class="text-decoration-none">info@belivery.by</a></p>
+    </div>
+</div>
 
-                <div class="tab-pane fade card p-3 shadow-sm rounded-4 mb-4"
-                     id="v-pills-belpost"
-                     role="tabpanel">
-
-                    <h5 class="mb-3">Белпочта</h5>
-                    <p>Если у вас есть договор на API Белпочты, свяжитесь со мной для реализации интеграции.</p>
-
-                    <p class="fw-semibold">Контакт для связи:</p>
-                    <p>
-                        📧 <a href="mailto:info@belivery.by" class="text-decoration-none">info@belivery.by</a>
-                    </p>
+<div class="tab-pane fade" id="v-pills-security" role="tabpanel">
+    <div class="card p-3 shadow-sm rounded-4 mb-4">
+        <div id="password-content" th:fragment="passwordFragment">
+            <h5 class="mb-3">Изменение пароля</h5>
+            <form id="password-settings-form" th:action="@{/profile/settings/password}" th:object="${userSettingsDTO}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <div class="form-floating mb-3 position-relative">
+                    <input type="password" class="form-control password-input" id="currentPassword" name="currentPassword" th:field="*{currentPassword}" placeholder="Текущий пароль" autocomplete="off">
+                    <label for="currentPassword">Текущий пароль</label>
+                    <span class="toggle-password" data-target="currentPassword">
+                        <i class="bi bi-eye"></i>
+                    </span>
+                    <div th:errors="*{currentPassword}" class="text-danger"></div>
                 </div>
-
-                <div class="tab-pane fade card p-4 shadow-sm rounded-4" id="v-pills-messages" role="tabpanel">
-                    <h5 class="mb-3">Удаление аккаунта</h5>
-                    <p class="fw-semibold">
-                        <strong>Вы уверены, что хотите удалить аккаунт?</strong>
-                    </p>
-
-                    <ul>
-                        <li>Вся ваша информация будет <strong>безвозвратно удалена</strong>, включая:</li>
-                        <ul>
-                            <li>Историю отслеживания посылок</li>
-                            <li>Все загруженные файлы и данные</li>
-                            <li>Настройки профиля и персональные данные</li>
-                        </ul>
-                    </ul>
-
-                    <p>
-                        <strong>Удаление аккаунта необратимо</strong> – вы не сможете восстановить доступ.
-                        Если в будущем вы захотите снова воспользоваться сервисом, вам потребуется
-                        <strong>создать новый аккаунт с нуля</strong>.
-                    </p>
-
-                    <p>
-                        <strong>Обратите внимание:</strong>
-                        Если ваш аккаунт имел <strong>дополнительные платные функции или подписки</strong>,
-                        они также будут <strong>аннулированы без возможности восстановления</strong>.
-                    </p>
-
-                    <p class="text-uppercase fw-bold">
-                        Это действие невозможно отменить.
-                    </p>
-
-                    <button class="btn btn-danger w-50 py-2" data-bs-toggle="modal"
-                            data-bs-target="#deleteAccountModal">
-                        <i class="bi bi-trash"></i>
-                        Удалить аккаунт
-                    </button>
+                <div class="form-floating mb-3 position-relative">
+                    <input type="password" class="form-control password-input" id="newPassword" name="newPassword" th:field="*{newPassword}" placeholder="Новый пароль" autocomplete="off">
+                    <label for="newPassword">Новый пароль</label>
+                    <span class="toggle-password" data-target="newPassword">
+                        <i class="bi bi-eye"></i>
+                    </span>
+                    <div th:errors="*{newPassword}" class="text-danger"></div>
+                </div>
+                <div class="form-floating mb-3 position-relative">
+                    <input type="password" class="form-control password-input" id="confirmPassword" name="confirmPassword" th:field="*{confirmPassword}" placeholder="Подтвердите пароль" autocomplete="off">
+                    <label for="confirmPassword">Подтвердите пароль</label>
+                    <span class="toggle-password" data-target="confirmPassword">
+                        <i class="bi bi-eye"></i>
+                    </span>
+                    <div th:errors="*{confirmPassword}" class="text-danger"></div>
+                </div>
+                <div th:if="${notification}" class="mb-3">
+                    <p th:text="${notification}" class="text-success"></p>
+                </div>
+                <button class="btn btn-primary w-100 py-2" type="submit">Изменить пароль</button>
+            </form>
+        </div>
+    </div>
+    <div class="card p-4 shadow-sm rounded-4">
+        <h5 class="mb-3">Удаление аккаунта</h5>
+        <p class="fw-semibold"><strong>Вы уверены, что хотите удалить аккаунт?</strong></p>
+        <ul>
+            <li>Вся ваша информация будет <strong>безвозвратно удалена</strong>, включая:
+                <ul>
+                    <li>Историю отслеживания посылок</li>
+                    <li>Все загруженные файлы и данные</li>
+                    <li>Настройки профиля и персональные данные</li>
+                </ul>
+            </li>
+        </ul>
+        <p>
+            <strong>Удаление аккаунта необратимо</strong> – вы не сможете восстановить доступ.
+            Если в будущем вы захотите снова воспользоваться сервисом, вам потребуется
+            <strong>создать новый аккаунт с нуля</strong>.
+        </p>
+        <p>
+            <strong>Обратите внимание:</strong>
+            Если ваш аккаунт имел <strong>дополнительные платные функции или подписки</strong>,
+            они также будут <strong>аннулированы без возможности восстановления</strong>.
+        </p>
+        <p class="text-uppercase fw-bold">Это действие невозможно отменить.</p>
+        <button class="btn btn-danger w-50 py-2" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
+            <i class="bi bi-trash"></i> Удалить аккаунт
+        </button>
+    </div>
+</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- reorganize profile tabs into new order
- add tariff, integrations and security sections
- move auto-update toggle into dedicated card

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b604a814832dafb6d2a91df00c13