### PR TITLE
Add custom bot edit button

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -508,15 +508,39 @@ function initTelegramCustomBotBlocks() {
         const systemRadio = form.querySelector('input[id^="tg-bot-system-"]');
         const customRadio = form.querySelector('input[id^="tg-bot-custom-"]');
         const fields = form.querySelector('.custom-bot-fields');
+        const editBtn = form.querySelector('.tg-edit-delete-btn');
+        const tokenInput = form.querySelector('input[id^="tg-token-"]');
         if (!systemRadio || !customRadio || !fields) return;
 
-        const update = () => {
-            if (customRadio.checked) {
-                slideDown(fields);
-            } else {
-                slideUp(fields);
+        const showFields = () => {
+            slideDown(fields);
+            editBtn?.classList.add('hidden');
+        };
+
+        const hideFields = () => {
+            slideUp(fields);
+            if (editBtn) {
+                if (tokenInput && tokenInput.value.trim()) {
+                    editBtn.classList.remove('hidden');
+                } else {
+                    editBtn.classList.add('hidden');
+                }
             }
         };
+
+        const update = () => {
+            if (systemRadio.checked) {
+                hideFields();
+            } else if (customRadio.checked) {
+                if (tokenInput && tokenInput.value.trim()) {
+                    hideFields();
+                } else {
+                    showFields();
+                }
+            }
+        };
+
+        editBtn?.addEventListener('click', showFields);
 
         update();
         systemRadio.addEventListener('change', update);
@@ -980,7 +1004,6 @@ async function appendTelegramBlock(store) {
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
     initTelegramCustomBotBlocks();
-    initTelegramBotModeHandlers();
     initTelegramNotificationsToggle();
 }
 
@@ -1465,7 +1488,6 @@ document.addEventListener("DOMContentLoaded", function () {
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
     initTelegramCustomBotBlocks();
-    initTelegramBotModeHandlers();
     initTelegramNotificationsToggle();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -488,6 +488,9 @@
                                value="custom"
                                th:checked="${store.telegramSettings?.botToken != null}">
                         <label class="form-check-label" th:for="'tg-bot-custom-' + ${store.id}">Собственный бот</label>
+                        <button type="button" class="btn btn-link btn-sm p-0 ms-2 tg-edit-delete-btn"
+                                th:id="'tg-edit-delete-bot-' + ${store.id}"
+                                th:if="${store.telegramSettings?.botToken != null}">Изменить / Удалить</button>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- show 'Изменить / Удалить' button for Telegram bot when token exists
- rework `initTelegramCustomBotBlocks` logic to show button or token form accordingly
- remove outdated bot mode handler calls

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb88c884832d82eab1808ce600d9