### PR TITLE
Update documentation for chromedriver path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Belpost and Evropost
 
 Скомпилированный `style.css` располагается в `src/main/resources/static/css` и подключается приложением при запуске.
 
+## Конфигурация ChromeDriver
+
+Для запуска веб-драйвера в файле `application.properties` используется свойство
+`webdriver.chrome.driver`, которое определяет путь к исполняемому файлу
+ChromeDriver. В контейнере по умолчанию применяется путь
+`/usr/local/bin/chromedriver`, задаваемый в `Dockerfile`. При локальном запуске
+приложения значение можно изменить, передав параметр JVM:
+
+```bash
+java -jar app.jar --webdriver.chrome.driver=/path/to/chromedriver
+```
+
 ## Автообновление треков
 
 Функция автообновления использует лимит `maxTrackUpdates` тарифного плана. Количество обновлений в сутки не может превышать этот показатель.


### PR DESCRIPTION
## Summary
- explain how to configure the `webdriver.chrome.driver` property
- mention default chromedriver path from Dockerfile

## Testing
- `apt-get update` *(fails: repository signatures cannot be verified)*
- `mvn test` *(fails: command not found)*
- `./mvnw test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687954a400fc832da41e38f46f194d8a