### PR TITLE
Update custom bot UI logic

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -512,40 +512,26 @@ function initTelegramCustomBotBlocks() {
         const parent = container.parentElement;
         const systemRadio = parent.querySelector(`#tg-bot-system-${storeId}`);
         const customRadio = parent.querySelector(`#tg-bot-custom-${storeId}`);
-        const editBtn = parent.querySelector(`#tg-edit-delete-bot-${storeId}`);
         const fields = parent.querySelector('.custom-bot-fields');
         const systemLabel = parent.querySelector(`label[for="tg-bot-system-${storeId}"]`);
         const customLabel = parent.querySelector(`label[for="tg-bot-custom-${storeId}"]`);
-        const tokenInput = fields?.querySelector('input[id^="tg-token-"]');
         const username = fields?.querySelector('.current-bot span')?.textContent?.trim() || null;
         updateBotInfo(storeId, username);
         if (!systemRadio || !customRadio || !fields) return;
 
         const showFields = () => {
             slideDown(fields);
-            editBtn?.classList.add('hidden');
         };
 
         const hideFields = () => {
             slideUp(fields);
-            if (editBtn) {
-                if (tokenInput && tokenInput.value.trim()) {
-                    editBtn.classList.remove('hidden');
-                } else {
-                    editBtn.classList.add('hidden');
-                }
-            }
         };
 
         const update = () => {
             if (systemRadio.checked) {
                 hideFields();
             } else if (customRadio.checked) {
-                if (tokenInput && tokenInput.value.trim()) {
-                    hideFields();
-                } else {
-                    showFields();
-                }
+                showFields();
             }
 
             // Обновляем стили выбранной опции
@@ -564,7 +550,11 @@ function initTelegramCustomBotBlocks() {
             }
         };
 
-        editBtn?.addEventListener('click', showFields);
+        customRadio.addEventListener('click', () => {
+            if (customRadio.checked) {
+                showFields();
+            }
+        });
 
         update();
         systemRadio.addEventListener('change', update);

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -425,10 +425,6 @@
                                   <span th:text="${store.telegramSettings?.botUsername != null ? '@' + store.telegramSettings.botUsername : 'Собственный бот'}"></span>
                               </label>
                     </div>
-                    <button type="button" class="btn btn-link btn-sm p-0 ms-2 tg-edit-delete-btn"
-                            th:id="'tg-edit-delete-bot-' + ${store.id}"
-                            th:if="${planDetails.allowCustomBot and store.telegramSettings?.botToken != null}">Изменить / Удалить</button>
-
                     <!-- Форма токена кастомного бота (показывается по JS при необходимости) -->
                     <div th:id="'tg-custom-bot-fields-' + ${store.id}" class="mb-2 ms-4 hidden custom-bot-fields" th:if="${planDetails.allowCustomBot}">
                         <label class="form-label" th:for="'tg-token-' + ${store.id}">Токен собственного бота</label>


### PR DESCRIPTION
## Summary
- remove obsolete custom bot edit button in profile page
- show custom bot token form whenever the custom bot option is chosen
- hide custom bot fields when system bot is selected

## Testing
- `./mvnw -q test` *(fails: mvn not found or wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e9848ca70832d9bae0d0e689b4f41