### PR TITLE
Fix telegram notification logic

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -221,7 +221,12 @@ public class CustomerService {
         Long customerId = customer.getId();
         Long storeId = store.getId();
         Optional<CustomerTelegramLink> linkOpt = linkRepository.findByCustomerIdAndStoreId(customerId, storeId);
-        if (linkOpt.isEmpty() || !linkOpt.get().isNotificationsEnabled()) {
+        if (linkOpt.isEmpty()) {
+            return false;
+        }
+
+        CustomerTelegramLink link = linkOpt.get();
+        if (!link.isNotificationsEnabled() || !link.isTelegramConfirmed()) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- ensure telegram notifications use correct bot
- look up chat only for parcel store
- require confirmed and enabled links

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f05b8a050832d97de76fbbfc968a0