### PR TITLE
Add default Telegram template placeholders

### DIFF
--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -484,6 +484,7 @@
                                       th:name="${'templates[' + status.name() + ']'}"
                                       rows="3"
                                       th:text="${store.telegramSettings?.templates?.get(status.name())}"
+                                      th:placeholder="${status.formatMessage('{track}', '{store}')}"
                                       th:disabled="${!allowCustomTemplates}"></textarea>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- show default message placeholder for Telegram templates

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_686701d599c4832d82499fec3a694dcf