### PR TITLE
Add custom Telegram bot support

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -28,6 +28,12 @@ public class StoreTelegramSettingsDTO {
     @Size(max = 200)
     private String customSignature;
 
+    /** Токен пользовательского Telegram-бота. */
+    private String botToken;
+
+    /** Имя пользовательского бота. */
+    private String botUsername;
+
 
     private boolean remindersEnabled = false;
 

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
@@ -20,4 +20,5 @@ public class SubscriptionLimitsDTO {
     private boolean allowAutoUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
+    private boolean allowCustomBot;
 }

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -23,6 +23,7 @@ public class SubscriptionPlanViewDTO {
     private boolean allowAutoUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
+    private boolean allowCustomBot;
     private String monthlyPriceLabel;
     private String annualPriceLabel;
 

--- a/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
@@ -47,6 +47,12 @@ public class StoreTelegramSettings {
     @Column(name = "custom_signature", length = 200)
     private String customSignature;
 
+    @Column(name = "bot_token")
+    private String botToken;
+
+    @Column(name = "bot_username")
+    private String botUsername;
+
 
     @Column(name = "reminders_enabled", nullable = false)
     private boolean remindersEnabled = false;

--- a/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
+++ b/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
@@ -18,7 +18,12 @@ public enum FeatureKey {
     /**
      * Автоматическое обновление треков.
      */
-    AUTO_UPDATE("autoUpdate");
+    AUTO_UPDATE("autoUpdate"),
+
+    /**
+     * Использование собственного Telegram-бота.
+     */
+    CUSTOM_BOT("customBot");
 
     private final String key;
 

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -203,6 +203,17 @@ public class SubscriptionService {
     }
 
     /**
+     * Проверяет, разрешено ли использование собственного Telegram-бота.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если функция включена в тарифе
+     */
+    @Transactional(readOnly = true)
+    public boolean canUseCustomBot(Long userId) {
+        return isFeatureEnabled(userId, FeatureKey.CUSTOM_BOT);
+    }
+
+    /**
      * Проверяет доступность функции для указанного пользователя.
      *
      * @param userId идентификатор пользователя

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -57,6 +57,7 @@ public class SubscriptionPlanService {
         limitsDto.setAllowBulkUpdate(plan.isFeatureEnabled(FeatureKey.BULK_UPDATE));
         limitsDto.setAllowAutoUpdate(plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE));
         limitsDto.setAllowTelegramNotifications(plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS));
+        limitsDto.setAllowCustomBot(plan.isFeatureEnabled(FeatureKey.CUSTOM_BOT));
 
         SubscriptionPlanDTO dto = new SubscriptionPlanDTO();
         dto.setId(plan.getId());
@@ -98,6 +99,7 @@ public class SubscriptionPlanService {
             setFeature(plan, FeatureKey.BULK_UPDATE, l.isAllowBulkUpdate());
             setFeature(plan, FeatureKey.AUTO_UPDATE, l.isAllowAutoUpdate());
             setFeature(plan, FeatureKey.TELEGRAM_NOTIFICATIONS, l.isAllowTelegramNotifications());
+            setFeature(plan, FeatureKey.CUSTOM_BOT, l.isAllowCustomBot());
         }
 
         BigDecimal monthly = dto.getMonthlyPrice();

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -434,6 +434,8 @@ public class StoreService {
         dto.setReminderStartAfterDays(settings.getReminderStartAfterDays());
         dto.setReminderRepeatIntervalDays(settings.getReminderRepeatIntervalDays());
         dto.setCustomSignature(settings.getCustomSignature());
+        dto.setBotToken(settings.getBotToken());
+        dto.setBotUsername(settings.getBotUsername());
         dto.setRemindersEnabled(settings.isRemindersEnabled());
         dto.setUseCustomTemplates(!settings.getTemplates().isEmpty());
         dto.setTemplates(settings.getTemplatesMap().entrySet().stream()
@@ -459,6 +461,8 @@ public class StoreService {
         settings.setReminderStartAfterDays(dto.getReminderStartAfterDays());
         settings.setReminderRepeatIntervalDays(dto.getReminderRepeatIntervalDays());
         settings.setCustomSignature(dto.getCustomSignature());
+        settings.setBotToken(dto.getBotToken());
+        settings.setBotUsername(dto.getBotUsername());
         settings.setRemindersEnabled(dto.isRemindersEnabled());
 
         // Составляем карту существующих шаблонов для быстрого доступа

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.controller.WebSocketController;
 import com.project.tracking_system.exception.InvalidTemplateException;
 import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.telegram.TelegramClientFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class StoreTelegramSettingsService {
     private final WebSocketController webSocketController;
     private final StoreService storeService;
     private final StoreTelegramTemplateRepository storeTelegramTemplateRepository;
+    private final TelegramClientFactory telegramClientFactory;
 
     /**
      * Создать или обновить настройки Telegram магазина.
@@ -58,6 +60,22 @@ public class StoreTelegramSettingsService {
         if (settings == null) {
             settings = new StoreTelegramSettings();
             settings.setStore(store);
+        }
+
+        String token = dto.getBotToken();
+        if (token != null && !token.isBlank()) {
+            if (!subscriptionService.isFeatureEnabled(userId, FeatureKey.CUSTOM_BOT)) {
+                throw new IllegalStateException("Использование собственного бота не разрешено на вашем тарифе");
+            }
+            try {
+                var client = telegramClientFactory.create(token);
+                var me = client.execute(new org.telegram.telegrambots.meta.api.methods.GetMe());
+                dto.setBotUsername(me.getUserName());
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Неверный токен бота", e);
+            }
+        } else {
+            dto.setBotUsername(null);
         }
 
         // Проверяем содержимое пользовательских шаблонов при их использовании

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -126,6 +126,7 @@ public class TariffService {
                 plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE),
                 limits.getMaxStores(),
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
+                plan.isFeatureEnabled(FeatureKey.CUSTOM_BOT),
                 monthlyLabel,
                 annualLabel,
                 fullAnnualPriceLabel,

--- a/src/main/java/com/project/tracking_system/service/telegram/DefaultTelegramClientFactory.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/DefaultTelegramClientFactory.java
@@ -1,0 +1,16 @@
+package com.project.tracking_system.service.telegram;
+
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.client.okhttp.OkHttpTelegramClient;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/**
+ * Реализация фабрики клиентов Telegram на базе OkHttp.
+ */
+@Component
+public class DefaultTelegramClientFactory implements TelegramClientFactory {
+    @Override
+    public TelegramClient create(String token) {
+        return new OkHttpTelegramClient(token);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramClientFactory.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramClientFactory.java
@@ -1,0 +1,16 @@
+package com.project.tracking_system.service.telegram;
+
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/**
+ * Фабрика клиентов Telegram для работы с разными токенами.
+ */
+public interface TelegramClientFactory {
+    /**
+     * Создаёт клиент Telegram для указанного токена.
+     *
+     * @param token токен бота
+     * @return клиент Telegram
+     */
+    TelegramClient create(String token);
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
+import com.project.tracking_system.service.telegram.TelegramClientFactory;
 
 /**
  * Сервис отправки уведомлений в Telegram-покупателям.
@@ -23,6 +24,7 @@ public class TelegramNotificationService {
 
     private final TelegramClient telegramClient;
     private final CustomerService customerService;
+    private final TelegramClientFactory telegramClientFactory;
 
     /**
      * Отправить уведомление о смене статуса посылки.
@@ -68,8 +70,13 @@ public class TelegramNotificationService {
 
         SendMessage message = new SendMessage(chatId.toString(), text);
 
+        TelegramClient client = telegramClient;
+        if (settings != null && settings.getBotToken() != null && !settings.getBotToken().isBlank()) {
+            client = telegramClientFactory.create(settings.getBotToken());
+        }
+
         try {
-            telegramClient.execute(message);
+            client.execute(message);
             log.info("📨 Уведомление отправлено: {} (статус {}) в чат {} для трека {}",
                     text, status, chatId, parcel.getNumber());
         } catch (TelegramApiException e) {
@@ -108,8 +115,13 @@ public class TelegramNotificationService {
 
         SendMessage message = new SendMessage(chatId.toString(), text);
 
+        TelegramClient client = telegramClient;
+        if (settings != null && settings.getBotToken() != null && !settings.getBotToken().isBlank()) {
+            client = telegramClientFactory.create(settings.getBotToken());
+        }
+
         try {
-            telegramClient.execute(message);
+            client.execute(message);
             log.info("✅ Напоминание отправлено в чат {} о треке {}", chatId, parcel.getNumber());
         } catch (TelegramApiException e) {
             log.error("❌ Ошибка отправки напоминания в чат {}: {}", chatId, e.getMessage(), e);

--- a/src/main/resources/db/migration/V20__add_custom_bot_columns.sql
+++ b/src/main/resources/db/migration/V20__add_custom_bot_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_store_telegram_settings
+    ADD COLUMN bot_token VARCHAR(200),
+    ADD COLUMN bot_username VARCHAR(100);

--- a/src/test/java/com/project/tracking_system/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/SubscriptionServiceTest.java
@@ -173,6 +173,20 @@ class SubscriptionServiceTest {
     }
 
     @Test
+    void canUseCustomBot_DelegatesToFeatureCheck() {
+        when(userSubscriptionRepository.getSubscriptionPlanCode(5L)).thenReturn("PREMIUM");
+        SubscriptionFeature feature = new SubscriptionFeature();
+        feature.setFeatureKey(FeatureKey.CUSTOM_BOT);
+        feature.setEnabled(true);
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setCode("PREMIUM");
+        plan.setFeatures(List.of(feature));
+        when(subscriptionPlanRepository.findByCode("PREMIUM")).thenReturn(Optional.of(plan));
+
+        assertTrue(subscriptionService.canUseCustomBot(5L));
+    }
+
+    @Test
     void changeSubscription_ToPaidPlan_SetsEndDate() {
         UserSubscription subscription = new UserSubscription();
         subscription.setUser(new User());

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -1,0 +1,81 @@
+package com.project.tracking_system.service.store;
+
+import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.model.subscription.FeatureKey;
+import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import com.project.tracking_system.repository.StoreTelegramTemplateRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.telegram.TelegramClientFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link StoreTelegramSettingsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StoreTelegramSettingsServiceTest {
+
+    @Mock
+    private StoreTelegramSettingsRepository settingsRepository;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private StoreService storeService;
+    @Mock
+    private StoreTelegramTemplateRepository templateRepository;
+    @Mock
+    private TelegramClientFactory clientFactory;
+    @Mock
+    private TelegramClient telegramClient;
+
+    @InjectMocks
+    private StoreTelegramSettingsService service;
+
+    @Test
+    void update_TokenWithoutFeature_Throws() {
+        Store store = new Store();
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setEnabled(false);
+        dto.setBotToken("t");
+
+        when(subscriptionService.isFeatureEnabled(1L, FeatureKey.CUSTOM_BOT)).thenReturn(false);
+        StoreTelegramSettings settings = new StoreTelegramSettings();
+        when(settingsRepository.findByStoreId(null)).thenReturn(settings);
+
+        assertThrows(IllegalStateException.class, () -> service.update(store, dto, 1L));
+    }
+
+    @Test
+    void update_ValidToken_SavesUsername() throws Exception {
+        Store store = new Store();
+        store.setId(2L);
+        StoreTelegramSettings settings = new StoreTelegramSettings();
+        when(settingsRepository.findByStoreId(2L)).thenReturn(settings);
+
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setEnabled(false);
+        dto.setBotToken("token");
+
+        when(subscriptionService.isFeatureEnabled(2L, FeatureKey.CUSTOM_BOT)).thenReturn(true);
+        when(clientFactory.create("token")).thenReturn(telegramClient);
+        User me = new User();
+        me.setUserName("bot");
+        when(telegramClient.execute(any(GetMe.class))).thenReturn(me);
+
+        service.update(store, dto, 2L);
+
+        verify(storeService).updateFromDto(eq(settings), eq(dto));
+        verify(settingsRepository).save(settings);
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -61,7 +61,11 @@ class TariffServiceTest {
         telegram.setFeatureKey(FeatureKey.TELEGRAM_NOTIFICATIONS);
         telegram.setEnabled(true);
         telegram.setSubscriptionPlan(plan);
-        plan.setFeatures(List.of(bulk, auto, telegram));
+        SubscriptionFeature customBot = new SubscriptionFeature();
+        customBot.setFeatureKey(FeatureKey.CUSTOM_BOT);
+        customBot.setEnabled(true);
+        customBot.setSubscriptionPlan(plan);
+        plan.setFeatures(List.of(bulk, auto, telegram, customBot));
     }
 
     @Test
@@ -101,6 +105,7 @@ class TariffServiceTest {
         assertTrue(dto.isAllowBulkUpdate());
         assertTrue(dto.isAllowAutoUpdate());
         assertTrue(dto.isAllowTelegramNotifications());
+        assertTrue(dto.isAllowCustomBot());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());


### PR DESCRIPTION
## Summary
- add CUSTOM_BOT feature flag
- expose allowCustomBot in plan DTOs
- handle custom bot flag in plan services
- provide canUseCustomBot in subscription service
- support bot token and username in store settings with migration
- verify custom bot token on update
- send notifications via store bot token
- supply telegram client factory
- cover features with new tests

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0eba68d4832d95bec00a3cace6cb