### PR TITLE
Update getSettings javadoc

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -37,6 +37,12 @@ public class StoreTelegramSettingsController {
 
     /**
      * Получить текущие настройки магазина.
+     * <p>
+     * Метод возвращает параметры Telegram для указанного магазина.
+     *
+     * @param storeId идентификатор магазина
+     * @param user    текущий пользователь
+     * @return {@link ResponseEntity} с {@link StoreTelegramSettingsDTO} в теле
      */
     @GetMapping
     @ResponseBody


### PR DESCRIPTION
## Summary
- expand JavaDoc of `getSettings` endpoint with details about parameters and response

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7767bb1c832db8ec8ce74cf0fc1a