### PR TITLE
Handle invalid template from profile form

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -145,7 +145,8 @@ public class StoreTelegramSettingsController {
             webSocketController.sendUpdateStatus(userId, "Настройки Telegram сохранены.", true);
         } catch (InvalidTemplateException e) {
             log.warn("Некорректный шаблон Telegram: {}", e.getMessage());
-            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            redirectAttributes.addFlashAttribute("templateError", e.getMessage());
+            redirectAttributes.addFlashAttribute("storeIdWithError", storeId);
         } catch (IllegalStateException e) {
             log.warn("Ошибка обновления настроек Telegram: {}", e.getMessage());
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -393,6 +393,7 @@
 
 <th:block th:fragment="telegramStoreBlock(store, first)" th:remove="tag">
     <div th:id="'store-block-' + ${store.id}" class="mt-3 border p-3 rounded bg-light-subtle">
+        <div th:if="${storeIdWithError == store.id}" class="alert alert-danger py-2" th:text="${templateError}"></div>
         <div class="d-flex justify-content-between align-items-center">
             <h5 class="mb-2">
                 <span class="text-decoration-none" th:text="${store.name}"></span>


### PR DESCRIPTION
## Summary
- catch InvalidTemplateException when updating Telegram settings
- show store-specific error alert on the profile page

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6d72bb94832d88887683def776b8