### PR TITLE
feat: link BuyerTelegramBot to store

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/TelegramConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/TelegramConfig.java
@@ -1,5 +1,7 @@
 package com.project.tracking_system.configuration;
 
+import com.project.tracking_system.service.telegram.BuyerTelegramBot;
+import com.project.tracking_system.service.telegram.TelegramBotFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,6 +29,17 @@ public class TelegramConfig {
     @Bean
     public TelegramClient telegramClient() {
         return new OkHttpTelegramClient(botToken);
+    }
+
+    /**
+     * Создает системного Telegram-бота.
+     *
+     * @param factory фабрика ботов
+     * @return экземпляр {@link BuyerTelegramBot}
+     */
+    @Bean
+    public BuyerTelegramBot buyerTelegramBot(TelegramBotFactory factory) {
+        return factory.create(botToken);
     }
 
 }

--- a/src/main/java/com/project/tracking_system/repository/StoreRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/StoreRepository.java
@@ -72,6 +72,15 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     List<Store> findByOwnerIdFetchSettings(@Param("ownerId") Long ownerId);
 
     /**
+     * Найти магазин с указанным токеном бота.
+     *
+     * @param token токен Telegram-бота
+     * @return магазин, которому назначен этот бот
+     */
+    @Query("SELECT s FROM Store s LEFT JOIN FETCH s.telegramSettings ts WHERE ts.botToken = :token")
+    Optional<Store> findByAssignedBotToken(@Param("token") String token);
+
+    /**
      * Получить все магазины с Telegram-настройками и подпиской владельца.
      *
      * @return список магазинов

--- a/src/main/java/com/project/tracking_system/service/telegram/DefaultTelegramBotFactory.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/DefaultTelegramBotFactory.java
@@ -1,0 +1,27 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.repository.StoreRepository;
+import com.project.tracking_system.service.customer.CustomerTelegramService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/**
+ * Реализация фабрики телеграм-ботов.
+ */
+@Component
+@RequiredArgsConstructor
+public class DefaultTelegramBotFactory implements TelegramBotFactory {
+
+    private final TelegramClientFactory clientFactory;
+    private final CustomerTelegramService telegramService;
+    private final StoreRepository storeRepository;
+
+    @Override
+    public BuyerTelegramBot create(String token) {
+        TelegramClient client = clientFactory.create(token);
+        Store store = storeRepository.findByAssignedBotToken(token).orElse(null);
+        return new BuyerTelegramBot(store, client, token, telegramService);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramBotFactory.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramBotFactory.java
@@ -1,0 +1,16 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.service.telegram.BuyerTelegramBot;
+
+/**
+ * Фабрика телеграм-ботов для покупателей.
+ */
+public interface TelegramBotFactory {
+    /**
+     * Создает экземпляр бота по заданному токену.
+     *
+     * @param token токен Telegram-бота
+     * @return настроенный бот
+     */
+    BuyerTelegramBot create(String token);
+}


### PR DESCRIPTION
## Summary
- allow BuyerTelegramBot to hold a linked store
- create new constructor with store parameter
- add TelegramBotFactory and default implementation
- fetch store for bot token in repository
- create system bot via TelegramConfig using the factory

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685f2bc0d5c4832d9a4b5bc6a8c00b60