### PR TITLE
Add store-specific Telegram link handling

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/CustomerTelegramLinkRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerTelegramLinkRepository.java
@@ -43,4 +43,21 @@ public interface CustomerTelegramLinkRepository extends JpaRepository<CustomerTe
      * @return найденная привязка или {@link java.util.Optional#empty()}
      */
     Optional<CustomerTelegramLink> findByCustomerIdAndStoreId(Long customerId, Long storeId);
+
+    /**
+     * Найти привязку Telegram по чату и магазину.
+     *
+     * @param chatId  идентификатор чата Telegram
+     * @param storeId идентификатор магазина
+     * @return найденная привязка или {@link java.util.Optional#empty()}
+     */
+    Optional<CustomerTelegramLink> findByTelegramChatIdAndStoreId(Long chatId, Long storeId);
+
+    /**
+     * Найти активные привязки покупателя (подтверждённые и с включёнными уведомлениями).
+     *
+     * @param customerId идентификатор покупателя
+     * @return список активных привязок
+     */
+    List<CustomerTelegramLink> findByCustomerIdAndTelegramConfirmedTrueAndNotificationsEnabledTrue(Long customerId);
 }

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -87,6 +87,24 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
                                              @Param("finalStatuses") List<GlobalStatus> finalStatuses);
 
     /**
+     * Найти активные посылки покупателя в конкретном магазине.
+     *
+     * @param customerId идентификатор покупателя
+     * @param storeId    идентификатор магазина
+     * @param finalStatuses статусы, при которых посылка считается завершённой
+     * @return список посылок
+     */
+    @Query("""
+            SELECT t FROM TrackParcel t
+            WHERE t.customer.id = :customerId
+              AND t.store.id = :storeId
+              AND t.status NOT IN (:finalStatuses)
+            """)
+    List<TrackParcel> findActiveByCustomerIdAndStoreId(@Param("customerId") Long customerId,
+                                                      @Param("storeId") Long storeId,
+                                                      @Param("finalStatuses") List<GlobalStatus> finalStatuses);
+
+    /**
      * Получить все посылки с загруженными пользователем и магазином.
      *
      * @return список посылок


### PR DESCRIPTION
## Summary
- support chat+store lookup and active link search in `CustomerTelegramLinkRepository`
- add query for active parcels by store in `TrackParcelRepository`
- implement store-aware link creation and notification logic in `CustomerTelegramService`
- allow enabling/disabling notifications per link
- keep compatibility wrappers for old chat-only operations

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f08c582d0832da5a91e44d362c860