### PR TITLE
Show inline success notification for Telegram forms

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -343,6 +343,8 @@ function initTelegramForms() {
                 if (response.ok) {
                     // Уведомление придёт через WebSocket
                     notifyUser('Настройки Telegram сохранены.', 'success');
+                    // Показываем уведомление прямо в форме на случай проблем с WebSocket
+                    showInlineNotification(form, 'Настройки Telegram сохранены.', 'success');
                 } else {
                     const errorText = await response.text();
                     // Показываем ошибку непосредственно в форме


### PR DESCRIPTION
## Summary
- display a success notification inline when Telegram settings are saved

## Testing
- `mvn -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ee952421c832d80d5f8b054f17d75