### PR TITLE
Adjust profile bot selector margin

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -27,6 +27,7 @@
 }
 
 .bot-selector {
+  margin-bottom: 1rem; // визуальный отступ после радиокнопок
   input[type=radio] {
     display: none;
   }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1465,6 +1465,10 @@ body.loading {
   margin-left: 0.5rem;
 }
 
+.bot-selector {
+  margin-bottom: 1rem;
+}
+
 .bot-selector input[type=radio] {
   display: none;
 }


### PR DESCRIPTION
## Summary
- add margin below radio selectors in `assets/scss/pages/_profile.scss`
- regenerate compiled CSS to include `.bot-selector` margin

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddae788d8832d8dfaf31c6792b05d