### PR TITLE
Add custom bot feature to views and controller

### DIFF
--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -22,6 +22,7 @@
             <th>Массовое обновление</th>
             <th>Автообновление</th>
             <th>Telegram-уведомления</th>
+            <th>Собственный бот</th>
             <th>Активный</th>
             <th>Действия</th>
         </tr>
@@ -41,6 +42,7 @@
                 <td class="text-center"><input type="checkbox" name="limits.allowBulkUpdate" th:checked="${plan.limits.allowBulkUpdate}" /></td>
                 <td class="text-center"><input type="checkbox" name="limits.allowAutoUpdate" th:checked="${plan.limits.allowAutoUpdate}" /></td>
                 <td class="text-center"><input type="checkbox" name="limits.allowTelegramNotifications" th:checked="${plan.limits.allowTelegramNotifications}" /></td>
+                <td class="text-center"><input type="checkbox" name="limits.allowCustomBot" th:checked="${plan.limits.allowCustomBot}" /></td>
                 <td class="text-center"><input type="checkbox" name="active" th:checked="${plan.active}" /></td>
                 <td>
                     <button type="submit" class="btn btn-success btn-sm me-1">Сохранить</button>
@@ -104,6 +106,12 @@
             <div class="form-check">
                 <input id="plan-telegram" type="checkbox" name="limits.allowTelegramNotifications" class="form-check-input" />
                 <label class="form-check-label" for="plan-telegram">Telegram-уведомления</label>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <div class="form-check">
+                <input id="plan-custom-bot" type="checkbox" name="limits.allowCustomBot" class="form-check-input" />
+                <label class="form-check-label" for="plan-custom-bot">Собственный бот</label>
             </div>
         </div>
         <div class="col-md-1">

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -41,6 +41,7 @@
             <th>Магазинов</th>
             <th>Массовое обновление</th>
             <th>Telegram-уведомления</th>
+            <th>Собственный бот</th>
         </tr>
         </thead>
         <tbody>
@@ -52,6 +53,7 @@
             <td th:text="${plan.maxStores}"></td>
             <td th:text="${plan.allowBulkUpdate}"></td>
             <td th:text="${plan.allowTelegramNotifications}"></td>
+            <td th:text="${plan.allowCustomBot}"></td>
         </tr>
         </tbody>
     </table>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -270,6 +270,10 @@
             <span th:if="${planDetails.allowTelegramNotifications}">📨 Telegram-уведомления</span>
             <span th:unless="${planDetails.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
         </li>
+        <li>
+            <span th:if="${planDetails.allowCustomBot}">🤖 Собственный бот</span>
+            <span th:unless="${planDetails.allowCustomBot}" class="text-muted">❌ Собственный бот</span>
+        </li>
     </ul>
 </div>
 

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -79,6 +79,10 @@
                                 <span th:if="${plan.allowTelegramNotifications}">📨 Telegram-уведомления</span>
                                 <span th:unless="${plan.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
                             </li>
+                            <li>
+                                <span th:if="${plan.allowCustomBot}">🤖 Собственный бот</span>
+                                <span th:unless="${plan.allowCustomBot}" class="text-muted">❌ Собственный бот</span>
+                            </li>
                         </ul>
 
 

--- a/src/main/resources/templates/telegram/token-form.html
+++ b/src/main/resources/templates/telegram/token-form.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Собственный Telegram-бот</title>
+</head>
+<main layout:fragment="content" class="container py-4">
+    <h1 class="mb-3">Собственный Telegram-бот</h1>
+    <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+    <form th:action="@{/stores/{id}/telegram-settings(id=${storeId})}" method="post" class="w-50">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+        <div class="form-floating mb-3">
+            <input type="text" class="form-control" id="botToken" name="botToken" th:value="${settings.botToken}" placeholder="Token">
+            <label for="botToken">Токен бота</label>
+        </div>
+        <button type="submit" class="btn btn-primary">Сохранить</button>
+    </form>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- display custom bot availability in tariff lists
- show custom bot status in user profile plan view
- expose custom bot settings in admin tariff management
- expose custom bot info in admin settings table
- add controller endpoint and template for custom bot token

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1284f6a4832db450caf3c86fedea