### PR TITLE
Add admin custom telegram message

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -390,6 +391,7 @@ public class AdminController {
         model.addAttribute("boundCustomers", adminService.countTelegramBoundCustomers());
         model.addAttribute("remindersEnabled", adminService.countStoresWithReminders());
         model.addAttribute("logs", adminService.getRecentLogs());
+        model.addAttribute("stores", adminService.getStoresInfo());
 
         // Хлебные крошки
         List<BreadcrumbItemDTO> breadcrumbs = List.of(
@@ -398,6 +400,28 @@ public class AdminController {
         );
         model.addAttribute("breadcrumbs", breadcrumbs);
         return "admin/telegram";
+    }
+
+    /**
+     * Отправить сообщение покупателю по номеру телефона.
+     *
+     * @param phone   номер телефона
+     * @param text    текст сообщения
+     * @param storeId идентификатор магазина или {@code null} для системного бота
+     * @return редирект на страницу Telegram статистики
+     */
+    @PostMapping("/telegram/send-message")
+    public String sendTelegramMessage(@RequestParam String phone,
+                                      @RequestParam String text,
+                                      @RequestParam(required = false) Long storeId,
+                                      RedirectAttributes redirectAttributes) {
+        boolean sent = adminService.sendTelegramMessage(phone, text, storeId);
+        if (sent) {
+            redirectAttributes.addFlashAttribute("successMessage", "Сообщение отправлено");
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Не удалось отправить сообщение");
+        }
+        return "redirect:/admin/telegram";
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/repository/CustomerTelegramLinkRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerTelegramLinkRepository.java
@@ -2,6 +2,8 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.CustomerTelegramLink;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -60,4 +62,19 @@ public interface CustomerTelegramLinkRepository extends JpaRepository<CustomerTe
      * @return список активных привязок
      */
     List<CustomerTelegramLink> findByCustomerIdAndTelegramConfirmedTrueAndNotificationsEnabledTrue(Long customerId);
+
+    /**
+     * Найти активные привязки по номеру телефона покупателя.
+     *
+     * @param phone телефон покупателя в формате 375XXXXXXXXX
+     * @return список активных привязок
+     */
+    @Query("""
+            SELECT l FROM CustomerTelegramLink l
+            JOIN l.customer c
+            WHERE c.phone = :phone
+              AND l.telegramConfirmed = true
+              AND l.notificationsEnabled = true
+            """)
+    List<CustomerTelegramLink> findActiveLinksByPhone(@Param("phone") String phone);
 }

--- a/src/main/java/com/project/tracking_system/service/admin/AdminService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminService.java
@@ -35,6 +35,7 @@ public class AdminService {
     private final TrackProcessingService trackProcessingService;
     private final com.project.tracking_system.service.user.UserService userService;
     private final com.project.tracking_system.service.store.StoreService storeService;
+    private final com.project.tracking_system.service.telegram.TelegramNotificationService telegramNotificationService;
 
     /**
      * Подсчитать общее количество покупателей.
@@ -328,6 +329,18 @@ public class AdminService {
         TrackParcel parcel = trackParcelRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Посылка не найдена"));
         trackProcessingService.processTrack(parcel.getNumber(), parcel.getStore().getId(), parcel.getUser().getId(), true);
+    }
+
+    /**
+     * Отправить текстовое сообщение покупателю по телефону.
+     *
+     * @param phone   номер телефона покупателя
+     * @param text    текст сообщения
+     * @param storeId идентификатор магазина или {@code null} для системного бота
+     * @return {@code true}, если сообщение было отправлено
+     */
+    public boolean sendTelegramMessage(String phone, String text, Long storeId) {
+        return telegramNotificationService.sendCustomMessage(phone, text, storeId);
     }
 
     /**

--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -9,6 +9,9 @@
 
 <main layout:fragment="content">
 
+    <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+    <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
     <div class="row mb-4">
         <div class="col-md-6">
             <div class="card shadow-sm custom-card">
@@ -47,5 +50,26 @@
         </tr>
         </tbody>
     </table>
+
+    <h4 class="mt-4">Отправить сообщение покупателю</h4>
+    <form th:action="@{/admin/telegram/send-message}" method="post" class="mb-3">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <div class="mb-3">
+            <label for="phone" class="form-label">Телефон</label>
+            <input type="text" id="phone" name="phone" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="storeId" class="form-label">Бот</label>
+            <select id="storeId" name="storeId" class="form-select">
+                <option value="0">Системный бот</option>
+                <option th:each="s : ${stores}" th:value="${s.id}" th:text="${s.name}"></option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="text" class="form-label">Текст сообщения</label>
+            <textarea id="text" name="text" rows="3" class="form-control" required></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Отправить</button>
+    </form>
 </main>
 </html>


### PR DESCRIPTION
## Summary
- allow repository to find active links by phone
- support sending arbitrary telegram text to a phone number
- expose new admin service and controller endpoints
- show a form in Telegram admin page for sending messages
- allow admin to pick which bot will send the message

## Testing
- `./mvnw -q -DskipTests package` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685faba486a8832d8b566ef18db41ae2