### PR TITLE
Add custom template restrictions

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -87,6 +87,7 @@ public class ProfileController {
         settingsDTO.setTelegramNotificationsEnabled(userService.isTelegramNotificationsEnabled(userId));
         model.addAttribute("userSettingsDTO", settingsDTO);
         model.addAttribute("passwordChangeDTO", new PasswordChangeDTO());
+        model.addAttribute("allowCustomTemplates", subscriptionService.canUseCustomNotifications(userId));
         model.addAttribute("evropostCredentialsDTO", userService.getEvropostCredentials(userId));
 
         return "profile";
@@ -117,6 +118,7 @@ public class ProfileController {
         settingsDTO.setTelegramNotificationsEnabled(userService.isTelegramNotificationsEnabled(userId));
         model.addAttribute("userSettingsDTO", settingsDTO);
         model.addAttribute("passwordChangeDTO", new PasswordChangeDTO());
+        model.addAttribute("allowCustomTemplates", subscriptionService.canUseCustomNotifications(userId));
 
         switch (tab) {
             case "evropost" -> {

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -492,9 +492,21 @@ function initTelegramTemplateBlocks() {
         const fields = form.querySelector('.custom-template-fields');
         if (!cb || !fields) return;
 
-        const update = () => toggleFieldsVisibility(cb, fields);
+        const update = () => {
+            if (cb.disabled) {
+                cb.checked = false;
+                fields.querySelectorAll('textarea').forEach(t => t.disabled = true);
+                slideUp(fields);
+                return;
+            }
+            fields.querySelectorAll('textarea').forEach(t => t.disabled = !cb.checked);
+            toggleFieldsVisibility(cb, fields);
+        };
+
         update();
-        cb.addEventListener('change', update);
+        if (!cb.disabled) {
+            cb.addEventListener('change', update);
+        }
     });
 }
 

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -458,18 +458,20 @@
                     </label>
                     <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}"
                            name="customSignature"
-                           th:value="${store.telegramSettings?.customSignature}" maxlength="200">
+                           th:value="${store.telegramSettings?.customSignature}" maxlength="200"
+                           th:disabled="${!allowCustomTemplates}">
                 </div>
 
                 <div class="form-check form-switch mb-2 ms-3">
                     <input class="form-check-input" type="checkbox" th:id="'tg-custom-templates-' + ${store.id}"
                            name="useCustomTemplates"
-                           th:checked="${store.telegramSettings?.templates?.size() > 0}">
+                           th:checked="${store.telegramSettings?.templates?.size() > 0}"
+                           th:disabled="${!allowCustomTemplates}">
                     <label class="form-check-label" th:for="'tg-custom-templates-' + ${store.id}">
                         Использовать собственные сообщения
                     </label>
-                    <p class="form-text text-danger ms-4" th:if="${!planDetails.allowCustomNotifications}">
-                        Функция доступна в тарифе "Команда" и выше
+                    <p class="form-text text-danger ms-4" th:if="${!allowCustomTemplates}">
+                        Доступно с тарифа PREMIUM
                     </p>
                 </div>
 
@@ -481,7 +483,8 @@
                                       th:id="${'tpl-' + status.name() + '-' + store.id}"
                                       th:name="${'templates[' + status.name() + ']'}"
                                       rows="3"
-                                      th:text="${store.telegramSettings?.templates?.get(status.name())}"></textarea>
+                                      th:text="${store.telegramSettings?.templates?.get(status.name())}"
+                                      th:disabled="${!allowCustomTemplates}"></textarea>
                         </div>
                     </div>
                     <p class="form-text">Шаблоны должны содержать {track} и {store}</p>

--- a/src/test/java/com/project/tracking_system/controller/ProfileControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ProfileControllerTest.java
@@ -26,9 +26,32 @@ class ProfileControllerTest {
     private UserService userService;
     @Mock
     private SubscriptionService subscriptionService;
+    @Mock
+    private StoreService storeService;
 
     @InjectMocks
     private ProfileController controller;
+
+    @Test
+    void profile_AddsAllowCustomTemplatesFlag() {
+        User user = new User();
+        user.setId(3L);
+
+        when(userService.getUserStoreLimit(3L)).thenReturn("0/1");
+        when(userService.getUserProfile(3L)).thenReturn(new com.project.tracking_system.dto.UserProfileDTO(null, null, null, null, null, false, new com.project.tracking_system.dto.SubscriptionPlanViewDTO(), 0, 0, 0));
+        when(storeService.getUserStoresDto(3L)).thenReturn(java.util.Collections.emptyList());
+        when(userService.isShowBulkUpdateButton(3L)).thenReturn(false);
+        when(userService.isTelegramNotificationsEnabled(3L)).thenReturn(false);
+        when(userService.getEvropostCredentials(3L)).thenReturn(new com.project.tracking_system.dto.EvropostCredentialsDTO());
+        when(subscriptionService.canUseCustomNotifications(3L)).thenReturn(false);
+
+        org.springframework.ui.ExtendedModelMap model = new org.springframework.ui.ExtendedModelMap();
+
+        String view = controller.profile(model, user);
+
+        assertEquals("profile", view);
+        assertEquals(false, model.get("allowCustomTemplates"));
+    }
 
     @Test
     void updateAutoUpdate_FeatureDisabled_ReturnsForbidden() {
@@ -52,5 +75,22 @@ class ProfileControllerTest {
 
         assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
         verify(userService, never()).updateTelegramNotificationsEnabled(anyLong(), anyBoolean());
+    }
+
+    @Test
+    void settings_AddsAllowCustomTemplatesFlag() {
+        User user = new User();
+        user.setId(4L);
+
+        org.springframework.ui.ExtendedModelMap model = new org.springframework.ui.ExtendedModelMap();
+        when(subscriptionService.canUseCustomNotifications(4L)).thenReturn(false);
+        when(userService.isShowBulkUpdateButton(4L)).thenReturn(false);
+        when(userService.isTelegramNotificationsEnabled(4L)).thenReturn(false);
+        when(storeService.getUserStoresWithSettings(4L)).thenReturn(java.util.Collections.emptyList());
+
+        String view = controller.settings("notifications", model, user);
+
+        assertEquals("profile", view);
+        assertEquals(false, model.get("allowCustomTemplates"));
     }
 }


### PR DESCRIPTION
## Summary
- expose allowCustomTemplates flag via SubscriptionService.canUseCustomNotifications
- render related Telegram template inputs disabled if feature not allowed
- update client JS to respect disabled state
- remove redundant CUSTOM_TEMPLATES feature key
- test model attribute for profiles and settings

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6866ef4a7f80832da34f1b124b0c36cf