### PR TITLE
Refactor track stats update

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/TrackStatisticsUpdater.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/TrackStatisticsUpdater.java
@@ -1,0 +1,179 @@
+package com.project.tracking_system.service.analytics;
+
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+
+/**
+ * Updates store and postal service statistics when a parcel is saved or moved.
+ *
+ * <p>The component encapsulates the logic of incrementing and decrementing
+ * statistics for {@link Store} and {@link PostalServiceType}.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrackStatisticsUpdater {
+
+    private final StoreAnalyticsRepository storeAnalyticsRepository;
+    private final PostalServiceStatisticsRepository postalServiceStatisticsRepository;
+    private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
+    private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+
+    /**
+     * Updates statistics for the given parcel.
+     *
+     * @param parcel          parcel being saved
+     * @param isNewParcel     {@code true} if the parcel is new
+     * @param previousStoreId store id before update (may be {@code null})
+     * @param previousDate    previous parcel timestamp
+     */
+    @Transactional
+    public void updateStatistics(TrackParcel parcel,
+                                 boolean isNewParcel,
+                                 Long previousStoreId,
+                                 ZonedDateTime previousDate) {
+        boolean storeChanged = !isNewParcel
+                && previousStoreId != null
+                && !previousStoreId.equals(parcel.getStore().getId());
+
+        PostalServiceType serviceType =
+                typeDefinitionTrackPostService.detectPostalService(parcel.getNumber());
+
+        if (isNewParcel || storeChanged) {
+            incrementNewStore(parcel, serviceType);
+        }
+        if (storeChanged) {
+            decrementOldStore(previousStoreId, serviceType, previousDate);
+        }
+    }
+
+    // Increment statistics for a new track or when the store changed
+    private void incrementNewStore(TrackParcel parcel,
+                                   PostalServiceType serviceType) {
+        Long storeId = parcel.getStore().getId();
+        StoreStatistics statistics = storeAnalyticsRepository.findByStoreId(storeId)
+                .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
+
+        // total sent for store
+        int updated = storeAnalyticsRepository.incrementTotalSent(storeId, 1);
+        if (updated == 0) {
+            statistics.setTotalSent(statistics.getTotalSent() + 1);
+            statistics.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            storeAnalyticsRepository.save(statistics);
+        }
+
+        LocalDate day = parcel.getTimestamp().toLocalDate();
+        int dailyUpdated = storeDailyStatisticsRepository.incrementSent(storeId, day, 1);
+        if (dailyUpdated == 0) {
+            StoreDailyStatistics daily = storeDailyStatisticsRepository
+                    .findByStoreIdAndDate(storeId, day)
+                    .orElseGet(() -> {
+                        StoreDailyStatistics d = new StoreDailyStatistics();
+                        d.setStore(statistics.getStore());
+                        d.setDate(day);
+                        return d;
+                    });
+            daily.setSent(daily.getSent() + 1);
+            daily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            storeDailyStatisticsRepository.save(daily);
+        }
+
+        if (serviceType != PostalServiceType.UNKNOWN) {
+            updatePostalIncrement(storeId, statistics.getStore(), serviceType, day);
+        } else {
+            log.warn("⛔ Пропуск обновления аналитики для UNKNOWN службы: {}", parcel.getNumber());
+        }
+    }
+
+    // Increment postal statistics for the new store
+    private void updatePostalIncrement(Long storeId,
+                                       Store store,
+                                       PostalServiceType serviceType,
+                                       LocalDate day) {
+        int psUpdated = postalServiceStatisticsRepository.incrementTotalSent(storeId, serviceType, 1);
+        if (psUpdated == 0) {
+            PostalServiceStatistics psStats = postalServiceStatisticsRepository
+                    .findByStoreIdAndPostalServiceType(storeId, serviceType)
+                    .orElseGet(() -> {
+                        PostalServiceStatistics s = new PostalServiceStatistics();
+                        s.setStore(store);
+                        s.setPostalServiceType(serviceType);
+                        return s;
+                    });
+            psStats.setTotalSent(psStats.getTotalSent() + 1);
+            psStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            postalServiceStatisticsRepository.save(psStats);
+        }
+
+        int psdUpdated = postalServiceDailyStatisticsRepository.incrementSent(storeId, serviceType, day, 1);
+        if (psdUpdated == 0) {
+            PostalServiceDailyStatistics psDaily = postalServiceDailyStatisticsRepository
+                    .findByStoreIdAndPostalServiceTypeAndDate(storeId, serviceType, day)
+                    .orElseGet(() -> {
+                        PostalServiceDailyStatistics d = new PostalServiceDailyStatistics();
+                        d.setStore(store);
+                        d.setPostalServiceType(serviceType);
+                        d.setDate(day);
+                        return d;
+                    });
+            psDaily.setSent(psDaily.getSent() + 1);
+            psDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            postalServiceDailyStatisticsRepository.save(psDaily);
+        }
+    }
+
+    // Decrement statistics for the previous store when parcel was moved
+    private void decrementOldStore(Long previousStoreId,
+                                   PostalServiceType serviceType,
+                                   ZonedDateTime previousDate) {
+        StoreStatistics oldStats = storeAnalyticsRepository.findByStoreId(previousStoreId)
+                .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
+        if (oldStats.getTotalSent() > 0) {
+            oldStats.setTotalSent(oldStats.getTotalSent() - 1);
+            oldStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            storeAnalyticsRepository.save(oldStats);
+        }
+
+        if (serviceType != PostalServiceType.UNKNOWN) {
+            PostalServiceStatistics oldPs = postalServiceStatisticsRepository
+                    .findByStoreIdAndPostalServiceType(previousStoreId, serviceType)
+                    .orElse(null);
+            if (oldPs != null && oldPs.getTotalSent() > 0) {
+                oldPs.setTotalSent(oldPs.getTotalSent() - 1);
+                oldPs.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                postalServiceStatisticsRepository.save(oldPs);
+            }
+        }
+
+        if (previousDate != null) {
+            LocalDate prevDay = previousDate.toLocalDate();
+            StoreDailyStatistics oldDaily = storeDailyStatisticsRepository
+                    .findByStoreIdAndDate(previousStoreId, prevDay)
+                    .orElse(null);
+            if (oldDaily != null && oldDaily.getSent() > 0) {
+                oldDaily.setSent(oldDaily.getSent() - 1);
+                oldDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                storeDailyStatisticsRepository.save(oldDaily);
+            }
+
+            if (serviceType != PostalServiceType.UNKNOWN) {
+                PostalServiceDailyStatistics oldPsDaily = postalServiceDailyStatisticsRepository
+                        .findByStoreIdAndPostalServiceTypeAndDate(previousStoreId, serviceType, prevDay)
+                        .orElse(null);
+                if (oldPsDaily != null && oldPsDaily.getSent() > 0) {
+                    oldPsDaily.setSent(oldPsDaily.getSent() - 1);
+                    oldPsDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    postalServiceDailyStatisticsRepository.save(oldPsDaily);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.track;
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.analytics.TrackStatisticsUpdater;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.analytics.DeliveryHistoryService;
 import com.project.tracking_system.service.customer.CustomerService;
@@ -38,10 +39,7 @@ public class TrackProcessingService {
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
     private final TrackParcelRepository trackParcelRepository;
-    private final StoreAnalyticsRepository storeAnalyticsRepository;
-    private final PostalServiceStatisticsRepository postalServiceStatisticsRepository;
-    private final StoreDailyStatisticsRepository storeDailyStatisticsRepository;
-    private final PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
+    private final TrackStatisticsUpdater trackStatisticsUpdater;
 
     /**
      * Обрабатывает номер посылки: получает информацию и при необходимости сохраняет её.
@@ -200,124 +198,7 @@ public class TrackProcessingService {
             customerStatsService.incrementSent(customer);
         }
 
-        boolean storeChanged = !isNewParcel && previousStoreId != null && !previousStoreId.equals(storeId);
-
-        PostalServiceType serviceType = typeDefinitionTrackPostService.detectPostalService(number);
-
-        // Инкрементируем статистику нового магазина при добавлении новой посылки или смене магазина
-        if (isNewParcel || storeChanged) {
-            StoreStatistics statistics = storeAnalyticsRepository.findByStoreId(storeId)
-                    .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
-
-            // Атомарное обновление счётчика отправлений
-            int updated = storeAnalyticsRepository.incrementTotalSent(storeId, 1);
-            if (updated == 0) {
-                statistics.setTotalSent(statistics.getTotalSent() + 1);
-                statistics.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                storeAnalyticsRepository.save(statistics);
-            }
-
-            // Статистика почтовой службы (пропустить UNKNOWN)
-            if (serviceType != PostalServiceType.UNKNOWN) {
-                int psUpdated = postalServiceStatisticsRepository.incrementTotalSent(storeId, serviceType, 1);
-                if (psUpdated == 0) {
-                    PostalServiceStatistics psStats = postalServiceStatisticsRepository
-                            .findByStoreIdAndPostalServiceType(storeId, serviceType)
-                            .orElseGet(() -> {
-                                PostalServiceStatistics s = new PostalServiceStatistics();
-                                s.setStore(statistics.getStore());
-                                s.setPostalServiceType(serviceType);
-                                return s;
-                            });
-                    psStats.setTotalSent(psStats.getTotalSent() + 1);
-                    psStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    postalServiceStatisticsRepository.save(psStats);
-                }
-            } else {
-                log.warn("⛔ Пропуск обновления аналитики для UNKNOWN службы: {}", number);
-            }
-
-            // Ежедневная статистика магазина
-            LocalDate day = zonedDateTime.toLocalDate();
-            int dailyUpdated = storeDailyStatisticsRepository.incrementSent(storeId, day, 1);
-            if (dailyUpdated == 0) {
-                StoreDailyStatistics daily = storeDailyStatisticsRepository
-                        .findByStoreIdAndDate(storeId, day)
-                        .orElseGet(() -> {
-                            StoreDailyStatistics d = new StoreDailyStatistics();
-                            d.setStore(statistics.getStore());
-                            d.setDate(day);
-                            return d;
-                        });
-                daily.setSent(daily.getSent() + 1);
-                daily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                storeDailyStatisticsRepository.save(daily);
-            }
-
-            // Ежедневная статистика почтовой службы
-            if (serviceType != PostalServiceType.UNKNOWN) {
-                int psdUpdated = postalServiceDailyStatisticsRepository.incrementSent(storeId, serviceType, day, 1);
-                if (psdUpdated == 0) {
-                    PostalServiceDailyStatistics psDaily = postalServiceDailyStatisticsRepository
-                            .findByStoreIdAndPostalServiceTypeAndDate(storeId, serviceType, day)
-                            .orElseGet(() -> {
-                                PostalServiceDailyStatistics d = new PostalServiceDailyStatistics();
-                                d.setStore(statistics.getStore());
-                                d.setPostalServiceType(serviceType);
-                                d.setDate(day);
-                                return d;
-                            });
-                    psDaily.setSent(psDaily.getSent() + 1);
-                    psDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    postalServiceDailyStatisticsRepository.save(psDaily);
-                }
-            }
-        }
-
-        // Декрементируем статистику старого магазина, если посылка перенесена
-        if (storeChanged) {
-            StoreStatistics oldStats = storeAnalyticsRepository.findByStoreId(previousStoreId)
-                    .orElseThrow(() -> new IllegalStateException("Статистика не найдена"));
-            if (oldStats.getTotalSent() > 0) {
-                oldStats.setTotalSent(oldStats.getTotalSent() - 1);
-                oldStats.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                storeAnalyticsRepository.save(oldStats);
-            }
-
-            if (serviceType != PostalServiceType.UNKNOWN) {
-                PostalServiceStatistics oldPs = postalServiceStatisticsRepository
-                        .findByStoreIdAndPostalServiceType(previousStoreId, serviceType)
-                        .orElse(null);
-                if (oldPs != null && oldPs.getTotalSent() > 0) {
-                    oldPs.setTotalSent(oldPs.getTotalSent() - 1);
-                    oldPs.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    postalServiceStatisticsRepository.save(oldPs);
-                }
-            }
-
-            if (previousDate != null) {
-                LocalDate prevDay = previousDate.toLocalDate();
-                StoreDailyStatistics oldDaily = storeDailyStatisticsRepository
-                        .findByStoreIdAndDate(previousStoreId, prevDay)
-                        .orElse(null);
-                if (oldDaily != null && oldDaily.getSent() > 0) {
-                    oldDaily.setSent(oldDaily.getSent() - 1);
-                    oldDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    storeDailyStatisticsRepository.save(oldDaily);
-                }
-
-                if (serviceType != PostalServiceType.UNKNOWN) {
-                    PostalServiceDailyStatistics oldPsDaily = postalServiceDailyStatisticsRepository
-                            .findByStoreIdAndPostalServiceTypeAndDate(previousStoreId, serviceType, prevDay)
-                            .orElse(null);
-                    if (oldPsDaily != null && oldPsDaily.getSent() > 0) {
-                        oldPsDaily.setSent(oldPsDaily.getSent() - 1);
-                        oldPsDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                        postalServiceDailyStatisticsRepository.save(oldPsDaily);
-                    }
-                }
-            }
-        }
+        trackStatisticsUpdater.updateStatistics(trackParcel, isNewParcel, previousStoreId, previousDate);
 
         // Обновляем историю доставки
         deliveryHistoryService.updateDeliveryHistory(trackParcel, oldStatus, newStatus, trackInfoListDTO);

--- a/src/test/java/com/project/tracking_system/service/analytics/TrackStatisticsUpdaterTest.java
+++ b/src/test/java/com/project/tracking_system/service/analytics/TrackStatisticsUpdaterTest.java
@@ -1,0 +1,113 @@
+package com.project.tracking_system.service.analytics;
+
+import com.project.tracking_system.entity.*;
+import com.project.tracking_system.repository.*;
+import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link TrackStatisticsUpdater}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackStatisticsUpdaterTest {
+
+    @Mock
+    private StoreAnalyticsRepository storeAnalyticsRepository;
+    @Mock
+    private PostalServiceStatisticsRepository postalServiceStatisticsRepository;
+    @Mock
+    private StoreDailyStatisticsRepository storeDailyStatisticsRepository;
+    @Mock
+    private PostalServiceDailyStatisticsRepository postalServiceDailyStatisticsRepository;
+    @Mock
+    private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+
+    @InjectMocks
+    private TrackStatisticsUpdater updater;
+
+    private TrackParcel parcel;
+    private Store store;
+
+    @BeforeEach
+    void setUp() {
+        store = new Store();
+        store.setId(2L);
+        parcel = new TrackParcel();
+        parcel.setStore(store);
+        parcel.setNumber("AA111");
+        parcel.setTimestamp(ZonedDateTime.now());
+    }
+
+    @Test
+    void updateStatistics_NewParcel_Increments() {
+        StoreStatistics st = new StoreStatistics();
+        st.setStore(store);
+        when(typeDefinitionTrackPostService.detectPostalService(anyString()))
+                .thenReturn(PostalServiceType.BELPOST);
+        when(storeAnalyticsRepository.findByStoreId(2L)).thenReturn(java.util.Optional.of(st));
+        when(storeAnalyticsRepository.incrementTotalSent(2L, 1)).thenReturn(1);
+        when(storeDailyStatisticsRepository.incrementSent(eq(2L), any(LocalDate.class), eq(1)))
+                .thenReturn(1);
+        when(postalServiceStatisticsRepository.incrementTotalSent(2L, PostalServiceType.BELPOST, 1))
+                .thenReturn(1);
+        when(postalServiceDailyStatisticsRepository.incrementSent(eq(2L), eq(PostalServiceType.BELPOST), any(LocalDate.class), eq(1)))
+                .thenReturn(1);
+
+        updater.updateStatistics(parcel, true, null, null);
+
+        verify(storeAnalyticsRepository).incrementTotalSent(2L, 1);
+        verify(postalServiceStatisticsRepository).incrementTotalSent(2L, PostalServiceType.BELPOST, 1);
+        verify(storeDailyStatisticsRepository).incrementSent(eq(2L), any(LocalDate.class), eq(1));
+        verify(postalServiceDailyStatisticsRepository)
+                .incrementSent(eq(2L), eq(PostalServiceType.BELPOST), any(LocalDate.class), eq(1));
+        verify(storeAnalyticsRepository, never()).findByStoreId(1L);
+    }
+
+    @Test
+    void updateStatistics_StoreChanged_DecrementsOld() {
+        StoreStatistics newStats = new StoreStatistics();
+        newStats.setStore(store);
+        StoreStatistics oldStats = new StoreStatistics();
+        oldStats.setStore(new Store());
+        oldStats.setTotalSent(1);
+        when(typeDefinitionTrackPostService.detectPostalService(anyString()))
+                .thenReturn(PostalServiceType.BELPOST);
+        when(storeAnalyticsRepository.findByStoreId(2L)).thenReturn(java.util.Optional.of(newStats));
+        when(storeAnalyticsRepository.incrementTotalSent(2L, 1)).thenReturn(1);
+        when(storeAnalyticsRepository.findByStoreId(1L)).thenReturn(java.util.Optional.of(oldStats));
+        when(storeDailyStatisticsRepository.incrementSent(eq(2L), any(LocalDate.class), eq(1))).thenReturn(1);
+        when(postalServiceStatisticsRepository.incrementTotalSent(2L, PostalServiceType.BELPOST, 1)).thenReturn(1);
+        when(postalServiceDailyStatisticsRepository.incrementSent(eq(2L), eq(PostalServiceType.BELPOST), any(LocalDate.class), eq(1))).thenReturn(1);
+        StoreDailyStatistics oldDaily = new StoreDailyStatistics();
+        oldDaily.setSent(1);
+        when(storeDailyStatisticsRepository.findByStoreIdAndDate(eq(1L), any(LocalDate.class))).thenReturn(java.util.Optional.of(oldDaily));
+        PostalServiceStatistics oldPs = new PostalServiceStatistics();
+        oldPs.setTotalSent(1);
+        when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(1L, PostalServiceType.BELPOST))
+                .thenReturn(java.util.Optional.of(oldPs));
+        PostalServiceDailyStatistics oldPsDaily = new PostalServiceDailyStatistics();
+        oldPsDaily.setSent(1);
+        when(postalServiceDailyStatisticsRepository.findByStoreIdAndPostalServiceTypeAndDate(eq(1L), eq(PostalServiceType.BELPOST), any(LocalDate.class)))
+                .thenReturn(java.util.Optional.of(oldPsDaily));
+
+        ZonedDateTime prev = ZonedDateTime.now().minusDays(1);
+        updater.updateStatistics(parcel, false, 1L, prev);
+
+        verify(storeAnalyticsRepository).incrementTotalSent(2L, 1);
+        verify(storeAnalyticsRepository).save(oldStats);
+        verify(postalServiceStatisticsRepository).save(oldPs);
+        verify(storeDailyStatisticsRepository).save(oldDaily);
+        verify(postalServiceDailyStatisticsRepository).save(oldPsDaily);
+    }
+}


### PR DESCRIPTION
## Summary
- move store/postal statistics update logic to new `TrackStatisticsUpdater` component
- clean up `TrackProcessingService` to delegate statistics updates
- cover statistics updater with unit tests

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb552f468832d891d18a85fb045a5