### PR TITLE
Fix registration path and tariff form target

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AuthController.java
+++ b/src/main/java/com/project/tracking_system/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
      * @param model модель для добавления данных в представление
      * @return имя представления страницы регистрации
      */
-    @GetMapping("/registration")
+    @GetMapping("/auth/registration")
     public String registration(@ModelAttribute("userDTO") UserRegistrationDTO userRegistrationDTO, Model model) {
         model.addAttribute("userDTO", new UserRegistrationDTO());
         return "auth/registration";
@@ -56,7 +56,7 @@ public class AuthController {
      * @param model модель для добавления данных в представление
      * @return имя представления для регистрации
      */
-    @PostMapping("/registration")
+    @PostMapping("/auth/registration")
     public String registration(@Valid @ModelAttribute("userDTO") UserRegistrationDTO userDTO,
                                BindingResult result, Model model) {
         if (registrationService.isInitialStep(userDTO)) {

--- a/src/main/resources/templates/app/tariffs.html
+++ b/src/main/resources/templates/app/tariffs.html
@@ -100,12 +100,12 @@
 
                         <!-- 🔒 Бесплатный тариф для незарегистрированных -->
                         <div th:if="${plan.code == 'FREE' && authenticatedUser == null}" class="mt-auto">
-                            <a href="/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
+                            <a href="/auth/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
                         </div>
 
                         <!-- ✅ Покупка или улучшение -->
                         <form th:if="${plan.code != 'FREE' && (userProfile == null || userPlanPosition == null || plan.position > userPlanPosition)}"
-                              th:action="@{/tariffs/buy}" method="post" class="mt-auto">
+                              th:action="@{/app/tariffs/buy}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <input type="hidden" name="plan" th:value="${plan.code}"/>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -60,7 +60,7 @@
                 <i class="bi bi-question-circle"></i> Восстановить пароль
             </a>
             <p class="mb-2">Нет аккаунта?</p>
-            <a href="/registration" class="btn btn-outline-primary w-100 mb-2">
+            <a href="/auth/registration" class="btn btn-outline-primary w-100 mb-2">
                 <i class="bi bi-person-plus"></i> Зарегистрироваться
             </a>
             <a href="/" class="btn btn-link">

--- a/src/main/resources/templates/auth/registration.html
+++ b/src/main/resources/templates/auth/registration.html
@@ -24,7 +24,7 @@
         <p class="mb-0" th:text="${message}"></p>
     </div>
 
-    <form th:action="@{/registration}" th:object="${userDTO}" method="post">
+    <form th:action="@{/auth/registration}" th:object="${userDTO}" method="post">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <!-- Первый этап: Ввод email и паролей -->
         <div th:unless="${confirmCodRegistration}">

--- a/src/main/resources/templates/marketing/pricing.html
+++ b/src/main/resources/templates/marketing/pricing.html
@@ -100,12 +100,12 @@
 
                         <!-- 🔒 Бесплатный тариф для незарегистрированных -->
                         <div th:if="${plan.code == 'FREE' && authenticatedUser == null}" class="mt-auto">
-                            <a href="/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
+                            <a href="/auth/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
                         </div>
 
                         <!-- ✅ Покупка или улучшение -->
                         <form th:if="${plan.code != 'FREE' && (userProfile == null || userPlanPosition == null || plan.position > userPlanPosition)}"
-                              th:action="@{/tariffs/buy}" method="post" class="mt-auto">
+                              th:action="@{/app/tariffs/buy}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <input type="hidden" name="plan" th:value="${plan.code}"/>

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -36,10 +36,10 @@
                 </a>
 
                 <!-- Регистрация -->
-                <a th:if="${authenticatedUser == null}" th:href="@{/registration}" class="btn btn-primary btn-text">
+                <a th:if="${authenticatedUser == null}" th:href="@{/auth/registration}" class="btn btn-primary btn-text">
                     <i class="bi bi-person-plus"></i> Регистрация
                 </a>
-                <a th:if="${authenticatedUser == null}" th:href="@{/registration}" class="icon-btn">
+                <a th:if="${authenticatedUser == null}" th:href="@{/auth/registration}" class="icon-btn">
                     <i class="bi bi-person-plus"></i>
                 </a>
 


### PR DESCRIPTION
## Summary
- route registration through `/auth/registration`
- send tariff purchases to `/app/tariffs/buy`
- update links in pages and header

## Testing
- `./mvnw -q test` *(fails: cannot open `maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6867b7d7bdf8832dac510e78d53b8aa5