### PR TITLE
Fix FAQ accordion closing animation

### DIFF
--- a/src/main/resources/assets/scss/pages/_faq.scss
+++ b/src/main/resources/assets/scss/pages/_faq.scss
@@ -26,12 +26,16 @@
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
 }
 
 .faq-item.open .faq-answer {
   margin-top: 0.5rem;
   opacity: 1;
+}
+
+.faq-item.closing .faq-answer {
+  margin-top: 0;
 }
 
 .faq-toggle-icon {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1498,12 +1498,16 @@ body.loading {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 0.3s ease, opacity 0.3s ease;
+  transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
 }
 
 .faq-item.open .faq-answer {
   margin-top: 0.5rem;
   opacity: 1;
+}
+
+.faq-item.closing .faq-answer {
+  margin-top: 0;
 }
 
 .faq-toggle-icon {

--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -248,16 +248,17 @@
             const icon = item.querySelector('.faq-toggle-icon');
 
             if (item.classList.contains('open')) {
-                
+
+                item.classList.add('closing');
                 answer.style.maxHeight = answer.scrollHeight + 'px';
                 requestAnimationFrame(function () {
                     answer.style.maxHeight = '0';
                 });
                 icon.textContent = '+';
-                item.classList.remove('open');
 
                 answer.addEventListener('transitionend', function handler(event) {
                     if (event.propertyName === 'max-height') {
+                        item.classList.remove('open', 'closing');
                         answer.style.maxHeight = '';
                         answer.removeEventListener('transitionend', handler);
                     }


### PR DESCRIPTION
## Summary
- keep `open` class during collapse to match opening animation
- add `.closing` style for margin-top transition

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697f38ab58832d82482df68ccdea85