### PR TITLE
Fix custom telegram template visibility when disabled

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -496,7 +496,8 @@ function initTelegramTemplateBlocks() {
             if (cb.disabled) {
                 cb.checked = false;
                 fields.querySelectorAll('textarea').forEach(t => t.disabled = true);
-                slideUp(fields);
+                // Показываем блок, но текстовые поля остаются недоступными
+                slideDown(fields);
                 return;
             }
             fields.querySelectorAll('textarea').forEach(t => t.disabled = !cb.checked);

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -490,7 +490,8 @@
                     </div>
                     <p class="form-text">Шаблоны должны содержать {track} и {store}</p>
                 </div>
-                <button type="submit" class="btn btn-sm btn-primary w-100">Сохранить</button>
+                <button type="submit" class="btn btn-sm btn-primary w-100"
+                        th:disabled="${!allowCustomTemplates}">Сохранить</button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure telegram template fields stay visible when option disabled
- disable save button when custom templates are unavailable

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686796b07cc8832db927a66697dcd774