### PR TITLE
Add active bot option highlight

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -64,3 +64,13 @@
   border: 1px solid var(--bs-border-color);
   border-radius: 0.25rem;
 }
+
+// Стили активной и неактивной опций выбора бота
+.active-bot-option {
+  font-weight: bold;
+  color: var(--bs-link-hover-color, #0a58ca);
+}
+
+.inactive-bot-option {
+  opacity: 0.6;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1313,6 +1313,13 @@ button:hover {
   border: 1px solid var(--bs-border-color);
   border-radius: 0.25rem;
 }
+.active-bot-option {
+  font-weight: bold;
+  color: var(--bs-link-hover-color, #0a58ca);
+}
+.inactive-bot-option {
+  opacity: 0.6;
+}
 
 .legal-container {
   font-family: "Inter", sans-serif;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -514,6 +514,8 @@ function initTelegramCustomBotBlocks() {
         const customRadio = parent.querySelector(`#tg-bot-custom-${storeId}`);
         const editBtn = parent.querySelector(`#tg-edit-delete-bot-${storeId}`);
         const fields = parent.querySelector('.custom-bot-fields');
+        const systemLabel = parent.querySelector(`label[for="tg-bot-system-${storeId}"]`);
+        const customLabel = parent.querySelector(`label[for="tg-bot-custom-${storeId}"]`);
         const tokenInput = fields?.querySelector('input[id^="tg-token-"]');
         const username = fields?.querySelector('.current-bot span')?.textContent?.trim() || null;
         updateBotInfo(storeId, username);
@@ -543,6 +545,21 @@ function initTelegramCustomBotBlocks() {
                     hideFields();
                 } else {
                     showFields();
+                }
+            }
+
+            // Обновляем стили выбранной опции
+            if (systemLabel && customLabel) {
+                if (systemRadio.checked) {
+                    systemLabel.classList.add('active-bot-option');
+                    systemLabel.classList.remove('inactive-bot-option');
+                    customLabel.classList.remove('active-bot-option');
+                    customLabel.classList.add('inactive-bot-option');
+                } else if (customRadio.checked) {
+                    customLabel.classList.add('active-bot-option');
+                    customLabel.classList.remove('inactive-bot-option');
+                    systemLabel.classList.remove('active-bot-option');
+                    systemLabel.classList.add('inactive-bot-option');
                 }
             }
         };


### PR DESCRIPTION
## Summary
- style Telegram bot selection in profile
- update JS to mark active/inactive radio labels

## Testing
- `npm run build:css` *(fails: sass not found)*
- `npx sass src/main/resources/assets/scss/main.scss src/main/resources/static/css/style.css` *(fails: E403 Forbidden)*
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_685e9743be94832dba5bae59f0756efd