### PR TITLE
Replace Telegram template checkbox with radio tabs

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -26,11 +26,9 @@
   }
 }
 
-.toggle-template-btn {
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.5rem;
 
-  i {
-    transition: transform 0.3s;
+.template-toggle-group {
+  .btn {
+    padding: 0.25rem 0.75rem;
   }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1282,12 +1282,8 @@ button:hover {
   resize: vertical;
 }
 
-.toggle-template-btn {
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.5rem;
-}
-.toggle-template-btn i {
-  transition: transform 0.3s;
+.template-toggle-group .btn {
+  padding: 0.25rem 0.75rem;
 }
 
 .legal-container {

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -488,52 +488,31 @@ function initTelegramReminderBlocks() {
 // Инициализация блока пользовательских шаблонов
 function initTelegramTemplateBlocks() {
     document.querySelectorAll('.telegram-settings-form').forEach(form => {
-        const cb = form.querySelector('input[name="useCustomTemplates"]');
+        const radios = form.querySelectorAll('input[name="useCustomTemplates"]');
         const fields = form.querySelector('.custom-template-fields');
-        if (!cb || !fields) return;
+        if (!radios.length || !fields) return;
 
-        const update = () => {
-            const disabled = cb.disabled || !cb.checked;
-            fields.querySelectorAll('textarea').forEach(t => t.disabled = disabled);
+        const isCustom = () => {
+            const selected = form.querySelector('input[name="useCustomTemplates"]:checked');
+            return selected && selected.value === 'custom' && !selected.disabled;
         };
 
-        update();
-
-        if (cb.checked && !cb.disabled && fields.classList.contains('hidden')) {
-            slideDown(fields);
-        }
-
-        cb.addEventListener('change', update);
-    });
-}
-
-/**
- * Инициализирует показ/скрытие блока пользовательских шаблонов.
- * Для каждой кнопки `.toggle-template-btn` ищет блок `.custom-template-fields` по атрибуту `data-store-id`.
- * При клике открывает или скрывает блок с анимацией.
- */
-function initCustomTemplateToggle() {
-    document.querySelectorAll('.toggle-template-btn').forEach(btn => {
-        if (btn.dataset.toggleInit) return;
-        btn.dataset.toggleInit = 'true';
-
-        const storeId = btn.getAttribute('data-store-id');
-        const fields = document.querySelector(`.custom-template-fields[data-store-id="${storeId}"]`);
-        const icon = btn.querySelector('i');
-        if (!fields) return;
-
-        btn.addEventListener('click', () => {
-            const hidden = fields.classList.contains('hidden');
-            if (hidden) {
+        const update = () => {
+            const custom = isCustom();
+            fields.querySelectorAll('textarea').forEach(t => t.disabled = !custom);
+            if (custom) {
                 slideDown(fields);
             } else {
                 slideUp(fields);
             }
-            icon?.classList.toggle('bi-chevron-down', !hidden);
-            icon?.classList.toggle('bi-chevron-up', hidden);
-        });
+        };
+
+        update();
+
+        radios.forEach(r => r.addEventListener('change', update));
     });
 }
+
 
 let lastPage = window.location.pathname; // Запоминаем текущую страницу при загрузке
 let isInitialLoad = true;
@@ -962,7 +941,6 @@ async function appendTelegramBlock(store) {
     initTelegramToggle();
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
-    initCustomTemplateToggle();
     initTelegramNotificationsToggle();
 }
 
@@ -1359,7 +1337,6 @@ document.addEventListener("DOMContentLoaded", function () {
     initTelegramToggle();
     initTelegramReminderBlocks();
     initTelegramTemplateBlocks();
-    initCustomTemplateToggle();
     initTelegramNotificationsToggle();
 
     // Назначаем обработчик кнопки "Добавить магазин" - с проверкой на наличие

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -482,23 +482,27 @@
                 </div>
 
 
-                <div class="form-check form-switch mb-2 ms-3">
-                    <input class="form-check-input" type="checkbox" th:id="'tg-custom-templates-' + ${store.id}"
-                           name="useCustomTemplates"
+                <div class="btn-group mb-2 ms-3 template-toggle-group" role="group">
+                    <input type="radio" class="btn-check" name="useCustomTemplates"
+                           th:id="'tg-templates-system-' + ${store.id}"
+                           value="system"
+                           th:checked="${store.telegramSettings?.templates?.size() == 0}">
+                    <label class="btn btn-outline-secondary" th:for="'tg-templates-system-' + ${store.id}">
+                        Системные
+                    </label>
+
+                    <input type="radio" class="btn-check" name="useCustomTemplates"
+                           th:id="'tg-templates-custom-' + ${store.id}"
+                           value="custom"
                            th:checked="${store.telegramSettings?.templates?.size() > 0}"
                            th:disabled="${!allowCustomTemplates}">
-                    <!-- Кнопка раскрытия блока с пользовательскими шаблонами -->
-                    <button type="button" class="btn btn-sm btn-outline-secondary toggle-template-btn ms-2"
-                            th:attr="data-store-id=${store.id}">
-                        <i class="bi bi-chevron-down"></i>
-                    </button>
-                    <label class="form-check-label" th:for="'tg-custom-templates-' + ${store.id}">
-                        Использовать собственные сообщения
+                    <label class="btn btn-outline-secondary" th:for="'tg-templates-custom-' + ${store.id}">
+                        Собственные
                     </label>
-                    <p class="form-text text-danger ms-4" th:if="${!allowCustomTemplates}">
-                        Функция доступна в тарифе "Бизнес" и выше
-                    </p>
                 </div>
+                <p class="form-text text-danger ms-4" th:if="${!allowCustomTemplates}">
+                    Доступно в тарифе Бизнес и выше
+                </p>
 
                 <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields"
                      th:attr="data-store-id=${store.id}">


### PR DESCRIPTION
## Summary
- switch Telegram template checkbox to a radio group
- remove obsolete toggle-template-btn and JS handler
- adjust styles for new radio tabs

## Testing
- `npm run build:css` *(fails: `sass` not found)*
- `./mvnw -q test` *(fails: maven wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869886078c4832d8dfbaf3578c88e4e