### PR TITLE
Validate telegram template statuses

### DIFF
--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -69,4 +69,20 @@ class StoreTelegramSettingsServiceTest {
 
         assertThrows(InvalidTemplateException.class, () -> service.update(store, dto, 1L));
     }
+
+    @Test
+    void update_UnknownStatus_Throws() {
+        Store store = new Store();
+        store.setId(1L);
+        StoreTelegramSettings settings = new StoreTelegramSettings();
+        settings.setStore(store);
+        when(repository.findByStoreId(1L)).thenReturn(settings);
+        when(subscriptionService.isFeatureEnabled(1L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
+
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+        dto.setTemplates(Map.of("UNKNOWN", "Msg {track} {store}"));
+
+        assertThrows(InvalidTemplateException.class, () -> service.update(store, dto, 1L));
+    }
 }


### PR DESCRIPTION
## Summary
- log and throw exception when template key is not a valid BuyerStatus
- test unknown status handling in StoreTelegramSettingsService

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c734db23c832da8a3a3b7b6ddc7b1