### PR TITLE
Add CSP nonce attribute to FAQ script

### DIFF
--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -26,7 +26,7 @@
         <h3 class="fw-bold mb-4 text-primary">Работа с отправлениями</h3>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Как добавить посылки?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -36,7 +36,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Можно ли обновлять статусы автоматически?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -46,7 +46,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Как быстро обновляются статусы?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -56,7 +56,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Какие почтовые службы поддерживаются?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -66,7 +66,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Можно ли отслеживать возвраты?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -81,7 +81,7 @@
         <h3 class="fw-bold mb-4 text-primary">Telegram и уведомления</h3>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Как клиенты получают уведомления?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -91,7 +91,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Можно ли редактировать тексты уведомлений?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -101,7 +101,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Что делать, если клиент не забирает посылку?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -116,7 +116,7 @@
         <h3 class="fw-bold mb-4 text-primary">Управление аккаунтом</h3>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Могу ли я подключить несколько магазинов?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -126,7 +126,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Есть ли доступ для сотрудников?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -136,7 +136,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Где посмотреть аналитику?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -146,7 +146,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Можно ли следить за надёжностью покупателей?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -161,7 +161,7 @@
         <h3 class="fw-bold mb-4 text-primary">Тарифы и оплата</h3>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Какие ограничения у бесплатного тарифа?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -171,7 +171,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Как продлить или сменить тариф?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -181,7 +181,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Поддерживается ли безналичная оплата?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -196,7 +196,7 @@
         <h3 class="fw-bold mb-4 text-primary">Безопасность и данные</h3>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Кто видит мои данные?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -206,7 +206,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Сохраняются ли номера клиентов?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -216,7 +216,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Можно ли удалить аккаунт?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -226,7 +226,7 @@
         </div>
 
         <div class="faq-item mb-3">
-            <div class="faq-question" onclick="toggleFaq(this)">
+            <div class="faq-question">
                 <span class="question-text">Насколько безопасны уведомления в Telegram?</span>
                 <span class="faq-toggle-icon">+</span>
             </div>
@@ -241,7 +241,8 @@
         <a href="marketing/contacts" class="btn btn-outline-primary">Связаться с нами</a>
     </div>
 
-    <script>
+    <script th:attr="nonce=${nonce}">
+        // Функция раскрывает или сворачивает блок ответа
         function toggleFaq(el) {
             const item = el.closest('.faq-item');
             const answer = item.querySelector('.faq-answer');
@@ -257,6 +258,13 @@
 
             item.classList.toggle('open');
         }
+
+        // Добавляем обработчики кликов без inline-скриптов
+        document.querySelectorAll('.faq-question').forEach(function (question) {
+            question.addEventListener('click', function () {
+                toggleFaq(this);
+            });
+        });
     </script>
 </main>
 </html>


### PR DESCRIPTION
## Summary
- apply CSP nonce on the FAQ page script tag so Content Security Policy functions correctly
- remove inline JS handlers and attach click listeners via the script
- add a comment explaining the FAQ toggling function

## Testing
- `./mvnw test -q` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68697710f73c832d8fdfc94788cdad04