### PR TITLE
Add null chatId checks in telegram service

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -59,6 +59,10 @@ public class TelegramNotificationService {
         }
 
         Long chatId = getChatId(parcel);
+        if (chatId == null) {
+            log.warn("⚠️ Чат покупателя не найден: уведомление не отправлено для трека {}", parcel.getNumber());
+            return;
+        }
         String text;
         if (settings != null && settings.getTemplatesMap().containsKey(buyerStatus)) {
             text = settings.getTemplatesMap().get(buyerStatus)
@@ -102,6 +106,10 @@ public class TelegramNotificationService {
         }
 
         Long chatId = getChatId(parcel);
+        if (chatId == null) {
+            log.warn("⚠️ Чат покупателя не найден: напоминание не отправлено для трека {}", parcel.getNumber());
+            return;
+        }
 
         String text = String.format(
                 "🔔 Не забудьте забрать посылку %s из магазина %s — она ждёт вас в пункте выдачи.",


### PR DESCRIPTION
## Summary
- check chatId in `sendStatusUpdate`
- check chatId in `sendReminder`

## Testing
- `./mvnw -q test` *(fails: cannot open ./mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685d5b081538832d897b6d481c4a966f