### PR TITLE
Add decline option and improved cookie modal

### DIFF
--- a/src/main/java/com/project/tracking_system/utils/CspNonceFilter.java
+++ b/src/main/java/com/project/tracking_system/utils/CspNonceFilter.java
@@ -88,6 +88,11 @@ public class CspNonceFilter extends OncePerRequestFilter {
             response.addHeader("Set-Cookie", "cookie_consent=not_set; Path=/; SameSite=None; Secure");
         }
 
+        if ("declined".equals(cookieConsent)) {
+            // Если пользователь отказался — очищаем сторонние куки, например аналитику
+            clearCookie(response, "analytics");
+        }
+
         // Продолжаем цепочку фильтров
         filterChain.doFilter(request, response);
     }
@@ -114,6 +119,22 @@ public class CspNonceFilter extends OncePerRequestFilter {
             }
         }
         return null;
+    }
+
+    /**
+     * Очищает указанную куку у клиента.
+     *
+     * @param response   HTTP-ответ
+     * @param cookieName имя куки
+     */
+    private void clearCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setAttribute("SameSite", "None");
+        response.addCookie(cookie);
     }
 
 }

--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -109,11 +109,13 @@
   position: fixed;
   bottom: 15px;
   left: 50%;
-  transform: translateX(-50%);
-  background: ui.$white;
-  padding: 14px 20px;
-  border-radius: ui.$border-radius;
-  box-shadow: ui.$box-shadow;
+  transform: translateX(-50%) translateY(100px); // добавить плавный выезд снизу
+  transition: all 0.4s ease-in-out;
+  background: #ffffff;
+  padding: 20px 26px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -131,6 +133,7 @@
   @include ui.transition(opacity, 0.3s, ease-in-out);
 
   &.show {
+    transform: translateX(-50%) translateY(0);
     opacity: 1;
     visibility: visible;
   }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1260,14 +1260,21 @@ document.addEventListener("DOMContentLoaded", function () {
      */
     const cookieModal = document.getElementById("cookieConsentModal");
     const acceptButton = document.getElementById("acceptCookies");
+    const declineButton = document.getElementById("declineCookies");
 
     if (!localStorage.getItem("cookiesAccepted")) {
-        cookieModal.classList.add("show");
+        setTimeout(() => cookieModal.classList.add("show"), 800);
     }
 
     acceptButton.addEventListener("click", function () {
         localStorage.setItem("cookiesAccepted", "true");
         setCookie("cookie_consent", "accepted", 365);
+        cookieModal.classList.remove("show");
+    });
+
+    declineButton.addEventListener("click", function () {
+        localStorage.setItem("cookiesAccepted", "false");
+        setCookie("cookie_consent", "declined", 365);
         cookieModal.classList.remove("show");
     });
 
@@ -1293,9 +1300,9 @@ document.addEventListener("DOMContentLoaded", function () {
         return null;
     }
 
-    // Если кука нет - показываем окно
+    // Если кука нет - показываем окно с задержкой
     if (!getCookie("cookie_consent")) {
-        cookieModal.classList.add("show");
+        setTimeout(() => cookieModal.classList.add("show"), 800);
     }
 
     /**

--- a/src/main/resources/templates/partials/cookies.html
+++ b/src/main/resources/templates/partials/cookies.html
@@ -1,8 +1,12 @@
 <div id="cookieConsent" th:fragment="cookieFragment">
-    <div id="cookieConsentModal" class="cookie-modal">
-        <p>Мы используем файлы cookie. Подробнее в <a href="/privacy-policy" target="_blank">Политике конфиденциальности</a>.</p>
+    <div id="cookieConsentModal" class="cookie-modal" role="dialog" aria-live="polite" aria-label="Согласие на cookie">
+        <p>
+            <i class="bi bi-shield-check text-primary me-2"></i>
+            Мы используем файлы cookie. Подробнее в <a href="/privacy-policy" target="_blank">Политике конфиденциальности</a>.
+        </p>
         <div class="cookie-buttons">
-            <button id="acceptCookies" class="btn btn-primary">Принять</button>
+            <button id="acceptCookies" class="btn btn-primary me-2">Принять</button>
+            <button id="declineCookies" class="btn btn-outline-secondary">Отклонить</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- enhance cookie consent modal styles and add smooth animation
- add icon and decline button
- improve accessibility of modal
- handle declined cookies in filter
- show modal after short delay in JS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679934986c832daa764480458c1cbc