### PR TITLE
Fix profile save error with radio template mode

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
+++ b/src/main/java/com/project/tracking_system/controller/StoreTelegramSettingsController.java
@@ -72,7 +72,7 @@ public class StoreTelegramSettingsController {
                         binding.getAllErrors().get(0).getDefaultMessage());
             }
 
-            if (dto.isUseCustomTemplates() &&
+            if (dto.isCustomTemplates() &&
                     !subscriptionService.canUseCustomNotifications(userId)) {
                 return ResponseBuilder.error(HttpStatus.FORBIDDEN,
                         "Индивидуальные шаблоны недоступны на вашем тарифе");
@@ -118,7 +118,7 @@ public class StoreTelegramSettingsController {
                     .body(binding.getAllErrors().get(0).getDefaultMessage());
         }
 
-        if (dto.isUseCustomTemplates() &&
+        if (dto.isCustomTemplates() &&
                 !subscriptionService.canUseCustomNotifications(userId)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body("Индивидуальные шаблоны недоступны на вашем тарифе");
@@ -160,7 +160,7 @@ public class StoreTelegramSettingsController {
             return "redirect:/app/profile#v-pills-stores";
         }
 
-        if (dto.isUseCustomTemplates() &&
+        if (dto.isCustomTemplates() &&
                 !subscriptionService.canUseCustomNotifications(userId)) {
             redirectAttributes.addFlashAttribute("errorMessage",
                     "Индивидуальные шаблоны недоступны на вашем тарифе");

--- a/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/StoreTelegramSettingsDTO.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Min;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * DTO настроек Telegram для магазина.
@@ -30,8 +30,32 @@ public class StoreTelegramSettingsDTO {
 
     private boolean remindersEnabled = false;
 
-    /** Использовать пользовательские шаблоны сообщений. */
-    private boolean useCustomTemplates = false;
+    /**
+     * Режим использования шаблонов уведомлений.
+     * <p>
+     * Возможные значения: {@code system} или {@code custom}. По умолчанию
+     * используется {@code system}.
+     * </p>
+     */
+    private String useCustomTemplates = "system";
+
+    /**
+     * Проверяет, активирован ли режим собственных шаблонов.
+     *
+     * @return {@code true}, если выбран вариант {@code custom}
+     */
+    public boolean isCustomTemplates() {
+        return "custom".equalsIgnoreCase(useCustomTemplates);
+    }
+
+    /**
+     * Устанавливает режим шаблонов по булеву значению.
+     *
+     * @param enabled {@code true} для режима {@code custom}, иначе {@code system}
+     */
+    public void setCustomTemplates(boolean enabled) {
+        this.useCustomTemplates = enabled ? "custom" : "system";
+    }
 
     /** Статус → шаблон сообщения. */
     private Map<String, String> templates = new HashMap<>();

--- a/src/main/java/com/project/tracking_system/service/store/StoreService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreService.java
@@ -435,7 +435,7 @@ public class StoreService {
         dto.setReminderRepeatIntervalDays(settings.getReminderRepeatIntervalDays());
         dto.setReminderTemplate(settings.getReminderTemplate());
         dto.setRemindersEnabled(settings.isRemindersEnabled());
-        dto.setUseCustomTemplates(!settings.getTemplates().isEmpty());
+        dto.setCustomTemplates(!settings.getTemplates().isEmpty());
         dto.setTemplates(settings.getTemplatesMap().entrySet().stream()
                 .collect(java.util.stream.Collectors.toMap(e -> e.getKey().name(), Map.Entry::getValue)));
         return dto;
@@ -467,7 +467,7 @@ public class StoreService {
             current.put(template.getStatus(), template);
         }
 
-        if (dto.isUseCustomTemplates()) {
+        if (dto.isCustomTemplates()) {
             // Обновляем или создаём шаблоны
             dto.getTemplates().forEach((statusName, text) -> {
                 if (!isValidBuyerStatus(statusName)) {

--- a/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/store/StoreTelegramSettingsService.java
@@ -51,7 +51,7 @@ public class StoreTelegramSettingsService {
             throw new IllegalStateException(msg);
         }
 
-        boolean customRequested = dto.isUseCustomTemplates() ||
+        boolean customRequested = dto.isCustomTemplates() ||
                 (dto.getTemplates() != null && !dto.getTemplates().isEmpty());
         if (customRequested && !subscriptionService.canUseCustomNotifications(userId)) {
             String msg = "Индивидуальные шаблоны недоступны на вашем тарифе.";
@@ -67,7 +67,7 @@ public class StoreTelegramSettingsService {
         }
 
         // Проверяем содержимое пользовательских шаблонов при их использовании
-        if (dto.isUseCustomTemplates()) {
+        if (dto.isCustomTemplates()) {
             if (dto.getTemplates() != null) {
                 dto.getTemplates().values().forEach(this::validateTemplate);
             }

--- a/src/test/java/com/project/tracking_system/controller/StoreTelegramSettingsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/StoreTelegramSettingsControllerTest.java
@@ -44,7 +44,7 @@ class StoreTelegramSettingsControllerTest {
         User user = new User();
         user.setId(1L);
         StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
-        dto.setUseCustomTemplates(true);
+        dto.setCustomTemplates(true);
 
         BeanPropertyBindingResult binding = new BeanPropertyBindingResult(dto, "dto");
         when(subscriptionService.canUseCustomNotifications(1L)).thenReturn(false);

--- a/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/store/StoreTelegramSettingsServiceTest.java
@@ -40,7 +40,7 @@ class StoreTelegramSettingsServiceTest {
         Store store = new Store();
         store.setId(1L);
         StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
-        dto.setUseCustomTemplates(true);
+        dto.setCustomTemplates(true);
 
         when(subscriptionService.isFeatureEnabled(1L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
         when(subscriptionService.canUseCustomNotifications(1L)).thenReturn(false);
@@ -54,7 +54,7 @@ class StoreTelegramSettingsServiceTest {
         Store store = new Store();
         store.setId(2L);
         StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
-        dto.setUseCustomTemplates(true);
+        dto.setCustomTemplates(true);
 
         when(subscriptionService.isFeatureEnabled(2L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);
         when(subscriptionService.canUseCustomNotifications(2L)).thenReturn(true);
@@ -72,7 +72,7 @@ class StoreTelegramSettingsServiceTest {
         Store store = new Store();
         store.setId(3L);
         StoreTelegramSettingsDTO dto = new StoreTelegramSettingsDTO();
-        dto.setUseCustomTemplates(true);
+        dto.setCustomTemplates(true);
         dto.setReminderTemplate("Неверный шаблон");
 
         when(subscriptionService.isFeatureEnabled(3L, FeatureKey.TELEGRAM_NOTIFICATIONS)).thenReturn(true);


### PR DESCRIPTION
## Summary
- allow `useCustomTemplates` radio values through a String field
- add boolean helpers `isCustomTemplates` and `setCustomTemplates`
- update services, controllers and tests to use new helpers

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6869874e28a4832d9281d421b3cd6515