### PR TITLE
Add lightweight StoreDTO for profile

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.dto.EvropostCredentialsDTO;
 import com.project.tracking_system.dto.UserSettingsDTO;
 import com.project.tracking_system.dto.PasswordChangeDTO;
 import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.dto.StoreDTO;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.user.UserService;
@@ -70,7 +71,7 @@ public class ProfileController {
         var userProfile = userService.getUserProfile(userId);
 
         // Загружаем магазины с настройками Telegram
-        List<Store> stores = storeService.getUserStoresWithSettings(userId);
+        List<StoreDTO> stores = storeService.getUserStoresDto(userId);
 
         // Добавляем данные профиля в модель
         model.addAttribute("username", user.getEmail());
@@ -325,13 +326,13 @@ public class ProfileController {
      * </p>
      *
      * @param user текущий пользователь
-     * @return список магазинов пользователя
+     * @return список магазинов пользователя в виде DTO
      */
     @GetMapping("/stores")
     @ResponseBody
-    public List<Store> getUserStores(@AuthenticationPrincipal User user) {
+    public List<StoreDTO> getUserStores(@AuthenticationPrincipal User user) {
         storeService.getDefaultStoreId(user.getId());
-        return storeService.getUserStores(user.getId());
+        return storeService.getUserStoresDto(user.getId());
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/dto/StoreDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreDTO.java
@@ -1,0 +1,22 @@
+package com.project.tracking_system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Лёгкое представление магазина для профиля.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreDTO {
+    private Long id;
+    private String name;
+    /** Признак магазина по умолчанию. */
+    private boolean isDefault;
+    /** Настройки Telegram данного магазина. */
+    private StoreTelegramSettingsDTO telegramSettings;
+}

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import com.project.tracking_system.dto.StoreDTO;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -458,6 +459,35 @@ public class StoreService {
                 settings.getTemplates().add(t);
             });
         }
+    }
+
+    /**
+     * Преобразует сущность магазина в {@link StoreDTO}.
+     *
+     * @param store сущность магазина
+     * @return DTO с необходимыми для профиля полями
+     */
+    public StoreDTO toDto(Store store) {
+        if (store == null) return null;
+        StoreDTO dto = new StoreDTO();
+        dto.setId(store.getId());
+        dto.setName(store.getName());
+        dto.setDefault(store.isDefault());
+        dto.setTelegramSettings(toDto(store.getTelegramSettings()));
+        return dto;
+    }
+
+    /**
+     * Возвращает список магазинов пользователя в виде DTO.
+     *
+     * @param userId идентификатор пользователя
+     * @return список магазинов с минимальным набором полей
+     */
+    @Transactional(readOnly = true)
+    public List<StoreDTO> getUserStoresDto(Long userId) {
+        return storeRepository.findByOwnerIdFetchSettings(userId).stream()
+                .map(this::toDto)
+                .toList();
     }
 
 


### PR DESCRIPTION
## Summary
- add new `StoreDTO` for profile needs
- map stores to DTOs in StoreService
- update ProfileController to use StoreDTO

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685bf79dac30832da7b5adbee035844a