### PR TITLE
Use @AuthenticationPrincipal in controllers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
+++ b/src/main/java/com/project/tracking_system/controller/AnalyticsController.java
@@ -15,8 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.Authentication;
-import com.project.tracking_system.utils.AuthUtils;
 import com.project.tracking_system.utils.ResponseBuilder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -55,12 +53,10 @@ public class AnalyticsController {
             @RequestParam(name = "storeId", required = false) String rawStoreId,
             @RequestParam(defaultValue = "WEEKS") String interval,
             Model model,
-            Authentication authentication,
+            @AuthenticationPrincipal User user,
             HttpServletRequest request) {
 
         // 1) Проверяем аутентификацию
-        User user = AuthUtils.getCurrentUser(authentication);
-
         Long userId = user.getId();
         ZoneId userZone = ZoneId.of(user.getTimeZone());
         List<Store> stores = storeService.getUserStores(userId);
@@ -162,13 +158,12 @@ public class AnalyticsController {
      *
      * @param storeId        идентификатор магазина. Если не указан, обновляется
      *                       аналитика по всем магазинам пользователя
-     * @param authentication текущая аутентификация пользователя
+     * @param user           текущий пользователь
      * @return JSON-ответ с сообщением о результате обновления
      */
     @PostMapping("/update")
     public ResponseEntity<?> updateAnalytics(@RequestParam(required = false) Long storeId,
-                                             Authentication authentication) {
-        User user = AuthUtils.getCurrentUser(authentication);
+                                             @AuthenticationPrincipal User user) {
         Long userId = user.getId();
         log.info("Обновление timestamp аналитики (данные считаются инкрементально): userId={}, storeId={}", userId, storeId);
 
@@ -194,15 +189,14 @@ public class AnalyticsController {
      * @param storeId        идентификатор магазина. Если null, данные собираются
      *                       по всем магазинам пользователя
      * @param interval       интервал агрегации (DAYS/WEEKS/MONTHS/YEARS)
-     * @param authentication текущая аутентификация пользователя
+     * @param user       текущий пользователь
      * @return карта с данными для круговой диаграммы и статистикой по периодам
      */
     @GetMapping("/json")
     @ResponseBody
     public Map<String, Object> getAnalyticsJson(@RequestParam(required = false) Long storeId,
                                                 @RequestParam(defaultValue = "WEEKS") String interval,
-                                                Authentication authentication) {
-        User user = AuthUtils.getCurrentUser(authentication);
+                                                @AuthenticationPrincipal User user) {
         Long userId = user.getId();
         List<Store> stores = storeService.getUserStores(userId);
         List<StoreStatistics> visibleStats;

--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -19,9 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import com.project.tracking_system.utils.ResponseBuilder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
-import org.springframework.security.core.Authentication;
-import com.project.tracking_system.utils.AuthUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -59,8 +58,8 @@ public class DeparturesController {
      * @param statusString строковое представление статуса для фильтрации.
      * @param page         номер страницы для пагинации.
      * @param size         размер страницы.
-     * @param model        модель для передачи данных на представление.
-     * @param authentication информация о пользователе.
+     * @param model модель для передачи данных на представление.
+     * @param user  текущий пользователь.
      * @return имя представления для отображения истории.
      */
     @GetMapping()
@@ -70,9 +69,8 @@ public class DeparturesController {
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "20") int size,
             Model model,
-            Authentication authentication) {
+            @AuthenticationPrincipal User user) {
 
-        User user = AuthUtils.getCurrentUser(authentication);
         Long userId = user.getId();
         List<Store> stores = storeService.getUserStores(userId); // Загружаем магазины с именами
         List<Long> storeIds = storeService.getUserStoreIds(userId); // Все id магазины пользователя
@@ -144,18 +142,17 @@ public class DeparturesController {
     /**
      * Метод для отображения подробной информации о посылке.
      *
-     * @param model       модель для передачи данных на представление.
-     * @param itemNumber  номер отслеживаемой посылки.
-     * @param authentication информация о пользователе.
+     * @param model      модель для передачи данных на представление.
+     * @param itemNumber номер отслеживаемой посылки.
+     * @param user       текущий пользователь.
      * @return имя частичного представления с информацией о посылке.
      */
     @GetMapping("/{itemNumber}")
     public String departures(
             Model model,
             @PathVariable("itemNumber") String itemNumber,
-            Authentication authentication) {
+            @AuthenticationPrincipal User user) {
 
-        User user = AuthUtils.getCurrentUser(authentication);
         Long userId = user.getId();
         log.info("🔍 Запрос информации о посылке {} для пользователя ID={}", itemNumber, userId);
 
@@ -184,9 +181,8 @@ public class DeparturesController {
     @PostMapping("/track-update")
     public ResponseEntity<?> updateDepartures(
             @RequestParam(required = false) List<String> selectedNumbers,
-            Authentication authentication
+            @AuthenticationPrincipal User user
     ) {
-        User user = AuthUtils.getCurrentUser(authentication);
         Long userId = user.getId();
         log.info("🔄 Запрос на обновление посылок: userId={}", userId);
 
@@ -216,14 +212,13 @@ public class DeparturesController {
      * </p>
      *
      * @param selectedNumbers список номеров посылок, которые нужно удалить.
-     * @param redirectAttributes атрибуты для передачи сообщений о результате операции.
+     * @param user            текущий пользователь
      * @return перенаправление на страницу истории.
      */
     @PostMapping("/delete-selected")
     public ResponseEntity<?> deleteSelected(
             @RequestParam List<String> selectedNumbers,
-            Authentication authentication) {
-        User user = AuthUtils.getCurrentUser(authentication);
+            @AuthenticationPrincipal User user) {
         Long userId = user.getId();
         log.info("Запрос на удаление посылок {} для пользователя с ID: {}", selectedNumbers, userId);
 

--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -3,22 +3,22 @@ package com.project.tracking_system.controller;
 import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import com.project.tracking_system.utils.ResponseBuilder;
-import com.project.tracking_system.utils.AuthUtils;
 import com.project.tracking_system.controller.WebSocketController;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.validation.BindingResult;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 /**
  * Управление Telegram-настройками магазина.
@@ -39,8 +39,8 @@ public class StoreTelegramSettingsController {
      */
     @GetMapping
     @ResponseBody
-    public ResponseEntity<?> getSettings(@PathVariable Long storeId, Authentication authentication) {
-        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+    public ResponseEntity<?> getSettings(@PathVariable Long storeId, @AuthenticationPrincipal User user) {
+        Long userId = user.getId();
         Store store = storeService.getStore(storeId, userId);
         StoreTelegramSettings settings = settingsRepository.findByStoreId(store.getId());
         return ResponseBuilder.ok(storeService.toDto(settings));
@@ -54,8 +54,8 @@ public class StoreTelegramSettingsController {
     public ResponseEntity<?> updateSettings(@PathVariable Long storeId,
                                             @Valid @RequestBody StoreTelegramSettingsDTO dto,
                                             BindingResult binding,
-                                            Authentication authentication) {
-        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+                                            @AuthenticationPrincipal User user) {
+        Long userId = user.getId();
         try {
             if (binding.hasErrors()) {
                 return ResponseBuilder.error(HttpStatus.BAD_REQUEST,
@@ -84,7 +84,7 @@ public class StoreTelegramSettingsController {
      * @param storeId        идентификатор магазина
      * @param dto            заполненные настройки Telegram
      * @param binding        результаты валидации формы
-     * @param authentication текущая аутентификация пользователя
+     * @param user           текущий пользователь
      * @return {@link ResponseEntity} с HTTP 200 или ошибкой в тексте
      */
     @PostMapping(consumes = org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -92,8 +92,8 @@ public class StoreTelegramSettingsController {
     public ResponseEntity<?> updateSettingsAjax(@PathVariable Long storeId,
                                                 @Valid @ModelAttribute StoreTelegramSettingsDTO dto,
                                                 BindingResult binding,
-                                                Authentication authentication) {
-        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+                                                @AuthenticationPrincipal User user) {
+        Long userId = user.getId();
         if (binding.hasErrors()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(binding.getAllErrors().get(0).getDefaultMessage());
@@ -115,17 +115,17 @@ public class StoreTelegramSettingsController {
      *
      * @param storeId            идентификатор магазина
      * @param dto                заполненные настройки Telegram
-     * @param authentication     текущая аутентификация пользователя
-     * @param redirectAttributes атрибуты для передачи уведомления об успехе
+     * @param user                текущий пользователь
+     * @param redirectAttributes  атрибуты для передачи уведомления об успехе
      * @return редирект на страницу профиля пользователя
      */
     @PostMapping(consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public String updateSettingsForm(@PathVariable("storeId") Long storeId,
                                      @Valid @ModelAttribute StoreTelegramSettingsDTO dto,
                                      BindingResult binding,
-                                     Authentication authentication,
+                                     @AuthenticationPrincipal User user,
                                      RedirectAttributes redirectAttributes) {
-        Long userId = AuthUtils.getCurrentUser(authentication).getId();
+        Long userId = user.getId();
         if (binding.hasErrors()) {
             redirectAttributes.addFlashAttribute("errorMessage",
                     binding.getAllErrors().get(0).getDefaultMessage());

--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -4,9 +4,10 @@ import com.project.tracking_system.dto.SubscriptionPlanViewDTO;
 import com.project.tracking_system.dto.UserProfileDTO;
 import com.project.tracking_system.service.tariff.TariffService;
 import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,13 +32,13 @@ public class TariffController {
     /**
      * Отображает страницу с тарифными планами.
      *
-     * @param model          модель представления
-     * @param authentication текущая аутентификация
+     * @param model модель представления
+     * @param user  текущий пользователь (может быть {@code null})
      * @return имя шаблона страницы тарифов
      */
     @GetMapping
-    public String tariffs(Model model, Authentication authentication) {
-        Long userId = userService.extractUserId(authentication);
+    public String tariffs(Model model, @AuthenticationPrincipal User user) {
+        Long userId = user != null ? user.getId() : null;
         Integer userPlanPosition = null;
         if (userId != null) {
             // пользователь авторизован
@@ -58,14 +59,14 @@ public class TariffController {
     /**
      * Выполняет апгрейд подписки пользователя до премиум-тарифа.
      *
-     * @param months         количество месяцев продления
-     * @param authentication текущая аутентификация
+     * @param months количество месяцев продления
+     * @param user   текущий пользователь
      * @return редирект на страницу профиля
      */
     @PostMapping("/upgrade")
     public String upgrade(@RequestParam(value = "months", defaultValue = "1") int months,
-                          Authentication authentication) {
-        Long userId = userService.extractUserId(authentication);
+                          @AuthenticationPrincipal User user) {
+        Long userId = user.getId();
         if (userId == null) {
             return "redirect:/login";
         }
@@ -79,16 +80,16 @@ public class TariffController {
     /**
      * Покупает выбранный тарифный план для пользователя.
      *
-     * @param planCode       код плана
-     * @param months         срок в месяцах
-     * @param authentication текущая аутентификация
+     * @param planCode код плана
+     * @param months   срок в месяцах
+     * @param user     текущий пользователь
      * @return редирект на страницу профиля
      */
     @PostMapping("/buy")
     public String buy(@RequestParam("plan") String planCode,
                       @RequestParam(value = "months", defaultValue = "1") int months,
-                      Authentication authentication) {
-        Long userId = userService.extractUserId(authentication);
+                      @AuthenticationPrincipal User user) {
+        Long userId = user.getId();
         if (userId == null) {
             return "redirect:/login";
         }

--- a/src/test/java/com/project/tracking_system/controller/ProfileControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ProfileControllerTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -36,14 +35,11 @@ class ProfileControllerTest {
 
     @Test
     void updateAutoUpdate_FeatureDisabled_ReturnsForbidden() {
-        Authentication authentication = mock(Authentication.class);
         User user = new User();
         user.setId(1L);
-        when(authentication.isAuthenticated()).thenReturn(true);
-        when(authentication.getPrincipal()).thenReturn(user);
         when(subscriptionService.canUseAutoUpdate(1L)).thenReturn(false);
 
-        ResponseEntity<?> response = controller.updateAutoUpdate(true, authentication);
+        ResponseEntity<?> response = controller.updateAutoUpdate(true, user);
 
         assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
         verify(userService, never()).updateAutoUpdateEnabled(anyLong(), anyBoolean());


### PR DESCRIPTION
## Summary
- update controllers to inject `User` with `@AuthenticationPrincipal`
- remove `AuthUtils` usages and pass `user.getId()` directly
- adjust imports and JavaDocs accordingly
- update `ProfileControllerTest` to use new method signature

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdc310bb8832d9d890144f94519a4