### PR TITLE
Fix default settings transaction

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/UserSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserSettingsService.java
@@ -26,7 +26,7 @@ public class UserSettingsService {
      * @param userId идентификатор пользователя
      * @return найденные или созданные настройки
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public UserSettings getUserSettings(Long userId) {
         UserSettings settings = settingsRepository.findByUserId(userId);
         if (settings == null) {

--- a/src/test/java/com/project/tracking_system/service/user/UserSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/user/UserSettingsServiceTest.java
@@ -1,0 +1,62 @@
+package com.project.tracking_system.service.user;
+
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.entity.UserSettings;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.repository.UserSettingsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link UserSettingsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserSettingsServiceTest {
+
+    @Mock
+    private UserSettingsRepository settingsRepository;
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserSettingsService service;
+
+    @Test
+    void getUserSettings_SettingsMissing_CreatesDefault() {
+        User user = new User();
+        user.setId(1L);
+
+        when(settingsRepository.findByUserId(1L)).thenReturn(null);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(settingsRepository.save(any(UserSettings.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserSettings result = service.getUserSettings(1L);
+
+        assertNotNull(result);
+        assertEquals(user, result.getUser());
+        verify(settingsRepository).save(any(UserSettings.class));
+    }
+
+    @Test
+    void getUserSettings_ExistingSettings_ReturnedAsIs() {
+        UserSettings existing = new UserSettings();
+        existing.setId(2L);
+
+        when(settingsRepository.findByUserId(2L)).thenReturn(existing);
+
+        UserSettings result = service.getUserSettings(2L);
+
+        assertEquals(existing, result);
+        verify(settingsRepository, never()).save(any());
+        verify(userRepository, never()).findById(any());
+    }
+}


### PR DESCRIPTION
## Summary
- remove readOnly flag so default settings can be created in `UserSettingsService`
- cover new behavior in a dedicated service test

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcdd6e3e8832d886c68c0da89b357