### PR TITLE
Fix template and API paths

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/LegacyRedirectController.java
+++ b/src/main/java/com/project/tracking_system/controller/LegacyRedirectController.java
@@ -1,0 +1,21 @@
+package com.project.tracking_system.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Контроллер перенаправлений для поддержки старых URL.
+ */
+@Controller
+public class LegacyRedirectController {
+
+    /**
+     * Перенаправляет запросы со старого пути "/tariffs" на новый "/app/tariffs".
+     *
+     * @return строка с редиректом на новую страницу тарифов
+     */
+    @GetMapping("/tariffs")
+    public String redirectTariffs() {
+        return "redirect:/app/tariffs";
+    }
+}

--- a/src/main/resources/static/js/analytics.js
+++ b/src/main/resources/static/js/analytics.js
@@ -292,7 +292,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         debugLog("loadAnalyticsData invoked!")
 
-        fetch("/analytics/json?" + params.toString())
+        fetch("/app/analytics/json?" + params.toString())
             .then(res => res.json())
             .then(freshData => {
                 debugLog("🚀 [Debug] Fetched data:", freshData);
@@ -328,7 +328,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 formData.append("storeId", storeId);
             }
 
-            fetch("/analytics/update", {
+            fetch("/app/analytics/update", {
                 method: "POST",
                 headers: { [csrfHeader]: csrfToken },
                 body: formData

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -62,7 +62,7 @@ document.getElementById("actionSelect")?.addEventListener("change", updateApplyB
 function loadModal(itemNumber) {
     if (!itemNumber) return;
 
-    fetch(`/departures/${itemNumber}`)
+    fetch(`/app/departures/${itemNumber}`)
         .then(response => {
             if (!response.ok) {
                 throw new Error('Ошибка при загрузке данных');
@@ -79,7 +79,7 @@ function loadModal(itemNumber) {
 
 function loadCustomerInfo(trackId) {
     if (!trackId) return;
-    fetch(`/customers/parcel/${trackId}`)
+    fetch(`/app/customers/parcel/${trackId}`)
         .then(response => {
             if (!response.ok) {
                 throw new Error('Ошибка при загрузке данных');
@@ -149,7 +149,7 @@ function initializeCustomCredentialsCheckbox() {
         checkbox.addEventListener('change', function () {
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
-                fetch('/profile/settings/use-custom-credentials', {
+                fetch('/app/profile/settings/use-custom-credentials', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded',
@@ -186,7 +186,7 @@ function initAutoUpdateToggle() {
     checkbox.addEventListener('change', function () {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
-            fetch('/profile/settings/auto-update', {
+            fetch('/app/profile/settings/auto-update', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
@@ -218,7 +218,7 @@ function initBulkButtonToggle() {
     checkbox.addEventListener('change', function () {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
-            fetch('/profile/settings/bulk-button', {
+            fetch('/app/profile/settings/bulk-button', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
@@ -268,7 +268,7 @@ function initTelegramNotificationsToggle() {
             updateFormState();
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
-                fetch('/profile/settings/telegram-notifications', {
+                fetch('/app/profile/settings/telegram-notifications', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded',
@@ -723,7 +723,7 @@ function connectWebSocket() {
 function reloadParcelTable() {
     debugLog("🔄 AJAX-запрос для обновления таблицы...");
 
-    fetch("/departures", { method: "GET", cache: "no-store" })
+    fetch("/app/departures", { method: "GET", cache: "no-store" })
         .then(response => {
             if (!response.ok) {
                 throw new Error("Ошибка загрузки данных");
@@ -823,7 +823,7 @@ let analyticsActionUrl = null;
  * Загружает магазины пользователя и обновляет таблицу
  */
 async function loadStores() {
-    const response = await fetch('/profile/stores');
+    const response = await fetch('/app/profile/stores');
     if (!response.ok) {
         console.error("Ошибка загрузки магазинов:", await response.text());
         return;
@@ -879,7 +879,7 @@ async function loadStores() {
  * Загружает магазины и формирует кнопки для очистки аналитики.
  */
 async function loadAnalyticsButtons() {
-    const response = await fetch('/profile/stores');
+    const response = await fetch('/app/profile/stores');
     if (!response.ok) return;
 
     const stores = await response.json();
@@ -899,7 +899,7 @@ async function loadAnalyticsButtons() {
         btn.innerHTML = `<i class="bi bi-brush me-2"></i> Очистить аналитику — ${store.name}`;
 
         btn.addEventListener('click', () => {
-            analyticsActionUrl = `/analytics/reset/store/${store.id}`;
+            analyticsActionUrl = `/app/analytics/reset/store/${store.id}`;
             showResetModal(`Вы действительно хотите очистить аналитику магазина «${store.name}»?`);
         });
 
@@ -914,7 +914,7 @@ async function loadAnalyticsButtons() {
  * Формирует DOM-блок настроек Telegram для магазина
  */
 async function renderTelegramBlock(storeId) {
-    const response = await fetch(`/profile/stores/${storeId}/telegram-block`);
+    const response = await fetch(`/app/profile/stores/${storeId}/telegram-block`);
     if (!response.ok) return null;
 
     const html = await response.text();
@@ -976,7 +976,7 @@ function toggleEditStore(storeId) {
     }
 }
 
-const baseUrl = "/profile/stores"; // Базовый URL для всех запросов
+const baseUrl = "/app/profile/stores"; // Базовый URL для всех запросов
 
 /**
  * Сохраняет обновленное название магазина
@@ -1060,7 +1060,7 @@ async function saveNewStore(event) {
         return;
     }
 
-    const response = await fetch("/profile/stores", {
+    const response = await fetch("/app/profile/stores", {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -1129,7 +1129,7 @@ async function deleteStore() {
  */
 async function updateStoreLimit() {
     try {
-        const response = await fetch('/profile/stores/limit');
+        const response = await fetch('/app/profile/stores/limit');
         if (!response.ok) {
             console.error("Ошибка при получении лимита магазинов:", response.status);
             return;
@@ -1186,7 +1186,7 @@ if (storeTableBody) {
         const storeId = radio.dataset.storeId;
 
         try {
-            const response = await fetch(`/profile/stores/default/${storeId}`, {
+            const response = await fetch(`/app/profile/stores/default/${storeId}`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -1389,14 +1389,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // === Управление аналитикой ===
     document.getElementById("resetAllAnalyticsBtn")?.addEventListener("click", () => {
-        analyticsActionUrl = "/analytics/reset/all";
+        analyticsActionUrl = "/app/analytics/reset/all";
         showResetModal("Вы уверены, что хотите удалить всю аналитику?");
     });
 
     document.body.addEventListener("click", function (event) {
         const btn = event.target.closest(".reset-store-analytics-btn");
         if (!btn) return;
-        analyticsActionUrl = `/analytics/reset/store/${btn.dataset.storeId}`;
+        analyticsActionUrl = `/app/analytics/reset/store/${btn.dataset.storeId}`;
         showResetModal(`Очистить аналитику магазина \u00AB${btn.dataset.storeName}\u00BB?`);
     });
 
@@ -1602,7 +1602,7 @@ document.addEventListener("DOMContentLoaded", function () {
         refreshBtn.disabled = true;
         refreshBtn.innerHTML = '<i class="bi bi-arrow-repeat spin"></i>';
 
-        fetch("/departures/track-update", {
+        fetch("/app/departures/track-update", {
             method: "POST",
             headers: {
                 [csrfHeader]: csrfToken // CSRF-токен
@@ -1695,7 +1695,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const formData = new URLSearchParams();
         selectedNumbers.forEach(number => formData.append("selectedNumbers", number));
 
-        fetch("/departures/delete-selected", {
+        fetch("/app/departures/delete-selected", {
             method: "POST",
             headers: {
                 [csrfHeader]: csrfToken // CSRF-токен
@@ -1741,7 +1741,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const formData = new URLSearchParams();
         selectedNumbers.forEach(number => formData.append("selectedNumbers", number));
 
-        fetch("/departures/track-update", {
+        fetch("/app/departures/track-update", {
             method: "POST",
             headers: {
                 [csrfHeader]: csrfToken // CSRF-токен

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -98,7 +98,7 @@
 
                     <!-- Таблица истории -->
                     <div th:if="${trackParcelDTO != null and !trackParcelDTO.isEmpty()}" class="mt-3">
-                        <form action="/departures/delete-selected" method="post">
+                        <form action="/app/departures/delete-selected" method="post">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                             <div class="table-responsive">
                                 <table class="table history-table">

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -29,7 +29,7 @@
 
                 <!-- Форма поиска посылки и загрузка файла -->
                 <div class="card shadow-sm p-4 rounded-4">
-                    <form th:action="@{/}" method="post" class="w-100 mb-4">
+                    <form th:action="@{/app}" method="post" class="w-100 mb-4">
                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 
                         <!-- Блок выбора магазина, если их больше одного -->
@@ -74,7 +74,7 @@
 
                     <hr class="my-3">
 
-                    <form th:action="@{/upload}" method="post" enctype="multipart/form-data" class="w-100">
+                    <form th:action="@{/app/upload}" method="post" enctype="multipart/form-data" class="w-100">
                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 
                         <!-- Оборачиваем метку и ссылку в flex-контейнер для равномерного распределения -->
@@ -85,7 +85,7 @@
                                    data-bs-placement="right" title="Поддерживаются форматы: .xls, .xlsx"></i>
                             </label>
                             <!-- Ссылка-образец, оформленная как текстовая кнопка -->
-                            <a th:href="@{/download-sample}" class="text-secondary link-hover">Образец</a>
+                            <a th:href="@{/app/download-sample}" class="text-secondary link-hover">Образец</a>
                         </div>
 
                         <div class="input-group">

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -279,7 +279,7 @@
         <div id="evropostNotificationContainer"></div>
         <div id="evropost-content" th:fragment="evropostFragment">
             <h5 class="mb-3">Настройки Европочты</h5>
-            <form id="evropost-settings-form" th:action="@{/profile/settings/evropost}" th:object="${evropostCredentialsDTO}" method="post">
+            <form id="evropost-settings-form" th:action="@{/app/profile/settings/evropost}" th:object="${evropostCredentialsDTO}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-check form-switch">
                     <input class="form-check-input" type="checkbox" id="useCustomCredentials" name="useCustomCredentials" th:field="*{useCustomCredentials}">
@@ -324,7 +324,7 @@
     <div class="card p-3 shadow-sm rounded-4 mb-4">
         <div id="password-content" th:fragment="passwordFragment">
             <h5 class="mb-3">Изменение пароля</h5>
-            <form id="password-settings-form" th:action="@{/profile/settings/password}" th:object="${passwordChangeDTO}" method="post">
+            <form id="password-settings-form" th:action="@{/app/profile/settings/password}" th:object="${passwordChangeDTO}" method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-floating mb-3 position-relative">
                     <input type="password" class="form-control password-input" id="currentPassword" name="currentPassword" th:field="*{currentPassword}" placeholder="Текущий пароль" autocomplete="off">
@@ -407,7 +407,7 @@
              class="tg-settings-content"
              th:attr="data-store-id=${store.id}"
              th:classappend="${first} ? ' expanded' : ' collapsed'">
-            <form class="telegram-settings-form" th:action="@{/stores/{id}/telegram-settings(id=${store.id})}"
+            <form class="telegram-settings-form" th:action="@{/app/stores/{id}/telegram-settings(id=${store.id})}"
                   method="post">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                 <div class="form-check form-switch mb-2">
@@ -519,7 +519,7 @@
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
-                    <form th:action="@{/profile/settings/delete}" method="post">
+                    <form th:action="@{/app/profile/settings/delete}" method="post">
                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                         <button class="btn btn-danger">
                             <i class="bi bi-trash-fill"></i> Да, удалить

--- a/src/main/resources/templates/app/tariffs.html
+++ b/src/main/resources/templates/app/tariffs.html
@@ -100,12 +100,12 @@
 
                         <!-- 🔒 Бесплатный тариф для незарегистрированных -->
                         <div th:if="${plan.code == 'FREE' && authenticatedUser == null}" class="mt-auto">
-                            <a href="/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
+                            <a href="/auth/registration" class="btn btn-primary w-100">Зарегистрироваться</a>
                         </div>
 
                         <!-- ✅ Покупка или улучшение -->
                         <form th:if="${plan.code != 'FREE' && (userProfile == null || userPlanPosition == null || plan.position > userPlanPosition)}"
-                              th:action="@{/tariffs/buy}" method="post" class="mt-auto">
+                              th:action="@{/app/tariffs/buy}" method="post" class="mt-auto">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <input type="hidden" name="plan" th:value="${plan.code}"/>

--- a/src/main/resources/templates/auth/forgot-password.html
+++ b/src/main/resources/templates/auth/forgot-password.html
@@ -24,7 +24,7 @@
       <p class="mb-0" th:text="${error}"></p>
     </div>
 
-    <form th:action="@{/forgot-password}" method="post">
+    <form th:action="@{/auth/forgot-password}" method="post">
       <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 
       <div class="form-floating mb-3 position-relative">
@@ -39,10 +39,10 @@
       </button>
 
       <div class="text-center mt-3">
-        <a href="/login" class="btn btn-outline-secondary w-100 mb-2">
+        <a href="/auth/login" class="btn btn-outline-secondary w-100 mb-2">
           <i class="bi bi-box-arrow-in-right"></i> Вернуться ко входу
         </a>
-        <a href="/" class="btn btn-link">
+        <a href="/app" class="btn btn-link">
           <i class="bi bi-house-door"></i> На главную
         </a>
       </div>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -27,7 +27,7 @@
         <p class="mb-0" th:text="'Осталось попыток входа: ' + ${remainingAttempts}"></p>
     </div>
 
-    <form th:action="@{/login}" method="post">
+    <form th:action="@{/auth/login}" method="post">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <!-- Поле Email -->
         <div class="form-floating mb-3">
@@ -56,14 +56,14 @@
         <!-- Дополнительные ссылки -->
         <div class="text-center mt-4">
             <p class="mb-2">Забыли пароль?</p>
-            <a href="/forgot-password" class="btn btn-outline-secondary w-100 mb-2">
+            <a href="/auth/forgot-password" class="btn btn-outline-secondary w-100 mb-2">
                 <i class="bi bi-question-circle"></i> Восстановить пароль
             </a>
             <p class="mb-2">Нет аккаунта?</p>
-            <a href="/registration" class="btn btn-outline-primary w-100 mb-2">
+            <a href="/auth/registration" class="btn btn-outline-primary w-100 mb-2">
                 <i class="bi bi-person-plus"></i> Зарегистрироваться
             </a>
-            <a href="/" class="btn btn-link">
+            <a href="/app" class="btn btn-link">
                 <i class="bi bi-house-door"></i> На главную
             </a>
         </div>

--- a/src/main/resources/templates/auth/registration.html
+++ b/src/main/resources/templates/auth/registration.html
@@ -24,7 +24,7 @@
         <p class="mb-0" th:text="${message}"></p>
     </div>
 
-    <form th:action="@{/registration}" th:object="${userDTO}" method="post">
+    <form th:action="@{/auth/registration}" th:object="${userDTO}" method="post">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <!-- Первый этап: Ввод email и паролей -->
         <div th:unless="${confirmCodRegistration}">
@@ -81,10 +81,10 @@
 
         <div class="text-center mt-4">
             <p class="mb-2">Уже есть аккаунт?</p>
-            <a href="/login" class="btn btn-outline-primary w-100 mb-2">
+            <a href="/auth/login" class="btn btn-outline-primary w-100 mb-2">
                 <i class="bi bi-box-arrow-in-right"></i> Войти
             </a>
-            <a href="/" class="btn btn-link">
+            <a href="/app" class="btn btn-link">
                 <i class="bi bi-house-door"></i> На главную
             </a>
         </div>

--- a/src/main/resources/templates/auth/reset-password.html
+++ b/src/main/resources/templates/auth/reset-password.html
@@ -24,7 +24,7 @@
             <p class="mb-0" th:text="${errorMessage}"></p>
         </div>
 
-        <form th:action="@{/reset-password}" th:object="${passwordResetDTO}" method="post">
+        <form th:action="@{/auth/reset-password}" th:object="${passwordResetDTO}" method="post">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
             <input type="hidden" name="token" th:value="${token}"/>
 
@@ -51,10 +51,10 @@
             </button>
 
             <div class="text-center mt-3">
-                <a href="/login" class="btn btn-outline-secondary w-100 mb-2">
+                <a href="/auth/login" class="btn btn-outline-secondary w-100 mb-2">
                     <i class="bi bi-box-arrow-in-right"></i> Вернуться ко входу
                 </a>
-                <a href="/" class="btn btn-link">
+                <a href="/app" class="btn btn-link">
                     <i class="bi bi-house-door"></i> На главную
                 </a>
             </div>

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -9,7 +9,7 @@
 
             <!-- Логотип -->
            <div class="logo">
-                <a href="/" class="d-inline-flex link-body-emphasis text-decoration-none">
+                <a href="/app" class="d-inline-flex link-body-emphasis text-decoration-none">
                     <img th:src="@{/images/logo.svg}" alt="Logo">
                 </a>
             </div>
@@ -28,18 +28,18 @@
             <!-- Кнопки авторизации -->
             <div class="auth-buttons">
                 <!-- Вход -->
-                <a th:if="${authenticatedUser == null}" th:href="@{/login}" class="btn btn-outline-primary btn-text">
+                <a th:if="${authenticatedUser == null}" th:href="@{/auth/login}" class="btn btn-outline-primary btn-text">
                     <i class="bi bi-box-arrow-in-right"></i> Войти
                 </a>
-                <a th:if="${authenticatedUser == null}" th:href="@{/login}" class="icon-btn">
+                <a th:if="${authenticatedUser == null}" th:href="@{/auth/login}" class="icon-btn">
                     <i class="bi bi-box-arrow-in-right"></i>
                 </a>
 
                 <!-- Регистрация -->
-                <a th:if="${authenticatedUser == null}" th:href="@{/registration}" class="btn btn-primary btn-text">
+                <a th:if="${authenticatedUser == null}" th:href="@{/auth/registration}" class="btn btn-primary btn-text">
                     <i class="bi bi-person-plus"></i> Регистрация
                 </a>
-                <a th:if="${authenticatedUser == null}" th:href="@{/registration}" class="icon-btn">
+                <a th:if="${authenticatedUser == null}" th:href="@{/auth/registration}" class="icon-btn">
                     <i class="bi bi-person-plus"></i>
                 </a>
 


### PR DESCRIPTION
## Summary
- adjust header links for `/app` and `/auth`
- update actions in moved templates
- fetch JSON from new `/app` routes
- add legacy redirect for `/tariffs`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b2386b58832daaddf3c8d8c06cef