### PR TITLE
Adjust security paths for auth namespace

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -83,17 +83,22 @@ public class SecurityConfiguration {
                                 .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.SAME_ORIGIN))
                 )
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/", "/login", "/logout", "/registration", "/forgot-password", "/reset-password",
-                                "/privacy", "/terms", "/features", "/pricing",
+                        // Публичные маршруты и статические ресурсы
+                        .requestMatchers("/", "/features", "/pricing", "/terms", "/privacy",
+                                "/auth/**",
                                 "/css/**", "/js/**", "/bootstrap/**", "/images/**",
                                 "/upload", "/ws/**", "/wss/**", "/sample/**", "/download-sample").permitAll()
+                        // Доступ к административному разделу только для ROLE_ADMIN
                         .requestMatchers("/admin/**").hasRole("ADMIN")
+                        // Требуется аутентификация для пользовательской части приложения
+                        .requestMatchers("/app/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .formLogin(formLogin -> formLogin
-                        .loginPage("/login")
+                        .loginPage("/auth/login")
                         .usernameParameter("email")
                         .passwordParameter("password")
+                        .defaultSuccessUrl("/app", true)
                         .successHandler((request, response, authentication) -> {
                             String email = request.getParameter("email");
                             String ip = request.getRemoteAddr();
@@ -108,7 +113,8 @@ public class SecurityConfiguration {
                                     return;
                                 }
                             }
-                            response.sendRedirect("/");
+                            // Перенаправление на пользовательскую страницу по умолчанию
+                            response.sendRedirect("/app");
                         })
                         .failureHandler((request, response, exception) -> {
                             String email = request.getParameter("email");
@@ -120,7 +126,7 @@ public class SecurityConfiguration {
 
                             loginAttemptService.loginFailed(email, ip);
                             log.info("Неудачная попытка входа: email={}, IP={}", com.project.tracking_system.utils.EmailUtils.maskEmail(email), ip);
-                            response.sendRedirect("/login?error=true");
+                            response.sendRedirect("/auth/login?error=true");
                         })
                 )
                 .rememberMe(rememberMe -> rememberMe

--- a/src/main/java/com/project/tracking_system/controller/AuthController.java
+++ b/src/main/java/com/project/tracking_system/controller/AuthController.java
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter;
 @Slf4j
 @RequiredArgsConstructor
 @Controller
-@RequestMapping("/")
+@RequestMapping("/auth")
 public class AuthController {
 
     private final LoginAttemptService loginAttemptService;
@@ -80,7 +80,7 @@ public class AuthController {
 
         try {
             registrationService.confirm(userDTO);
-            return "redirect:/login";
+            return "redirect:/auth/login";
         } catch (IllegalArgumentException e) {
             model.addAttribute("confirmCodRegistration", true);
             model.addAttribute("errorMessage", e.getMessage());

--- a/src/main/java/com/project/tracking_system/controller/PasswordController.java
+++ b/src/main/java/com/project/tracking_system/controller/PasswordController.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 @Slf4j
 @RequiredArgsConstructor
 @Controller
-@RequestMapping("/")
+@RequestMapping("/auth")
 public class PasswordController {
 
     private final PasswordResetService passwordResetService;

--- a/src/main/java/com/project/tracking_system/controller/TariffController.java
+++ b/src/main/java/com/project/tracking_system/controller/TariffController.java
@@ -68,7 +68,7 @@ public class TariffController {
                           @AuthenticationPrincipal User user) {
         Long userId = user.getId();
         if (userId == null) {
-            return "redirect:/login";
+            return "redirect:/auth/login";
         }
         if (months <= 0) {
             months = 1;
@@ -91,7 +91,7 @@ public class TariffController {
                       @AuthenticationPrincipal User user) {
         Long userId = user.getId();
         if (userId == null) {
-            return "redirect:/login";
+            return "redirect:/auth/login";
         }
         if (months <= 0) {
             months = 1;

--- a/src/main/java/com/project/tracking_system/service/user/LoginAttemptService.java
+++ b/src/main/java/com/project/tracking_system/service/user/LoginAttemptService.java
@@ -223,13 +223,15 @@ public class LoginAttemptService {
                                     String email, String ip) throws IOException {
         if (isIPBlocked(ip)) {
             log.warn("Блокировка по IP: {} (Попытка входа заблокирована)", ip);
-            response.sendRedirect("/login?blockedIP=true");
+            // Перенаправляем на страницу входа с сообщением о блокировке IP
+            response.sendRedirect("/auth/login?blockedIP=true");
             return true;
         }
 
         if (email != null && isEmailBlocked(email)) {
             log.warn("Блокировка по email: {} (Попытка входа заблокирована)", EmailUtils.maskEmail(email));
-            response.sendRedirect("/login?blocked=true");
+            // Перенаправляем на страницу входа с сообщением о блокировке аккаунта
+            response.sendRedirect("/auth/login?blocked=true");
             return true;
         }
 


### PR DESCRIPTION
## Summary
- update spring security configuration with new public routes and login page
- move auth and password controllers under `/auth` namespace
- redirect tariff actions to new login page
- update login attempt redirects for new path

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6867b0916a00832d97696c9a144a09bb