### PR TITLE
Add FAQ link to marketing header

### DIFF
--- a/src/main/resources/templates/partials/header-marketing.html
+++ b/src/main/resources/templates/partials/header-marketing.html
@@ -19,6 +19,7 @@
                     <li><a href="/" class="nav-link px-2" data-path="/">Главная</a></li>
                     <li><a href="/features" class="nav-link px-2" data-path="/features">Возможности</a></li>
                     <li><a href="/pricing" class="nav-link px-2" data-path="/pricing">Тарифы</a></li>
+                    <li><a href="/faq" class="nav-link px-2" data-path="/faq">FAQ</a></li>
                 </ul>
             </div>
 
@@ -63,6 +64,7 @@
                 <li><a href="/" data-path="/">Главная</a></li>
                 <li><a href="/features" data-path="/features">Возможности</a></li>
                 <li><a href="/pricing" data-path="/pricing">Тарифы</a></li>
+                <li><a href="/faq" data-path="/faq">FAQ</a></li>
             </ul>
         </nav>
 


### PR DESCRIPTION
## Summary
- add a new anchor to `/faq` in the marketing header for desktop
- add the same link in the mobile navigation menu

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868051edc60832d88d40e2312e1d2a3