### PR TITLE
Add Telegram settings success notification

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -342,6 +342,7 @@ function initTelegramForms() {
 
                 if (response.ok) {
                     // Уведомление придёт через WebSocket
+                    notifyUser('Настройки Telegram сохранены.', 'success');
                 } else {
                     const errorText = await response.text();
                     // Показываем ошибку непосредственно в форме


### PR DESCRIPTION
## Summary
- notify about successful Telegram settings save

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685edeec43ac832d865fe46c0ab5989d