### PR TITLE
Add custom template toggle in profile

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -25,3 +25,12 @@
     resize: vertical;
   }
 }
+
+.toggle-template-btn {
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+
+  i {
+    transition: transform 0.3s;
+  }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1275,6 +1275,13 @@ button:hover {
   min-height: 4rem;
   resize: vertical;
 }
+.toggle-template-btn {
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+.toggle-template-btn i {
+  transition: transform 0.3s;
+}
 
 .legal-container {
   font-family: "Inter", sans-serif;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -493,21 +493,45 @@ function initTelegramTemplateBlocks() {
         if (!cb || !fields) return;
 
         const update = () => {
-            if (cb.disabled) {
-                cb.checked = false;
-                fields.querySelectorAll('textarea').forEach(t => t.disabled = true);
-                // Показываем блок, но текстовые поля остаются недоступными
-                slideDown(fields);
-                return;
-            }
-            fields.querySelectorAll('textarea').forEach(t => t.disabled = !cb.checked);
-            toggleFieldsVisibility(cb, fields);
+            const disabled = cb.disabled || !cb.checked;
+            fields.querySelectorAll('textarea').forEach(t => t.disabled = disabled);
         };
 
         update();
-        if (!cb.disabled) {
-            cb.addEventListener('change', update);
+
+        if (cb.checked && !cb.disabled && fields.classList.contains('hidden')) {
+            slideDown(fields);
         }
+
+        cb.addEventListener('change', update);
+    });
+}
+
+/**
+ * Инициализирует показ/скрытие блока пользовательских шаблонов.
+ * Для каждой кнопки `.toggle-template-btn` ищет блок `.custom-template-fields` по атрибуту `data-store-id`.
+ * При клике открывает или скрывает блок с анимацией.
+ */
+function initCustomTemplateToggle() {
+    document.querySelectorAll('.toggle-template-btn').forEach(btn => {
+        if (btn.dataset.toggleInit) return;
+        btn.dataset.toggleInit = 'true';
+
+        const storeId = btn.getAttribute('data-store-id');
+        const fields = document.querySelector(`.custom-template-fields[data-store-id="${storeId}"]`);
+        const icon = btn.querySelector('i');
+        if (!fields) return;
+
+        btn.addEventListener('click', () => {
+            const hidden = fields.classList.contains('hidden');
+            if (hidden) {
+                slideDown(fields);
+            } else {
+                slideUp(fields);
+            }
+            icon?.classList.toggle('bi-chevron-down', !hidden);
+            icon?.classList.toggle('bi-chevron-up', hidden);
+        });
     });
 }
 
@@ -938,6 +962,7 @@ async function appendTelegramBlock(store) {
     initTelegramToggle();
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
+    initCustomTemplateToggle();
     initTelegramNotificationsToggle();
 }
 
@@ -1334,6 +1359,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initTelegramToggle();
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
+    initCustomTemplateToggle();
     initTelegramNotificationsToggle();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -462,6 +462,11 @@
                            name="useCustomTemplates"
                            th:checked="${store.telegramSettings?.templates?.size() > 0}"
                            th:disabled="${!allowCustomTemplates}">
+                    <!-- Кнопка раскрытия блока с пользовательскими шаблонами -->
+                    <button type="button" class="btn btn-sm btn-outline-secondary toggle-template-btn ms-2"
+                            th:attr="data-store-id=${store.id}">
+                        <i class="bi bi-chevron-down"></i>
+                    </button>
                     <label class="form-check-label" th:for="'tg-custom-templates-' + ${store.id}">
                         Использовать собственные сообщения
                     </label>
@@ -470,7 +475,8 @@
                     </p>
                 </div>
 
-                <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields">
+                <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields"
+                     th:attr="data-store-id=${store.id}">
                     <div th:each="status : ${T(com.project.tracking_system.entity.BuyerStatus).values()}">
                         <div class="mb-2">
                             <label class="form-label" th:for="${'tpl-' + status.name() + '-' + store.id}" th:text="${status.displayName}"></label>


### PR DESCRIPTION
## Summary
- add toggle button for custom template section in telegram store settings
- implement JS logic for custom template block toggling
- enable textarea state management separated from visibility
- style the new toggle button

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e25f82f4832db1be4d7067111329