### PR TITLE
Add bulk update button flag control

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/PasswordChangeDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/PasswordChangeDTO.java
@@ -1,0 +1,28 @@
+package com.project.tracking_system.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO для смены пароля пользователя.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordChangeDTO {
+
+    @NotEmpty(message = "Текущий пароль обязателен")
+    private String currentPassword;
+
+    @NotEmpty(message = "Новый пароль обязателен")
+    @Size(min = 6, max = 15, message = "Пароль должен быть не менее 6 символов и не более 15")
+    private String newPassword;
+
+    @NotEmpty(message = "Подтверждение пароля обязательно")
+    private String confirmPassword;
+}

--- a/src/main/java/com/project/tracking_system/dto/UserSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/UserSettingsDTO.java
@@ -1,26 +1,25 @@
 package com.project.tracking_system.dto;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@NoArgsConstructor
-@AllArgsConstructor
+/**
+ * DTO общих настроек пользователя.
+ * <p>
+ * Используется для отображения/изменения различных флагов в профиле.
+ * Поля для смены пароля вынесены в {@link PasswordChangeDTO}.
+ * </p>
+ */
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserSettingsDTO {
 
-    @NotEmpty(message = "Текущий пароль обязателен")
-    private String currentPassword;
-
-    @NotEmpty(message = "Новый пароль обязателен")
-    @Size(min = 6, max = 15, message = "Пароль должен быть не менее 6 символов и не более 15")
-    private String newPassword;
-
-    @NotEmpty(message = "Подтверждение пароля обязательно")
-    private String confirmPassword;
-
+    /**
+     * Показывать кнопку массового обновления треков.
+     */
+    private Boolean showBulkUpdateButton;
 }

--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.dto.EvropostCredentialsDTO;
 import com.project.tracking_system.dto.ResolvedCredentialsDTO;
 import com.project.tracking_system.dto.UserRegistrationDTO;
 import com.project.tracking_system.dto.UserSettingsDTO;
+import com.project.tracking_system.dto.PasswordChangeDTO;
 import com.project.tracking_system.dto.UserProfileDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
@@ -353,6 +354,26 @@ public class UserService {
     }
 
     /**
+     * Проверяет, должна ли отображаться кнопка массового обновления треков.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если кнопка должна отображаться
+     */
+    public boolean isShowBulkUpdateButton(Long userId) {
+        return userSettingsService.getUserSettings(userId).isShowBulkUpdateButton();
+    }
+
+    /**
+     * Обновляет видимость кнопки массового обновления треков.
+     *
+     * @param userId идентификатор пользователя
+     * @param value  новое значение флага
+     */
+    public void updateShowBulkUpdateButton(Long userId, boolean value) {
+        userSettingsService.updateShowBulkUpdateButton(userId, value);
+    }
+
+    /**
      * Получает сохранённые учётные данные Evropost пользователя.
      *
      * @param userId идентификатор пользователя
@@ -467,20 +488,20 @@ public class UserService {
      * </p>
      *
      * @param email            Email пользователя.
-     * @param userSettingsDTO DTO с новыми данными пользователя.
+     * @param passwordChangeDTO DTO с новыми данными пользователя.
      * @throws IllegalArgumentException Если текущий пароль неверен или пользователь не найден.
      */
-    public void changePassword(Long userId, UserSettingsDTO userSettingsDTO) {
+    public void changePassword(Long userId, PasswordChangeDTO passwordChangeDTO) {
         log.info("Начало смены пароля пользователя ID={}", userId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("Пользователь не найден с ID: " + userId));
 
-        if (!passwordEncoder.matches(userSettingsDTO.getCurrentPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(passwordChangeDTO.getCurrentPassword(), user.getPassword())) {
             throw new IllegalArgumentException("Текущий пароль введён неверно");
         }
 
-        user.setPassword(passwordEncoder.encode(userSettingsDTO.getNewPassword()));
+        user.setPassword(passwordEncoder.encode(passwordChangeDTO.getNewPassword()));
         userRepository.save(user);
 
         log.info("Пароль пользователя с ID {} был успешно изменен.", userId);

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -308,7 +308,7 @@
     <div class="card p-3 shadow-sm rounded-4 mb-4">
         <div id="password-content" th:fragment="passwordFragment">
             <h5 class="mb-3">Изменение пароля</h5>
-            <form id="password-settings-form" th:action="@{/profile/settings/password}" th:object="${userSettingsDTO}" method="post">
+            <form id="password-settings-form" th:action="@{/profile/settings/password}" th:object="${passwordChangeDTO}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-floating mb-3 position-relative">
                     <input type="password" class="form-control password-input" id="currentPassword" name="currentPassword" th:field="*{currentPassword}" placeholder="Текущий пароль" autocomplete="off">


### PR DESCRIPTION
## Summary
- separate password change from user settings
- add new `PasswordChangeDTO`
- populate settings DTO with bulk update flag
- update profile template and controller

## Testing
- `mvn -q test` *(fails: command not found)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685bb973d4dc832d9d9cb5e5cb083e92