### PR TITLE
Add auto creation for user settings

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/UserService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserService.java
@@ -169,7 +169,7 @@ public class UserService {
 
         userRepository.save(user);
         // Создаём настройки пользователя по умолчанию
-        userSettingsService.getUserSettings(user.getId());
+        userSettingsService.getOrCreateSettings(user.getId());
         storeService.createDefaultStoreForUser(user);
         confirmationTokenRepository.deleteByEmail(userDTO.getEmail());
 
@@ -250,7 +250,7 @@ public class UserService {
         userRepository.save(user);
 
         // Создаём настройки пользователя по умолчанию
-        userSettingsService.getUserSettings(user.getId());
+        userSettingsService.getOrCreateSettings(user.getId());
 
         // Создаём магазин по умолчанию
         storeService.createDefaultStoreForUser(user);

--- a/src/main/java/com/project/tracking_system/service/user/UserSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/user/UserSettingsService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserSettingsService {
 
     private final UserSettingsRepository settingsRepository;
+    private final UserRepository userRepository;
 
     /**
      * Получить настройки пользователя. Если они отсутствуют, возвращается null.
@@ -25,6 +26,29 @@ public class UserSettingsService {
     @Transactional(readOnly = true)
     public UserSettings getUserSettings(Long userId) {
         return settingsRepository.findByUserId(userId);
+    }
+
+    /**
+     * Получить настройки пользователя или создать их при отсутствии.
+     *
+     * @param userId идентификатор пользователя
+     * @return существующие или новые настройки
+     */
+    @Transactional
+    public UserSettings getOrCreateSettings(Long userId) {
+        UserSettings settings = settingsRepository.findByUserId(userId);
+        if (settings != null) {
+            return settings;
+        }
+
+        // Получаем пользователя и создаём настройки с значениями по умолчанию
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден"));
+        settings = new UserSettings();
+        settings.setUser(user);
+        settingsRepository.save(settings);
+        log.info("Созданы новые настройки для пользователя {}", userId);
+        return settings;
     }
 
     /**
@@ -47,7 +71,7 @@ public class UserSettingsService {
      */
     @Transactional
     public void updateShowBulkUpdateButton(Long userId, boolean value) {
-        UserSettings settings = getUserSettings(userId);
+        UserSettings settings = getOrCreateSettings(userId);
         settings.setShowBulkUpdateButton(value);
         settingsRepository.save(settings);
         log.info("Настройка showBulkUpdateButton обновлена для пользователя {}: {}", userId, value);
@@ -61,7 +85,7 @@ public class UserSettingsService {
      */
     @Transactional
     public void updateTelegramNotificationsEnabled(Long userId, boolean enabled) {
-        UserSettings settings = getUserSettings(userId);
+        UserSettings settings = getOrCreateSettings(userId);
         settings.setTelegramNotificationsEnabled(enabled);
         settingsRepository.save(settings);
         log.info("Флаг telegramNotificationsEnabled обновлен для пользователя {}: {}", userId, enabled);

--- a/src/test/java/com/project/tracking_system/service/user/UserServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/user/UserServiceTest.java
@@ -117,6 +117,6 @@ class UserServiceTest {
         userService.createUserByAdmin("new@example.com", "pass", "ROLE_USER", "FREE");
 
         verify(userRepository).save(argThat(u -> "Europe/Minsk".equals(u.getTimeZone())));
-        verify(userSettingsService).getUserSettings(anyLong());
+        verify(userSettingsService).getOrCreateSettings(anyLong());
     }
 }


### PR DESCRIPTION
## Summary
- ensure user settings are created automatically on demand
- use new retrieval method in registration flows
- update unit tests for the new method and behaviour

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c34d5daac832d914439e07cd56de9