### PR TITLE
Handle null plan limits in TariffService

### DIFF
--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -124,7 +124,7 @@ public class TariffService {
                 maxTrackUpdates,
                 plan.isFeatureEnabled(FeatureKey.BULK_UPDATE),
                 plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE),
-                limits.getMaxStores(),
+                maxStores,
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
                 plan.isFeatureEnabled(FeatureKey.CUSTOM_BOT),
                 monthlyLabel,

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -131,5 +131,27 @@ class TariffServiceTest {
         assertNull(dto);
 
     }
+
+    @Test
+    void getAllPlans_NullLimits_ReturnsDtoWithNullFields() {
+        SubscriptionPlan planWithoutLimits = new SubscriptionPlan();
+        planWithoutLimits.setCode("FREE");
+        planWithoutLimits.setName("Free");
+        planWithoutLimits.setMonthlyPrice(BigDecimal.ZERO);
+        planWithoutLimits.setAnnualPrice(BigDecimal.ZERO);
+        planWithoutLimits.setPosition(1);
+        planWithoutLimits.setLimits(null);
+
+        when(planRepository.findAllByOrderByPositionAsc()).thenReturn(List.of(planWithoutLimits));
+
+        List<SubscriptionPlanViewDTO> dtos = assertDoesNotThrow(() -> tariffService.getAllPlans());
+
+        assertEquals(1, dtos.size());
+        SubscriptionPlanViewDTO dto = dtos.get(0);
+        assertNull(dto.getMaxTracksPerFile());
+        assertNull(dto.getMaxSavedTracks());
+        assertNull(dto.getMaxTrackUpdates());
+        assertNull(dto.getMaxStores());
+    }
   
 }


### PR DESCRIPTION
## Summary
- prevent NPE by using computed `maxStores` variable in `TariffService.toViewDto`
- cover null limits case in `TariffServiceTest`

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d2df1eb90832db553b1e2e9062c59