### PR TITLE
Configure ChromeDriver path

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -10,6 +10,7 @@ import com.project.tracking_system.webdriver.ChromeWebDriverFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * Конфигурационный класс для приложения.
@@ -24,6 +25,15 @@ import org.springframework.web.client.RestTemplate;
 @ComponentScan(basePackages = "com.project.tracking_system")
 @Configuration
 public class AppConfiguration {
+
+    /**
+     * Путь к исполняемому файлу chromedriver.
+     * <p>
+     * Инжектируется из конфигурации приложения и передаётся в фабрику драйверов.
+     * </p>
+     */
+    @Value("${webdriver.chrome.driver}")
+    private String chromeDriverPath;
 
     /**
      * Создает бин {@link RestTemplate} для выполнения HTTP-запросов.
@@ -79,12 +89,16 @@ public class AppConfiguration {
 
     /**
      * Предоставляет фабрику {@link WebDriverFactory} для создания драйверов.
+     * <p>
+     * Путь к исполняемому файлу драйвера передаётся в конструктор, что позволяет
+     * избежать проблем с правами доступа при запуске браузера.
+     * </p>
      *
      * @return реализация фабрики для браузера Chrome
      */
     @Bean
     public WebDriverFactory webDriverFactory() {
-        return new ChromeWebDriverFactory();
+        return new ChromeWebDriverFactory(chromeDriverPath);
     }
 
 }

--- a/src/main/java/com/project/tracking_system/webdriver/ChromeWebDriverFactory.java
+++ b/src/main/java/com/project/tracking_system/webdriver/ChromeWebDriverFactory.java
@@ -9,13 +9,34 @@ import org.openqa.selenium.chrome.ChromeOptions;
  */
 public class ChromeWebDriverFactory implements WebDriverFactory {
 
+    /** Путь к исполняемому файлу chromedriver. */
+    private final String driverPath;
+
+    /**
+     * Создаёт фабрику с указанным путём к драйверу.
+     *
+     * @param driverPath путь к исполняемому файлу chromedriver. Передача
+     *                   значения через конструктор позволяет конфигурировать
+     *                   запуск и избегать проблем с правами доступа.
+     */
+    public ChromeWebDriverFactory(String driverPath) {
+        this.driverPath = driverPath;
+    }
+
     /**
      * Создаёт {@link ChromeDriver} с набором стандартных опций.
+     * <p>
+     * Перед созданием драйвера устанавливается системное свойство
+     * {@code webdriver.chrome.driver}, что позволяет избежать проблем с
+     * доступом к бинарному файлу ChromeDriver.
+     * </p>
      *
      * @return сконфигурированный экземпляр ChromeDriver
      */
     @Override
     public WebDriver create() {
+        System.setProperty("webdriver.chrome.driver", driverPath);
+
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless=new");
         options.addArguments("--disable-gpu");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,4 @@ security.remember-me-key=${REMEMBER_ME_KEY}
 app.default-timezone=Europe/Minsk
 
 server.forward-headers-strategy=framework
+webdriver.chrome.driver=/usr/local/bin/chromedriver


### PR DESCRIPTION
## Summary
- inject ChromeDriver path from application properties
- forward property to `ChromeWebDriverFactory`
- set system property before creating driver
- document new behaviour
- add `webdriver.chrome.driver` property to `application.properties`

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687953a8c344832d9b55f1987422ffed