### PR TITLE
Add Telegram buyer stats

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/CustomerStatisticsDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/CustomerStatisticsDTO.java
@@ -1,0 +1,64 @@
+package com.project.tracking_system.dto;
+
+import com.project.tracking_system.entity.BuyerReputation;
+import java.util.List;
+
+/**
+ * Краткая статистика о покупателе.
+ * <p>
+ * Используется при запросе статистики через Telegram.
+ * </p>
+ */
+public class CustomerStatisticsDTO {
+
+    private final int pickedUpCount;
+    private final int returnedCount;
+    private final List<String> storeNames;
+    private final BuyerReputation reputation;
+
+    /**
+     * Создать неизменяемый объект статистики покупателя.
+     *
+     * @param pickedUpCount  количество забранных посылок
+     * @param returnedCount  количество не забранных и возвращённых посылок
+     * @param storeNames     список магазинов, в которых покупатель делал заказы
+     * @param reputation     текущая репутация покупателя
+     */
+    public CustomerStatisticsDTO(int pickedUpCount,
+                                 int returnedCount,
+                                 List<String> storeNames,
+                                 BuyerReputation reputation) {
+        this.pickedUpCount = pickedUpCount;
+        this.returnedCount = returnedCount;
+        this.storeNames = storeNames;
+        this.reputation = reputation;
+    }
+
+    /**
+     * @return сколько посылок покупатель забрал
+     */
+    public int getPickedUpCount() {
+        return pickedUpCount;
+    }
+
+    /**
+     * @return сколько посылок было возвращено
+     */
+    public int getReturnedCount() {
+        return returnedCount;
+    }
+
+    /**
+     * @return список магазинов, где покупатель делал заказы
+     */
+    public List<String> getStoreNames() {
+        return storeNames;
+    }
+
+    /**
+     * @return текущая репутация покупателя
+     */
+    public BuyerReputation getReputation() {
+        return reputation;
+    }
+}

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -132,4 +132,13 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     @Query("UPDATE TrackParcel t SET t.customer = null WHERE t.customer.id = :customerId")
     void clearCustomer(@Param("customerId") Long customerId);
 
+    /**
+     * Получить уникальные названия магазинов для покупателя.
+     *
+     * @param customerId идентификатор покупателя
+     * @return список названий магазинов
+     */
+    @Query("SELECT DISTINCT t.store.name FROM TrackParcel t WHERE t.customer.id = :customerId")
+    List<String> findDistinctStoreNamesByCustomerId(@Param("customerId") Long customerId);
+
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -11,6 +11,8 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.project.tracking_system.dto.CustomerStatisticsDTO;
+
 import com.project.tracking_system.utils.PhoneUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -188,6 +190,30 @@ public class CustomerTelegramService {
                     return true;
                 })
                 .orElse(false);
+    }
+
+    /**
+     * Получить статистику покупателя по идентификатору Telegram-чата.
+     * <p>
+     * Возвращает количество забранных и возвращённых посылок,
+     * список магазинов, где покупатель делал заказы, и его репутацию.
+     * </p>
+     *
+     * @param chatId идентификатор чата Telegram
+     * @return опциональная статистика покупателя
+     */
+    @Transactional(readOnly = true)
+    public Optional<CustomerStatisticsDTO> getStatistics(Long chatId) {
+        return customerRepository.findByTelegramChatId(chatId)
+                .map(customer -> {
+                    List<String> stores = trackParcelRepository.findDistinctStoreNamesByCustomerId(customer.getId());
+                    return new CustomerStatisticsDTO(
+                            customer.getPickedUpCount(),
+                            customer.getReturnedCount(),
+                            stores,
+                            customer.getReputation()
+                    );
+                });
     }
 
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -110,6 +110,31 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                         sendNotificationsKeyboard(message.getChatId(), true);
                     }
                 }
+                // Покупатель запросил статистику о своих посылках
+                if ("/stats".equals(text) || "📊 Моя статистика".equals(text)) {
+                    telegramService.getStatistics(message.getChatId())
+                            .ifPresent(stats -> {
+                                String stores = stats.getStoreNames().isEmpty()
+                                        ? "-" : String.join(", ", stats.getStoreNames());
+                                String reply = String.format(
+                                        "\uD83D\uDCCA Ваша статистика:\n" +
+                                                "Забрано: %d\n" +
+                                                "Не забрано: %d\n" +
+                                                "Магазины: %s\n" +
+                                                "Репутация: %s",
+                                        stats.getPickedUpCount(),
+                                        stats.getReturnedCount(),
+                                        stores,
+                                        stats.getReputation().getDisplayName()
+                                );
+                                SendMessage msg = new SendMessage(message.getChatId().toString(), reply);
+                                try {
+                                    telegramClient.execute(msg);
+                                } catch (TelegramApiException e) {
+                                    log.error("❌ Ошибка отправки статистики", e);
+                                }
+                            });
+                }
             }
 
             if (message.hasContact()) {
@@ -118,6 +143,11 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
     }
 
+    /**
+     * Попросить покупателя отправить номер телефона для привязки Telegram.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
     private void sendSharePhoneKeyboard(Long chatId) {
         KeyboardButton button = new KeyboardButton("📱 Поделиться номером");
         button.setRequestContact(true);
@@ -136,13 +166,21 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
     }
 
+    /**
+     * Отправить клавиатуру для управления уведомлениями и просмотра статистики.
+     *
+     * @param chatId  идентификатор чата Telegram
+     * @param enabled включены ли уведомления в данный момент
+     */
     private void sendNotificationsKeyboard(Long chatId, boolean enabled) {
         String buttonText = enabled ? "🔕 Отключить уведомления"
                 : "🔔 Включить уведомления";
 
-        KeyboardButton button = new KeyboardButton(buttonText);
-        KeyboardRow row = new KeyboardRow(List.of(button));
-        ReplyKeyboardMarkup markup = new ReplyKeyboardMarkup(List.of(row));
+        KeyboardButton notifyButton = new KeyboardButton(buttonText);
+        KeyboardButton statsButton = new KeyboardButton("📊 Моя статистика");
+        KeyboardRow firstRow = new KeyboardRow(List.of(notifyButton));
+        KeyboardRow secondRow = new KeyboardRow(List.of(statsButton));
+        ReplyKeyboardMarkup markup = new ReplyKeyboardMarkup(List.of(firstRow, secondRow));
         markup.setResizeKeyboard(true);
         markup.setOneTimeKeyboard(true);
 
@@ -156,6 +194,13 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
     }
 
+    /**
+     * Обработать контакт с номером телефона от пользователя.
+     * Привязывает номер к покупателю и отправляет подтверждение.
+     *
+     * @param chatId  идентификатор чата Telegram
+     * @param contact объект контакта с номером телефона
+     */
     private void handleContact(Long chatId, Contact contact) {
         String rawPhone = contact.getPhoneNumber();
         String phone = PhoneUtils.normalizePhone(rawPhone);


### PR DESCRIPTION
## Summary
- add `CustomerStatisticsDTO`
- query store names for buyer
- fetch buyer statistics in `CustomerTelegramService`
- show statistics via Telegram bot with new command/button
- перевести комментарии на русский

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_6877c3a51a08832d8826e8619713f8b8