### PR TITLE
Add caffeine cache for tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <version>4.33.0</version>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>5.3.0</version>

--- a/src/main/java/com/project/tracking_system/configuration/CacheConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/CacheConfig.java
@@ -1,0 +1,31 @@
+package com.project.tracking_system.configuration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Конфигурация кэша для хранения результатов трекинга.
+ */
+@Configuration
+public class CacheConfig {
+
+    /**
+     * Создаёт кэш для объектов {@link TrackInfoListDTO} с временем жизни записи
+     * несколько минут. Максимальный размер кэша ограничен, чтобы предотвратить
+     * избыточное потребление памяти.
+     *
+     * @return кэш, ключом которого является номер трека
+     */
+    @Bean
+    public Cache<String, TrackInfoListDTO> trackInfoCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .maximumSize(1000)
+                .build();
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.mapper.JsonEvroTrackingResponseMapper;
 import com.project.tracking_system.model.evropost.jsonResponseModel.JsonEvroTrackingResponse;
@@ -34,6 +35,11 @@ public class TypeDefinitionTrackPostService {
     private final WebBelPost webBelPost;
     private final JsonEvroTrackingService jsonEvroTrackingService;
     private final JsonEvroTrackingResponseMapper jsonEvroTrackingResponseMapper;
+    /**
+     * Кэш для хранения информации по трек-номерам.
+     * Позволяет снизить количество обращений к внешним сервисам.
+     */
+    private final Cache<String, TrackInfoListDTO> trackInfoCache;
 
     private final Map<String, Object> trackLocks = new ConcurrentHashMap<>();
 
@@ -52,6 +58,8 @@ public class TypeDefinitionTrackPostService {
 
     /**
      * Асинхронный метод для получения информации о статусе посылки по номеру отслеживания.
+     * Перед выполнением запроса метод проверяет наличие данных в кэше и
+     * возвращает их при наличии, что снижает количество обращений к веб-сервисам.
      *
      * @param number номер отслеживания посылки
      * @return объект {@link CompletableFuture} с результатом обработки запроса
@@ -59,29 +67,38 @@ public class TypeDefinitionTrackPostService {
      */
     @Async("Post")
     public CompletableFuture<TrackInfoListDTO> getTypeDefinitionTrackPostServiceAsync(Long userId, String number) {
+        TrackInfoListDTO cached = trackInfoCache.getIfPresent(number);
+        if (cached != null) {
+            log.debug("📦 Данные по треку {} получены из кэша", number);
+            return CompletableFuture.completedFuture(cached);
+        }
+
         return CompletableFuture.supplyAsync(() -> {
-
-
             PostalServiceType postalService = detectPostalService(number);
 
             log.info("📦 Запрос информации по треку: {} (Пользователь ID={})", number, userId);
             log.debug("🔎 Определяем почтовую службу: {} → {}", number, postalService);
 
             try {
+                TrackInfoListDTO result;
                 switch (postalService) {
                     case BELPOST:
                         log.info("📨 Запрос к Белпочте для номера: {}", number);
-                        return webBelPost.webAutomationAsync(number).join();
+                        result = webBelPost.webAutomationAsync(number).join();
+                        break;
 
                     case EVROPOST:
                         log.info("📨 Запрос к Европочте для номера: {}", number);
                         JsonEvroTrackingResponse json = jsonEvroTrackingService.getJson(userId, number);
-                        return jsonEvroTrackingResponseMapper.mapJsonEvroTrackingResponseToDTO(json);
+                        result = jsonEvroTrackingResponseMapper.mapJsonEvroTrackingResponseToDTO(json);
+                        break;
 
                     default:
                         log.warn("⚠️ Неизвестный формат трек-номера: {} (UNKNOWN)", number);
                         throw new IllegalArgumentException("Указан некорректный код посылки: " + number);
                 }
+                trackInfoCache.put(number, result);
+                return result;
             } catch (Exception e) {
                 log.error("Ошибка при обработке трек-номера {} для пользователя с ID {}: {}", number, userId, e.getMessage(), e);
                 return new TrackInfoListDTO();
@@ -93,7 +110,8 @@ public class TypeDefinitionTrackPostService {
     /**
      * Синхронный метод для получения информации о статусе посылки.
      * <p>
-     * Этот метод ожидает завершения асинхронного запроса и возвращает результат или пустой объект в случае ошибки.
+     * Сначала выполняется проверка кэша, после чего при необходимости
+     * выполняется асинхронный запрос к почтовым сервисам.
      * </p>
      *
      * @param number номер отслеживания посылки
@@ -101,12 +119,20 @@ public class TypeDefinitionTrackPostService {
      * @throws IllegalArgumentException если номер отслеживания имеет некорректный формат
      */
     public TrackInfoListDTO getTypeDefinitionTrackPostService(Long userId, String number) {
+        TrackInfoListDTO cached = trackInfoCache.getIfPresent(number);
+        if (cached != null) {
+            log.debug("📦 Синхронный запрос: данные по треку {} получены из кэша", number);
+            return cached;
+        }
+
         Object lock = trackLocks.computeIfAbsent(number, key -> new Object());
 
         synchronized (lock) {
             try {
                 log.info("⏳ [LOCKED] Запрос (синхронный) для трека: {} (Пользователь ID={})", number, userId);
-                return getTypeDefinitionTrackPostServiceAsync(userId, number).get();
+                TrackInfoListDTO result = getTypeDefinitionTrackPostServiceAsync(userId, number).get();
+                trackInfoCache.put(number, result);
+                return result;
             } catch (ExecutionException | InterruptedException e) {
                 log.error("Ошибка при получении данных по треку {} для пользователя с ID {}: {}", number, userId, e.getMessage(), e);
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
## Summary
- introduce caffeine dependency
- create cache configuration with 5 minute TTL
- cache track info requests in `TypeDefinitionTrackPostService`

## Testing
- `./mvnw -q test` *(fails: cannot open wrapper)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687980c09598832d9c791e49eb94d496