### PR TITLE
Update telegram templates UX

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -499,12 +499,11 @@ function initTelegramTemplateBlocks() {
 
         const update = () => {
             const custom = isCustom();
-            fields.querySelectorAll('textarea').forEach(t => t.disabled = !custom);
-            if (custom) {
-                slideDown(fields);
-            } else {
-                slideUp(fields);
-            }
+            fields.querySelectorAll('textarea').forEach(t => {
+                t.disabled = !custom;
+            });
+            fields.classList.toggle('bg-light', !custom);
+            fields.classList.toggle('text-muted', !custom);
         };
 
         update();

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -504,8 +504,9 @@
                     Доступно в тарифе Бизнес и выше
                 </p>
 
-                <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 hidden custom-template-fields"
-                     th:attr="data-store-id=${store.id}">
+                <div th:id="'tg-custom-template-fields-' + ${store.id}" class="ms-4 custom-template-fields"
+                     th:attr="data-store-id=${store.id}"
+                     th:attrappend="${!allowCustomTemplates} ? 'data-bs-toggle=tooltip title=\'Доступно в тарифе Бизнес и выше\'' : ''">
                     <div th:each="status : ${T(com.project.tracking_system.entity.BuyerStatus).values()}">
                         <div class="mb-2">
                             <label class="form-label" th:for="${'tpl-' + status.name() + '-' + store.id}" th:text="${status.displayName}"></label>


### PR DESCRIPTION
## Summary
- reveal custom template fields by default and add tooltip
- disable and gray out fields when choosing system templates

## Testing
- `npm test` *(fails: Missing script)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698a1b31e8832d8377c3d64b9d38b4