### PR TITLE
Fix unused import in UserSettingsService

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/UserSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserSettingsService.java
@@ -2,7 +2,6 @@ package com.project.tracking_system.service.user;
 
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.UserSettings;
-import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.repository.UserSettingsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
## Summary
- remove obsolete `UserRepository` import from `UserSettingsService`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c34dcbe4c832dba5f0dba70fc48bf