### PR TITLE
Support {track}/{store} placeholders

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerStatus.java
@@ -35,13 +35,24 @@ public enum BuyerStatus {
     }
 
     /**
-     * Формирует сообщение на основе переданных данных.
+     * Формирует текст уведомления для покупателя.
+     * <p>
+     * Метод поддерживает два формата шаблонов: классический с {@code %s}
+     * и новый с плейсхолдерами {@code {track}} и {@code {store}}.
+     * Если в шаблоне присутствуют фигурные скобки, они будут заменены
+     * напрямую, иначе используется {@link String#format}.
+     * </p>
      *
      * @param track трек-номер посылки
      * @param store название магазина
-     * @return сформированное сообщение
+     * @return готовое сообщение
      */
     public String formatMessage(String track, String store) {
+        // Поддерживаем как шаблоны с %s, так и с {track}/{store}
+        if (messageTemplate.contains("{track}") || messageTemplate.contains("{store}")) {
+            return messageTemplate.replace("{track}", track)
+                    .replace("{store}", store);
+        }
         return String.format(messageTemplate, track, store);
     }
 }


### PR DESCRIPTION
## Summary
- improve `BuyerStatus.formatMessage` to handle templates with `{track}` and `{store}`
- update `TelegramNotificationServiceTest` to verify replacement for default templates

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6f3d7cb0832d815b86c5fe5fff95