### PR TITLE
Remove InjectMocks usage in test

### DIFF
--- a/src/test/java/com/project/tracking_system/service/belpost/BelPostSessionParserTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/BelPostSessionParserTest.java
@@ -4,7 +4,6 @@ import com.project.tracking_system.webdriver.WebDriverFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openqa.selenium.WebDriver;
@@ -25,15 +24,27 @@ class BelPostSessionParserTest {
     @Mock
     private WebDriver driver;
 
-    @InjectMocks
     private BelPostSessionParser parser;
 
+    /**
+     * Подготавливает мок-объекты и создаёт тестируемый сервис перед каждым тестом.
+     */
     @BeforeEach
     void init() {
+        // фабрика должна вернуть наш мок драйвера
         when(factory.create()).thenReturn(driver);
+        // любые попытки найти элемент приводят к исключению,
+        // чтобы не требовался настоящий браузер
         when(driver.findElement(any(By.class))).thenThrow(new NoSuchElementException("mock"));
+
+        // создаём экземпляр парсера вручную после настройки мока
+        parser = new BelPostSessionParser(factory);
     }
 
+    /**
+     * Убеждаемся, что при многократном вызове {@link BelPostSessionParser#parseTrack(String)}
+     * драйвер создаётся только один раз.
+     */
     @Test
     void parseTrack_ReusesSingleDriver() {
         parser.parseTrack("111");
@@ -42,6 +53,9 @@ class BelPostSessionParserTest {
         verify(factory, times(1)).create();
     }
 
+    /**
+     * Проверяем, что метод {@link BelPostSessionParser#cleanup()} корректно завершает сессию.
+     */
     @Test
     void cleanup_QuitsDriver() {
         parser.cleanup();


### PR DESCRIPTION
## Summary
- initialize BelPostSessionParser manually in tests
- stub WebDriverFactory before construction
- add detailed comments to explain test logic

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687aa5f166e0832dba41db22148ee5fe