### PR TITLE
Fix bot label update

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1251,9 +1251,10 @@ function showResetModal(message) {
  * @param {string|null} username имя пользователя бота или null для системного
  */
 function updateBotInfo(storeId, username) {
-    const infoEl = document.getElementById(`tg-bot-info-${storeId}`);
-    if (infoEl) {
-        infoEl.textContent = username ? `Бот: @${username}` : 'Бот: Системный';
+    // Обновляем подпись радиокнопки собственного бота
+    const labelEl = document.getElementById(`tg-custom-bot-label-${storeId}`);
+    if (labelEl) {
+        labelEl.textContent = username ? `@${username}` : 'Собственный бот';
     }
 
     const fields = document.getElementById(`tg-custom-bot-fields-${storeId}`);


### PR DESCRIPTION
## Summary
- update `updateBotInfo()` to modify custom bot label
- remove unused code for `tg-bot-info-{storeId}`

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dd72e3088832d8c9a73c21307327e