### PR TITLE
Handle invalid telegram templates

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.service.store.StoreTelegramSettingsService;
+import com.project.tracking_system.exception.InvalidTemplateException;
 import com.project.tracking_system.utils.ResponseBuilder;
 import com.project.tracking_system.controller.WebSocketController;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +67,9 @@ public class StoreTelegramSettingsController {
             telegramSettingsService.update(store, dto, userId);
             webSocketController.sendUpdateStatus(userId, "Настройки Telegram сохранены.", true);
             return ResponseBuilder.ok(storeService.toDto(store.getTelegramSettings()));
+        } catch (InvalidTemplateException e) {
+            log.warn("Некорректный шаблон Telegram: {}", e.getMessage());
+            return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         } catch (IllegalStateException e) {
             log.warn("Ошибка обновления настроек Telegram: {}", e.getMessage());
             return ResponseBuilder.error(HttpStatus.FORBIDDEN, e.getMessage());
@@ -104,6 +108,9 @@ public class StoreTelegramSettingsController {
             telegramSettingsService.update(store, dto, userId);
             webSocketController.sendUpdateStatus(userId, "Настройки Telegram сохранены.", true);
             return ResponseEntity.ok().build();
+        } catch (InvalidTemplateException e) {
+            log.warn("Некорректный шаблон Telegram: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         } catch (IllegalStateException e) {
             log.warn("Ошибка обновления настроек Telegram: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
@@ -136,6 +143,9 @@ public class StoreTelegramSettingsController {
             telegramSettingsService.update(store, dto, userId);
             redirectAttributes.addFlashAttribute("successMessage", "Настройки Telegram сохранены.");
             webSocketController.sendUpdateStatus(userId, "Настройки Telegram сохранены.", true);
+        } catch (InvalidTemplateException e) {
+            log.warn("Некорректный шаблон Telegram: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         } catch (IllegalStateException e) {
             log.warn("Ошибка обновления настроек Telegram: {}", e.getMessage());
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());

--- a/src/main/java/com/project/tracking_system/exception/InvalidTemplateException.java
+++ b/src/main/java/com/project/tracking_system/exception/InvalidTemplateException.java
@@ -1,0 +1,16 @@
+package com.project.tracking_system.exception;
+
+/**
+ * Исключение, возникающее при некорректном пользовательском шаблоне Telegram.
+ */
+public class InvalidTemplateException extends RuntimeException {
+
+    /**
+     * Создаёт исключение с описанием ошибки.
+     *
+     * @param message подробности некорректности шаблона
+     */
+    public InvalidTemplateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.exception.InvalidTemplateException;
 import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.service.store.StoreService;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +72,7 @@ public class StoreTelegramSettingsService {
     // Проверяем наличие обязательных плейсхолдеров
     private void validateTemplate(String template) {
         if (!template.contains("{track}") || !template.contains("{store}")) {
-            throw new IllegalArgumentException("Шаблон должен содержать {track} и {store}");
+            throw new InvalidTemplateException("Шаблон должен содержать {track} и {store}");
         }
     }
 }

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Map;
 
+import com.project.tracking_system.exception.InvalidTemplateException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -66,6 +67,6 @@ class StoreTelegramSettingsServiceTest {
         dto.setUseCustomTemplates(true);
         dto.setTemplates(Map.of("WAITING", "Неверный шаблон"));
 
-        assertThrows(IllegalArgumentException.class, () -> service.update(store, dto, 1L));
+        assertThrows(InvalidTemplateException.class, () -> service.update(store, dto, 1L));
     }
 }


### PR DESCRIPTION
## Summary
- add `InvalidTemplateException`
- validate telegram templates with `InvalidTemplateException`
- catch the new exception in `StoreTelegramSettingsController`
- update unit test expectations

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685c6c477d6c832da5787562c5698761