### PR TITLE
Add missing JavaDoc to subscription entity

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/UserSubscription.java
+++ b/src/main/java/com/project/tracking_system/entity/UserSubscription.java
@@ -44,7 +44,10 @@ public class UserSubscription {
 
     @Column(name = "reset_date")
     private LocalDate resetDate;
-
+    /**
+     * Проверяет дату последнего сброса и при необходимости обнуляет лимиты обновлений.
+     * Метод не принимает параметров и ничего не возвращает.
+     */
     public void checkAndResetLimits() {
         LocalDate today = LocalDate.now();
         if (!today.equals(resetDate)) {


### PR DESCRIPTION
## Summary
- document method that resets subscription limits

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6868021e0204832d9175db68a096ed64