### PR TITLE
Implement Telegram bot token validation

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramBotValidationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramBotValidationService.java
@@ -1,0 +1,37 @@
+package com.project.tracking_system.service.telegram;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/**
+ * Сервис проверки токенов Telegram-бота.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TelegramBotValidationService {
+
+    private final TelegramClientFactory telegramClientFactory;
+
+    /**
+     * Проверяет токен бота методом GetMe и возвращает имя бота.
+     *
+     * @param token токен бота
+     * @return имя пользователя Telegram-бота
+     */
+    public String validateToken(String token) {
+        try {
+            TelegramClient client = telegramClientFactory.create(token);
+            User me = client.execute(new GetMe());
+            log.info("✅ Токен Telegram валиден, бот: {}", me.getUserName());
+            return me.getUserName();
+        } catch (Exception e) {
+            log.error("❌ Ошибка проверки токена Telegram", e);
+            throw new IllegalArgumentException("Неверный токен бота", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TelegramBotValidationService` to verify bot tokens with GetMe
- validate token from `StoreTelegramSettingsService` using the new service
- notify user via websocket on invalid bot token
- adjust tests to use new service and cover invalid token case

## Testing
- `./mvnw test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_685d4b5a5d50832d8764fa0fc45d6efc