### PR TITLE
Organize template directories

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/PasswordController.java
+++ b/src/main/java/com/project/tracking_system/controller/PasswordController.java
@@ -113,13 +113,13 @@ public class PasswordController {
         try {
             passwordResetService.resetPassword(token, passwordResetDTO.getNewPassword());
             model.addAttribute("message", "Ваш пароль успешно сброшен. Пожалуйста, войдите с новым паролем.");
-            return "login";
+            return "auth/login";
         } catch (IllegalArgumentException e) {
             model.addAttribute("error", "Токен сброса пароля недействителен или срок его действия истек.");
             return "auth/reset-password";
         } catch (Exception e) {
             model.addAttribute("error", "Не удалось сбросить пароль. Попробуйте снова.");
-            return "reset-password";
+            return "auth/reset-password";
         }
     }
 }


### PR DESCRIPTION
## Summary
- reorganize templates: rename analytics dashboard back to `analytics/dashboard.html`
- revert marketing terms and privacy page names
- update controllers to return old template names
- remove leftover comments from controllers

## Testing
- `./mvnw test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*


------
https://chatgpt.com/codex/tasks/task_e_6867ab3be038832dbccfd577b3bb606f