### PR TITLE
Remove unused StoreTelegramSettingsService field

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -8,7 +8,6 @@ import com.project.tracking_system.mapper.BuyerStatusMapper;
 import com.project.tracking_system.service.customer.CustomerService;
 import com.project.tracking_system.repository.CustomerTelegramLinkRepository;
 import com.project.tracking_system.entity.CustomerTelegramLink;
-import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import com.project.tracking_system.service.telegram.TelegramBotResolverService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +26,6 @@ public class TelegramNotificationService {
 
     private final CustomerService customerService;
     private final CustomerTelegramLinkRepository linkRepository;
-    private final StoreTelegramSettingsService telegramSettingsService;
     private final TelegramBotResolverService botResolverService;
 
     /**


### PR DESCRIPTION
## Summary
- clean TelegramNotificationService by dropping StoreTelegramSettingsService dependency

## Testing
- `mvnw test -q` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685f3365d294832dafd80d3bb6ac2c36