### PR TITLE
Add recommended badge for Business plan

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/SubscriptionPlanViewDTO.java
@@ -32,6 +32,9 @@ public class SubscriptionPlanViewDTO {
     private String annualFullPriceLabel;     // "180 BYN"
     private String annualDiscountLabel;      // "выгода −16%"
 
+    /** Показывать ли плашку "Рекомендуем". */
+    private boolean recommended;
+
     /**
      * Позиция плана в общей иерархии.
      */

--- a/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
+++ b/src/main/java/com/project/tracking_system/service/tariff/TariffService.java
@@ -131,6 +131,7 @@ public class TariffService {
                 annualLabel,
                 fullAnnualPriceLabel,
                 discountLabel,
+                "BUSINESS".equals(plan.getCode()),
                 plan.getPosition()
         );
     }

--- a/src/main/resources/assets/scss/pages/_tariffs.scss
+++ b/src/main/resources/assets/scss/pages/_tariffs.scss
@@ -14,3 +14,12 @@
   font-size: 0.875rem;
   margin-left: 0.5rem;
 }
+
+.recommended-label {
+  background-color: ui.$primary-color;
+  color: ui.$white;
+  font-weight: 500;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1474,6 +1474,14 @@ body.loading {
   font-size: 0.875rem;
   margin-left: 0.5rem;
 }
+.recommended-label {
+  background-color: #0d6efd;
+  color: #ffffff;
+  font-weight: 500;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
 
 .faq-container {
   max-width: 800px;

--- a/src/main/resources/templates/marketing/pricing.html
+++ b/src/main/resources/templates/marketing/pricing.html
@@ -32,6 +32,9 @@
 
                     <!-- Название -->
                     <h3 class="text-center fw-bold fs-3 mt-3 mb-1" th:text="${plan.name}">Premium</h3>
+                    <div class="text-center mb-2" th:if="${plan.recommended}">
+                        <span class="recommended-label">Рекомендуем</span>
+                    </div>
 
                     <!-- Цена (ежемесячно) -->
                     <p class="text-center mb-2 mt-2 fw-semibold fs-5 price-monthly text-dark"

--- a/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/tariff/TariffServiceTest.java
@@ -110,6 +110,7 @@ class TariffServiceTest {
         assertEquals("150.00 BYN/год", dto.getAnnualPriceLabel());
         assertEquals("180.00 BYN", dto.getAnnualFullPriceLabel());
         assertEquals("выгода −17%", dto.getAnnualDiscountLabel());
+        assertFalse(dto.isRecommended());
     }
 
     @Test
@@ -137,6 +138,15 @@ class TariffServiceTest {
 
         assertNull(dto);
 
+    }
+
+    @Test
+    void recommendedFlagForBusinessPlan() {
+        plan.setCode("BUSINESS");
+
+        SubscriptionPlanViewDTO dto = tariffService.toViewDto(plan);
+
+        assertTrue(dto.isRecommended());
     }
   
 }


### PR DESCRIPTION
## Summary
- mark Business tariff as recommended
- show a special badge in pricing page
- style the badge
- cover the recommended flag in tests

## Testing
- `npm run build:css` *(fails: sass not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699d883bb8832daa0a3e313f3781cf