### PR TITLE
Update Telegram template hints

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.dto.StoreDTO;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.model.subscription.FeatureKey;
@@ -49,6 +50,7 @@ public class ProfileController {
     private final StoreService storeService;
     private final WebSocketController webSocketController;
     private final SubscriptionService subscriptionService;
+    private final StoreTelegramSettingsService telegramSettingsService;
 
     /**
      * Отображает страницу профиля пользователя.
@@ -471,7 +473,9 @@ public class ProfileController {
                                    Model model) {
         Long userId = user.getId();
         Store store = storeService.getStore(storeId, userId);
+        boolean usingSystemBot = telegramSettingsService.isUsingSystemBot(store.getTelegramSettings());
         model.addAttribute("store", store);
+        model.addAttribute("usingSystemBot", usingSystemBot);
         return "profile :: telegramStoreBlock";
     }
 

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -151,4 +151,19 @@ public class StoreTelegramSettingsService {
         log.info("Пользовательский бот удалён для магазина ID={}", store.getId());
     }
 
+    /**
+     * Проверяет, используется ли системный Telegram-бот.
+     *
+     * @param settings текущие настройки магазина
+     * @return {@code true}, если токен бота не указан
+     */
+    @Transactional(readOnly = true)
+    public boolean isUsingSystemBot(StoreTelegramSettings settings) {
+        if (settings == null) {
+            return true;
+        }
+        String token = settings.getBotToken();
+        return token == null || token.isBlank();
+    }
+
 }

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -534,7 +534,8 @@
                                       th:text="${store.telegramSettings?.templates?.get(status.name())}"></textarea>
                         </div>
                     </div>
-                    <p class="form-text">Шаблоны должны содержать {track} и {store}</p>
+                    <p th:if="${usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track} и {store}</p>
+                    <p th:if="${!usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track}</p>
                 </div>
 
                 <button type="submit" class="btn btn-sm btn-primary w-100">Сохранить</button>


### PR DESCRIPTION
## Summary
- adjust Telegram template hint in profile.html
- add system bot detection in `StoreTelegramSettingsService`
- expose the detection result in `ProfileController`

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_685ea15840c0832d910dcef40b0543ce