### PR TITLE
Fix reminder template validation

### DIFF
--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -46,6 +46,7 @@ public class StoreTelegramSettingsService {
     @Transactional
     public void update(Store store, StoreTelegramSettingsDTO dto, Long userId) {
         boolean enableRequested = dto.isEnabled();
+        boolean remindersEnabled = dto.isRemindersEnabled();
 
         if (enableRequested && !subscriptionService.isFeatureEnabled(userId, FeatureKey.TELEGRAM_NOTIFICATIONS)) {
             String msg = "Telegram-уведомления недоступны на вашем тарифе.";
@@ -89,7 +90,7 @@ public class StoreTelegramSettingsService {
             final boolean placeholderRequired = requireStorePlaceholder;
             dto.getTemplates().values().forEach(t -> validateTemplate(t, placeholderRequired));
         }
-        if (dto.getReminderTemplate() != null && !dto.getReminderTemplate().isBlank()) {
+        if (remindersEnabled && dto.getReminderTemplate() != null && !dto.getReminderTemplate().isBlank()) {
             validateTemplate(dto.getReminderTemplate(), requireStorePlaceholder);
         }
 


### PR DESCRIPTION
## Summary
- ensure the reminders flag is checked before validating the template

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0fecd08832d8e30b46aafb910a2