### PR TITLE
Refactor JWT fetch and add tests

### DIFF
--- a/src/main/java/com/project/tracking_system/service/jsonEvropostService/GetJwtTokenService.java
+++ b/src/main/java/com/project/tracking_system/service/jsonEvropostService/GetJwtTokenService.java
@@ -41,28 +41,7 @@ public class GetJwtTokenService {
                 jsonData.getLoginNameTypeId()
         );
 
-        JsonPacket packet = new JsonPacket(
-                null,
-                JsonMethodName.GET_JWT.toString(),
-                jsonPacket.getServiceNumber(),
-                data
-                );
-
-        JsonRequest request = new JsonRequest(
-                jsonRequest.getCrc(),
-                packet
-        );
-
-        // Делаем запрос
-        JsonNode response = jsonHandlerService.jsonRequest(request);
-
-        // Извлекаем JWT токен из ответа
-        JsonNode jwtNode = response.path("Table").path(0).path("JWT");
-        if (jwtNode.isMissingNode()) {
-            throw new RuntimeException("Токен JWT не найден в ответе при запросе системного JWT");
-        }
-
-        return jwtNode.asText();
+        return fetchJwtToken(data, jsonPacket.getServiceNumber());
     }
 
     // Получение пользовательского токена
@@ -73,6 +52,19 @@ public class GetJwtTokenService {
                 password,
                 jsonData.getLoginNameTypeId()
         );
+
+        return fetchJwtToken(data, serviceNumber);
+    }
+
+    /**
+     * Формирует запрос и извлекает JWT токен из ответа.
+     *
+     * @param data          данные для аутентификации
+     * @param serviceNumber номер сервиса ЕвроПочты
+     * @return JWT токен в виде строки
+     * @throws RuntimeException если токен отсутствует в ответе
+     */
+    private String fetchJwtToken(JsonDataAbstract data, String serviceNumber) {
 
         JsonPacket packet = new JsonPacket(
                 null,
@@ -92,7 +84,7 @@ public class GetJwtTokenService {
         // Извлекаем JWT токен из ответа
         JsonNode jwtNode = response.path("Table").path(0).path("JWT");
         if (jwtNode.isMissingNode()) {
-            throw new RuntimeException("Токен JWT не найден в ответе при запросе пользовательского JWT");
+            throw new RuntimeException("Токен JWT не найден в ответе");
         }
 
         return jwtNode.asText();

--- a/src/test/java/com/project/tracking_system/service/jsonEvropostService/GetJwtTokenServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/jsonEvropostService/GetJwtTokenServiceTest.java
@@ -1,0 +1,100 @@
+package com.project.tracking_system.service.jsonEvropostService;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.project.tracking_system.model.evropost.jsonRequestModel.JsonData;
+import com.project.tracking_system.model.evropost.jsonRequestModel.JsonPacket;
+import com.project.tracking_system.model.evropost.jsonRequestModel.JsonRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link GetJwtTokenService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class GetJwtTokenServiceTest {
+
+    @Mock
+    private JsonHandlerService jsonHandlerService;
+
+    private JsonData jsonData;
+    private JsonRequest jsonRequest;
+    private JsonPacket jsonPacket;
+
+    private GetJwtTokenService service;
+
+    @BeforeEach
+    void setUp() {
+        jsonData = new JsonData();
+        jsonRequest = new JsonRequest();
+        jsonPacket = new JsonPacket();
+        service = new GetJwtTokenService(jsonHandlerService, jsonData, jsonRequest, jsonPacket);
+    }
+
+    @Test
+    void getSystemTokenFromApi_ReturnsToken() throws Exception {
+        jsonData.setLoginName("log");
+        jsonData.setPassword("pass");
+        jsonData.setLoginNameTypeId("type");
+        jsonRequest.setCrc("crc");
+        jsonPacket.setServiceNumber("srv");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode response = mapper.createObjectNode();
+        ObjectNode tableItem = mapper.createObjectNode();
+        tableItem.put("JWT", "jwt");
+        response.putArray("Table").add(tableItem);
+        when(jsonHandlerService.jsonRequest(any())).thenReturn(response);
+
+        String token = service.getSystemTokenFromApi();
+
+        assertEquals("jwt", token);
+
+        ArgumentCaptor<JsonRequest> captor = ArgumentCaptor.forClass(JsonRequest.class);
+        verify(jsonHandlerService).jsonRequest(captor.capture());
+        JsonPacket packet = captor.getValue().getPacket();
+        assertEquals("GET_JWT", packet.getMethodName());
+        assertEquals("srv", packet.getServiceNumber());
+    }
+
+    @Test
+    void getSystemTokenFromApi_NoToken_ThrowsException() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode response = mapper.createObjectNode();
+        response.putArray("Table").add(mapper.createObjectNode());
+        when(jsonHandlerService.jsonRequest(any())).thenReturn(response);
+
+        assertThrows(RuntimeException.class, () -> service.getSystemTokenFromApi());
+    }
+
+    @Test
+    void getUserTokenFromApi_ReturnsToken() throws Exception {
+        jsonData.setLoginNameTypeId("type");
+        jsonRequest.setCrc("crc");
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode response = mapper.createObjectNode();
+        ObjectNode tableItem = mapper.createObjectNode();
+        tableItem.put("JWT", "jwt2");
+        response.putArray("Table").add(tableItem);
+        when(jsonHandlerService.jsonRequest(any())).thenReturn(response);
+
+        String token = service.getUserTokenFromApi("user", "pwd", "srv2");
+
+        assertEquals("jwt2", token);
+
+        ArgumentCaptor<JsonRequest> captor = ArgumentCaptor.forClass(JsonRequest.class);
+        verify(jsonHandlerService).jsonRequest(captor.capture());
+        JsonPacket packet = captor.getValue().getPacket();
+        assertEquals("GET_JWT", packet.getMethodName());
+        assertEquals("srv2", packet.getServiceNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- centralize JWT request/response logic in `fetchJwtToken`
- use the new private method from token retrieval methods
- add unit tests for `GetJwtTokenService`

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_685e549b9f04832db6e8a9ae0ec9f2df