### PR TITLE
Add unique constraint to customer telegram links

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/CustomerTelegramLink.java
+++ b/src/main/java/com/project/tracking_system/entity/CustomerTelegramLink.java
@@ -17,7 +17,8 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "tb_customer_telegram_links")
+@Table(name = "tb_customer_telegram_links",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"customer_id", "store_id"}))
 public class CustomerTelegramLink {
 
     @Id

--- a/src/main/resources/db/migration/V42__deduplicate_customer_telegram_links.sql
+++ b/src/main/resources/db/migration/V42__deduplicate_customer_telegram_links.sql
@@ -1,0 +1,31 @@
+-- Объединяем дубликаты перед добавлением уникального ограничения
+WITH dedup AS (
+    SELECT MIN(id)            AS keep_id,
+           customer_id,
+           store_id,
+           MAX(telegram_chat_id)      AS telegram_chat_id,
+           BOOL_OR(notifications_enabled) AS notifications_enabled,
+           BOOL_OR(telegram_confirmed) AS telegram_confirmed,
+           MIN(linked_at)        AS linked_at
+    FROM tb_customer_telegram_links
+    GROUP BY customer_id, store_id
+)
+UPDATE tb_customer_telegram_links t
+SET telegram_chat_id = d.telegram_chat_id,
+    notifications_enabled = d.notifications_enabled,
+    telegram_confirmed = d.telegram_confirmed,
+    linked_at = d.linked_at
+FROM dedup d
+WHERE t.id = d.keep_id;
+
+-- Удаляем лишние записи
+DELETE FROM tb_customer_telegram_links t
+USING dedup d
+WHERE t.customer_id = d.customer_id
+  AND t.store_id = d.store_id
+  AND t.id <> d.keep_id;
+
+-- Добавляем уникальное ограничение
+ALTER TABLE tb_customer_telegram_links
+    ADD CONSTRAINT uk_customer_telegram_links_customer_store UNIQUE (customer_id, store_id);
+


### PR DESCRIPTION
## Summary
- add unique constraint definition to `CustomerTelegramLink`
- migrate duplicates and add database-level unique constraint

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1eb38608832d802009ed67134c7e