### PR TITLE
Add marketing static pages

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/MarketingController.java
+++ b/src/main/java/com/project/tracking_system/controller/MarketingController.java
@@ -64,4 +64,34 @@ public class MarketingController {
     public String privacy() {
         return "marketing/privacy";
     }
+
+    /**
+     * Отображает страницу с часто задаваемыми вопросами.
+     *
+     * @return имя представления страницы с ответами на вопросы
+     */
+    @GetMapping("faq")
+    public String faq() {
+        return "marketing/faq";
+    }
+
+    /**
+     * Отображает страницу с информацией о компании.
+     *
+     * @return имя представления страницы "О нас"
+     */
+    @GetMapping("about")
+    public String about() {
+        return "marketing/about";
+    }
+
+    /**
+     * Отображает страницу с контактной информацией.
+     *
+     * @return имя представления страницы с контактами
+     */
+    @GetMapping("contacts")
+    public String contacts() {
+        return "marketing/contacts";
+    }
 }

--- a/src/main/resources/templates/marketing/about.html
+++ b/src/main/resources/templates/marketing/about.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">О нас</title>
+</head>
+<main layout:fragment="content" class="container mt-4">
+    <h1 class="text-center">О нас</h1>
+    <p class="text-center">Страница в разработке.</p>
+</main>
+</html>

--- a/src/main/resources/templates/marketing/contacts.html
+++ b/src/main/resources/templates/marketing/contacts.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">Контакты</title>
+</head>
+<main layout:fragment="content" class="container mt-4">
+    <h1 class="text-center">Контакты</h1>
+    <p class="text-center">Страница в разработке.</p>
+</main>
+</html>

--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/layout}">
+<head>
+    <title layout:fragment="title">FAQ</title>
+</head>
+<main layout:fragment="content" class="container mt-4">
+    <h1 class="text-center">FAQ</h1>
+    <p class="text-center">Страница в разработке.</p>
+</main>
+</html>


### PR DESCRIPTION
## Summary
- add /faq, /about and /contacts endpoints to marketing controller
- create templates for FAQ, About and Contacts pages

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686803b006b8832da90a56c22367b02b