### PR TITLE
Add email executor and annotate EmailService method

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
@@ -43,6 +43,26 @@ public class AsyncConfig {
     }
 
     /**
+     * Создает пул потоков для отправки email.
+     * <p>
+     * Выделенный executor гарантирует, что отправка писем не будет блокировать
+     * другие асинхронные операции приложения.
+     * </p>
+     *
+     * @return настроенный {@link TaskExecutor} для email-уведомлений
+     */
+    @Bean(name = "emailExecutor")
+    public TaskExecutor emailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Email-");
+        executor.initialize();
+        return executor;
+    }
+
+    /**
      * Создаёт пул потоков для {@link com.project.tracking_system.service.track.TrackUpdateService}.
      * <p>
      * Используется только для обновления треков, чтобы разграничить нагрузку от других

--- a/src/main/java/com/project/tracking_system/service/email/EmailService.java
+++ b/src/main/java/com/project/tracking_system/service/email/EmailService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import com.project.tracking_system.utils.EmailUtils;
 
@@ -31,6 +32,12 @@ public class EmailService {
 
     private final JavaMailSender emailSender;
     private final HtmlEmailTemplateService templateService;
+    /**
+     * Исполнитель задач, используемый для асинхронной отправки email.
+     * Инъекция позволяет легко заменить реализацию и соответствует принципу
+     * инверсии зависимостей.
+     */
+    private final TaskExecutor emailExecutor;
 
     @Value("${spring.mail.username}")
     private String senderEmail;
@@ -85,12 +92,17 @@ public class EmailService {
 
     /**
      * Асинхронно отправляет HTML email сообщение.
+     * <p>
+     * Метод запускается в отдельном потоке из {@code emailExecutor}, что
+     * позволяет не блокировать основной поток приложения во время отправки
+     * писем.
+     * </p>
      *
      * @param to      адрес получателя.
      * @param subject тема письма.
      * @param content HTML-содержимое письма.
      */
-    @Async
+    @Async("emailExecutor")
     public void sendHtmlEmailAsync(String to, String subject, String content) {
         log.info("📧 Начинаем отправку email на {}", EmailUtils.maskEmail(to));
 


### PR DESCRIPTION
## Summary
- create `emailExecutor` bean in `AsyncConfig`
- inject `TaskExecutor` into `EmailService`
- run `sendHtmlEmailAsync` using the new executor

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687a2793b2a0832d9b17e16bccbd6580