### PR TITLE
Update Telegram toggle logic

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -180,8 +180,9 @@
         <form id="telegram-notifications-form" class="mt-2">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <div class="form-check form-switch">
+                <!-- При недоступной функции переключатель всегда выключен -->
                 <input class="form-check-input" type="checkbox" id="telegramNotificationsToggle"
-                       th:checked="${userSettingsDTO.telegramNotificationsEnabled}"
+                       th:checked="${planDetails.allowTelegramNotifications and userSettingsDTO.telegramNotificationsEnabled}"
                        th:disabled="${!planDetails.allowTelegramNotifications}">
                 <label class="form-check-label" for="telegramNotificationsToggle">Получать уведомления о статусах посылок</label>
             </div>


### PR DESCRIPTION
## Summary
- ensure Telegram notifications toggle is only checked when the feature is available and enabled
- document that the toggle stays off when the feature is unavailable

## Testing
- `./mvnw test -q` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685c3b234c50832d890d1603fffa14c9