### PR TITLE
Add custom reminder template

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -42,4 +42,7 @@ public class StoreTelegramSettingsDTO {
 
     /** Статус → шаблон сообщения. */
     private Map<String, String> templates = new HashMap<>();
+
+    /** Шаблон напоминания. */
+    private String reminderTemplate;
 }

--- a/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
@@ -57,6 +57,10 @@ public class StoreTelegramSettings {
     @Column(name = "reminders_enabled", nullable = false)
     private boolean remindersEnabled = false;
 
+    /** Шаблон напоминания покупателю. */
+    @Column(name = "reminder_template", columnDefinition = "text")
+    private String reminderTemplate;
+
     @OneToMany(mappedBy = "settings", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnore
     private List<StoreTelegramTemplate> templates = new ArrayList<>();

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -82,6 +82,9 @@ public class StoreTelegramSettingsService {
         if (dto.isUseCustomTemplates() && dto.getTemplates() != null) {
             dto.getTemplates().values().forEach(t -> validateTemplate(t, requireStorePlaceholder));
         }
+        if (dto.getReminderTemplate() != null && !dto.getReminderTemplate().isBlank()) {
+            validateTemplate(dto.getReminderTemplate(), requireStorePlaceholder);
+        }
 
         // Передаём обработку полей общему сервису
         storeService.updateFromDto(settings, dto);

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -111,11 +111,18 @@ public class TelegramNotificationService {
             return;
         }
 
-        String text = String.format(
-                "🔔 Не забудьте забрать посылку %s из магазина %s — она ждёт вас в пункте выдачи.",
-                parcel.getNumber(),
-                parcel.getStore().getName()
-        );
+        String text;
+        if (settings != null && settings.getReminderTemplate() != null && !settings.getReminderTemplate().isBlank()) {
+            text = settings.getReminderTemplate()
+                    .replace("{track}", parcel.getNumber())
+                    .replace("{store}", parcel.getStore().getName());
+        } else {
+            text = String.format(
+                    "🔔 Не забудьте забрать посылку %s из магазина %s — она ждёт вас в пункте выдачи.",
+                    parcel.getNumber(),
+                    parcel.getStore().getName()
+            );
+        }
 
         if (settings != null && settings.getCustomSignature() != null && !settings.getCustomSignature().isBlank()) {
             text += "\n\n" + settings.getCustomSignature();

--- a/src/main/resources/db/migration/V38__add_reminder_template.sql
+++ b/src/main/resources/db/migration/V38__add_reminder_template.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_store_telegram_settings
+    ADD COLUMN reminder_template TEXT;

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -502,6 +502,15 @@
                                name="reminderRepeatIntervalDays"
                                th:value="${store.telegramSettings?.reminderRepeatIntervalDays ?: 2}" min="1" max="14">
                     </div>
+                    <div class="mb-2">
+                        <label class="form-label" th:for="'tg-remind-tpl-' + ${store.id}">Текст напоминания</label>
+                        <textarea class="form-control form-control-sm"
+                                  th:id="'tg-remind-tpl-' + ${store.id}"
+                                  name="reminderTemplate" rows="3"
+                                  th:text="${store.telegramSettings?.reminderTemplate}"></textarea>
+                        <p th:if="${usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track} и {store}</p>
+                        <p th:if="${!usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track}</p>
+                    </div>
                 </div>
 
                 <div class="mb-2">


### PR DESCRIPTION
## Summary
- support reminder template in Telegram settings
- expose reminder template editing in profile
- migrate DB schema for reminder template
- use custom text for reminders if provided

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685ea2f4c7a4832d9d1dede05bdbec31