### PR TITLE
Add global user settings advice

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/UserSettingsAdvice.java
+++ b/src/main/java/com/project/tracking_system/configuration/UserSettingsAdvice.java
@@ -1,0 +1,49 @@
+package com.project.tracking_system.configuration;
+
+import com.project.tracking_system.dto.UserSettingsDTO;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * Глобальная обработка добавления пользовательских настроек в модель.
+ * <p>
+ * Класс использует {@link ControllerAdvice}, чтобы автоматически помещать в
+ * модель объект {@link UserSettingsDTO} со значением флага отображения кнопки
+ * массового обновления. Если пользователь не аутентифицирован, значение флага
+ * будет {@code false}.
+ * </p>
+ */
+@ControllerAdvice
+@RequiredArgsConstructor
+public class UserSettingsAdvice {
+
+    private final UserService userService;
+
+    /**
+     * Добавляет в модель настройки текущего пользователя.
+     * <p>
+     * Метод извлекает идентификатор аутентифицированного пользователя и
+     * запрашивает у {@link UserService} значение флага отображения кнопки
+     * массового обновления. Для неаутентифицированных пользователей
+     * возвращается значение {@code false}.
+     * </p>
+     *
+     * @return DTO с настройками пользователя
+     */
+    @ModelAttribute("userSettings")
+    public UserSettingsDTO addUserSettings() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken)
+                && authentication.getPrincipal() instanceof User user) {
+            return new UserSettingsDTO(userService.isShowBulkUpdateButton(user.getId()));
+        }
+        return new UserSettingsDTO(false);
+    }
+}

--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -11,7 +11,6 @@ import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackFacade;
 import com.project.tracking_system.service.store.StoreService;
-import com.project.tracking_system.dto.UserSettingsDTO;
 import com.project.tracking_system.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -135,7 +134,6 @@ public class DeparturesController {
         model.addAttribute("currentPage", trackParcelPage.getNumber());
         model.addAttribute("totalPages", trackParcelPage.getTotalPages());
         model.addAttribute("trackParcelNotification", trackParcelPage.isEmpty() ? "Отслеживаемых посылок нет" : null);
-        model.addAttribute("userSettings", new UserSettingsDTO(userService.isShowBulkUpdateButton(userId)));
 
         return "departures";
     }


### PR DESCRIPTION
## Summary
- add `UserSettingsAdvice` to inject user settings globally
- remove manual user settings attribute from `DeparturesController`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc5b5244832d8464dbec90838637