### PR TITLE
Fix custom bot fields position

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -513,8 +513,8 @@ function initTelegramCustomBotBlocks() {
         const systemRadio = parent.querySelector(`#tg-bot-system-${storeId}`);
         const customRadio = parent.querySelector(`#tg-bot-custom-${storeId}`);
         const editBtn = parent.querySelector(`#tg-edit-delete-bot-${storeId}`);
-        const fields = form.querySelector('.custom-bot-fields');
-        const tokenInput = form.querySelector('input[id^="tg-token-"]');
+        const fields = parent.querySelector('.custom-bot-fields');
+        const tokenInput = fields?.querySelector('input[id^="tg-token-"]');
         if (!systemRadio || !customRadio || !fields) return;
 
         const showFields = () => {

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -432,6 +432,22 @@
                                 th:id="'tg-edit-delete-bot-' + ${store.id}"
                                 th:if="${store.telegramSettings?.botToken != null}">Изменить / Удалить</button>
                     </div>
+
+                    <!-- Форма токена кастомного бота (показывается по JS при необходимости) -->
+                    <div th:id="'tg-custom-bot-fields-' + ${store.id}" class="mb-2 ms-4 hidden custom-bot-fields">
+                        <label class="form-label" th:for="'tg-token-' + ${store.id}">Токен собственного бота</label>
+                        <input type="text" class="form-control form-control-sm" th:id="'tg-token-' + ${store.id}"
+                               name="botToken" th:value="${store.telegramSettings?.botToken}">
+                        <p class="form-text" th:if="${store.telegramSettings?.botUsername}">
+                            Текущий бот: <span th:text="${store.telegramSettings.botUsername}"></span>
+                        </p>
+                        <div class="d-flex">
+                            <button type="button" class="btn btn-sm btn-outline-primary me-2"
+                                    th:id="'tg-save-bot-' + ${store.id}">Сохранить</button>
+                            <button type="button" class="btn btn-sm btn-outline-danger"
+                                    th:id="'tg-delete-bot-' + ${store.id}">Удалить</button>
+                        </div>
+                    </div>
                 </div>
 
                 <p class="form-text text-danger mb-1" th:unless="${planDetails.allowCustomBot}">
@@ -505,21 +521,6 @@
                            th:value="${store.telegramSettings?.customSignature}" maxlength="200">
                 </div>
 
-                <!-- Форма токена кастомного бота (показывается по JS при необходимости) -->
-                <div th:id="'tg-custom-bot-fields-' + ${store.id}" class="mb-2 ms-4 hidden custom-bot-fields">
-                    <label class="form-label" th:for="'tg-token-' + ${store.id}">Токен собственного бота</label>
-                    <input type="text" class="form-control form-control-sm" th:id="'tg-token-' + ${store.id}"
-                           name="botToken" th:value="${store.telegramSettings?.botToken}">
-                    <p class="form-text" th:if="${store.telegramSettings?.botUsername}">
-                        Текущий бот: <span th:text="${store.telegramSettings.botUsername}"></span>
-                    </p>
-                    <div class="d-flex">
-                        <button type="button" class="btn btn-sm btn-outline-primary me-2"
-                                th:id="'tg-save-bot-' + ${store.id}">Сохранить</button>
-                        <button type="button" class="btn btn-sm btn-outline-danger"
-                                th:id="'tg-delete-bot-' + ${store.id}">Удалить</button>
-                    </div>
-                </div>
 
                 <div class="form-check form-switch mb-2 ms-3">
                     <input class="form-check-input" type="checkbox" th:id="'tg-custom-templates-' + ${store.id}"


### PR DESCRIPTION
## Summary
- reposition custom bot token block right after bot type selector
- adjust JS logic for new custom bot block location

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685dca387a5c832da3c8dfdfa9f0fbc7