### PR TITLE
Initialize shared Tesseract once

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Belpost and Evropost
 
 Для работы OCR-сервиса в `application.properties` необходимо указать путь к каталогу с данными Tesseract через свойство `tesseract.datapath`. По умолчанию используется `/usr/local/share/tessdata`.
 
+Сервис `TrackNumberOcrService` инициализирует единый экземпляр Tesseract при запуске приложения, поэтому библиотека подготавливается один раз.
+
 ## Компиляция CSS
 
 Для генерации стилей используется Sass, исходный SCSS размещён в каталоге `src/main/resources/assets/scss`.

--- a/src/main/java/com/project/tracking_system/service/track/TrackNumberOcrService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackNumberOcrService.java
@@ -46,12 +46,24 @@ public class TrackNumberOcrService {
     @Value("${tesseract.datapath}")
     private String tesseractDataPath;
 
+    /** Tesseract OCR, инициализируемый после загрузки OpenCV. */
+    private Tesseract tesseract;
+
     /**
-     * Инициализация библиотеки OpenCV.
+     * Инициализация библиотек OpenCV и Tesseract.
+     * <p>
+     * Загружает нативную библиотеку OpenCV и создаёт настроенный экземпляр Tesseract.
+     * </p>
      */
     @PostConstruct
     public void init() {
         System.load(opencvLibPath);
+        tesseract = new Tesseract();
+        tesseract.setDatapath(tesseractDataPath);
+        tesseract.setLanguage("rus+eng");
+        tesseract.setVariable("user_defined_dpi", "300");
+        tesseract.setPageSegMode(3);
+        tesseract.setOcrEngineMode(1); // Только LSTM
     }
 
     /**
@@ -106,18 +118,15 @@ public class TrackNumberOcrService {
 
     /**
      * Распознает текст на изображении с использованием Tesseract OCR.
-     * @param image Изображение, с которого нужно распознать текст.
-     * @return Распознанный текст.
-     * @throws TesseractException Если возникла ошибка при распознавании текста.
+     * <p>
+     * Использует единый экземпляр {@link Tesseract}, созданный при инициализации сервиса.
+     * </p>
+     *
+     * @param image изображение, с которого нужно распознать текст
+     * @return распознанный текст
+     * @throws TesseractException если возникла ошибка при распознавании текста
      */
-    public String recognizeText(BufferedImage image) throws TesseractException {
-        Tesseract tesseract = new Tesseract();
-        tesseract.setDatapath(tesseractDataPath);
-        tesseract.setLanguage("rus+eng");
-        tesseract.setVariable("user_defined_dpi", "300");
-        tesseract.setPageSegMode(3);
-        tesseract.setOcrEngineMode(1); // Только LSTM
-
+    public synchronized String recognizeText(BufferedImage image) throws TesseractException {
         return tesseract.doOCR(image);
     }
 


### PR DESCRIPTION
## Summary
- initialize a singleton Tesseract in `TrackNumberOcrService`
- reuse the shared OCR instance when processing images
- document new behaviour in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866caeae108832d920aef273cbc693f