### PR TITLE
Add form-action origins to CSP

### DIFF
--- a/src/main/java/com/project/tracking_system/utils/CspNonceFilter.java
+++ b/src/main/java/com/project/tracking_system/utils/CspNonceFilter.java
@@ -27,12 +27,20 @@ public class CspNonceFilter extends OncePerRequestFilter {
     private final String[] allowedConnectOrigins;
 
     /**
-     * Создаёт фильтр с разрешёнными источниками connect-src.
-     *
-     * @param allowedConnectOrigins список разрешённых адресов
+     * Разрешённые адреса для директивы form-action.
      */
-    public CspNonceFilter(@Value("${csp.allowed-connect-origins}") String[] allowedConnectOrigins) {
+    private final String[] allowedFormActionOrigins;
+
+    /**
+     * Создаёт фильтр с разрешёнными источниками connect-src и form-action.
+     *
+     * @param allowedConnectOrigins     список разрешённых адресов для connect-src
+     * @param allowedFormActionOrigins  список разрешённых адресов для form-action
+     */
+    public CspNonceFilter(@Value("${csp.allowed-connect-origins}") String[] allowedConnectOrigins,
+                          @Value("${csp.allowed-form-action-origins:}") String[] allowedFormActionOrigins) {
         this.allowedConnectOrigins = allowedConnectOrigins;
+        this.allowedFormActionOrigins = allowedFormActionOrigins;
     }
 
     @Override
@@ -50,6 +58,7 @@ public class CspNonceFilter extends OncePerRequestFilter {
 
         // Формируем заголовок CSP
         String connectSrc = String.join(" ", allowedConnectOrigins);
+        String formAction = String.join(" ", allowedFormActionOrigins);
 
         String cspPolicy = "default-src 'self'; " +
                 "script-src 'self' 'nonce-" + nonce + "' https://code.jquery.com https://cdn.jsdelivr.net; " +
@@ -62,7 +71,7 @@ public class CspNonceFilter extends OncePerRequestFilter {
                 "object-src 'none'; " +
                 "frame-ancestors 'none'; " +
                 "base-uri 'self'; " +
-                "form-action 'self';";
+                "form-action 'self'" + (formAction.isBlank() ? "" : " " + formAction) + ";";
 
         // Устанавливаем заголовки безопасности
         response.setHeader("Content-Security-Policy", cspPolicy);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,7 @@ application.version=0.0.1-SNAPSHOT
 telegram.webhook.enabled=false
 websocket.allowed-origins=*
 csp.allowed-connect-origins=wss://belivery.by,ws://localhost:8080
+csp.allowed-form-action-origins=https://belivery.by
 
 security.remember-me-key=REMEMBER_ME_KEY
 


### PR DESCRIPTION
## Summary
- configure allowed form-action origins in `application.properties`
- inject allowed form-action origins into `CspNonceFilter`
- include new origins in CSP header generation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adcb42e48832db9533e999a1325ee