### PR TITLE
Update Telegram template initialization

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -492,13 +492,13 @@ function initTelegramTemplateBlocks() {
         const fields = form.querySelector('.custom-template-fields');
         if (!radios.length || !fields) return;
 
-        const isCustom = () => {
-            const selected = form.querySelector('input[name="useCustomTemplates"]:checked');
-            return selected && selected.value === 'custom' && !selected.disabled;
+        const getSelectedMode = () => {
+            const checked = form.querySelector('input[name="useCustomTemplates"]:checked');
+            return checked ? checked.value : 'system';
         };
 
         const update = () => {
-            const custom = isCustom();
+            const custom = getSelectedMode() === 'custom';
             fields.querySelectorAll('textarea').forEach(t => {
                 t.disabled = !custom;
             });


### PR DESCRIPTION
## Summary
- adjust telegram template initialization to read the active radio value

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698b791f6c832da14d748502b248ea