### PR TITLE
Add Telegram bot manager

### DIFF
--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -11,6 +11,7 @@ import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.telegram.TelegramBotValidationService;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
+import com.project.tracking_system.service.telegram.TelegramBotManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class StoreTelegramSettingsService {
     private final StoreTelegramTemplateRepository storeTelegramTemplateRepository;
     private final TelegramBotValidationService botValidationService;
     private final TelegramNotificationService telegramNotificationService;
+    private final TelegramBotManager telegramBotManager;
 
     /**
      * Создать или обновить настройки Telegram магазина.
@@ -152,6 +154,8 @@ public class StoreTelegramSettingsService {
 
         settingsRepository.save(settings);
         telegramNotificationService.invalidateClient(oldToken);
+        telegramBotManager.unregisterBot(oldToken); // останавливаем старый бот
+        telegramBotManager.registerBot(botToken);  // запускаем новый
         store.setTelegramSettings(settings);
         log.info("Пользовательский бот сохранён для магазина ID={}", store.getId());
         return username;
@@ -175,6 +179,7 @@ public class StoreTelegramSettingsService {
         settings.setBotUsername(null);
         settingsRepository.save(settings);
         telegramNotificationService.invalidateClient(oldToken);
+        telegramBotManager.unregisterBot(oldToken); // останавливаем бота
         store.setTelegramSettings(settings);
         log.info("Пользовательский бот удалён для магазина ID={}", store.getId());
     }

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramBotManager.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramBotManager.java
@@ -1,0 +1,63 @@
+package com.project.tracking_system.service.telegram;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.TelegramBotsApi;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.BotSession;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Сервис управления пользовательскими Telegram-ботами.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TelegramBotManager {
+
+    private final TelegramBotsApi telegramBotsApi;
+    private final TelegramBotFactory botFactory;
+
+    /** Сессии ботов по токену. */
+    private final Map<String, BotSession> sessions = new ConcurrentHashMap<>();
+
+    /**
+     * Регистрирует и запускает Telegram-бота по указанному токену.
+     *
+     * @param token токен бота
+     */
+    public synchronized void registerBot(String token) {
+        if (token == null || token.isBlank() || sessions.containsKey(token)) {
+            return;
+        }
+        try {
+            BuyerTelegramBot bot = botFactory.create(token);
+            BotSession session = telegramBotsApi.registerBot(bot);
+            session.start();
+            sessions.put(token, session);
+            log.info("▶️ Пользовательский бот запущен: {}", token);
+        } catch (TelegramApiException e) {
+            log.error("❌ Ошибка запуска бота {}", token, e);
+            throw new IllegalStateException("Не удалось зарегистрировать бота", e);
+        }
+    }
+
+    /**
+     * Останавливает и удаляет бота с указанным токеном.
+     *
+     * @param token токен бота
+     */
+    public synchronized void unregisterBot(String token) {
+        if (token == null || token.isBlank()) {
+            return;
+        }
+        BotSession session = sessions.remove(token);
+        if (session != null) {
+            session.stop();
+            log.info("⏹ Пользовательский бот остановлен: {}", token);
+        }
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -11,6 +11,7 @@ import com.project.tracking_system.repository.StoreTelegramTemplateRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.telegram.TelegramBotValidationService;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
+import com.project.tracking_system.service.telegram.TelegramBotManager;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.store.StoreTelegramSettingsService;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,8 @@ class StoreTelegramSettingsServiceTest {
     private TelegramBotValidationService botValidationService;
     @Mock
     private TelegramNotificationService telegramNotificationService;
+    @Mock
+    private TelegramBotManager telegramBotManager;
 
     @InjectMocks
     private StoreTelegramSettingsService service;
@@ -140,6 +143,8 @@ class StoreTelegramSettingsServiceTest {
 
         verify(settingsRepository).save(settings);
         verify(telegramNotificationService).invalidateClient("old");
+        verify(telegramBotManager).unregisterBot("old");
+        verify(telegramBotManager).registerBot("new");
         org.junit.jupiter.api.Assertions.assertEquals("new", settings.getBotToken());
     }
 
@@ -153,6 +158,7 @@ class StoreTelegramSettingsServiceTest {
 
         verify(settingsRepository).save(settings);
         verify(telegramNotificationService).invalidateClient("old");
+        verify(telegramBotManager).unregisterBot("old");
         org.junit.jupiter.api.Assertions.assertNull(settings.getBotToken());
     }
 }


### PR DESCRIPTION
## Summary
- manage BuyerTelegramBot instances by token
- register custom bot when connecting Telegram settings
- stop and unregister bot when removing custom bot
- test manager interactions

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685fb3fab138832dbde0dddaf307c847