### PR TITLE
Fix duplicated Telegram link

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,7 @@ spring.web.resources.static-locations=classpath:/static/
 application.version=0.0.1-SNAPSHOT
 
 telegram.webhook.enabled=false
-# Ссылка на бота в Telegram, используется для выдачи инструкции клиентам
+# Ссылка на бота в Telegram, используется для выдачи инструкции клиентам и отправки уведомлений
 telegram.bot.link=https://t.me/Belivery_bot
 websocket.allowed-origins=*
 csp.allowed-connect-origins=wss://belivery.by,ws://localhost:8080
@@ -44,6 +44,3 @@ security.remember-me-key=${REMEMBER_ME_KEY}
 app.default-timezone=Europe/Minsk
 
 server.forward-headers-strategy=framework
-
-# Ссылка на Telegram-бота для уведомлений
-telegram.bot.link=https://t.me/Belivery_bot


### PR DESCRIPTION
## Summary
- remove duplicate Telegram link in `application.properties`
- clarify that the link is used for instructions and notifications

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68779116d388832d82deebada9c42593