### PR TITLE
Implement hashed password reset tokens

### DIFF
--- a/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
+++ b/src/main/java/com/project/tracking_system/service/user/PasswordResetService.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.service.email.EmailService;
 import com.project.tracking_system.utils.EmailUtils;
 import com.project.tracking_system.utils.TokenUtils;
+import com.project.tracking_system.utils.HashUtils;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,8 +45,8 @@ public class PasswordResetService {
     /**
      * Создаёт токен для восстановления пароля и отправляет ссылку на email пользователя.
      * <p>
-     * Этот метод генерирует уникальный токен для сброса пароля, сохраняет его в базе данных, устанавливает время
-     * его истечения через 1 час и отправляет пользователю ссылку для восстановления пароля на его email.
+     * Этот метод генерирует уникальный токен для сброса пароля, сохраняет в базе данных его хеш,
+     * устанавливает время истечения через 1 час и отправляет пользователю ссылку для восстановления пароля.
      * </p>
      *
      * @param email адрес электронной почты пользователя, для которого нужно восстановить пароль
@@ -63,12 +64,13 @@ public class PasswordResetService {
         log.info("✅ Пользователь {} найден. Генерируем токен...", EmailUtils.maskEmail(user.getEmail()));
 
         String token = randomStringGenerator.generateConfirmationCode();
+        String hashedToken = HashUtils.sha256(token);
         String resetLink = LINK + token;
 
         // Не выводим значение токена в лог по соображениям безопасности
         log.debug("🔑 Сгенерирован токен для email {}", EmailUtils.maskEmail(email));
 
-        saveOrUpdatePasswordResetToken(email, token);
+        saveOrUpdatePasswordResetToken(email, hashedToken);
 
         log.info("📧 Отправка email для сброса пароля пользователю {}", EmailUtils.maskEmail(email));
         emailService.sendPasswordResetEmail(email, resetLink);
@@ -76,20 +78,23 @@ public class PasswordResetService {
     }
 
     /**
-     * Обновляет токен для сброса пароля, если он уже есть, или создает новый.
+     * Сохраняет или обновляет хеш токена для сброса пароля.
+     * <p>
+     * В базе данных хранится только хеш токена, чтобы исключить его утечку.
+     * </p>
      */
-    private void saveOrUpdatePasswordResetToken(String email, String token) {
+    private void saveOrUpdatePasswordResetToken(String email, String hashedToken) {
         tokenRepository.findByEmail(email)
                 .ifPresentOrElse(
                         existingToken -> {
                             log.info("♻️ Обновление существующего токена для email {}", EmailUtils.maskEmail(email));
-                            existingToken.setToken(token);
+                            existingToken.setToken(hashedToken);
                             existingToken.setExpirationDate(ZonedDateTime.now(ZoneOffset.UTC).plusHours(1));
                             tokenRepository.save(existingToken);
                         },
                         () -> {
                             log.info("🆕 Создание нового токена для email {}", EmailUtils.maskEmail(email));
-                            PasswordResetToken newToken = new PasswordResetToken(email, token);
+                            PasswordResetToken newToken = new PasswordResetToken(email, hashedToken);
                             tokenRepository.save(newToken);
                         }
                 );
@@ -114,7 +119,8 @@ public class PasswordResetService {
             throw new IllegalArgumentException("Срок действия токена истек");
         }
 
-        PasswordResetToken resetToken = tokenRepository.findByToken(token)
+        String hashedToken = HashUtils.sha256(token);
+        PasswordResetToken resetToken = tokenRepository.findByToken(hashedToken)
                 .orElseThrow(() -> new IllegalArgumentException("Недействительный токен"));
 
         String email = resetToken.getEmail();
@@ -124,7 +130,7 @@ public class PasswordResetService {
 
         user.setPassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);
-        tokenRepository.deleteByToken(token);
+        tokenRepository.deleteByToken(hashedToken);
 
         log.info("Пароль для пользователя {} успешно сброшен", EmailUtils.maskEmail(email));
     }
@@ -132,14 +138,15 @@ public class PasswordResetService {
     /**
      * Проверяет, действителен ли токен для сброса пароля.
      * <p>
-     * Этот метод проверяет, существует ли токен в базе данных и не истёк ли его срок действия.
+     * Этот метод проверяет, существует ли хеш токена в базе данных и не истёк ли его срок действия.
      * </p>
      *
      * @param token токен для сброса пароля
      * @return {@code true}, если токен действителен, иначе {@code false}
      */
     public boolean isTokenValid(String token) {
-        Optional<PasswordResetToken> resetToken = tokenRepository.findByToken(token);
+        String hashedToken = HashUtils.sha256(token);
+        Optional<PasswordResetToken> resetToken = tokenRepository.findByToken(hashedToken);
         if (resetToken.isPresent()) {
             PasswordResetToken tokenEntity = resetToken.get();
 
@@ -153,3 +160,4 @@ public class PasswordResetService {
         return false;
     }
 }
+

--- a/src/main/java/com/project/tracking_system/utils/HashUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/HashUtils.java
@@ -1,0 +1,34 @@
+package com.project.tracking_system.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Утилиты для хеширования строк.
+ */
+public final class HashUtils {
+
+    private HashUtils() {
+    }
+
+    /**
+     * Вычисляет SHA-256 хеш для переданной строки.
+     *
+     * @param value исходное значение
+     * @return шестнадцатеричное представление хеша
+     */
+    public static String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/user/PasswordResetServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/user/PasswordResetServiceTest.java
@@ -1,0 +1,72 @@
+package com.project.tracking_system.service.user;
+
+import com.project.tracking_system.entity.PasswordResetToken;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.PasswordResetTokenRepository;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.service.email.EmailService;
+import com.project.tracking_system.utils.HashUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link PasswordResetService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock
+    private PasswordResetTokenRepository tokenRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private RandomlyGeneratedString randomStringGenerator;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private PasswordResetService service;
+
+    @Test
+    void createPasswordResetToken_SavesHashedToken() {
+        String email = "user@example.com";
+        User user = new User();
+        user.setEmail(email);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(randomStringGenerator.generateConfirmationCode()).thenReturn("rawtok");
+        when(tokenRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        service.createPasswordResetToken(email);
+
+        verify(tokenRepository).save(argThat(t ->
+                HashUtils.sha256("rawtok").equals(t.getToken()) && email.equals(t.getEmail())
+        ));
+        verify(emailService).sendPasswordResetEmail(eq(email), contains("rawtok"));
+    }
+
+    @Test
+    void isTokenValid_ValidToken_ReturnsTrue() {
+        String token = "tok123";
+        String hashed = HashUtils.sha256(token);
+        PasswordResetToken resetToken = new PasswordResetToken("a@b.com", hashed);
+        resetToken.setExpirationDate(ZonedDateTime.now(ZoneOffset.UTC).plusMinutes(10));
+        when(tokenRepository.findByToken(hashed)).thenReturn(Optional.of(resetToken));
+
+        assertTrue(service.isTokenValid(token));
+    }
+}
+


### PR DESCRIPTION
## Summary
- hash password reset tokens using SHA-256
- only store hashed tokens in the database
- validate and delete tokens by hash
- add utility for hashing
- cover hashing logic with unit tests

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d27d03f0832da9af703254d0f56f