### PR TITLE
Fix profile save error with radio template mode

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Min;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * DTO настроек Telegram для магазина.
@@ -30,8 +30,32 @@ public class StoreTelegramSettingsDTO {
 
     private boolean remindersEnabled = false;
 
-    /** Использовать пользовательские шаблоны сообщений. */
-    private boolean useCustomTemplates = false;
+    /**
+     * Режим использования шаблонов уведомлений.
+     * <p>
+     * Возможные значения: {@code system} или {@code custom}. По умолчанию
+     * используется {@code system}.
+     * </p>
+     */
+    private String useCustomTemplates = "system";
+
+    /**
+     * Возвращает {@code true}, если выбран режим собственных шаблонов.
+     *
+     * @return {@code true}, когда пользователь выбрал вариант {@code custom}
+     */
+    public boolean isUseCustomTemplates() {
+        return "custom".equalsIgnoreCase(useCustomTemplates);
+    }
+
+    /**
+     * Устанавливает режим использования шаблонов по булеву значению.
+     *
+     * @param value {@code true} для режима {@code custom}, иначе {@code system}
+     */
+    public void setUseCustomTemplates(boolean value) {
+        this.useCustomTemplates = value ? "custom" : "system";
+    }
 
     /** Статус → шаблон сообщения. */
     private Map<String, String> templates = new HashMap<>();


### PR DESCRIPTION
## Summary
- allow `useCustomTemplates` to accept `system` and `custom` values from the profile form
- derive boolean behaviour from the string value and keep compatibility

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6869874e28a4832d9281d421b3cd6515