### PR TITLE
Add custom bot fields style

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -54,3 +54,12 @@
     width: 100%;
   }
 }
+
+// Дополнительные поля для собственного бота
+.custom-bot-fields {
+  margin: 0.5rem 0 1rem 1.5rem; // сверху и снизу по 0.5–1rem, слева стандартный отступ
+  padding: 0.75rem;
+  background-color: var(--bs-light-bg-subtle);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1502,4 +1502,12 @@ body.loading {
   width: 100%;
 }
 
+.custom-bot-fields {
+  margin: 0.5rem 0 1rem 1.5rem;
+  padding: 0.75rem;
+  background-color: var(--bs-light-bg-subtle);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+}
+
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
## Summary
- style custom bot fields in profile page
- update compiled CSS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddaed3bac832daaddf5c833e1b78f