### PR TITLE
Add opacity transition for bot selector labels

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1477,6 +1477,16 @@ body.loading {
   position: relative;
 }
 
+.bot-selector input[type=radio] + label {
+  opacity: 0.5;
+  transition: opacity 0.3s;
+}
+
+.bot-selector input[type=radio]:checked + label {
+  opacity: 1;
+  font-weight: 600;
+}
+
 .bot-selector label::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- tweak bot selector CSS to highlight the selected option

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685dd834f614832d8e3286a02102cf6a