### PR TITLE
Add custom templates feature flag

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionLimitsDTO.java
@@ -20,4 +20,6 @@ public class SubscriptionLimitsDTO {
     private boolean allowAutoUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
+    /** Флаг, разрешающий собственные уведомления. */
+    private boolean allowCustomNotifications;
 }

--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -23,6 +23,8 @@ public class SubscriptionPlanViewDTO {
     private boolean allowAutoUpdate;
     private Integer maxStores;
     private boolean allowTelegramNotifications;
+    /** Возможность отправлять собственные уведомления. */
+    private boolean allowCustomNotifications;
     private String monthlyPriceLabel;
     private String annualPriceLabel;
 

--- a/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
+++ b/src/main/java/com/project/tracking_system/model/subscription/FeatureKey.java
@@ -21,7 +21,12 @@ public enum FeatureKey {
     /**
      * Автоматическое обновление треков.
      */
-    AUTO_UPDATE("autoUpdate");
+    AUTO_UPDATE("autoUpdate"),
+
+    /**
+     * Индивидуальные уведомления с собственными шаблонами.
+     */
+    CUSTOM_NOTIFICATIONS("customNotifications");
 
     /**
      * -- GETTER --

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -203,6 +203,17 @@ public class SubscriptionService {
     }
 
     /**
+     * Проверяет, разрешено ли использование собственных шаблонов уведомлений.
+     *
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если функция доступна в тарифном плане
+     */
+    @Transactional(readOnly = true)
+    public boolean canUseCustomNotifications(Long userId) {
+        return isFeatureEnabled(userId, FeatureKey.CUSTOM_NOTIFICATIONS);
+    }
+
+    /**
      * Проверяет доступность функции для указанного пользователя.
      *
      * @param userId идентификатор пользователя

--- a/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/SubscriptionPlanService.java
@@ -57,6 +57,7 @@ public class SubscriptionPlanService {
         limitsDto.setAllowBulkUpdate(plan.isFeatureEnabled(FeatureKey.BULK_UPDATE));
         limitsDto.setAllowAutoUpdate(plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE));
         limitsDto.setAllowTelegramNotifications(plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS));
+        limitsDto.setAllowCustomNotifications(plan.isFeatureEnabled(FeatureKey.CUSTOM_NOTIFICATIONS));
 
         SubscriptionPlanDTO dto = new SubscriptionPlanDTO();
         dto.setId(plan.getId());
@@ -98,6 +99,7 @@ public class SubscriptionPlanService {
             setFeature(plan, FeatureKey.BULK_UPDATE, l.isAllowBulkUpdate());
             setFeature(plan, FeatureKey.AUTO_UPDATE, l.isAllowAutoUpdate());
             setFeature(plan, FeatureKey.TELEGRAM_NOTIFICATIONS, l.isAllowTelegramNotifications());
+            setFeature(plan, FeatureKey.CUSTOM_NOTIFICATIONS, l.isAllowCustomNotifications());
         }
 
         BigDecimal monthly = dto.getMonthlyPrice();

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -51,6 +51,15 @@ public class StoreTelegramSettingsService {
             throw new IllegalStateException(msg);
         }
 
+        boolean customRequested = dto.isUseCustomTemplates() ||
+                (dto.getTemplates() != null && !dto.getTemplates().isEmpty());
+        if (customRequested && !subscriptionService.canUseCustomNotifications(userId)) {
+            String msg = "Индивидуальные шаблоны недоступны на вашем тарифе.";
+            webSocketController.sendUpdateStatus(userId, msg, false);
+            log.warn("⛔ Попытка сохранить пользовательские шаблоны магазином ID={}", store.getId());
+            throw new IllegalStateException(msg);
+        }
+
         StoreTelegramSettings settings = settingsRepository.findByStoreId(store.getId());
         if (settings == null) {
             settings = new StoreTelegramSettings();

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -126,6 +126,7 @@ public class TariffService {
                 plan.isFeatureEnabled(FeatureKey.AUTO_UPDATE),
                 maxStores,
                 plan.isFeatureEnabled(FeatureKey.TELEGRAM_NOTIFICATIONS),
+                plan.isFeatureEnabled(FeatureKey.CUSTOM_NOTIFICATIONS),
                 monthlyLabel,
                 annualLabel,
                 fullAnnualPriceLabel,

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -468,6 +468,9 @@
                     <label class="form-check-label" th:for="'tg-custom-templates-' + ${store.id}">
                         Использовать собственные сообщения
                     </label>
+                    <p class="form-text text-danger ms-4" th:if="${!planDetails.allowCustomNotifications}">
+                        Функция доступна в тарифе "Команда" и выше
+                    </p>
                 </div>
 
                 <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields">

--- a/src/test/java/com/project/tracking_system/controller/StoreTelegramSettingsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/StoreTelegramSettingsControllerTest.java
@@ -1,0 +1,57 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import com.project.tracking_system.service.store.StoreTelegramSettingsService;
+import com.project.tracking_system.model.subscription.FeatureKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Проверка {@link StoreTelegramSettingsController}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StoreTelegramSettingsControllerTest {
+
+    @Mock
+    private StoreService storeService;
+    @Mock
+    private StoreTelegramSettingsRepository settingsRepository;
+    @Mock
+    private StoreTelegramSettingsService telegramSettingsService;
+    @Mock
+    private WebSocketController webSocketController;
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @InjectMocks
+    private StoreTelegramSettingsController controller;
+
+    @Test
+    void updateSettings_CustomTemplatesFeatureDisabled_ReturnsForbidden() {
+        User user = new User();
+        user.setId(1L);
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+
+        BeanPropertyBindingResult binding = new BeanPropertyBindingResult(dto, "dto");
+        when(subscriptionService.canUseCustomNotifications(1L)).thenReturn(false);
+
+        ResponseEntity<?> response = controller.updateSettings(1L, dto, binding, user);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        verify(telegramSettingsService, never()).update(any(), any(), anyLong());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -1,0 +1,68 @@
+package com.project.tracking_system.service.store;
+
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.StoreTelegramSettingsDTO;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.model.subscription.FeatureKey;
+import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Проверка {@link StoreTelegramSettingsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StoreTelegramSettingsServiceTest {
+
+    @Mock
+    private StoreTelegramSettingsRepository settingsRepository;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private WebSocketController webSocketController;
+    @Mock
+    private StoreService storeService;
+
+    @InjectMocks
+    private StoreTelegramSettingsService service;
+
+    @Test
+    void update_CustomTemplatesFeatureDisabled_Throws() {
+        Store store = new Store();
+        store.setId(1L);
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+
+        when(subscriptionService.isFeatureEnabled(1L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
+        when(subscriptionService.canUseCustomNotifications(1L)).thenReturn(false);
+
+        assertThrows(IllegalStateException.class, () -> service.update(store, dto, 1L));
+        verify(storeService, never()).updateFromDto(any(), any());
+    }
+
+    @Test
+    void update_CustomTemplatesAllowed_Saves() {
+        Store store = new Store();
+        store.setId(2L);
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+
+        when(subscriptionService.isFeatureEnabled(2L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
+        when(subscriptionService.canUseCustomNotifications(2L)).thenReturn(true);
+        when(settingsRepository.findByStoreId(2L)).thenReturn(null);
+        when(settingsRepository.save(any(StoreTelegramSettings.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.update(store, dto, 2L);
+
+        verify(storeService).updateFromDto(any(StoreTelegramSettings.class), eq(dto));
+        verify(settingsRepository).save(any(StoreTelegramSettings.class));
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -61,7 +61,11 @@ class TariffServiceTest {
         telegram.setFeatureKey(FeatureKey.TELEGRAM_NOTIFICATIONS);
         telegram.setEnabled(true);
         telegram.setSubscriptionPlan(plan);
-        plan.setFeatures(List.of(bulk, auto, telegram));
+        SubscriptionFeature custom = new SubscriptionFeature();
+        custom.setFeatureKey(FeatureKey.CUSTOM_NOTIFICATIONS);
+        custom.setEnabled(true);
+        custom.setSubscriptionPlan(plan);
+        plan.setFeatures(List.of(bulk, auto, telegram, custom));
     }
 
     @Test
@@ -100,6 +104,7 @@ class TariffServiceTest {
         assertEquals(100, dto.getMaxSavedTracks());
         assertTrue(dto.isAllowBulkUpdate());
         assertTrue(dto.isAllowAutoUpdate());
+        assertTrue(dto.isAllowCustomNotifications());
         assertTrue(dto.isAllowTelegramNotifications());
         assertEquals("15.00 BYN/мес", dto.getMonthlyPriceLabel());
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());


### PR DESCRIPTION
## Summary
- introduce `CUSTOM_TEMPLATES` feature flag
- expose new flag in subscription DTOs and mappers
- check feature when saving store telegram settings
- block API if user without feature sends custom templates
- test tariff mapping and telegram settings permissions
- rename DTO flag to `allowCustomNotifications` and show warning in profile view
- add helper `canUseCustomTemplates` to SubscriptionService
- rename custom templates feature to custom notifications

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `./mvnw -q test` *(fails: `cannot open ./.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6866e1e78a70832d8fc4c12ca20d5f3d