### PR TITLE
Add CSP nonce attribute to FAQ script

### DIFF
--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -241,7 +241,7 @@
         <a href="marketing/contacts" class="btn btn-outline-primary">Связаться с нами</a>
     </div>
 
-    <script>
+    <script th:attr="nonce=${nonce}">
         function toggleFaq(el) {
             const item = el.closest('.faq-item');
             const answer = item.querySelector('.faq-answer');


### PR DESCRIPTION
## Summary
- apply CSP nonce on the FAQ page script tag so Content Security Policy functions correctly

## Testing
- `./mvnw test -q` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697710f73c832d8fdfc94788cdad04