### PR TITLE
Implement upload processing pipeline

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -87,7 +87,7 @@ public class SecurityConfiguration {
                         .requestMatchers("/", "/features", "/pricing", "/terms", "/privacy",
                                 "/auth/**", "/favicon.ico",
                                 "/css/**", "/js/**", "/bootstrap/**", "/images/**",
-                                "/app/upload", "/ws/**", "/wss/**", "/sample/**", "/app/download-sample",
+                                "/ws/**", "/wss/**", "/sample/**", "/app/download-sample",
                                 "/faq", "/about", "/contacts").permitAll()
                         // Доступ к административному разделу только для ROLE_ADMIN
                         .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/project/tracking_system/controller/UploadController.java
+++ b/src/main/java/com/project/tracking_system/controller/UploadController.java
@@ -1,9 +1,7 @@
 package com.project.tracking_system.controller;
 
 import com.project.tracking_system.model.TrackingResponse;
-import com.project.tracking_system.service.track.TrackBatchData;
-import com.project.tracking_system.service.track.TrackBatchProcessingService;
-import com.project.tracking_system.service.track.TrackingNumberServiceXLS;
+import com.project.tracking_system.service.track.TrackUploadProcessorService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,8 +22,7 @@ import java.io.IOException;
 @RequestMapping("/app")
 public class UploadController {
 
-    private final TrackingNumberServiceXLS trackingNumberServiceXLS;
-    private final TrackBatchProcessingService trackBatchProcessingService;
+    private final TrackUploadProcessorService trackUploadProcessorService;
 
     /**
      * Обрабатывает загрузку файла (XLS или XLSX).
@@ -60,10 +57,7 @@ public class UploadController {
 
         try {
             if (contentType.equals("application/vnd.ms-excel") || contentType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
-                TrackBatchData data = trackingNumberServiceXLS.processTrackingNumber(file, userId);
-                TrackingResponse trackingResponse = new TrackingResponse(
-                        trackBatchProcessingService.processBatch(data.tracksByService(), userId),
-                        data.limitExceededMessage());
+                TrackingResponse trackingResponse = trackUploadProcessorService.process(file, userId);
 
                 log.info("Передаём в модель limitExceededMessage: {}", trackingResponse.getLimitExceededMessage());
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackExcelParser.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackExcelParser.java
@@ -1,0 +1,73 @@
+package com.project.tracking_system.service.track;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Сервис чтения XLS/XLSX-файлов с трек-номерами.
+ * <p>
+ * Возвращает список строк без нормализации значений.
+ * </p>
+ */
+@Slf4j
+@Service
+public class TrackExcelParser {
+
+    /**
+     * Читает файл и извлекает все строки с данными.
+     * Первая строка (заголовок) пропускается.
+     *
+     * @param file загруженный пользователем файл
+     * @return список необработанных строк
+     * @throws IOException при ошибке чтения файла
+     */
+    public List<TrackExcelRow> parse(MultipartFile file) throws IOException {
+        List<TrackExcelRow> rows = new ArrayList<>();
+        try (InputStream in = file.getInputStream(); Workbook workbook = WorkbookFactory.create(in)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            int last = sheet.getLastRowNum();
+            for (int i = 1; i <= last; i++) { // пропускаем заголовок
+                Row row = sheet.getRow(i);
+                if (row == null) {
+                    continue;
+                }
+                Cell numberCell = row.getCell(0);
+                if (numberCell == null) {
+                    continue;
+                }
+                String number = readCell(numberCell).trim();
+                if (number.isEmpty()) {
+                    continue;
+                }
+                String store = null;
+                Cell storeCell = row.getCell(1);
+                if (storeCell != null) {
+                    store = readCell(storeCell).trim();
+                }
+                String phone = null;
+                Cell phoneCell = row.getCell(2);
+                if (phoneCell != null) {
+                    phone = readCell(phoneCell).trim();
+                }
+                rows.add(new TrackExcelRow(number, store, phone));
+            }
+        }
+        log.info("Разобрано {} строк из файла", rows.size());
+        return rows;
+    }
+
+    private String readCell(Cell cell) {
+        return switch (cell.getCellType()) {
+            case NUMERIC -> String.valueOf((long) cell.getNumericCellValue());
+            case STRING -> cell.getStringCellValue();
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackExcelRow.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackExcelRow.java
@@ -1,0 +1,14 @@
+package com.project.tracking_system.service.track;
+
+/**
+ * Сырые данные строки XLS-файла.
+ * <p>
+ * Используется для хранения значений ячеек без предварительной обработки.
+ * </p>
+ *
+ * @param number номер трека
+ * @param store  значение ячейки магазина
+ * @param phone  значение ячейки телефона
+ */
+public record TrackExcelRow(String number, String store, String phone) {
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidationResult.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidationResult.java
@@ -1,0 +1,13 @@
+package com.project.tracking_system.service.track;
+
+import java.util.List;
+
+/**
+ * Результат валидации и нормализации треков.
+ *
+ * @param validTracks список корректных треков
+ * @param limitExceededMessage сообщение о превышении лимитов (может быть null)
+ */
+public record TrackMetaValidationResult(List<TrackMeta> validTracks,
+                                        String limitExceededMessage) {
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
@@ -1,0 +1,114 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.utils.PhoneUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Проверяет и нормализует сырые данные треков.
+ * <p>
+ * Также применяет лимиты пользователя на обработку и сохранение треков.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrackMetaValidator {
+
+    private final TrackParcelService trackParcelService;
+    private final SubscriptionService subscriptionService;
+    private final StoreService storeService;
+
+    /**
+     * Валидирует сырые строки и преобразует их в {@link TrackMeta}.
+     *
+     * @param rows  строки из XLS-файла
+     * @param userId идентификатор пользователя, не {@code null}
+     * @return результат валидации
+     */
+    public TrackMetaValidationResult validate(List<TrackExcelRow> rows, Long userId) {
+        // Загрузка файлов доступна только авторизованным пользователям,
+        // поэтому идентификатор пользователя обязателен
+        Objects.requireNonNull(userId, "User ID must not be null");
+
+        StringBuilder messageBuilder = new StringBuilder();
+        int maxLimit = subscriptionService.canUploadTracks(userId, Integer.MAX_VALUE);
+        int saveSlots = subscriptionService.canSaveMoreTracks(userId, Integer.MAX_VALUE);
+        Long defaultStoreId = storeService.getDefaultStoreId(userId);
+
+        int processed = 0;
+        int savedNew = 0;
+        List<String> skipped = new ArrayList<>();
+        List<TrackMeta> result = new ArrayList<>();
+
+        for (TrackExcelRow row : rows) {
+            if (processed >= maxLimit) {
+                break;
+            }
+            String number = row.number().toUpperCase();
+            Long storeId = defaultStoreId;
+            if (row.store() != null && !row.store().isBlank()) {
+                try {
+                    storeId = Long.parseLong(row.store());
+                } catch (NumberFormatException e) {
+                    Long byName = storeService.findStoreIdByName(row.store(), userId);
+                    if (byName != null) {
+                        storeId = byName;
+                    } else {
+                        log.warn("Магазин '{}' не найден, используем дефолтный", row.store());
+                    }
+                }
+            }
+            if (storeId != null && !storeService.userOwnsStore(storeId, userId)) {
+                log.warn("Магазин ID={} не принадлежит пользователю ID={}", storeId, userId);
+                storeId = defaultStoreId;
+            }
+            String phone = row.phone();
+            if (phone != null && !phone.isBlank()) {
+                try {
+                    phone = PhoneUtils.normalizePhone(phone);
+                } catch (Exception e) {
+                    log.warn("Некорректный телефон '{}' пропущен", phone);
+                    phone = null;
+                }
+            }
+            boolean isNew = trackParcelService.isNewTrack(number, storeId);
+            boolean canSave;
+            if (isNew) {
+                if (savedNew < saveSlots) {
+                    canSave = true;
+                    savedNew++;
+                } else {
+                    canSave = false;
+                    skipped.add(number);
+                }
+            } else {
+                canSave = true;
+            }
+            result.add(new TrackMeta(number, storeId, phone, canSave));
+            processed++;
+        }
+
+        if (rows.size() > maxLimit) {
+            int skippedRows = rows.size() - maxLimit;
+            messageBuilder.append(String.format(
+                    "Вы загрузили %d треков, но можете проверить только %d. Пропущено %d треков.%n",
+                    rows.size(), maxLimit, skippedRows));
+        }
+        if (!skipped.isEmpty()) {
+            messageBuilder.append(String.format(
+                    "Из %d обработанных треков не удалось сохранить %d из-за лимита подписки: %s%n",
+                    processed, skipped.size(), skipped));
+        }
+
+        String message = messageBuilder.isEmpty() ? null : messageBuilder.toString().trim();
+        return new TrackMetaValidationResult(result, message);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadGroupingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadGroupingService.java
@@ -1,0 +1,35 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.PostalServiceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Группировка валидированных треков по типу почтовой службы.
+ */
+@Service
+@RequiredArgsConstructor
+public class TrackUploadGroupingService {
+
+    private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+
+    /**
+     * Раскладывает треки по типам почтовых служб.
+     *
+     * @param tracks валидированные трек-метаданные
+     * @return отображение "служба → список треков"
+     */
+    public Map<PostalServiceType, List<TrackMeta>> group(List<TrackMeta> tracks) {
+        Map<PostalServiceType, List<TrackMeta>> grouped = new EnumMap<>(PostalServiceType.class);
+        for (TrackMeta meta : tracks) {
+            PostalServiceType type = typeDefinitionTrackPostService.detectPostalService(meta.number());
+            grouped.computeIfAbsent(type, k -> new ArrayList<>()).add(meta);
+        }
+        return grouped;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -1,0 +1,43 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.model.TrackingResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Координирует загрузку и обработку XLS-файла с треками.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrackUploadProcessorService {
+
+    private final TrackExcelParser trackExcelParser;
+    private final TrackMetaValidator trackMetaValidator;
+    private final TrackUploadGroupingService trackUploadGroupingService;
+    private final TrackBatchProcessingService trackBatchProcessingService;
+
+    /**
+     * Полный цикл загрузки файла: парсинг, валидация, группировка и отправка на обработку.
+     *
+     * @param file  загруженный файл
+     * @param userId идентификатор пользователя
+     * @return результат обработки для отображения в UI
+     * @throws IOException при ошибке чтения файла
+     */
+    public TrackingResponse process(MultipartFile file, Long userId) throws IOException {
+        List<TrackExcelRow> rows = trackExcelParser.parse(file);
+        TrackMetaValidationResult validation = trackMetaValidator.validate(rows, userId);
+        Map<PostalServiceType, List<TrackMeta>> grouped = trackUploadGroupingService.group(validation.validTracks());
+        List<TrackingResultAdd> results = trackBatchProcessingService.processBatch(grouped, userId);
+        return new TrackingResponse(results, validation.limitExceededMessage());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackExcelParserTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackExcelParserTest.java
@@ -1,0 +1,35 @@
+package com.project.tracking_system.service.track;
+
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TrackExcelParserTest {
+
+    @Test
+    void parse_ReturnsRows() throws Exception {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        var sheet = wb.createSheet();
+        sheet.createRow(0).createCell(0).setCellValue("num");
+        var row1 = sheet.createRow(1);
+        row1.createCell(0).setCellValue("AA111");
+        row1.createCell(1).setCellValue("1");
+        row1.createCell(2).setCellValue("+375291234567");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        MockMultipartFile file = new MockMultipartFile("f", out.toByteArray());
+
+        TrackExcelParser parser = new TrackExcelParser();
+        List<TrackExcelRow> rows = parser.parse(file);
+
+        assertEquals(1, rows.size());
+        assertEquals("AA111", rows.get(0).number());
+        assertEquals("1", rows.get(0).store());
+        assertEquals("+375291234567", rows.get(0).phone());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
@@ -1,0 +1,54 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.store.StoreService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrackMetaValidatorTest {
+
+    @Mock
+    private TrackParcelService trackParcelService;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private StoreService storeService;
+
+    private TrackMetaValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new TrackMetaValidator(trackParcelService, subscriptionService, storeService);
+    }
+
+    @Test
+    void validate_RespectsSaveLimit() {
+        when(subscriptionService.canUploadTracks(anyLong(), anyInt())).thenReturn(2);
+        when(subscriptionService.canSaveMoreTracks(anyLong(), anyInt())).thenReturn(1);
+        when(storeService.getDefaultStoreId(1L)).thenReturn(1L);
+        when(storeService.userOwnsStore(1L, 1L)).thenReturn(true);
+        when(trackParcelService.isNewTrack(anyString(), any())).thenReturn(true);
+
+        List<TrackExcelRow> rows = List.of(
+                new TrackExcelRow("A1", "1", "375291111111"),
+                new TrackExcelRow("A2", "1", "375291111112")
+        );
+
+        TrackMetaValidationResult result = validator.validate(rows, 1L);
+
+        assertEquals(2, result.validTracks().size());
+        assertTrue(result.validTracks().get(0).canSave());
+        assertFalse(result.validTracks().get(1).canSave());
+        assertNotNull(result.limitExceededMessage());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadGroupingServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadGroupingServiceTest.java
@@ -1,0 +1,46 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.PostalServiceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrackUploadGroupingServiceTest {
+
+    @Mock
+    private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+
+    private TrackUploadGroupingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TrackUploadGroupingService(typeDefinitionTrackPostService);
+    }
+
+    @Test
+    void group_SplitsByService() {
+        when(typeDefinitionTrackPostService.detectPostalService(anyString()))
+                .thenReturn(PostalServiceType.BELPOST)
+                .thenReturn(PostalServiceType.EVROPOST);
+
+        List<TrackMeta> list = List.of(
+                new TrackMeta("B1", 1L, null, true),
+                new TrackMeta("E1", 1L, null, true)
+        );
+
+        Map<PostalServiceType, List<TrackMeta>> map = service.group(list);
+
+        assertEquals(1, map.get(PostalServiceType.BELPOST).size());
+        assertEquals(1, map.get(PostalServiceType.EVROPOST).size());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -1,0 +1,54 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.model.TrackingResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrackUploadProcessorServiceTest {
+
+    @Mock
+    private TrackExcelParser parser;
+    @Mock
+    private TrackMetaValidator validator;
+    @Mock
+    private TrackUploadGroupingService groupingService;
+    @Mock
+    private TrackBatchProcessingService batchProcessingService;
+
+    private TrackUploadProcessorService processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new TrackUploadProcessorService(parser, validator, groupingService, batchProcessingService);
+    }
+
+    @Test
+    void process_ReturnsResponse() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("f", new byte[0]);
+        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", null, null)));
+        TrackMeta meta = new TrackMeta("A1", null, null, true);
+        when(validator.validate(anyList(), any())).thenReturn(new TrackMetaValidationResult(List.of(meta), null));
+        Map<PostalServiceType, List<TrackMeta>> grouped = Map.of(PostalServiceType.BELPOST, List.of(meta));
+        when(groupingService.group(anyList())).thenReturn(grouped);
+        List<TrackingResultAdd> results = List.of(new TrackingResultAdd("A1", "ok"));
+        when(batchProcessingService.processBatch(grouped, 1L)).thenReturn(results);
+
+        TrackingResponse response = processor.process(file, 1L);
+
+        assertEquals(results, response.getTrackingResults());
+    }
+}


### PR DESCRIPTION
## Summary
- add `TrackExcelParser` for raw file reading
- add `TrackMetaValidator` with user limits
- group tracks with `TrackUploadGroupingService`
- orchestrate upload in `TrackUploadProcessorService`
- use new processor in `UploadController`
- provide unit tests for each service
- split Evro/Belpost handling in `TrackBatchProcessingService`
- restrict `/app/upload` to authenticated users
- require non-null user ID during track validation

## Testing
- `./mvnw -q test` *(fails: `cannot open ./.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_687b71d4ed9c832da94c69dee50292ad