### PR TITLE
Configure batch upload executor

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/AsyncConfig.java
@@ -72,4 +72,25 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    /**
+     * Отдельный пул потоков для пакетной загрузки треков.
+     * <p>
+     * Используется при {@link com.project.tracking_system.service.track.TrackBatchProcessingService}
+     * для выполнения запросов Европочты параллельно. Ограничения по потокам
+     * задают верхнюю границу нагрузки от одновременных загрузок.
+     * </p>
+     *
+     * @return executor для задач пакетной загрузки
+     */
+    @Bean(name = "batchUploadExecutor")
+    public TaskExecutor batchUploadExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2); // минимально 2 потока
+        executor.setMaxPoolSize(4); // не более 4 одновременных задач
+        executor.setQueueCapacity(50); // очередь на 50 задач
+        executor.setThreadNamePrefix("BatchUpload-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackBatchProcessingServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackBatchProcessingServiceTest.java
@@ -10,6 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
+
+import java.util.concurrent.Executors;
 
 import java.util.List;
 import java.util.Map;
@@ -29,10 +33,12 @@ class TrackBatchProcessingServiceTest {
     private WebBelPostBatchService webBelPostBatchService;
 
     private TrackBatchProcessingService service;
+    private TaskExecutor executor;
 
     @BeforeEach
     void setUp() {
-        service = new TrackBatchProcessingService(trackFacade, webBelPostBatchService);
+        executor = new ConcurrentTaskExecutor(Executors.newFixedThreadPool(2));
+        service = new TrackBatchProcessingService(trackFacade, webBelPostBatchService, executor);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add dedicated `batchUploadExecutor` bean
- inject executor into `TrackBatchProcessingService`
- use executor when processing Evropost tracks
- update unit test for injected executor

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687baadeaf8c832db0fdb402fe9a6dfa