### PR TITLE
Hide subscription end date for free accounts

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -117,7 +117,7 @@
                       th:text="${userProfile.subscriptionDisplayName}"></span>
             </div>
         </div>
-        <div class="row mb-2">
+        <div class="row mb-2" th:if="${userProfile.subscriptionEndDate != null}">
             <div class="col-sm-4 text-muted">Оплачено до</div>
             <div class="col-sm-8" th:text="${userProfile.subscriptionEndDate}"></div>
         </div>


### PR DESCRIPTION
## Summary
- hide subscription end date block when user has no subscription with expiration date

## Testing
- `./mvnw test -q` *(fails: cannot open maven wrapper properties)*
- `./mvnw -q -DskipTests=false test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_685b17834398832d988b07cd3e4f1477