### PR TITLE
Add async WebDriver pool initialization

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
@@ -37,6 +37,10 @@ public class AsyncConfig {
     @Value("${xls.executor.queue-capacity:100}")
     private int xlsQueueCapacity;
 
+    /** Размер пула потоков для создания WebDriver. */
+    @Value("${webdriver.executor.pool-size:1}")
+    private int webDriverExecutorPoolSize;
+
     /**
      * Создает и настраивает {@link Executor} для асинхронных задач.
      * <p>
@@ -75,6 +79,26 @@ public class AsyncConfig {
         executor.setMaxPoolSize(10); // максимальное количество потоков
         executor.setQueueCapacity(100); // размер очереди задач
         executor.setThreadNamePrefix("TrackUpdate-"); // префикс для имен потоков
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Создаёт пул потоков для асинхронного заполнения {@link com.project.tracking_system.webdriver.WebDriverPool}.
+     * <p>
+     * Размер пула регулируется свойством {@code webdriver.executor.pool-size}, что обеспечивает
+     * гибкую настройку в зависимости от ресурсов приложения.
+     * </p>
+     *
+     * @return настроенный {@link TaskExecutor} для создания WebDriver
+     */
+    @Bean(name = "webDriverExecutor")
+    public TaskExecutor webDriverExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(webDriverExecutorPoolSize);
+        executor.setMaxPoolSize(webDriverExecutorPoolSize);
+        executor.setQueueCapacity(webDriverExecutorPoolSize);
+        executor.setThreadNamePrefix("WebDriver-");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/project/tracking_system/webdriver/WebDriverPool.java
+++ b/src/main/java/com/project/tracking_system/webdriver/WebDriverPool.java
@@ -1,10 +1,12 @@
 package com.project.tracking_system.webdriver;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.WebDriver;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Async;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -25,6 +27,12 @@ public class WebDriverPool {
     /** Очередь свободных драйверов. */
     private final BlockingQueue<WebDriver> pool;
 
+    /** Фабрика для создания экземпляров WebDriver. */
+    private final WebDriverFactory webDriverFactory;
+
+    /** Размер пула драйверов. */
+    private final int poolSize;
+
     /**
      * Создаёт пул указанного размера и заполняет его драйверами.
      *
@@ -33,9 +41,28 @@ public class WebDriverPool {
      */
     public WebDriverPool(WebDriverFactory webDriverFactory,
                          @Value("${webdriver.pool.size:2}") int poolSize) {
+        this.webDriverFactory = webDriverFactory;
+        this.poolSize = poolSize;
         this.pool = new LinkedBlockingQueue<>(poolSize);
+    }
+
+    /**
+     * Асинхронно заполняет пул созданными драйверами после инициализации бина.
+     * <p>
+     * Метод помечен {@link Async}, поэтому создание драйверов не блокирует запуск
+     * приложения. Каждая ошибка при создании драйвера логируется, не прерывая
+     * заполнение пула.
+     * </p>
+     */
+    @PostConstruct
+    @Async("webDriverExecutor")
+    public void populatePool() {
         for (int i = 0; i < poolSize; i++) {
-            pool.add(webDriverFactory.create());
+            try {
+                pool.add(webDriverFactory.create());
+            } catch (Exception e) {
+                log.warn("Не удалось создать WebDriver: {}", e.getMessage(), e);
+            }
         }
         log.info("Создан пул WebDriver на {} экземпляров", poolSize);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,6 +45,8 @@ app.default-timezone=Europe/Minsk
 server.forward-headers-strategy=framework
 webdriver.chrome.driver=${CHROMEDRIVER_PATH:/usr/local/bin/chromedriver}
 webdriver.pool.size=2
+# Размер пула потоков, используемых для асинхронного создания WebDriver
+webdriver.executor.pool-size=1
 
 # Параметры пула потоков для обработки XLS-файлов
 xls.executor.core-pool-size=5


### PR DESCRIPTION
## Summary
- configure new async `webDriverExecutor` task executor
- initialize `WebDriverPool` asynchronously using this executor
- log driver creation failures without failing startup
- document `webdriver.executor.pool-size` in application properties

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68799776ce34832dbf3f5b937ad08490