### PR TITLE
Add tooltips for custom template controls

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -935,6 +935,9 @@ async function appendTelegramBlock(store) {
     if (!block) return;
     document.getElementById('telegram-management').appendChild(block);
 
+    // Инициализируем подсказки в добавленном блоке
+    enableTooltips(block);
+
     // --- Инициализируем формы и collapse
     initTelegramForms();
     initTelegramToggle();

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -496,7 +496,8 @@
                            value="custom"
                            th:checked="${store.telegramSettings?.templates?.size() > 0}"
                            th:disabled="${!allowCustomTemplates}">
-                    <label class="btn btn-outline-secondary" th:for="'tg-templates-custom-' + ${store.id}">
+                    <label class="btn btn-outline-secondary" th:for="'tg-templates-custom-' + ${store.id}"
+                           th:attrappend="${!allowCustomTemplates} ? 'data-bs-toggle=tooltip title=\'Доступно в тарифе Бизнес и выше\'' : ''">
                         Собственные
                     </label>
                 </div>
@@ -531,7 +532,10 @@
                     <p class="form-text">Шаблоны должны содержать {track} и {store}</p>
                 </div>
                 <button type="submit" class="btn btn-sm btn-primary w-100"
-                        th:disabled="${!allowCustomTemplates}">Сохранить</button>
+                        th:disabled="${!allowCustomTemplates}"
+                        th:attrappend="${!allowCustomTemplates} ? 'data-bs-toggle=tooltip title=\'Доступно в тарифе Бизнес и выше\'' : ''">
+                    Сохранить
+                </button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show tooltip when custom templates can't be modified
- ensure tooltip initialization for dynamically added Telegram blocks

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698cecd1b0832dafb8b14deba24b22