### PR TITLE
Add Telegram bot resolver service

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramBotResolverService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramBotResolverService.java
@@ -1,0 +1,75 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.service.store.StoreTelegramSettingsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Сервис определения Telegram-бота для магазина.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TelegramBotResolverService {
+
+    private final TelegramClient systemTelegramClient;
+    private final TelegramClientFactory telegramClientFactory;
+    private final StoreTelegramSettingsService telegramSettingsService;
+
+    /** Кэш клиентов Telegram по токену пользовательского бота. */
+    private final Map<String, TelegramClient> clientCache = new ConcurrentHashMap<>();
+
+    /**
+     * Получить {@link TelegramClient} для уведомлений магазина.
+     *
+     * @param store магазин
+     * @return клиент Telegram соответствующего бота
+     */
+    public TelegramClient resolveBotForStore(Store store) {
+        if (store == null) {
+            return systemTelegramClient;
+        }
+
+        StoreTelegramSettings settings = store.getTelegramSettings();
+        if (settings == null || telegramSettingsService.isUsingSystemBot(settings)) {
+            return systemTelegramClient;
+        }
+
+        String token = settings.getBotToken();
+        if (token == null || token.isBlank()) {
+            return systemTelegramClient;
+        }
+
+        // Создаем или возвращаем из кэша клиента для пользовательского токена
+        return clientCache.computeIfAbsent(token, telegramClientFactory::create);
+    }
+
+    /**
+     * Удалить клиент из кэша по токену.
+     *
+     * @param token токен бота
+     */
+    public void invalidateClient(String token) {
+        if (token != null && !token.isBlank()) {
+            clientCache.remove(token);
+        }
+    }
+
+    /**
+     * Удалить клиент из кэша по настройкам магазина.
+     *
+     * @param settings настройки Telegram
+     */
+    public void invalidateClient(StoreTelegramSettings settings) {
+        if (settings != null) {
+            invalidateClient(settings.getBotToken());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `TelegramBotResolverService` to determine client for store
- inject resolver into `TelegramNotificationService` and use it when sending notifications

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2df9b1a0832d8d29ee57891d67fa