### PR TITLE
fix: handle missing XSRF token cookie

### DIFF
--- a/src/main/java/com/project/tracking_system/utils/CspNonceFilter.java
+++ b/src/main/java/com/project/tracking_system/utils/CspNonceFilter.java
@@ -106,6 +106,12 @@ public class CspNonceFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * Извлекает значение куки {@code XSRF-TOKEN} из запроса.
+     *
+     * @param request HTTP-запрос
+     * @return значение токена или {@code null}, если кука отсутствует
+     */
     private String getTokenFromRequest(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
@@ -115,7 +121,7 @@ public class CspNonceFilter extends OncePerRequestFilter {
                 }
             }
         }
-        return "";
+        return null;
     }
 
     private String getCookieValue(HttpServletRequest request, String cookieName) {


### PR DESCRIPTION
## Summary
- return `null` from `getTokenFromRequest` when XSRF cookie is missing
- document method behaviour in Russian
- rely on `null` check to avoid setting cookie when absent

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae9e195c4832db642e37115445d11