### PR TITLE
Add custom notifications feature

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
@@ -21,4 +21,6 @@ public class SubscriptionLimitsDTO {
     private Integer maxStores;
     private boolean allowTelegramNotifications;
     private boolean allowCustomBot;
+    /** Возможность использовать собственные шаблоны уведомлений. */
+    private boolean allowCustomNotifications;
 }

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -24,6 +24,8 @@ public class SubscriptionPlanViewDTO {
     private Integer maxStores;
     private boolean allowTelegramNotifications;
     private boolean allowCustomBot;
+    /** Возможность использовать собственные шаблоны уведомлений. */
+    private boolean allowCustomNotifications;
     private String monthlyPriceLabel;
     private String annualPriceLabel;
 

--- a/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
+++ b/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
@@ -23,7 +23,12 @@ public enum FeatureKey {
     /**
      * Использование собственного Telegram-бота.
      */
-    CUSTOM_BOT("customBot");
+    CUSTOM_BOT("customBot"),
+
+    /**
+     * Использование собственных шаблонов уведомлений.
+     */
+    CUSTOM_NOTIFICATIONS("customNotifications");
 
     private final String key;
 

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -214,6 +214,17 @@ public class SubscriptionService {
     }
 
     /**
+     * Проверяет, разрешено ли использование собственных уведомлений.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если функция включена в тарифе
+     */
+    @Transactional(readOnly = true)
+    public boolean canUseCustomNotifications(Long userId) {
+        return isFeatureEnabled(userId, FeatureKey.CUSTOM_NOTIFICATIONS);
+    }
+
+    /**
      * Проверяет доступность функции для указанного пользователя.
      *
      * @param userId идентификатор пользователя

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -58,6 +58,7 @@ public class SubscriptionPlanService {
         limitsDto.setAllowAutoUpdate(plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE));
         limitsDto.setAllowTelegramNotifications(plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS));
         limitsDto.setAllowCustomBot(plan.isFeatureEnabled(FeatureKey.CUSTOM_BOT));
+        limitsDto.setAllowCustomNotifications(plan.isFeatureEnabled(FeatureKey.CUSTOM_NOTIFICATIONS));
 
         SubscriptionPlanDTO dto = new SubscriptionPlanDTO();
         dto.setId(plan.getId());
@@ -100,6 +101,7 @@ public class SubscriptionPlanService {
             setFeature(plan, FeatureKey.AUTO_UPDATE, l.isAllowAutoUpdate());
             setFeature(plan, FeatureKey.TELEGRAM_NOTIFICATIONS, l.isAllowTelegramNotifications());
             setFeature(plan, FeatureKey.CUSTOM_BOT, l.isAllowCustomBot());
+            setFeature(plan, FeatureKey.CUSTOM_NOTIFICATIONS, l.isAllowCustomNotifications());
         }
 
         BigDecimal monthly = dto.getMonthlyPrice();

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -78,6 +78,12 @@ public class StoreTelegramSettingsService {
             requireStorePlaceholder = true; // токен отсутствует, используется системный бот
         }
 
+        // Проверяем доступность пользовательских шаблонов уведомлений
+        if ((dto.isUseCustomTemplates() || (dto.getReminderTemplate() != null && !dto.getReminderTemplate().isBlank()))
+                && !subscriptionService.canUseCustomNotifications(userId)) {
+            throw new IllegalStateException("Собственные уведомления недоступны на вашем тарифе");
+        }
+
         // Проверяем содержимое пользовательских шаблонов при их использовании
         if (dto.isUseCustomTemplates() && dto.getTemplates() != null) {
             dto.getTemplates().values().forEach(t -> validateTemplate(t, requireStorePlaceholder));

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -127,6 +127,7 @@ public class TariffService {
                 maxStores,
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
                 plan.isFeatureEnabled(FeatureKey.CUSTOM_BOT),
+                plan.isFeatureEnabled(FeatureKey.CUSTOM_NOTIFICATIONS),
                 monthlyLabel,
                 annualLabel,
                 fullAnnualPriceLabel,

--- a/src/main/resources/db/migration/V39__add_custom_notifications_feature.sql
+++ b/src/main/resources/db/migration/V39__add_custom_notifications_feature.sql
@@ -1,0 +1,3 @@
+-- Добавление функции пользовательских уведомлений
+INSERT INTO subscription_features (subscription_plan_id, feature_key, enabled)
+SELECT id, 'CUSTOM_NOTIFICATIONS', false FROM subscription_plans;

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -23,6 +23,7 @@
             <th>Автообновление</th>
             <th>Telegram-уведомления</th>
             <th>Собственный бот</th>
+            <th>Свои уведомления</th>
             <th>Активный</th>
             <th>Действия</th>
         </tr>
@@ -43,6 +44,7 @@
                 <td class="text-center"><input type="checkbox" name="limits.allowAutoUpdate" th:checked="${plan.limits.allowAutoUpdate}" /></td>
                 <td class="text-center"><input type="checkbox" name="limits.allowTelegramNotifications" th:checked="${plan.limits.allowTelegramNotifications}" /></td>
                 <td class="text-center"><input type="checkbox" name="limits.allowCustomBot" th:checked="${plan.limits.allowCustomBot}" /></td>
+                <td class="text-center"><input type="checkbox" name="limits.allowCustomNotifications" th:checked="${plan.limits.allowCustomNotifications}" /></td>
                 <td class="text-center"><input type="checkbox" name="active" th:checked="${plan.active}" /></td>
                 <td>
                     <button type="submit" class="btn btn-success btn-sm me-1">Сохранить</button>
@@ -112,6 +114,12 @@
             <div class="form-check">
                 <input id="plan-custom-bot" type="checkbox" name="limits.allowCustomBot" class="form-check-input" />
                 <label class="form-check-label" for="plan-custom-bot">Собственный бот</label>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <div class="form-check">
+                <input id="plan-custom-notify" type="checkbox" name="limits.allowCustomNotifications" class="form-check-input" />
+                <label class="form-check-label" for="plan-custom-notify">Свои уведомления</label>
             </div>
         </div>
         <div class="col-md-1">

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -42,6 +42,7 @@
             <th>Массовое обновление</th>
             <th>Telegram-уведомления</th>
             <th>Собственный бот</th>
+            <th>Свои уведомления</th>
         </tr>
         </thead>
         <tbody>
@@ -54,6 +55,7 @@
             <td th:text="${plan.allowBulkUpdate}"></td>
             <td th:text="${plan.allowTelegramNotifications}"></td>
             <td th:text="${plan.allowCustomBot}"></td>
+            <td th:text="${plan.allowCustomNotifications}"></td>
         </tr>
         </tbody>
     </table>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -529,13 +529,16 @@
                 <div class="form-check form-switch mb-2 ms-3">
                     <input class="form-check-input" type="checkbox" th:id="'tg-custom-templates-' + ${store.id}"
                            name="useCustomTemplates"
-                           th:checked="${store.telegramSettings?.templates?.size() > 0}">
+                           th:checked="${store.telegramSettings?.templates?.size() > 0}"
+                           th:disabled="${!planDetails.allowCustomNotifications}"
+                           th:attr="data-bs-toggle=${!planDetails.allowCustomNotifications} ? 'tooltip' : null,
+                                    title=${!planDetails.allowCustomNotifications} ? 'Доступно в тарифе \'Бизнес\' и выше' : null">
                     <label class="form-check-label" th:for="'tg-custom-templates-' + ${store.id}">
                         Использовать собственные сообщения
                     </label>
                 </div>
 
-                <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields">
+                <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields" th:if="${planDetails.allowCustomNotifications}">
                     <div th:each="status : ${T(com.project.tracking_system.entity.BuyerStatus).values()}">
                         <div class="mb-2">
                             <label class="form-label" th:for="${'tpl-' + status.name() + '-' + store.id}" th:text="${status.displayName}"></label>
@@ -549,6 +552,10 @@
                     <p th:if="${usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track} и {store}</p>
                     <p th:if="${!usingSystemBot}" class="form-text text-muted">Шаблон должен содержать: {track}</p>
                 </div>
+
+                <p class="form-text text-danger mb-1" th:unless="${planDetails.allowCustomNotifications}">
+                    Функция собственных уведомлений доступна в тарифе "Бизнес" и выше
+                </p>
 
                 <button type="submit" class="btn btn-sm btn-primary w-100">Сохранить</button>
             </form>

--- a/src/main/resources/templates/tariffs.html
+++ b/src/main/resources/templates/tariffs.html
@@ -83,6 +83,10 @@
                                 <span th:if="${plan.allowCustomBot}">🤖 Собственный бот</span>
                                 <span th:unless="${plan.allowCustomBot}" class="text-muted">❌ Собственный бот</span>
                             </li>
+                            <li>
+                                <span th:if="${plan.allowCustomNotifications}">✏️ Свои уведомления</span>
+                                <span th:unless="${plan.allowCustomNotifications}" class="text-muted">❌ Свои уведомления</span>
+                            </li>
                         </ul>
 
 

--- a/src/test/java/com/project/tracking_system/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/SubscriptionServiceTest.java
@@ -187,6 +187,20 @@ class SubscriptionServiceTest {
     }
 
     @Test
+    void canUseCustomNotifications_DelegatesToFeatureCheck() {
+        when(userSubscriptionRepository.getSubscriptionPlanCode(6L)).thenReturn("PREMIUM");
+        SubscriptionFeature feature = new SubscriptionFeature();
+        feature.setFeatureKey(FeatureKey.CUSTOM_NOTIFICATIONS);
+        feature.setEnabled(true);
+        SubscriptionPlan plan = new SubscriptionPlan();
+        plan.setCode("PREMIUM");
+        plan.setFeatures(List.of(feature));
+        when(subscriptionPlanRepository.findByCode("PREMIUM")).thenReturn(Optional.of(plan));
+
+        assertTrue(subscriptionService.canUseCustomNotifications(6L));
+    }
+
+    @Test
     void changeSubscription_ToPaidPlan_SetsEndDate() {
         UserSubscription subscription = new UserSubscription();
         subscription.setUser(new User());

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -65,7 +65,11 @@ class TariffServiceTest {
         customBot.setFeatureKey(FeatureKey.CUSTOM_BOT);
         customBot.setEnabled(true);
         customBot.setSubscriptionPlan(plan);
-        plan.setFeatures(List.of(bulk, auto, telegram, customBot));
+        SubscriptionFeature customNotifications = new SubscriptionFeature();
+        customNotifications.setFeatureKey(FeatureKey.CUSTOM_NOTIFICATIONS);
+        customNotifications.setEnabled(true);
+        customNotifications.setSubscriptionPlan(plan);
+        plan.setFeatures(List.of(bulk, auto, telegram, customBot, customNotifications));
     }
 
     @Test
@@ -82,6 +86,7 @@ class TariffServiceTest {
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
         assertEquals("выгода −17%", dto.getAnnualDiscountLabel());
+        assertTrue(dto.isAllowCustomNotifications());
     }
 
     @Test
@@ -106,6 +111,7 @@ class TariffServiceTest {
         assertTrue(dto.isAllowAutoUpdate());
         assertTrue(dto.isAllowTelegramNotifications());
         assertTrue(dto.isAllowCustomBot());
+        assertTrue(dto.isAllowCustomNotifications());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());


### PR DESCRIPTION
## Summary
- support CUSTOM_NOTIFICATIONS feature in subscription plans
- include new capability in plan DTOs
- expose feature through services and templates
- create Flyway migration for existing plans
- restrict custom templates usage when feature disabled
- update unit tests

## Testing
- `./mvnw test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685ea8dee858832d9dea4e37818ab16d