### PR TITLE
Refactor async track service execution

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
@@ -52,41 +52,43 @@ public class TypeDefinitionTrackPostService {
 
     /**
      * Асинхронный метод для получения информации о статусе посылки по номеру отслеживания.
+     * Метод использует аннотацию {@code @Async} для выполнения в отдельном потоке
+     * и возвращает завершённый {@link CompletableFuture}.
      *
+     * @param userId идентификатор пользователя
      * @param number номер отслеживания посылки
      * @return объект {@link CompletableFuture} с результатом обработки запроса
      * @throws IllegalArgumentException если номер отслеживания имеет некорректный формат
      */
     @Async("Post")
     public CompletableFuture<TrackInfoListDTO> getTypeDefinitionTrackPostServiceAsync(Long userId, String number) {
-        return CompletableFuture.supplyAsync(() -> {
+        PostalServiceType postalService = detectPostalService(number);
 
+        log.info("📦 Запрос информации по треку: {} (Пользователь ID={})", number, userId);
+        log.debug("🔎 Определяем почтовую службу: {} → {}", number, postalService);
 
-            PostalServiceType postalService = detectPostalService(number);
-
-            log.info("📦 Запрос информации по треку: {} (Пользователь ID={})", number, userId);
-            log.debug("🔎 Определяем почтовую службу: {} → {}", number, postalService);
-
-            try {
-                switch (postalService) {
-                    case BELPOST:
-                        log.info("📨 Запрос к Белпочте для номера: {}", number);
-                        return webBelPost.webAutomationAsync(number).join();
-
-                    case EVROPOST:
-                        log.info("📨 Запрос к Европочте для номера: {}", number);
-                        JsonEvroTrackingResponse json = jsonEvroTrackingService.getJson(userId, number);
-                        return jsonEvroTrackingResponseMapper.mapJsonEvroTrackingResponseToDTO(json);
-
-                    default:
-                        log.warn("⚠️ Неизвестный формат трек-номера: {} (UNKNOWN)", number);
-                        throw new IllegalArgumentException("Указан некорректный код посылки: " + number);
-                }
-            } catch (Exception e) {
-                log.error("Ошибка при обработке трек-номера {} для пользователя с ID {}: {}", number, userId, e.getMessage(), e);
-                return new TrackInfoListDTO();
+        TrackInfoListDTO result;
+        try {
+            switch (postalService) {
+                case BELPOST:
+                    log.info("📨 Запрос к Белпочте для номера: {}", number);
+                    result = webBelPost.webAutomationAsync(number).join();
+                    break;
+                case EVROPOST:
+                    log.info("📨 Запрос к Европочте для номера: {}", number);
+                    JsonEvroTrackingResponse json = jsonEvroTrackingService.getJson(userId, number);
+                    result = jsonEvroTrackingResponseMapper.mapJsonEvroTrackingResponseToDTO(json);
+                    break;
+                default:
+                    log.warn("⚠️ Неизвестный формат трек-номера: {} (UNKNOWN)", number);
+                    throw new IllegalArgumentException("Указан некорректный код посылки: " + number);
             }
-        });
+        } catch (Exception e) {
+            log.error("Ошибка при обработке трек-номера {} для пользователя с ID {}: {}", number, userId, e.getMessage(), e);
+            result = new TrackInfoListDTO();
+        }
+
+        return CompletableFuture.completedFuture(result);
     }
 
 


### PR DESCRIPTION
## Summary
- simplify TypeDefinitionTrackPostService async handling
- document async method

## Testing
- `./mvnw -q test` *(fails: cannot open .mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687a278f99dc832db874ef08039dbe68