### PR TITLE
Remove unused OpenCV artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Belpost and Evropost
 
 ## Конфигурация OpenCV
 
-В файле `application.properties` добавлено свойство `opencv.lib.path`, которое определяет путь к нативной библиотеке OpenCV. По умолчанию используется `/usr/lib/jni/libopencv_java4100.so`.
+Используется зависимость `org.bytedeco:opencv-platform`, которая содержит нативные библиотеки для различных платформ. 
+Путь к библиотеке можно задать через свойство `opencv.lib.path` в `application.properties`. 
+По умолчанию используется `/usr/lib/jni/libopencv_java4100.so`.
 
 ## Конфигурация Tesseract
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
             <version>4.10.0-1.5.11</version>
         </dependency>
         <dependency>
-            <groupId>org.openpnp</groupId>
-            <artifactId>opencv</artifactId>
-            <version>4.9.0-0</version>
-        </dependency>
-        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>11.2.0</version>


### PR DESCRIPTION
## Summary
- remove `org.openpnp:opencv` from dependencies
- clarify README about OpenCV dependency

## Testing
- `./mvnw -v` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6866caec90e0832d8368fe2bc614f44d