### PR TITLE
Improve telegram bot selector UI

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -25,3 +25,32 @@
     resize: vertical;
   }
 }
+
+.bot-selector {
+  input[type=radio] {
+    display: none;
+  }
+
+  label {
+    display: inline-block;
+    color: var(--bs-link-color, #0d6efd);
+    cursor: pointer;
+    margin-right: 0.5rem;
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: -2px;
+      width: 0;
+      height: 2px;
+      background: currentColor;
+      transition: width 0.3s;
+    }
+  }
+
+  input[type=radio]:checked + label::after {
+    width: 100%;
+  }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1465,4 +1465,31 @@ body.loading {
   margin-left: 0.5rem;
 }
 
+.bot-selector input[type=radio] {
+  display: none;
+}
+
+.bot-selector label {
+  display: inline-block;
+  color: var(--bs-link-color, #0d6efd);
+  cursor: pointer;
+  margin-right: 0.5rem;
+  position: relative;
+}
+
+.bot-selector label::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 0;
+  height: 2px;
+  background: currentColor;
+  transition: width 0.3s;
+}
+
+.bot-selector input[type=radio]:checked + label::after {
+  width: 100%;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -557,7 +557,7 @@ function initTelegramCustomBotBlocks() {
 function initTelegramBotModeHandlers() {
     const groups = {};
     // Находим все группы радиокнопок вида tg-bot-type-{storeId}
-    document.querySelectorAll('input[type="radio"][name^="tg-bot-type-"]').forEach(radio => {
+    document.querySelectorAll('.bot-selector input[type="radio"][name^="tg-bot-type-"]').forEach(radio => {
         const name = radio.name; // имя вида tg-bot-type-{storeId}
         (groups[name] = groups[name] || []).push(radio);
     });
@@ -568,7 +568,7 @@ function initTelegramBotModeHandlers() {
         if (!fields) return;
 
         const update = () => {
-            const selected = document.querySelector(`input[name="${name}"]:checked`);
+            const selected = document.querySelector(`.bot-selector input[name="${name}"]:checked`);
             if (selected && selected.value === 'custom') {
                 slideDown(fields);
             } else {

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -413,25 +413,24 @@
 
                 <div th:if="${planDetails.allowCustomBot}" class="mb-1">
                     <span class="form-label d-block">Выбор бота</span>
-                    <div class="form-check form-check-inline">
-                        <input class="form-check-input" type="radio"
+                    <div class="bot-selector">
+                        <input type="radio"
                                th:id="'tg-bot-system-' + ${store.id}"
                                th:name="'tg-bot-type-' + ${store.id}"
                                value="system"
                                th:checked="${store.telegramSettings?.botToken == null}">
-                        <label class="form-check-label" th:for="'tg-bot-system-' + ${store.id}">Системный бот</label>
-                    </div>
-                    <div class="form-check form-check-inline">
-                        <input class="form-check-input" type="radio"
+                        <label th:for="'tg-bot-system-' + ${store.id}">Системный бот</label>
+
+                        <input type="radio"
                                th:id="'tg-bot-custom-' + ${store.id}"
                                th:name="'tg-bot-type-' + ${store.id}"
                                value="custom"
                                th:checked="${store.telegramSettings?.botToken != null}">
-                        <label class="form-check-label" th:for="'tg-bot-custom-' + ${store.id}">Собственный бот</label>
-                        <button type="button" class="btn btn-link btn-sm p-0 ms-2 tg-edit-delete-btn"
-                                th:id="'tg-edit-delete-bot-' + ${store.id}"
-                                th:if="${store.telegramSettings?.botToken != null}">Изменить / Удалить</button>
+                        <label th:for="'tg-bot-custom-' + ${store.id}">Собственный бот</label>
                     </div>
+                    <button type="button" class="btn btn-link btn-sm p-0 ms-2 tg-edit-delete-btn"
+                            th:id="'tg-edit-delete-bot-' + ${store.id}"
+                            th:if="${store.telegramSettings?.botToken != null}">Изменить / Удалить</button>
 
                     <!-- Форма токена кастомного бота (показывается по JS при необходимости) -->
                     <div th:id="'tg-custom-bot-fields-' + ${store.id}" class="mb-2 ms-4 hidden custom-bot-fields">


### PR DESCRIPTION
## Summary
- style telegram bot selector as inline links via SCSS
- wrap radio buttons in `.bot-selector` container
- keep JS logic working with the updated markup

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `npm test` *(fails: missing script & network access)*
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd2d5f104832d96c48b68e2acda0a