### PR TITLE
Fix Telegram bot removal when updating settings

### DIFF
--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -62,7 +62,7 @@ public class StoreTelegramSettingsService {
         }
 
         String token = dto.getBotToken();
-        boolean requireStorePlaceholder = true; // системный бот по умолчанию
+        boolean requireStorePlaceholder;
 
         if (token != null && !token.isBlank()) {
             try {
@@ -73,10 +73,15 @@ public class StoreTelegramSettingsService {
                 webSocketController.sendUpdateStatus(userId, "Неверный токен бота", false);
                 throw e;
             }
+        } else if (settings.getBotToken() != null && !settings.getBotToken().isBlank()) {
+            // Токен не передан, но в настройках уже есть пользовательский бот
+            dto.setBotToken(settings.getBotToken());
+            dto.setBotUsername(settings.getBotUsername());
+            requireStorePlaceholder = false;
         } else {
             removeCustomBot(store);
             dto.setBotUsername(null);
-            requireStorePlaceholder = true; // токен отсутствует, используется системный бот
+            requireStorePlaceholder = true; // системный бот
         }
 
         // Проверяем доступность пользовательских шаблонов уведомлений

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -106,4 +106,22 @@ class StoreTelegramSettingsServiceTest {
 
         assertDoesNotThrow(() -> service.update(store, dto, 1L));
     }
+
+    @Test
+    void update_ExistingCustomBot_TokenNotProvided_BotRemains() {
+        StoreTelegramSettings settings = new StoreTelegramSettings();
+        settings.setBotToken("token");
+        settings.setBotUsername("bot");
+        when(settingsRepository.findByStoreId(1L)).thenReturn(settings);
+        when(subscriptionService.isFeatureEnabled(1L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
+        when(subscriptionService.canUseCustomNotifications(1L)).thenReturn(true);
+
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+        dto.getTemplates().put("SENT", "Посылка {track}");
+
+        assertDoesNotThrow(() -> service.update(store, dto, 1L));
+        verify(settingsRepository).save(settings);
+        org.junit.jupiter.api.Assertions.assertEquals("token", settings.getBotToken());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure existing custom bot isn't removed when bot token is absent on update
- add regression test for telegram settings service

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ed185e400832daafa509f6618165d