### PR TITLE
Fix Telegram tab auto scroll

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -507,10 +507,10 @@ function initTelegramTemplateBlocks() {
         const fields = form.querySelector('.custom-template-fields');
         if (!cb || !fields) return;
 
-        const update = () => {
+        const update = (scrollOnShow = false) => {
             const wasHidden = fields.classList.contains('hidden');
             toggleFieldsVisibility(cb, fields);
-            if (cb.checked && wasHidden) {
+            if (scrollOnShow && cb.checked && wasHidden) {
                 setTimeout(() => {
                     window.scrollTo({
                         top: document.body.scrollHeight,
@@ -519,8 +519,8 @@ function initTelegramTemplateBlocks() {
                 }, 100);
             }
         };
-        update();
-        cb.addEventListener('change', update);
+        update(false);
+        cb.addEventListener('change', () => update(true));
     });
 }
 


### PR DESCRIPTION
## Summary
- avoid scrolling page when Telegram settings tab initially loads

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eeba918b4832dbcd0857df782f5a5