### PR TITLE
Update bot label rendering

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -515,6 +515,8 @@ function initTelegramCustomBotBlocks() {
         const editBtn = parent.querySelector(`#tg-edit-delete-bot-${storeId}`);
         const fields = parent.querySelector('.custom-bot-fields');
         const tokenInput = fields?.querySelector('input[id^="tg-token-"]');
+        const username = fields?.querySelector('.current-bot span')?.textContent?.trim() || null;
+        updateBotInfo(storeId, username);
         if (!systemRadio || !customRadio || !fields) return;
 
         const showFields = () => {
@@ -1254,7 +1256,12 @@ function updateBotInfo(storeId, username) {
     // Обновляем подпись радиокнопки собственного бота
     const labelEl = document.getElementById(`tg-custom-bot-label-${storeId}`);
     if (labelEl) {
-        labelEl.textContent = username ? `@${username}` : 'Собственный бот';
+        const span = labelEl.querySelector('span');
+        if (span) {
+            span.textContent = username ? `@${username}` : 'Собственный бот';
+        } else {
+            labelEl.textContent = username ? `@${username}` : 'Собственный бот';
+        }
     }
 
     const fields = document.getElementById(`tg-custom-bot-fields-${storeId}`);

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -421,7 +421,9 @@
                                th:disabled="${!planDetails.allowCustomBot}"
                                th:attr="data-bs-toggle=${!planDetails.allowCustomBot} ? 'tooltip' : null,
                                     title=${!planDetails.allowCustomBot} ? 'Доступно в тарифе \'Бизнес\' и выше' : null">
-                              <label th:for="'tg-bot-custom-' + ${store.id}" th:id="'tg-custom-bot-label-' + ${store.id}">Собственный бот</label>
+                              <label th:for="'tg-bot-custom-' + ${store.id}" th:id="'tg-custom-bot-label-' + ${store.id}">
+                                  <span th:text="${store.telegramSettings?.botUsername != null ? '@' + store.telegramSettings.botUsername : 'Собственный бот'}"></span>
+                              </label>
                     </div>
                     <button type="button" class="btn btn-link btn-sm p-0 ms-2 tg-edit-delete-btn"
                             th:id="'tg-edit-delete-bot-' + ${store.id}"
@@ -432,7 +434,7 @@
                         <label class="form-label" th:for="'tg-token-' + ${store.id}">Токен собственного бота</label>
                         <input type="text" class="form-control form-control-sm" th:id="'tg-token-' + ${store.id}"
                                name="botToken" th:value="${store.telegramSettings?.botToken}">
-                        <p class="form-text" th:if="${store.telegramSettings?.botUsername}">
+                        <p class="form-text current-bot" th:if="${store.telegramSettings?.botUsername}">
                             Текущий бот: <span th:text="${store.telegramSettings.botUsername}"></span>
                         </p>
                         <div class="d-flex gap-2 mt-2">


### PR DESCRIPTION
## Summary
- render Telegram bot name in profile with Thymeleaf expression
- show current custom bot under token field with class for JS handling
- init Telegram bot blocks with username extracted from DOM
- keep span inside label when updating bot info

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_685e96299d00832d9e8ab2aac39ce7f9