### PR TITLE
Implement Selenium WebDriver pooling

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import com.project.tracking_system.webdriver.WebDriverFactory;
 import com.project.tracking_system.webdriver.ChromeWebDriverFactory;
+import com.project.tracking_system.webdriver.WebDriverPool;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
@@ -99,6 +100,21 @@ public class AppConfiguration {
     @Bean
     public WebDriverFactory webDriverFactory() {
         return new ChromeWebDriverFactory(chromeDriverPath);
+    }
+
+    /**
+     * Создает пул для управления экземплярами {@link org.openqa.selenium.WebDriver}.
+     * <p>
+     * Пул позволяет переиспользовать драйверы и корректно завершает их работу
+     * при остановке приложения.
+     * </p>
+     *
+     * @param webDriverFactory фабрика для создания новых драйверов
+     * @return бин {@link WebDriverPool}
+     */
+    @Bean
+    public WebDriverPool webDriverPool(WebDriverFactory webDriverFactory) {
+        return new WebDriverPool(webDriverFactory);
     }
 
 }

--- a/src/main/java/com/project/tracking_system/webdriver/WebDriverPool.java
+++ b/src/main/java/com/project/tracking_system/webdriver/WebDriverPool.java
@@ -1,0 +1,72 @@
+package com.project.tracking_system.webdriver;
+
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.WebDriver;
+import org.springframework.stereotype.Component;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Менеджер повторного использования экземпляров {@link WebDriver}.
+ * <p>
+ * Хранит созданные драйверы в очереди и отдаёт их по запросу, создавая новые
+ * при отсутствии свободных. При завершении работы приложения все сохранённые
+ * драйверы корректно завершаются.
+ * </p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class WebDriverPool {
+
+    /** Фабрика для непосредственного создания драйверов. */
+    private final WebDriverFactory webDriverFactory;
+
+    /** Очередь свободных драйверов. */
+    private final Queue<WebDriver> pool = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Предоставляет драйвер для использования.
+     * <p>
+     * Если в пуле нет свободных экземпляров, создаётся новый через фабрику.
+     * </p>
+     *
+     * @return экземпляр {@link WebDriver}
+     */
+    public WebDriver borrowDriver() {
+        WebDriver driver = pool.poll();
+        if (driver == null) {
+            driver = webDriverFactory.create();
+        }
+        return driver;
+    }
+
+    /**
+     * Возвращает драйвер обратно в пул.
+     *
+     * @param driver использованный драйвер
+     */
+    public void returnDriver(WebDriver driver) {
+        if (driver != null) {
+            pool.offer(driver);
+        }
+    }
+
+    /**
+     * Завершает работу всех драйверов при остановке приложения.
+     */
+    @PreDestroy
+    public void shutdown() {
+        for (WebDriver driver : pool) {
+            try {
+                driver.quit();
+            } catch (Exception e) {
+                log.warn("Не удалось корректно завершить драйвер: {}", e.getMessage(), e);
+            }
+        }
+        pool.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- add `WebDriverPool` for reusing Selenium drivers
- update `WebBelPost` to borrow and return drivers
- configure `WebDriverPool` bean in application configuration

## Testing
- `./mvnw -q test` *(fails: `mvnw` cannot run without wrapper files)*

------
https://chatgpt.com/codex/tasks/task_e_687a864b76c0832da6382b2f086de849