### PR TITLE
Fix duplicate tab id in profile page

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -26,7 +26,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Закрыть"></button>
                 </div>
                 <div class="offcanvas-body">
-                    <div class="nav flex-column nav-pills profile-tab-menu" id="v-pills-tab" role="tablist" aria-orientation="vertical">
+                    <div class="nav flex-column nav-pills profile-tab-menu" id="v-pills-tab-offcanvas" role="tablist" aria-orientation="vertical">
                         <a class="nav-link active d-flex align-items-center" id="v-pills-home-tab" data-bs-toggle="pill"
                            href="#v-pills-home" role="tab">
                             <i class="bi bi-person me-2" title="Об аккаунте"></i> Об аккаунте


### PR DESCRIPTION
## Summary
- prevent DOM ID conflict on profile page by renaming `v-pills-tab` of the offcanvas menu to `v-pills-tab-offcanvas`

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e6fc86698832d9db48227e3491644