### PR TITLE
Show tariff name on profile page

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -217,6 +217,9 @@
 
 <div class="tab-pane fade card p-3 shadow-sm rounded-4 mb-4" id="v-pills-plan" role="tabpanel">
     <h5 class="mb-3">Тариф и лимиты</h5>
+    <p class="fw-semibold mb-2">Текущий тариф:
+        <span class="badge bg-primary" th:text="${planDetails.name}"></span>
+    </p>
     <ul class="list-unstyled">
         <li>📥 Треков в файле:
             <strong th:text="${planDetails.maxTracksPerFile != null ? planDetails.maxTracksPerFile : 'Без лимита'}"></strong>


### PR DESCRIPTION
## Summary
- display current tariff name before limits on the profile page

## Testing
- `./mvnw -q test` *(fails: cannot open `./.mvn/wrapper/maven-wrapper.properties`)*
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b07a00b68832d9cbf537c3badc948