### PR TITLE
Add custom bot management

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -178,7 +178,7 @@ public class StoreTelegramSettingsController {
         Long userId = user.getId();
         try {
             Store store = storeService.getStore(storeId, userId);
-            telegramSettingsService.setCustomBot(store, botToken, userId);
+            telegramSettingsService.connectCustomBot(store, botToken, userId);
             webSocketController.sendUpdateStatus(userId, "Бот сохранён", true);
             return ResponseBuilder.ok(storeService.toDto(store.getTelegramSettings()));
         } catch (IllegalStateException e) {
@@ -204,7 +204,7 @@ public class StoreTelegramSettingsController {
         Long userId = user.getId();
         try {
             Store store = storeService.getStore(storeId, userId);
-            telegramSettingsService.deleteCustomBot(store, userId);
+            telegramSettingsService.removeCustomBot(store);
             webSocketController.sendUpdateStatus(userId, "Бот удалён", true);
             return ResponseBuilder.ok(storeService.toDto(store.getTelegramSettings()));
         } catch (IllegalStateException e) {


### PR DESCRIPTION
## Summary
- create `connectCustomBot` and `removeCustomBot` for Telegram bots
- use them when updating Telegram settings
- update controller to call new service methods
- revise tests for new API

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685d68e422d8832db0f5fa1b3336e684