### PR TITLE
Handle Telegram bot token cache updates

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -36,6 +36,28 @@ public class TelegramNotificationService {
     private final Map<String, TelegramClient> clientCache = new ConcurrentHashMap<>();
 
     /**
+     * Удаляет клиента, связанный с указанным токеном, из кэша.
+     *
+     * @param token токен бота
+     */
+    public void invalidateClient(String token) {
+        if (token != null && !token.isBlank()) {
+            clientCache.remove(token);
+        }
+    }
+
+    /**
+     * Удаляет клиента из кэша по токену из настроек магазина.
+     *
+     * @param settings настройки Telegram магазина
+     */
+    public void invalidateClient(StoreTelegramSettings settings) {
+        if (settings != null) {
+            invalidateClient(settings.getBotToken());
+        }
+    }
+
+    /**
      * Отправить уведомление о смене статуса посылки.
      * <p>
      * Если в профиле магазина указана подпись, она будет добавлена


### PR DESCRIPTION
## Summary
- let TelegramNotificationService invalidate cached clients
- add TelegramNotificationService dependency to StoreTelegramSettingsService
- clear Telegram client cache when custom bot token changes or removed
- test that cached clients are invalidated when updating bots

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1eb96700832dbeefeff71554ce36