### PR TITLE
Implement reminder template for Telegram

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProfileController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProfileController.java
@@ -88,6 +88,7 @@ public class ProfileController {
         model.addAttribute("userSettingsDTO", settingsDTO);
         model.addAttribute("passwordChangeDTO", new PasswordChangeDTO());
         model.addAttribute("allowCustomTemplates", subscriptionService.canUseCustomNotifications(userId));
+        model.addAttribute("defaultReminderTemplate", com.project.tracking_system.service.telegram.TelegramNotificationService.DEFAULT_REMINDER_TEMPLATE);
         model.addAttribute("evropostCredentialsDTO", userService.getEvropostCredentials(userId));
 
         return "profile";
@@ -119,6 +120,7 @@ public class ProfileController {
         model.addAttribute("userSettingsDTO", settingsDTO);
         model.addAttribute("passwordChangeDTO", new PasswordChangeDTO());
         model.addAttribute("allowCustomTemplates", subscriptionService.canUseCustomNotifications(userId));
+        model.addAttribute("defaultReminderTemplate", com.project.tracking_system.service.telegram.TelegramNotificationService.DEFAULT_REMINDER_TEMPLATE);
 
         switch (tab) {
             case "evropost" -> {

--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -2,7 +2,6 @@ package com.project.tracking_system.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Size;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -25,8 +24,8 @@ public class StoreTelegramSettingsDTO {
     @Max(14)
     private int reminderRepeatIntervalDays = 2;
 
-    @Size(max = 200)
-    private String customSignature;
+
+    private String reminderTemplate;
 
 
     private boolean remindersEnabled = false;

--- a/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/StoreTelegramSettings.java
@@ -44,8 +44,8 @@ public class StoreTelegramSettings {
     @Column(name = "reminder_repeat_interval_days", nullable = false)
     private int reminderRepeatIntervalDays = 2;
 
-    @Column(name = "custom_signature", length = 200)
-    private String customSignature;
+    @Column(name = "reminder_template", columnDefinition = "TEXT")
+    private String reminderTemplate;
 
 
     @Column(name = "reminders_enabled", nullable = false)

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -433,7 +433,7 @@ public class StoreService {
         dto.setEnabled(settings.isEnabled());
         dto.setReminderStartAfterDays(settings.getReminderStartAfterDays());
         dto.setReminderRepeatIntervalDays(settings.getReminderRepeatIntervalDays());
-        dto.setCustomSignature(settings.getCustomSignature());
+        dto.setReminderTemplate(settings.getReminderTemplate());
         dto.setRemindersEnabled(settings.isRemindersEnabled());
         dto.setUseCustomTemplates(!settings.getTemplates().isEmpty());
         dto.setTemplates(settings.getTemplatesMap().entrySet().stream()
@@ -458,7 +458,7 @@ public class StoreService {
         settings.setEnabled(dto.isEnabled());
         settings.setReminderStartAfterDays(dto.getReminderStartAfterDays());
         settings.setReminderRepeatIntervalDays(dto.getReminderRepeatIntervalDays());
-        settings.setCustomSignature(dto.getCustomSignature());
+        settings.setReminderTemplate(dto.getReminderTemplate());
         settings.setRemindersEnabled(dto.isRemindersEnabled());
 
         // Составляем карту существующих шаблонов для быстрого доступа

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -67,8 +67,13 @@ public class StoreTelegramSettingsService {
         }
 
         // Проверяем содержимое пользовательских шаблонов при их использовании
-        if (dto.isUseCustomTemplates() && dto.getTemplates() != null) {
-            dto.getTemplates().values().forEach(this::validateTemplate);
+        if (dto.isUseCustomTemplates()) {
+            if (dto.getTemplates() != null) {
+                dto.getTemplates().values().forEach(this::validateTemplate);
+            }
+            if (dto.getReminderTemplate() != null) {
+                validateTemplate(dto.getReminderTemplate());
+            }
         }
 
         // Передаём обработку полей общему сервису

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramNotificationService.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.StoreTelegramSettings;
 import com.project.tracking_system.mapper.BuyerStatusMapper;
 import com.project.tracking_system.service.customer.CustomerService;
+import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,15 +22,15 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 @Slf4j
 public class TelegramNotificationService {
 
+    /** Стандартный шаблон напоминания. */
+    public static final String DEFAULT_REMINDER_TEMPLATE =
+            "\uD83D\uDD14 Не забудьте забрать посылку {track} из магазина {store} — она ждёт вас в пункте выдачи.";
+
     private final TelegramClient telegramClient;
     private final CustomerService customerService;
 
     /**
      * Отправить уведомление о смене статуса посылки.
-     * <p>
-     * Если в профиле магазина указана подпись, она будет добавлена
-     * в конец сообщения.
-     * </p>
      *
      * @param parcel посылка
      * @param status новый статус
@@ -62,9 +63,6 @@ public class TelegramNotificationService {
             text = buyerStatus.formatMessage(parcel.getNumber(), parcel.getStore().getName());
         }
 
-        if (settings != null && settings.getCustomSignature() != null && !settings.getCustomSignature().isBlank()) {
-            text += "\n\n" + settings.getCustomSignature();
-        }
 
         SendMessage message = new SendMessage(chatId.toString(), text);
 
@@ -96,15 +94,11 @@ public class TelegramNotificationService {
 
         Long chatId = getChatId(parcel);
 
-        String text = String.format(
-                "🔔 Не забудьте забрать посылку %s из магазина %s — она ждёт вас в пункте выдачи.",
-                parcel.getNumber(),
-                parcel.getStore().getName()
-        );
-
-        if (settings != null && settings.getCustomSignature() != null && !settings.getCustomSignature().isBlank()) {
-            text += "\n\n" + settings.getCustomSignature();
-        }
+        String template = (settings != null && StringUtils.hasText(settings.getReminderTemplate()))
+                ? settings.getReminderTemplate()
+                : DEFAULT_REMINDER_TEMPLATE;
+        String text = template.replace("{track}", parcel.getNumber())
+                .replace("{store}", parcel.getStore().getName());
 
         SendMessage message = new SendMessage(chatId.toString(), text);
 

--- a/src/main/resources/db/migration/V2__update_telegram_settings.sql
+++ b/src/main/resources/db/migration/V2__update_telegram_settings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_store_telegram_settings
+  ADD COLUMN reminder_template TEXT,
+  DROP COLUMN custom_signature;

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -452,15 +452,6 @@
                     </div>
                 </div>
 
-                <div class="mb-2">
-                    <label class="form-label" th:for="'tg-sign-' + ${store.id}">
-                        Подпись к уведомлениям (отображается во всех сообщениях)
-                    </label>
-                    <input type="text" class="form-control form-control-sm" th:id="'tg-sign-' + ${store.id}"
-                           name="customSignature"
-                           th:value="${store.telegramSettings?.customSignature}" maxlength="200"
-                           th:disabled="${!allowCustomTemplates}">
-                </div>
 
                 <div class="form-check form-switch mb-2 ms-3">
                     <input class="form-check-input" type="checkbox" th:id="'tg-custom-templates-' + ${store.id}"
@@ -487,6 +478,15 @@
                                       th:placeholder="${status.formatMessage('{track}', '{store}')}"
                                       th:disabled="${!allowCustomTemplates}"></textarea>
                         </div>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label" th:for="${'tpl-reminder-' + store.id}">Текст напоминания</label>
+                        <textarea class="form-control form-control-sm"
+                                  th:id="${'tpl-reminder-' + store.id}"
+                                  name="reminderTemplate"
+                                  rows="3"
+                                  th:text="${store.telegramSettings?.reminderTemplate}"
+                                  th:placeholder="${defaultReminderTemplate}" th:disabled="${!allowCustomTemplates}"></textarea>
                     </div>
                     <p class="form-text">Шаблоны должны содержать {track} и {store}</p>
                 </div>

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.entity.StoreTelegramSettings;
 import com.project.tracking_system.model.subscription.FeatureKey;
 import com.project.tracking_system.repository.StoreTelegramSettingsRepository;
 import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.exception.InvalidTemplateException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -64,5 +65,21 @@ class StoreTelegramSettingsServiceTest {
 
         verify(storeService).updateFromDto(any(StoreTelegramSettings.class), eq(dto));
         verify(settingsRepository).save(any(StoreTelegramSettings.class));
+    }
+
+    @Test
+    void update_InvalidReminderTemplate_Throws() {
+        Store store = new Store();
+        store.setId(3L);
+        StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
+        dto.setUseCustomTemplates(true);
+        dto.setReminderTemplate("Неверный шаблон");
+
+        when(subscriptionService.isFeatureEnabled(3L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
+        when(subscriptionService.canUseCustomNotifications(3L)).thenReturn(true);
+        when(settingsRepository.findByStoreId(3L)).thenReturn(null);
+
+        assertThrows(InvalidTemplateException.class, () -> service.update(store, dto, 3L));
+        verify(settingsRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- add `reminderTemplate` field to `StoreTelegramSettings` and dto
- support reminder template in service layer
- validate reminder template when using custom templates
- customize Telegram notification to use template without signatures
- update profile page to allow editing reminder template
- include migration to drop obsolete column and add new one
- expand unit tests for invalid reminder template

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68678f35902c832dbb8e377c09964ed5