### PR TITLE
Add comments about unavailable features

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -176,6 +176,7 @@ function initializeCustomCredentialsCheckbox() {
 function initAutoUpdateToggle() {
     const checkbox = document.getElementById("autoUpdateToggle");
     if (!checkbox) return;
+    // Переключатель может быть отключён сервером при бесплатном тарифе
 
     let debounceTimer;
     checkbox.addEventListener('change', function () {
@@ -203,8 +204,8 @@ function initAutoUpdateToggle() {
 function initBulkButtonToggle() {
     const checkbox = document.getElementById("showBulkUpdateButton");
     if (!checkbox) return;
+    // Форма может быть отключена на бесплатном тарифе
 
-    let debounceTimer;
     checkbox.addEventListener('change', function () {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -175,6 +175,7 @@
                 </div>
 
 <div class="tab-pane fade" id="v-pills-notifications" role="tabpanel">
+    <!-- Уведомления недоступны на бесплатных тарифах -->
     <div class="card p-3 shadow-sm rounded-4 mb-4">
         <h5 class="mb-3">Уведомления (Telegram)</h5>
         <form id="telegram-notifications-form" class="mt-2">


### PR DESCRIPTION
## Summary
- clarify that notifications are not available on free plans in profile view
- add explanatory comments in app.js when form controls are disabled

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c442ea4a4832d820cfb588c131b41