### PR TITLE
Fix FAQ accordion closing animation

### DIFF
--- a/src/main/resources/assets/scss/pages/_faq.scss
+++ b/src/main/resources/assets/scss/pages/_faq.scss
@@ -26,7 +26,7 @@
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
 }
 
 .faq-item.open .faq-answer {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1498,7 +1498,7 @@ body.loading {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
 }
 
 .faq-item.open .faq-answer {


### PR DESCRIPTION
## Summary
- make margin-top transition when collapsing FAQ sections

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697f38ab58832d82482df68ccdea85