### PR TITLE
Add custom bot selector UI in profile

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -502,6 +502,28 @@ function initTelegramTemplateBlocks() {
     });
 }
 
+// Инициализация выбора пользовательского Telegram-бота
+function initTelegramCustomBotBlocks() {
+    document.querySelectorAll('.telegram-settings-form').forEach(form => {
+        const systemRadio = form.querySelector('input[id^="tg-bot-system-"]');
+        const customRadio = form.querySelector('input[id^="tg-bot-custom-"]');
+        const fields = form.querySelector('.custom-bot-fields');
+        if (!systemRadio || !customRadio || !fields) return;
+
+        const update = () => {
+            if (customRadio.checked) {
+                slideDown(fields);
+            } else {
+                slideUp(fields);
+            }
+        };
+
+        update();
+        systemRadio.addEventListener('change', update);
+        customRadio.addEventListener('change', update);
+    });
+}
+
 let lastPage = window.location.pathname; // Запоминаем текущую страницу при загрузке
 let isInitialLoad = true;
 
@@ -929,6 +951,7 @@ async function appendTelegramBlock(store) {
     initTelegramToggle();
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
+    initTelegramCustomBotBlocks();
     initTelegramNotificationsToggle();
 }
 
@@ -1318,6 +1341,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initTelegramToggle();
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
+    initTelegramCustomBotBlocks();
     initTelegramNotificationsToggle();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -466,13 +466,40 @@
                 </div>
 
                 <div th:if="${planDetails.allowCustomBot}" class="mb-2">
+                    <span class="form-label d-block">Выбор бота</span>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio"
+                               th:id="'tg-bot-system-' + ${store.id}"
+                               th:name="'tg-bot-type-' + ${store.id}"
+                               value="system"
+                               th:checked="${store.telegramSettings?.botToken == null}">
+                        <label class="form-check-label" th:for="'tg-bot-system-' + ${store.id}">Системный бот</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio"
+                               th:id="'tg-bot-custom-' + ${store.id}"
+                               th:name="'tg-bot-type-' + ${store.id}"
+                               value="custom"
+                               th:checked="${store.telegramSettings?.botToken != null}">
+                        <label class="form-check-label" th:for="'tg-bot-custom-' + ${store.id}">Собственный бот</label>
+                    </div>
+                </div>
+
+                <div th:id="'tg-custom-bot-fields-' + ${store.id}" class="mb-2 ms-4 hidden custom-bot-fields">
                     <label class="form-label" th:for="'tg-token-' + ${store.id}">Токен собственного бота</label>
                     <input type="text" class="form-control form-control-sm" th:id="'tg-token-' + ${store.id}"
                            name="botToken" th:value="${store.telegramSettings?.botToken}">
                     <p class="form-text" th:if="${store.telegramSettings?.botUsername}">
                         Текущий бот: <span th:text="${store.telegramSettings.botUsername}"></span>
                     </p>
+                    <div class="d-flex">
+                        <button type="button" class="btn btn-sm btn-outline-primary me-2"
+                                th:id="'tg-save-bot-' + ${store.id}">Сохранить</button>
+                        <button type="button" class="btn btn-sm btn-outline-danger"
+                                th:id="'tg-delete-bot-' + ${store.id}">Удалить</button>
+                    </div>
                 </div>
+
                 <p class="form-text text-danger ms-4" th:unless="${planDetails.allowCustomBot}">
                     Функция собственного бота доступна в тарифе "Команда" и выше
                 </p>


### PR DESCRIPTION
## Summary
- add radio buttons to pick system or custom Telegram bot
- show token field with save/remove actions
- handle custom bot block toggling via JS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6bc2f1cc832d93d84fb0ad38ce72