### PR TITLE
Add JavaDoc for encryption and credential utils

### DIFF
--- a/src/main/java/com/project/tracking_system/utils/EncryptionUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/EncryptionUtils.java
@@ -25,6 +25,13 @@ public class EncryptionUtils {
         this.secretKeySpec = new SecretKeySpec(key.getBytes(), ALGORITHM);
     }
 
+    /**
+     * Шифрует переданные данные алгоритмом AES.
+     *
+     * @param data исходная строка
+     * @return зашифрованная строка в формате Base64
+     * @throws Exception если произошла ошибка при шифровании
+     */
     public String encrypt(String data) throws Exception {
         Cipher cipher = Cipher.getInstance(TRANSFORMATION);
         cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
@@ -32,6 +39,13 @@ public class EncryptionUtils {
         return Base64.getEncoder().encodeToString(encryptedData);
     }
 
+    /**
+     * Расшифровывает строку, полученную после {@link #encrypt(String)}.
+     *
+     * @param encryptedData зашифрованная строка в формате Base64
+     * @return исходная строка или пустая строка, если входные данные пусты
+     * @throws Exception если произошла ошибка при расшифровке
+     */
     public String decrypt(String encryptedData) throws Exception {
         if (encryptedData == null || encryptedData.isBlank()) {
             return "";

--- a/src/main/java/com/project/tracking_system/utils/UserCredentialsResolver.java
+++ b/src/main/java/com/project/tracking_system/utils/UserCredentialsResolver.java
@@ -21,6 +21,14 @@ public class UserCredentialsResolver {
     private final EncryptionUtils encryptionUtils;
     private final JsonPacket jsonPacket;
 
+    /**
+     * Определяет, какие учётные данные использовать для работы с API Evropost.
+     * Если пользовательские данные заданы и валидны, будут использованы они,
+     * иначе применяются системные данные.
+     *
+     * @param user пользователь, для которого подбираются данные
+     * @return объект с JWT и номером сервиса
+     */
     public ResolvedCredentialsDTO resolveCredentials(User user) {
         log.info("Начинается проверка использования данных для api evropost для пользователя: {}", user.getEmail());
 
@@ -63,6 +71,11 @@ public class UserCredentialsResolver {
         }
     }
 
+    /**
+     * Возвращает системные учётные данные для API Evropost.
+     *
+     * @return объект с системным JWT и номером сервиса
+     */
     public ResolvedCredentialsDTO getSystemCredentials() {
         return new ResolvedCredentialsDTO(
                 jwtTokenManager.getSystemToken(),


### PR DESCRIPTION
## Summary
- document encryption helpers
- add docs for resolving user credentials

## Testing
- `./mvnw -q test` *(fails: cannot open ./mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5498ac64832d83c7198c50b393f5