### PR TITLE
Handle telegram settings access by plan

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -299,9 +299,19 @@ function initAssignCustomerFormHandler() {
 
 // Инициализация форм настроек Telegram
 function initTelegramForms() {
+    const tgToggle = document.getElementById('telegramNotificationsToggle');
+    const telegramUnavailable = tgToggle && tgToggle.disabled;
+
     document.querySelectorAll('.telegram-settings-form').forEach(form => {
         if (form.dataset.initialized) return;
         form.dataset.initialized = 'true';
+
+        if (telegramUnavailable) {
+            // Отправка настроек запрещена на базовом тарифе
+            const saveBtn = form.querySelector('button[type="submit"]');
+            if (saveBtn) saveBtn.disabled = true;
+            return;
+        }
 
         form.addEventListener('submit', async function (event) {
             event.preventDefault();


### PR DESCRIPTION
## Summary
- respect plan restrictions for telegram forms
- disable Save when telegram notifications are unavailable

## Testing
- `./mvnw test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_685c40c5d00c832db6cb354c1cf0aa4d