### PR TITLE
Add validation message test for Telegram settings

### DIFF
--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -71,6 +71,24 @@ class StoreTelegramSettingsServiceTest {
     }
 
     @Test
+    void update_InvalidTemplate_Message() {
+        Store store = new Store();
+        store.setId(1L);
+        StoreTelegramSettings settings = new StoreTelegramSettings();
+        settings.setStore(store);
+        when(repository.findByStoreId(1L)).thenReturn(settings);
+        when(subscriptionService.isFeatureEnabled(1L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
+
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+        dto.setTemplates(Map.of("WAITING", "Неверный шаблон"));
+
+        InvalidTemplateException ex = assertThrows(InvalidTemplateException.class,
+                () -> service.update(store, dto, 1L));
+        assertEquals("Шаблон должен содержать {track} и {store}", ex.getMessage());
+    }
+
+    @Test
     void update_UnknownStatus_Throws() {
         Store store = new Store();
         store.setId(1L);


### PR DESCRIPTION
## Summary
- add test for invalid template message

## Testing
- `./mvnw -q -Dtest=StoreTelegramSettingsServiceTest test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685c74eee76c832da999890dab0ccca5