### PR TITLE
Adjust routing for app endpoints

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -87,7 +87,7 @@ public class SecurityConfiguration {
                         .requestMatchers("/", "/features", "/pricing", "/terms", "/privacy",
                                 "/auth/**",
                                 "/css/**", "/js/**", "/bootstrap/**", "/images/**",
-                                "/upload", "/ws/**", "/wss/**", "/sample/**", "/download-sample").permitAll()
+                                "/app/upload", "/ws/**", "/wss/**", "/sample/**", "/app/download-sample").permitAll()
                         // Доступ к административному разделу только для ROLE_ADMIN
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         // Требуется аутентификация для пользовательской части приложения

--- a/src/main/java/com/project/tracking_system/controller/CustomerController.java
+++ b/src/main/java/com/project/tracking_system/controller/CustomerController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Slf4j
 @RequiredArgsConstructor
 @Controller
-@RequestMapping("/customers")
+@RequestMapping("/app/customers")
 public class CustomerController {
 
     private final CustomerService customerService;

--- a/src/main/java/com/project/tracking_system/controller/FileDownloadController.java
+++ b/src/main/java/com/project/tracking_system/controller/FileDownloadController.java
@@ -25,7 +25,7 @@ public class FileDownloadController {
      *
      * @return ResponseEntity с файлом для скачивания
      */
-    @GetMapping("/download-sample")
+    @GetMapping("/app/download-sample")
     public ResponseEntity<?> downloadSample() {
         // Имя файла, которое должно использоваться при скачивании
         String filename = "Пример заполнения.XLSX";

--- a/src/main/java/com/project/tracking_system/controller/UploadController.java
+++ b/src/main/java/com/project/tracking_system/controller/UploadController.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 @Slf4j
 @RequiredArgsConstructor
 @Controller
-@RequestMapping("/")
+@RequestMapping("/app")
 public class UploadController {
 
     private final TrackingNumberServiceXLS trackingNumberServiceXLS;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1217,7 +1217,7 @@ document.addEventListener("DOMContentLoaded", function () {
     hideLoading();
 
     document.querySelector('form[action="/"]')?.addEventListener('submit', showLoading);
-    document.querySelector('form[action="/upload"]')?.addEventListener('submit', showLoading);
+    document.querySelector('form[action="/app/upload"]')?.addEventListener('submit', showLoading);
 
     // === Добавляем CSRF-токен ===
     const csrfToken = document.querySelector('meta[name="_csrf"]')?.content || "";

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -1,7 +1,7 @@
 <div id="customerInfoContainer">
     <div th:if="${notFound}">
         <p>Покупатель не найден</p>
-        <form id="assign-customer-form" th:action="@{/customers/assign}" method="post" class="mt-3">
+        <form id="assign-customer-form" th:action="@{/app/customers/assign}" method="post" class="mt-3">
             <input type="hidden" name="trackId" th:value="${trackId}">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
             <div class="input-group mb-2">


### PR DESCRIPTION
## Summary
- map customer operations under `/app/customers`
- move file upload controller under `/app`
- serve sample download from `/app/download-sample`
- update security configuration for new paths
- update templates and JS for updated routes

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6867bbbadae4832d8c3d010b7b053e24