### PR TITLE
Fix deleteCustomBot token reset

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1323,7 +1323,10 @@ async function deleteCustomBot(storeId) {
                 systemRadio.checked = true;
                 systemRadio.dispatchEvent(new Event('change'));
             }
-            document.getElementById(`tg-token-${storeId}`)?.value = '';
+            const tokenEl = document.getElementById(`tg-token-${storeId}`);
+            if (tokenEl) {
+                tokenEl.value = '';
+            }
             notifyUser('Бот удалён', 'success');
         } else {
             const errorText = await response.text();


### PR DESCRIPTION
## Summary
- replace invalid optional chaining assignment with a conditional element check in `deleteCustomBot`

## Testing
- `node --check src/main/resources/static/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_685dc5422e78832da82d71e50b4a7c68