### PR TITLE
Fix Telegram confirmation flow and bot response

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -66,7 +66,8 @@ public class CustomerTelegramService {
         link.setCustomer(customer);
         link.setTelegramChatId(chatId);
         link.setLinkedAt(ZonedDateTime.now(ZoneOffset.UTC));
-        link.setTelegramConfirmed(true);
+        // подтверждение будет получено после передачи контакта
+        link.setTelegramConfirmed(false);
         link.setNotificationsEnabled(true);
 
         CustomerTelegramLink saved = linkRepository.save(link);
@@ -107,7 +108,8 @@ public class CustomerTelegramService {
         link.setLinkedAt(ZonedDateTime.now(ZoneOffset.UTC));
 
         if (existing.isEmpty()) {
-            link.setTelegramConfirmed(true);
+            // при создании новой связи ждём подтверждения от покупателя
+            link.setTelegramConfirmed(false);
             link.setNotificationsEnabled(true);
         }
 

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -1,0 +1,82 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.CustomerTelegramLink;
+import com.project.tracking_system.service.customer.CustomerTelegramService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Contact;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link BuyerTelegramBot}.
+ */
+@ExtendWith(MockitoExtension.class)
+class BuyerTelegramBotTest {
+
+    @Mock
+    private TelegramClient telegramClient;
+    @Mock
+    private CustomerTelegramService telegramService;
+
+    private BuyerTelegramBot bot;
+
+    @BeforeEach
+    void setUp() {
+        bot = new BuyerTelegramBot(null, telegramClient, "token", telegramService);
+    }
+
+    @Test
+    void consume_WithContact_SendsConfirmationAndKeyboard() throws TelegramApiException {
+        // создаём контакт и сообщение
+        Contact contact = new Contact();
+        contact.setPhoneNumber("+375291234567");
+
+        Message message = mock(Message.class);
+        when(message.hasText()).thenReturn(false);
+        when(message.hasContact()).thenReturn(true);
+        when(message.getChatId()).thenReturn(100L);
+        when(message.getContact()).thenReturn(contact);
+
+        Update update = new Update();
+        update.setMessage(message);
+
+        CustomerTelegramLink link = new CustomerTelegramLink();
+        link.setTelegramChatId(100L);
+        link.setTelegramConfirmed(false);
+        link.setLinkedAt(ZonedDateTime.now(ZoneOffset.UTC));
+
+        when(telegramService.linkTelegramToCustomer(anyString(), anyLong())).thenReturn(link);
+        when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
+
+        bot.consume(update);
+
+        // проверяем отправку двух сообщений
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, times(2)).execute(captor.capture());
+        List<SendMessage> messages = captor.getAllValues();
+        assertEquals("✅ Номер сохранён. Спасибо!", messages.get(0).getText());
+        assertNull(messages.get(0).getReplyMarkup());
+        assertEquals("🔔 Настройки уведомлений", messages.get(1).getText());
+        assertNotNull(messages.get(1).getReplyMarkup());
+
+        verify(telegramService).confirmTelegram(link);
+        verify(telegramService).notifyActualStatuses(link);
+    }
+}


### PR DESCRIPTION
## Summary
- initialize telegram link with unconfirmed status
- add test ensuring buyer bot confirms phone and shows keyboard

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_685fb67ff298832d9a8448c9b5027e74