### PR TITLE
Add notification type heading and note

### DIFF
--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -481,6 +481,8 @@
                     </div>
                 </div>
 
+                <h6 class="mt-3">Тип уведомлений</h6>
+                <p class="form-text ms-3">Выберите, какие уведомления отправлять: системные или собственные.</p>
 
                 <div class="btn-group mb-2 ms-3 template-toggle-group" role="group">
                     <input type="radio" class="btn-check" name="useCustomTemplates"


### PR DESCRIPTION
## Summary
- show a subheading for notification type selection
- add explanation text about system vs custom notifications

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6869a2fe4cf8832db3741bd0abdb1058