### PR TITLE
Add store ID visibility in profile

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -844,6 +844,7 @@ async function loadStores() {
     stores.forEach(store => {
         const row = document.createElement("tr");
         row.innerHTML = `
+            <td>${store.id}</td>
             <td class="d-flex align-items-center">
                 <input type="radio" name="defaultStore"
                        class="default-store-radio me-2"
@@ -1021,6 +1022,7 @@ function addNewStore() {
 
     const row = document.createElement("tr");
     row.innerHTML = `
+        <td>—</td>
         <td>
             <input type="text" class="form-control store-name-input" id="store-name-${tempId}" placeholder="Введите название">
         </td>

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -129,6 +129,14 @@
             <div class="col-sm-4 text-muted">Часовой пояс</div>
             <div class="col-sm-8" th:text="${userProfile.timezone}"></div>
         </div>
+        <div class="row mb-2">
+            <div class="col-sm-4 text-muted">Мои магазины</div>
+            <div class="col-sm-8">
+                <ul class="list-unstyled mb-0">
+                    <li th:each="store : ${stores}" th:text="${store.name + ' (ID: ' + store.id + ')'}"></li>
+                </ul>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -147,6 +155,7 @@
                             <table class="table">
                                 <thead>
                                 <tr>
+                                    <th>ID</th>
                                     <th>Название магазина</th>
                                     <th>Действия</th>
                                 </tr>


### PR DESCRIPTION
## Summary
- show store IDs on profile page
- display store IDs in My Stores table
- include IDs when adding new stores

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762296bdb0832d87bd8bd2d27fd0e0