### PR TITLE
Add Telegram bot info to store block

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -407,6 +407,12 @@
                 <i class="bi bi-chevron-up"></i>
             </button>
         </div>
+        <p class="mb-2 text-muted small" th:id="'tg-bot-info-' + ${store.id}">
+            <span th:if="${store.telegramSettings?.botToken == null}">Бот: Системный</span>
+            <span th:if="${store.telegramSettings?.botToken != null}">
+                <span th:text="'Бот: @' + ${store.telegramSettings.botUsername}"></span>
+            </span>
+        </p>
         <div th:id="'collapse-tg-' + ${store.id}"
              class="tg-settings-content"
              th:attr="data-store-id=${store.id}"


### PR DESCRIPTION
## Summary
- show active Telegram bot within each store block in profile page

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db7a5fa54832da30e9fe52b63b9e2