### PR TITLE
Add bulk update button setting

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -11,6 +11,8 @@ import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackFacade;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.dto.UserSettingsDTO;
+import com.project.tracking_system.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -48,6 +50,7 @@ public class DeparturesController {
     private final StoreService storeService;
     private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
     private final WebSocketController webSocketController;
+    private final UserService userService;
 
     /**
      * Метод для отображения списка отслеживаемых посылок пользователя с возможностью фильтрации по магазину и статусу.
@@ -132,6 +135,7 @@ public class DeparturesController {
         model.addAttribute("currentPage", trackParcelPage.getNumber());
         model.addAttribute("totalPages", trackParcelPage.getTotalPages());
         model.addAttribute("trackParcelNotification", trackParcelPage.isEmpty() ? "Отслеживаемых посылок нет" : null);
+        model.addAttribute("userSettings", new UserSettingsDTO(userService.isShowBulkUpdateButton(userId)));
 
         return "departures";
     }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -199,6 +199,33 @@ function initAutoUpdateToggle() {
     });
 }
 
+// Инициализация переключателя отображения кнопки массового обновления
+function initBulkButtonToggle() {
+    const checkbox = document.getElementById("showBulkUpdateButton");
+    if (!checkbox) return;
+
+    let debounceTimer;
+    checkbox.addEventListener('change', function () {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            fetch('/profile/settings/bulk-button', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    [document.querySelector('meta[name="_csrf_header"]').content]: document.querySelector('meta[name="_csrf"]').content
+                },
+                body: new URLSearchParams({ show: checkbox.checked })
+            }).then(response => {
+                if (!response.ok) {
+                    alert('Ошибка при обновлении настройки.');
+                }
+            }).catch(() => {
+                alert('Ошибка сети при обновлении настройки.');
+            });
+        }, 300);
+    });
+}
+
 // Инициализация переключателя для ввода телефона
 function initializePhoneToggle() {
     const toggle = document.getElementById("togglePhone");
@@ -1185,6 +1212,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initEvropostFormHandler();
     initializeCustomCredentialsCheckbox();
     initAutoUpdateToggle();
+    initBulkButtonToggle();
     initializePhoneToggle();
     initAssignCustomerFormHandler();
     initTelegramForms();

--- a/src/main/resources/templates/departures.html
+++ b/src/main/resources/templates/departures.html
@@ -23,7 +23,8 @@
                                 data-bs-toggle="tooltip"
                                 data-bs-placement="right"
                                 title="Обновить все посылки"
-                                aria-label="Обновить данные">
+                                aria-label="Обновить данные"
+                                th:if="${userSettings.showBulkUpdateButton}">
                             <i class="bi bi-arrow-repeat"></i>
                         </button>
                     </div>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -222,6 +222,17 @@
             </p>
             <p class="form-text ms-4">Автообновления расходуют дневной лимит обновлений.</p>
         </form>
+        <form id="bulk-button-form" class="mt-3">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="showBulkUpdateButton"
+                       th:checked="${userSettingsDTO.showBulkUpdateButton}" th:disabled="${!planDetails.allowBulkUpdate}">
+                <label class="form-check-label" for="showBulkUpdateButton">Показывать кнопку массового обновления</label>
+            </div>
+            <p class="form-text text-danger ms-4" th:if="${!planDetails.allowBulkUpdate}">
+                Доступно только в тарифе Premium
+            </p>
+        </form>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- support enabling bulk update button in user settings
- show bulk update button option in profile automation settings
- wrap "Обновить все" button visibility by user settings
- add JS handler for bulk update button setting

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc61f509c832d9dbc98b6b82acdc3