### PR TITLE
Add reminder example in profile template

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -510,6 +510,9 @@
                                   th:text="${store.telegramSettings?.reminderTemplate}"></textarea>
                         <p th:if="${usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track} и {store}</p>
                         <p th:if="${!usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track}</p>
+                        <p th:if="${#strings.isEmpty(store.telegramSettings?.reminderTemplate)}" class="form-text">
+                            Пример уведомления: "🔔 Не забудьте забрать посылку {track} из магазина {store} — она ждёт вас."
+                        </p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- show default reminder example in profile settings when no custom template is set

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea51a0b7c832daf19a8ff25f78f2a