### PR TITLE
Add Telegram bot link setting and clipboard button

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,6 @@ security.remember-me-key=${REMEMBER_ME_KEY}
 app.default-timezone=Europe/Minsk
 
 server.forward-headers-strategy=framework
+
+# Ссылка на Telegram-бота для уведомлений
+telegram.bot.link=https://t.me/Belivery_bot

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -41,6 +41,16 @@ function hideLoading() {
 }
 
 /**
+ * Копирует текст в буфер обмена и показывает уведомление о результате.
+ * @param {string} text - копируемый текст
+ */
+function copyToClipboard(text) {
+    navigator.clipboard.writeText(text)
+        .then(() => notifyUser('Ссылка скопирована в буфер обмена', 'success'))
+        .catch(() => notifyUser('Не удалось скопировать ссылку', 'danger'));
+}
+
+/**
  * Устанавливает активную вкладку профиля во всех меню.
  * @param {string} href - Идентификатор вкладки (href вида '#v-pills-home').
  */

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -210,10 +210,17 @@
             <p class="form-text text-danger" th:if="${!planDetails.allowTelegramNotifications}">
                 Функция доступна в тарифе "Команда" и выше
             </p>
-            <p class="text-muted mb-3">
+            <p class="form-text text-muted mb-3">
                 Настройки уведомлений для покупателей в Telegram. Если включено, покупатели будут
                 получать автоматические уведомления о статусах посылок (например, «отправлена», «прибыла
-                в пункт выдачи» и др.).
+                в пункт выдачи» и др.). Попросите покупателей запустить
+                <a th:href='@{${@environment.getProperty("telegram.bot.link")}}' target="_blank">бота Belivery</a>
+                <button type="button" class="btn btn-sm btn-outline-secondary ms-1"
+                        title="Скопировать ссылку"
+                        onclick="copyToClipboard([[${@environment.getProperty('telegram.bot.link')}]]);">
+                    <i class="bi bi-clipboard"></i>
+                </button>
+                и поделиться номером, чтобы получать уведомления.
             </p>
             <th:block th:each="store, iter : ${stores}">
                 <div th:replace="~{app/profile :: telegramStoreBlock(store=${store}, first=${iter.first})}"></div>


### PR DESCRIPTION
## Summary
- add `telegram.bot.link` application property
- show Telegram bot link in profile and allow copying
- implement small JS utility for clipboard and notification

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778efabcf8832da330cfa4c1799ab2