### PR TITLE
Implement store telegram link management

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -10,6 +10,8 @@ import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.customer.CustomerTelegramService;
+import com.project.tracking_system.dto.CustomerTelegramLinkDTO;
 import com.project.tracking_system.model.subscription.FeatureKey;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -51,6 +53,7 @@ public class ProfileController {
     private final WebSocketController webSocketController;
     private final SubscriptionService subscriptionService;
     private final StoreTelegramSettingsService telegramSettingsService;
+    private final CustomerTelegramService customerTelegramService;
 
     /**
      * Отображает страницу профиля пользователя.
@@ -474,8 +477,10 @@ public class ProfileController {
         Long userId = user.getId();
         Store store = storeService.getStore(storeId, userId);
         boolean usingSystemBot = telegramSettingsService.isUsingSystemBot(store.getTelegramSettings());
+        List<CustomerTelegramLinkDTO> links = customerTelegramService.getLinksByStore(storeId);
         model.addAttribute("store", store);
         model.addAttribute("usingSystemBot", usingSystemBot);
+        model.addAttribute("links", links);
         return "profile :: telegramStoreBlock";
     }
 

--- a/src/main/java/com/project/tracking_system/dto/CustomerTelegramLinkDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/CustomerTelegramLinkDTO.java
@@ -1,0 +1,27 @@
+package com.project.tracking_system.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO c информацией о привязке покупателя к Telegram.
+ */
+@Getter
+@Setter
+public class CustomerTelegramLinkDTO {
+
+    /** Идентификатор привязки. */
+    private Long id;
+
+    /** Телефон покупателя. */
+    private String phone;
+
+    /** Идентификатор Telegram-чата. */
+    private Long telegramChatId;
+
+    /** Подтверждён ли Telegram. */
+    private boolean telegramConfirmed;
+
+    /** Включены ли уведомления. */
+    private boolean notificationsEnabled;
+}

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1048,6 +1048,7 @@ async function appendTelegramBlock(store) {
     initTelegramCustomBotBlocks();
     initTelegramBotInfo();
     initTelegramNotificationsToggle();
+    initCustomerNotificationToggles();
 }
 
 const baseUrl = "/profile/stores"; // Базовый URL для всех запросов
@@ -1293,6 +1294,31 @@ function initTelegramBotInfo() {
         if (username) {
             updateBotInfo(storeId, username);
         }
+    });
+}
+
+// Переключатели уведомлений покупателей
+function initCustomerNotificationToggles() {
+    document.querySelectorAll('.customer-notification-toggle').forEach(cb => {
+        if (cb.dataset.init) return;
+        cb.dataset.init = 'true';
+        cb.addEventListener('change', async function () {
+            const linkId = this.getAttribute('data-link-id');
+            const storeId = this.getAttribute('data-store-id');
+            const formData = new URLSearchParams({ enabled: this.checked });
+            try {
+                const response = await fetch(`/stores/${storeId}/telegram-settings/links/${linkId}/notifications`, {
+                    method: 'POST',
+                    headers: { [window.csrfHeader]: window.csrfToken, 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: formData
+                });
+                if (!response.ok) {
+                    this.checked = !this.checked;
+                }
+            } catch (e) {
+                this.checked = !this.checked;
+            }
+        });
     });
 }
 

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -582,6 +582,35 @@
 
                 <button type="submit" class="btn btn-sm btn-primary w-100">Сохранить</button>
             </form>
+
+            <div class="mt-3" th:if="${links}" >
+                <h6>Покупатели, подписанные на Telegram</h6>
+                <table class="table table-sm">
+                    <thead>
+                    <tr>
+                        <th>Телефон</th>
+                        <th>Подтверждено</th>
+                        <th>Уведомления</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="link : ${links}">
+                        <td th:text="${link.phone}"></td>
+                        <td>
+                            <i class="bi" th:classappend="${link.telegramConfirmed} ? 'bi-check-lg text-success' : 'bi-x-lg text-danger'"></i>
+                        </td>
+                        <td>
+                            <input class="form-check-input customer-notification-toggle"
+                                   type="checkbox"
+                                   th:id="'link-toggle-' + ${link.id}"
+                                   th:data-link-id="${link.id}"
+                                   th:data-store-id="${store.id}"
+                                   th:checked="${link.notificationsEnabled}">
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </th:block>


### PR DESCRIPTION
## Summary
- add DTO for customer telegram link information
- extend customer telegram service with link management APIs
- expose store-level endpoints for telegram link control
- include telegram link data in profile controller
- render link status table in profile template
- support notification toggle via JS

## Testing
- `mvnw -q test` *(fails: mvn wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f0aa54530832d9f8c9449253d1192