### PR TITLE
Fix telegram template references

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -459,7 +459,7 @@
                 <div class="form-check form-switch mb-2 ms-3">
                     <input class="form-check-input" type="checkbox" th:id="'tg-custom-templates-' + ${store.id}"
                            name="useCustomTemplates"
-                           th:checked="${store.telegramSettings?.templatesMap?.size() > 0}">
+                           th:checked="${store.telegramSettings?.templates?.size() > 0}">
                     <label class="form-check-label" th:for="'tg-custom-templates-' + ${store.id}">
                         Использовать собственные сообщения
                     </label>
@@ -473,7 +473,7 @@
                                       th:id="${'tpl-' + status.name() + '-' + store.id}"
                                       th:name="${'templates[' + status.name() + ']'}"
                                       rows="3"
-                                      th:text="${store.telegramSettings?.templatesMap?.get(status)}"></textarea>
+                                      th:text="${store.telegramSettings?.templates?.get(status.name())}"></textarea>
                         </div>
                     </div>
                     <p class="form-text">Шаблоны должны содержать {track} и {store}</p>


### PR DESCRIPTION
## Summary
- fix telegram settings check in profile.html
- access templates by status name

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfcd32100832db612aac66c68bcea