### PR TITLE
Expose application version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ java -jar app.jar --webdriver.chrome.driver=/path/to/chromedriver
 ## Автообновление треков
 
 Функция автообновления использует лимит `maxTrackUpdates` тарифного плана. Количество обновлений в сутки не может превышать этот показатель.
+
+## Версия приложения
+
+Актуальная версия задаётся в `application.properties` свойством `application.version`.
+Получить её можно через REST-эндпоинт `/app/version`, который возвращает JSON
+следующего вида:
+
+```json
+{ "version": "0.0.1-SNAPSHOT" }
+```

--- a/src/main/java/com/project/tracking_system/configuration/GlobalControllerAdvice.java
+++ b/src/main/java/com/project/tracking_system/configuration/GlobalControllerAdvice.java
@@ -1,5 +1,7 @@
 package com.project.tracking_system.configuration;
 
+import com.project.tracking_system.service.admin.AppInfoService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
  * @date 07.01.2025
  */
 @ControllerAdvice
+@RequiredArgsConstructor
 public class GlobalControllerAdvice {
 
     /**
@@ -29,6 +32,11 @@ public class GlobalControllerAdvice {
      */
     @Value("${telegram.bot.link}")
     private String telegramBotLink;
+
+    /**
+     * Сервис системной информации приложения.
+     */
+    private final AppInfoService appInfoService;
 
     /**
      * Добавляет имя аутентифицированного пользователя в модель.
@@ -61,5 +69,15 @@ public class GlobalControllerAdvice {
     @ModelAttribute("telegramBotLink")
     public String getTelegramBotLink() {
         return telegramBotLink;
+    }
+
+    /**
+     * Добавляет в модель текущую версию приложения.
+     *
+     * @return версия приложения
+     */
+    @ModelAttribute("appVersion")
+    public String getApplicationVersion() {
+        return appInfoService.getApplicationVersion();
     }
 }

--- a/src/main/java/com/project/tracking_system/controller/AppVersionController.java
+++ b/src/main/java/com/project/tracking_system/controller/AppVersionController.java
@@ -1,0 +1,30 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.AppVersionDTO;
+import com.project.tracking_system.service.admin.AppInfoService;
+import com.project.tracking_system.utils.ResponseBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST-контроллер для получения версии приложения.
+ */
+@RestController
+@RequiredArgsConstructor
+public class AppVersionController {
+
+    private final AppInfoService appInfoService;
+
+    /**
+     * Возвращает текущую версию приложения в формате JSON.
+     *
+     * @return {@link ResponseEntity} с {@link AppVersionDTO}
+     */
+    @GetMapping("/app/version")
+    public ResponseEntity<AppVersionDTO> getVersion() {
+        AppVersionDTO dto = new AppVersionDTO(appInfoService.getApplicationVersion());
+        return ResponseBuilder.ok(dto);
+    }
+}

--- a/src/main/java/com/project/tracking_system/dto/AppVersionDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/AppVersionDTO.java
@@ -1,0 +1,16 @@
+package com.project.tracking_system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * DTO с информацией о версии приложения.
+ */
+@Getter
+@AllArgsConstructor
+public class AppVersionDTO {
+    /**
+     * Текущая версия приложения.
+     */
+    private final String version;
+}

--- a/src/main/resources/templates/partials/footer.html
+++ b/src/main/resources/templates/partials/footer.html
@@ -59,6 +59,7 @@
         <div class="footer-bottom text-center">
             <span class="text-muted">
                 &copy; 2025 Belivery. Все права защищены.
+                <span th:text="'Версия ' + ${appVersion}"></span>
                 <a href="/privacy" class="text-muted">Политика конфиденциальности</a> |
                 <a href="/terms" class="text-muted">Пользовательское соглашение</a>
             </span>

--- a/src/test/java/com/project/tracking_system/controller/AppVersionControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/AppVersionControllerTest.java
@@ -1,0 +1,37 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.AppVersionDTO;
+import com.project.tracking_system.service.admin.AppInfoService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Проверка {@link AppVersionController}.
+ */
+@ExtendWith(MockitoExtension.class)
+class AppVersionControllerTest {
+
+    @Mock
+    private AppInfoService appInfoService;
+
+    @InjectMocks
+    private AppVersionController controller;
+
+    @Test
+    void getVersion_ReturnsVersion() {
+        when(appInfoService.getApplicationVersion()).thenReturn("1.2.3");
+
+        ResponseEntity<AppVersionDTO> response = controller.getVersion();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("1.2.3", response.getBody().getVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- add `AppVersionController` to serve the version via `/app/version`
- expose app version as global model attribute
- show version in the footer
- document the new endpoint in README
- unit test controller

## Testing
- `./mvnw test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68796d56bbc0832da151a38ceb79cfc9