### PR TITLE
Move Telegram settings to notifications tab

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -172,19 +172,6 @@
                         </div>
                     </div>
 
-                    <div class="card p-3 shadow-sm rounded-4 mb-4">
-                        <div id="telegram-management" class="mt-4">
-                            <h5 class="mb-3">Настройки Telegram</h5>
-                            <p class="text-muted mb-3">
-                                Настройки уведомлений для покупателей в Telegram. Если включено, покупатели будут
-                                получать автоматические уведомления о статусах посылок (например, «отправлена», «прибыла
-                                в пункт выдачи» и др.).
-                            </p>
-                            <th:block th:each="store, iter : ${stores}">
-                                <div th:replace="~{profile :: telegramStoreBlock(store=${store}, first=${iter.first})}"></div>
-                            </th:block>
-                        </div>
-                    </div>
                 </div>
 
 <div class="tab-pane fade" id="v-pills-notifications" role="tabpanel">
@@ -197,6 +184,19 @@
                 <label class="form-check-label" for="telegramNotificationsToggle">Получать уведомления о статусах посылок</label>
             </div>
         </form>
+    </div>
+    <div class="card p-3 shadow-sm rounded-4 mb-4">
+        <div id="telegram-management" class="mt-4">
+            <h5 class="mb-3">Настройки Telegram</h5>
+            <p class="text-muted mb-3">
+                Настройки уведомлений для покупателей в Telegram. Если включено, покупатели будут
+                получать автоматические уведомления о статусах посылок (например, «отправлена», «прибыла
+                в пункт выдачи» и др.).
+            </p>
+            <th:block th:each="store, iter : ${stores}">
+                <div th:replace="~{profile :: telegramStoreBlock(store=${store}, first=${iter.first})}"></div>
+            </th:block>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- move `telegram-management` container from the **Мои магазины** tab
- place it inside the **Уведомления (Telegram)** tab

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af449061c832db8ddad0241581346