### PR TITLE
Fix analytics store link

### DIFF
--- a/src/main/resources/templates/app/analytics/dashboard.html
+++ b/src/main/resources/templates/app/analytics/dashboard.html
@@ -21,7 +21,7 @@
 
                 <div th:if="${stores == null or #lists.isEmpty(stores)}">
                     <p class="text-muted">У вас пока нет магазинов. Добавьте магазин для просмотра аналитики.</p>
-                    <a href="/stores/add" class="btn btn-primary">Добавить магазин</a>
+                    <a href="/app/profile#v-pills-stores" class="btn btn-primary">Добавить магазин</a>
                 </div>
 
                 <div class="dashboard-container" th:if="${stores != null and not #lists.isEmpty(stores)}">


### PR DESCRIPTION
## Summary
- point analytics add-store link to the profile stores tab

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_6867b7cdc4d0832d99621fb8e9698031