### PR TITLE
Fix analytics redirect path

### DIFF
--- a/src/main/resources/static/js/analytics.js
+++ b/src/main/resources/static/js/analytics.js
@@ -368,7 +368,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
             debugLog("Selected storeId =", storeId);
             document.body.classList.add("loading");
-            window.location.href = "/analytics?" + params.toString();
+            window.location.href = "/app/analytics?" + params.toString();
         });
     }
 


### PR DESCRIPTION
## Summary
- update analytics redirect path to `/app/analytics`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b7ddc68c832d991193875b1537dc