### PR TITLE
Mask emails in log messages

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.service.admin.SubscriptionPlanService;
 import com.project.tracking_system.service.tariff.TariffService;
 import com.project.tracking_system.service.DynamicSchedulerService;
 import com.project.tracking_system.exception.UserAlreadyExistsException;
+import com.project.tracking_system.utils.EmailUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -161,7 +162,8 @@ public class AdminController {
             return "redirect:/admin/users";
         } catch (UserAlreadyExistsException e) {
             // Пользователь с таким email уже существует
-            log.warn("Не удалось создать пользователя: {} уже существует", email);
+            log.warn("Не удалось создать пользователя: {} уже существует",
+                    EmailUtils.maskEmail(email));
             model.addAttribute("errorMessage", e.getMessage());
         } catch (IllegalArgumentException e) {
             // Переданы некорректные параметры

--- a/src/main/java/com/project/tracking_system/service/SubscriptionService.java
+++ b/src/main/java/com/project/tracking_system/service/SubscriptionService.java
@@ -10,6 +10,7 @@ import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import com.project.tracking_system.repository.UserRepository;
 import org.springframework.transaction.annotation.Transactional;
+import com.project.tracking_system.utils.EmailUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -262,7 +263,8 @@ public class SubscriptionService {
                 .ifPresentOrElse(
                         id -> upgradeOrExtendSubscription(id, 1),
                         () -> {
-                            log.warn("Пользователь с email {} не найден", email);
+                            log.warn("Пользователь с email {} не найден",
+                                    EmailUtils.maskEmail(email));
                             throw new IllegalArgumentException("Пользователь не найден");
                         }
                 );

--- a/src/main/java/com/project/tracking_system/utils/UserCredentialsResolver.java
+++ b/src/main/java/com/project/tracking_system/utils/UserCredentialsResolver.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.dto.ResolvedCredentialsDTO;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.model.evropost.jsonRequestModel.JsonPacket;
 import com.project.tracking_system.service.jsonEvropostService.JwtTokenManager;
+import com.project.tracking_system.utils.EmailUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -21,33 +22,47 @@ public class UserCredentialsResolver {
     private final EncryptionUtils encryptionUtils;
     private final JsonPacket jsonPacket;
 
+    /**
+     * Определяет подходящие учётные данные для обращения к API Evropost.
+     *
+     * @param user пользователь, для которого выбираются данные
+     * @return разрешённые учётные данные
+     */
     public ResolvedCredentialsDTO resolveCredentials(User user) {
-        log.info("Начинается проверка использования данных для api evropost для пользователя: {}", user.getEmail());
+        log.info("Начинается проверка использования данных для api evropost для пользователя: {}",
+                EmailUtils.maskEmail(user.getEmail()));
 
         if (canUseCustomCredentials(user)) {
             try {
                 // Если можно использовать пользовательские данные
-                log.debug("Пользовательские данные для {} могут быть использованы.", user.getEmail());
+                log.debug("Пользовательские данные для {} могут быть использованы.", EmailUtils.maskEmail(user.getEmail()));
                 String jwt = jwtTokenManager.getUserToken(user);
                 String serviceNumber = encryptionUtils.decrypt(user.getEvropostServiceCredential().getServiceNumber());
-                log.debug("Успешно получены пользовательские данные для {}: JWT и ServiceNumber.", user.getEmail());
+                log.debug("Успешно получены пользовательские данные для {}: JWT и ServiceNumber.", EmailUtils.maskEmail(user.getEmail()));
                 return new ResolvedCredentialsDTO(jwt, serviceNumber);
             } catch (Exception e) {
                 // Если произошла ошибка, переключаемся на системные данные
-                log.error("Ошибка при использовании пользовательских данных для пользователя {}. Переключаемся на системные данные.", user.getEmail(), e);            }
+                log.error("Ошибка при использовании пользовательских данных для пользователя {}. Переключаемся на системные данные.", EmailUtils.maskEmail(user.getEmail()), e);
+            }
         }
 
         // Если пользовательские данные нельзя использовать, возвращаем системные данные
-        log.info("Используем системные данные для пользователя {}", user.getEmail());
+        log.info("Используем системные данные для пользователя {}", EmailUtils.maskEmail(user.getEmail()));
         return new ResolvedCredentialsDTO(jwtTokenManager.getSystemToken(), jsonPacket.getServiceNumber());
 
     }
 
+    /**
+     * Проверяет наличие и корректность пользовательских данных для API.
+     *
+     * @param user пользователь, чьи данные проверяются
+     * @return {@code true}, если можно использовать собственные учётные данные
+     */
     private boolean canUseCustomCredentials(User user) {
-        log.debug("Проверяем возможность использования пользовательских данных для пользователя: {}", user.getEmail());
+        log.debug("Проверяем возможность использования пользовательских данных для пользователя: {}", EmailUtils.maskEmail(user.getEmail()));
 
         if (!Boolean.TRUE.equals(user.getEvropostServiceCredential().getUseCustomCredentials())) {
-            log.debug("Пользователь {} не настроил использование пользовательских данных.", user.getEmail());
+            log.debug("Пользователь {} не настроил использование пользовательских данных.", EmailUtils.maskEmail(user.getEmail()));
             return false;
         }
 
@@ -55,10 +70,10 @@ public class UserCredentialsResolver {
             boolean result = user.getEvropostServiceCredential().getUsername() != null && !user.getEvropostServiceCredential().getUsername().isBlank()
                     && user.getEvropostServiceCredential().getPassword() != null && !encryptionUtils.decrypt(user.getEvropostServiceCredential().getPassword()).isBlank()
                     && user.getEvropostServiceCredential().getServiceNumber() != null && !encryptionUtils.decrypt(user.getEvropostServiceCredential().getServiceNumber()).isBlank();
-            log.debug("Результат проверки пользовательских данных для {}: {}", user.getEmail(), result);
+            log.debug("Результат проверки пользовательских данных для {}: {}", EmailUtils.maskEmail(user.getEmail()), result);
             return result;
         } catch (Exception e) {
-            log.error("Ошибка при проверке пользовательских данных для пользователя: {}", user.getEmail(), e);
+            log.error("Ошибка при проверке пользовательских данных для пользователя: {}", EmailUtils.maskEmail(user.getEmail()), e);
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- mask user emails in logging statements
- document credential resolution and JWT refresh helpers

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adbb0d088832d842b9b9df85da904