### PR TITLE
Fix TariffService maxStores bug and add regression test

### DIFF
--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -124,7 +124,7 @@ public class TariffService {
                 maxTrackUpdates,
                 plan.isFeatureEnabled(FeatureKey.BULK_UPDATE),
                 plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE),
-                limits.getMaxStores(),
+                maxStores,
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
                 monthlyLabel,
                 annualLabel,

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -108,6 +108,13 @@ class TariffServiceTest {
     }
 
     @Test
+    void toViewDto_WithoutLimits_DoesNotThrow() {
+        plan.setLimits(null);
+
+        assertDoesNotThrow(() -> tariffService.toViewDto(plan));
+    }
+
+    @Test
     void getPlanInfoByCode_ReturnsDto() {
         when(planRepository.findByCode("PREMIUM")).thenReturn(java.util.Optional.of(plan));
 


### PR DESCRIPTION
## Summary
- fix `TariffService.toViewDto` to use local `maxStores` variable
- add regression test for plan without limits

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6866e0f3dc4c832d9869dee3972b941f