### PR TITLE
Implement subscription renewal feature

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/SubscriptionController.java
+++ b/src/main/java/com/project/tracking_system/controller/SubscriptionController.java
@@ -1,0 +1,32 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+
+/**
+ * Контроллер операций с подпиской пользователя.
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    /**
+     * Продлевает текущую подписку пользователя.
+     *
+     * @param userDetails данные аутентифицированного пользователя
+     * @return редирект на страницу профиля
+     */
+    @PostMapping("/subscription/renew")
+    public String renewSubscription(@AuthenticationPrincipal UserDetails userDetails) {
+        subscriptionService.renewCurrentSubscription(userDetails.getUsername());
+        return "redirect:/app/profile?renewed";
+    }
+}

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -249,6 +249,9 @@
     <p class="fw-semibold mb-2">Текущий тариф:
         <span class="badge bg-primary" th:text="${planDetails.name}"></span>
     </p>
+    <p class="mb-2 small" th:if="${userProfile.subscriptionEndDate != null}">
+        Подписка активна до: <strong th:text="${userProfile.subscriptionEndDate}"></strong>
+    </p>
     <ul class="list-unstyled">
         <li>📥 Треков в файле:
             <strong th:text="${planDetails.maxTracksPerFile != null ? planDetails.maxTracksPerFile : 'Без лимита'}"></strong>
@@ -275,6 +278,14 @@
             <span th:unless="${planDetails.allowTelegramNotifications}" class="text-muted">❌ Telegram-уведомления</span>
         </li>
     </ul>
+    <div class="d-flex mt-3">
+        <form th:if="${userProfile.subscriptionCode != 'FREE'}"
+              th:action="@{/subscription/renew}" method="post">
+            <input type="hidden" name="_csrf" th:value="${_csrf.token}"/>
+            <button class="btn btn-outline-success">Продлить</button>
+        </form>
+        <a href="/pricing" class="btn btn-primary ms-2">Сменить тариф</a>
+    </div>
 </div>
 
 <div class="tab-pane fade" id="v-pills-integrations" role="tabpanel">


### PR DESCRIPTION
## Summary
- show subscription end date on profile tariff tab
- provide buttons to renew or change plan
- add `SubscriptionController` for renewal endpoint
- implement `renewCurrentSubscription` method in `SubscriptionService`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869088ff100832daf23545954be37c3