### PR TITLE
Enhance FAQ open-close animation

### DIFF
--- a/src/main/resources/assets/scss/pages/_faq.scss
+++ b/src/main/resources/assets/scss/pages/_faq.scss
@@ -22,15 +22,18 @@
   font-size: 1rem;
 }
 
-.faq-answer {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
+  // Ответы скрыты по умолчанию, прозрачность позволяет анимировать плавное появление
+  .faq-answer {
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition: max-height 0.3s ease, opacity 0.3s ease;
+  }
 
-.faq-item.open .faq-answer {
-  margin-top: 0.5rem;
-}
+  .faq-item.open .faq-answer {
+    margin-top: 0.5rem;
+    opacity: 1;
+  }
 
 .faq-toggle-icon {
   transition: transform 0.3s;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1497,11 +1497,13 @@ body.loading {
 .faq-answer {
   max-height: 0;
   overflow: hidden;
-  transition: max-height 0.3s ease;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
 }
 
 .faq-item.open .faq-answer {
   margin-top: 0.5rem;
+  opacity: 1;
 }
 
 .faq-toggle-icon {

--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -248,14 +248,23 @@
             const icon = item.querySelector('.faq-toggle-icon');
 
             if (item.classList.contains('open')) {
-                answer.style.maxHeight = null;
-                icon.textContent = '+';
-            } else {
+                // Плавное закрытие блока с ответом
                 answer.style.maxHeight = answer.scrollHeight + 'px';
+                requestAnimationFrame(function () {
+                    answer.style.maxHeight = '0';
+                });
+                icon.textContent = '+';
+                item.classList.remove('open');
+            } else {
+                // Плавное открытие блока с ответом
+                answer.style.maxHeight = answer.scrollHeight + 'px';
+                item.classList.add('open');
                 icon.textContent = '–';
+                answer.addEventListener('transitionend', function handler() {
+                    answer.style.maxHeight = 'none';
+                    answer.removeEventListener('transitionend', handler);
+                });
             }
-
-            item.classList.toggle('open');
         }
 
         document.querySelectorAll('.faq-question').forEach(function (question) {


### PR DESCRIPTION
## Summary
- smoothen FAQ answer transitions using opacity
- improve closing animation logic in FAQ script
- update compiled CSS

## Testing
- `npm run build:css` *(fails: sass not found)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68697bd22d78832d8a7ac78f71c50613