### PR TITLE
Fix Telegram bot field toggling

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -572,7 +572,11 @@ function initTelegramCustomBotBlocks() {
             if (systemRadio.checked) {
                 hideFields();
             } else if (customRadio.checked) {
-                showFields();
+                if (fields.querySelector('.current-bot')) {
+                    hideFields();
+                } else {
+                    showFields();
+                }
             }
 
             // Обновляем стили выбранной опции
@@ -1338,7 +1342,7 @@ async function saveCustomBot(storeId) {
         if (response.ok) {
             const data = await response.json();
             updateBotInfo(storeId, data.botUsername);
-            document.querySelector(`#tg-bot-custom-${storeId}`)?.dispatchEvent(new Event('change'));
+            slideUp(document.getElementById(`tg-custom-bot-fields-${storeId}`));
             notifyUser('Бот сохранён', 'success');
         } else {
             const errorText = await response.text();


### PR DESCRIPTION
## Summary
- refine custom bot field update logic to keep token block collapsed when a bot is already linked
- hide custom bot token fields after saving a new token

## Testing
- `./mvnw -q test` *(fails: cannot open .mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edeef6d20832d96a635eeb583b647