### PR TITLE
Fix tab issues: tooltip parsing error

### DIFF
--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -73,7 +73,7 @@
 
 <!-- Общие скрипты -->
 <script src="/bootstrap/bootstrap.bundle.min.js" defer></script>
-<script src="/js/libs/stomp.min.js"></script>
+<script src="/js/libs/stomp.min.js" defer></script>
 <script src="/js/app.js" defer></script>
 
 </body>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -419,7 +419,7 @@
                                value="custom"
                                th:checked="${store.telegramSettings?.botToken != null}"
                                th:disabled="${!planDetails.allowCustomBot}"
-                               th:attrappend="${!planDetails.allowCustomBot} ? ' data-bs-toggle=tooltip title=\'Доступно в тарифе \"Бизнес\" и выше\'' : ''">
+                               th:attr="${!planDetails.allowCustomBot} ? 'data-bs-toggle=\"tooltip\" title=\\'Доступно в тарифе \"Бизнес\" и выше\\'' : null">
                         <label th:for="'tg-bot-custom-' + ${store.id}" th:id="'tg-custom-bot-label-' + ${store.id}">Собственный бот</label>
                     </div>
                     <button type="button" class="btn btn-link btn-sm p-0 ms-2 tg-edit-delete-btn"


### PR DESCRIPTION
## Summary
- fix malformed tooltip attribute in `profile.html`
- ensure all scripts in layout load with `defer`

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(no output)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685e6e20d994832dbcac3e6cfab89913