### PR TITLE
Disable telegram notifications for non eligible plans

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -180,14 +180,21 @@
         <form id="telegram-notifications-form" class="mt-2">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" id="telegramNotificationsToggle">
+                <input class="form-check-input" type="checkbox" id="telegramNotificationsToggle"
+                       th:disabled="${!planDetails.allowTelegramNotifications}">
                 <label class="form-check-label" for="telegramNotificationsToggle">Получать уведомления о статусах посылок</label>
             </div>
+            <p class="form-text text-danger ms-4" th:if="${!planDetails.allowTelegramNotifications}">
+                Функция доступна в тарифе "Команда" и выше
+            </p>
         </form>
     </div>
     <div class="card p-3 shadow-sm rounded-4 mb-4">
         <div id="telegram-management" class="mt-4">
             <h5 class="mb-3">Настройки Telegram</h5>
+            <p class="form-text text-danger" th:if="${!planDetails.allowTelegramNotifications}">
+                Функция доступна в тарифе "Команда" и выше
+            </p>
             <p class="text-muted mb-3">
                 Настройки уведомлений для покупателей в Telegram. Если включено, покупатели будут
                 получать автоматические уведомления о статусах посылок (например, «отправлена», «прибыла
@@ -385,7 +392,8 @@
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-check form-switch mb-2">
                     <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
-                           th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}">
+                           th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}"
+                           th:disabled="${!planDetails.allowTelegramNotifications}">
                     <label class="form-check-label" th:for="'tg-enable-' + ${store.id}">
                         Отправлять уведомления покупателям этого магазина
                     </label>
@@ -398,7 +406,8 @@
                      class="form-check form-switch mb-2 ms-3 hidden reminders-container">
                     <input class="form-check-input" type="checkbox" th:id="'tg-reminders-' + ${store.id}"
                            name="remindersEnabled"
-                           th:checked="${store.telegramSettings?.remindersEnabled}">
+                           th:checked="${store.telegramSettings?.remindersEnabled}"
+                           th:disabled="${!planDetails.allowTelegramNotifications}">
                     <label class="form-check-label" th:for="'tg-reminders-' + ${store.id}">
                         Отправлять напоминания, если посылка не забрана
                     </label>


### PR DESCRIPTION
## Summary
- lock Telegram notification checkboxes when the tariff doesn't allow
- show hints that the feature is available starting from "Команда" plan

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b17b689d8832dbee588713732d4a4