### PR TITLE
Add display names for BuyerStatus

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerStatus.java
@@ -1,26 +1,47 @@
 package com.project.tracking_system.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 /**
- * @author Dmitriy Anisimov
- * @date 19.06.2025
+ * Статус посылки, предназначенный для отображения покупателю.
+ * Содержит шаблон сообщения и читабельное название на русском языке.
  */
-@Getter
-@AllArgsConstructor
 public enum BuyerStatus {
 
-    REGISTERED("Ваш заказ %s из магазина %s зарегистрирован и скоро будет отправлен."),
-    IN_TRANSIT("Посылка %s из магазина %s находится в пути."),
-    WAITING("Посылка %s из магазина %s прибыла и ждёт вас в пункте выдачи."),
-    DELIVERED("Посылка %s из магазина %s получена. Спасибо за покупку!"),
-    RETURNED("Посылка {track} из магазина {store} уже возвращается отправителю.");
+    /** Заказ зарегистрирован. */
+    REGISTERED("Зарегистрирован", "Ваш заказ %s из магазина %s зарегистрирован и скоро будет отправлен."),
+    /** Посылка находится в пути. */
+    IN_TRANSIT("В пути", "Посылка %s из магазина %s находится в пути."),
+    /** Посылка ожидает получения. */
+    WAITING("Ожидает получения", "Посылка %s из магазина %s прибыла и ждёт вас в пункте выдачи."),
+    /** Посылка получена покупателем. */
+    DELIVERED("Получена", "Посылка %s из магазина %s получена. Спасибо за покупку!"),
+    /** Посылка возвращается отправителю. */
+    RETURNED("Возврат", "Посылка %s из магазина %s уже возвращается отправителю.");
 
+    private final String displayName;
     private final String messageTemplate;
 
+    BuyerStatus(String displayName, String messageTemplate) {
+        this.displayName = displayName;
+        this.messageTemplate = messageTemplate;
+    }
+
+    /**
+     * Возвращает русскоязычное название статуса.
+     *
+     * @return читаемое название статуса
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Формирует сообщение на основе переданных данных.
+     *
+     * @param track трек-номер посылки
+     * @param store название магазина
+     * @return сформированное сообщение
+     */
     public String formatMessage(String track, String store) {
         return String.format(messageTemplate, track, store);
     }
-
 }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -472,7 +472,7 @@
                 <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields">
                     <div th:each="status : ${T(com.project.tracking_system.entity.BuyerStatus).values()}">
                         <div class="mb-2">
-                            <label class="form-label" th:for="${'tpl-' + status.name() + '-' + store.id}" th:text="${status.name()}"></label>
+                            <label class="form-label" th:for="${'tpl-' + status.name() + '-' + store.id}" th:text="${status.displayName}"></label>
                             <textarea class="form-control form-control-sm"
                                       th:id="${'tpl-' + status.name() + '-' + store.id}"
                                       th:name="${'templates[' + status.name() + ']'}"


### PR DESCRIPTION
## Summary
- show Russian display names for buyer statuses
- use display names in profile.html

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_685c6a79a9b0832db135bde1a544f723