### PR TITLE
Fix empty store analytics block

### DIFF
--- a/src/main/resources/templates/app/analytics/dashboard.html
+++ b/src/main/resources/templates/app/analytics/dashboard.html
@@ -78,9 +78,12 @@
                     </div>
                     </div>
 
-                    <div class="card p-3 shadow-sm rounded-4 mb-4">
                     <!-- Детальная аналитика по магазинам -->
-                    <div class="mt-4" th:if="${selectedStoreId == null}">
+                    <div class="card p-3 shadow-sm rounded-4 mb-4" th:if="${selectedStoreId == null}">
+                    <!-- Этот блок выводит статистику по каждому магазину.
+                         Он скрывается, когда выбран конкретный магазин, 
+                         чтобы не показывать пустую карту. -->
+                    <div class="mt-4">
                         <h5>Детально по магазинам</h5>
                         <div th:each="stat : ${statistics}" class="mb-5"
                              th:if="${selectedStoreId == null or stat.store.id == selectedStoreId}">


### PR DESCRIPTION
## Summary
- hide empty store analytics card when a single store is selected
- document why the card is hidden

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878061d11c4832dbebf6a879f5fb0e6