### PR TITLE
Mask password reset token

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.repository.PasswordResetTokenRepository;
 import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.service.email.EmailService;
 import com.project.tracking_system.utils.EmailUtils;
+import com.project.tracking_system.utils.TokenUtils;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -98,7 +99,7 @@ public class PasswordResetService {
      * Сбрасывает пароль пользователя с использованием токена для восстановления.
      * <p>
      * Этот метод проверяет действительность токена, находит пользователя и обновляет его пароль, после чего
-     * удаляет токен из базы данных.
+     * удаляет токен из базы данных. Полный токен в логах не выводится, чтобы предотвратить его утечку.
      * </p>
      *
      * @param token токен для сброса пароля
@@ -107,7 +108,8 @@ public class PasswordResetService {
      */
     @Transactional
     public void resetPassword(String token, String newPassword) {
-        log.info("Начало сброса пароля по токену {}", token);
+        // Логируем только первые символы токена из соображений безопасности
+        log.info("Начало сброса пароля по токену {}", TokenUtils.maskToken(token));
         if (!isTokenValid(token)) {
             throw new IllegalArgumentException("Срок действия токена истек");
         }

--- a/src/main/java/com/project/tracking_system/utils/TokenUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/TokenUtils.java
@@ -1,0 +1,26 @@
+package com.project.tracking_system.utils;
+
+/**
+ * Утилиты для работы с токенами.
+ */
+public final class TokenUtils {
+
+    private TokenUtils() {
+    }
+
+    /**
+     * Маскирует токен, оставляя первые четыре символа.
+     *
+     * @param token исходный токен
+     * @return маскированный токен или исходная строка, если она короче четырех символов
+     */
+    public static String maskToken(String token) {
+        if (token == null) {
+            return null;
+        }
+        if (token.length() <= 4) {
+            return token;
+        }
+        return token.substring(0, 4) + "***";
+    }
+}


### PR DESCRIPTION
## Summary
- mask token value in `PasswordResetService.resetPassword`
- document token masking in JavaDoc
- add `TokenUtils` helper for masking tokens

## Testing
- `./mvnw -q test` *(fails: cannot open .mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_686adbb72058832dadd0cb97b6caa06c