### PR TITLE
Implement TrackUpdateCoordinatorService and refactor update flows

### DIFF
--- a/src/main/java/com/project/tracking_system/service/admin/AdminService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminService.java
@@ -4,7 +4,8 @@ import com.project.tracking_system.dto.*;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
 import com.project.tracking_system.service.track.TrackDeletionService;
-import com.project.tracking_system.service.track.TrackProcessingService;
+import com.project.tracking_system.service.track.TrackUpdateCoordinatorService;
+import com.project.tracking_system.service.track.TrackMeta;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,7 @@ public class AdminService {
     private final TrackParcelRepository trackParcelRepository;
     private final UserRepository userRepository;
     private final TrackDeletionService trackDeletionService;
-    private final TrackProcessingService trackProcessingService;
+    private final TrackUpdateCoordinatorService trackUpdateCoordinatorService;
     private final com.project.tracking_system.service.user.UserService userService;
     private final com.project.tracking_system.service.store.StoreService storeService;
 
@@ -327,7 +328,8 @@ public class AdminService {
     public void forceUpdateParcel(Long id) {
         TrackParcel parcel = trackParcelRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Посылка не найдена"));
-        trackProcessingService.processTrack(parcel.getNumber(), parcel.getStore().getId(), parcel.getUser().getId(), true);
+        TrackMeta meta = new TrackMeta(parcel.getNumber(), parcel.getStore().getId(), null, true);
+        trackUpdateCoordinatorService.process(List.of(meta), parcel.getUser().getId());
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateCoordinatorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateCoordinatorService.java
@@ -1,0 +1,37 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.entity.PostalServiceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Coordinates update of track numbers for different postal services.
+ * <p>
+ * Service groups provided {@link TrackMeta} objects by {@link PostalServiceType}
+ * and delegates processing to {@link TrackBatchProcessingService}.
+ * It is used both for file uploads and manual update flows.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class TrackUpdateCoordinatorService {
+
+    private final TrackUploadGroupingService groupingService;
+    private final TrackBatchProcessingService batchProcessingService;
+
+    /**
+     * Processes the given tracks for the specified user.
+     *
+     * @param tracks list of track metadata
+     * @param userId id of the user performing the update
+     * @return list of aggregated processing results
+     */
+    public List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId) {
+        Map<PostalServiceType, List<TrackMeta>> grouped = groupingService.group(tracks);
+        return batchProcessingService.processBatch(grouped, userId);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -1,12 +1,12 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.controller.WebSocketController;
-import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.TrackParcelDTO;
 import com.project.tracking_system.entity.*;
 import com.project.tracking_system.repository.*;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.model.subscription.FeatureKey;
+import com.project.tracking_system.dto.TrackingResultAdd;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
@@ -15,8 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Сервис обновления треков пользователей.
@@ -30,7 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class TrackUpdateService {
 
     private final WebSocketController webSocketController;
-    private final TrackProcessingService trackProcessingService;
+    private final TrackUpdateCoordinatorService trackUpdateCoordinatorService;
     private final SubscriptionService subscriptionService;
     private final StoreRepository storeRepository;
     private final TrackParcelRepository trackParcelRepository;
@@ -38,14 +36,14 @@ public class TrackUpdateService {
     private final TaskExecutor taskExecutor;
 
     public TrackUpdateService(WebSocketController webSocketController,
-                              TrackProcessingService trackProcessingService,
+                              TrackUpdateCoordinatorService trackUpdateCoordinatorService,
                               SubscriptionService subscriptionService,
                               StoreRepository storeRepository,
                               TrackParcelRepository trackParcelRepository,
                               TrackParcelService trackParcelService,
                               @Qualifier("trackExecutor") TaskExecutor taskExecutor) {
         this.webSocketController = webSocketController;
-        this.trackProcessingService = trackProcessingService;
+        this.trackUpdateCoordinatorService = trackUpdateCoordinatorService;
         this.subscriptionService = subscriptionService;
         this.storeRepository = storeRepository;
         this.trackParcelRepository = trackParcelRepository;
@@ -100,52 +98,32 @@ public class TrackUpdateService {
     @Transactional
     public void processAllTrackUpdatesAsync(Long userId, List<TrackParcelDTO> parcelsToUpdate) {
         try {
-            AtomicInteger successfulUpdates = new AtomicInteger(0);
-
-            List<CompletableFuture<Void>> futures = parcelsToUpdate.stream()
-                    .map(trackParcelDTO -> CompletableFuture.runAsync(() -> {
-                        try {
-                            TrackInfoListDTO trackInfo = trackProcessingService.processTrack(
-                                    trackParcelDTO.getNumber(),
-                                    trackParcelDTO.getStoreId(),
-                                    userId,
-                                    true
-                            );
-
-                            if (trackInfo != null && !trackInfo.getList().isEmpty()) {
-                                successfulUpdates.incrementAndGet();
-                                log.debug("Трек {} обновлён для пользователя ID={}", trackParcelDTO.getNumber(), userId);
-                            } else {
-                                log.warn("Нет данных по треку {} (userId={})", trackParcelDTO.getNumber(), userId);
-                            }
-
-                        } catch (IllegalArgumentException e) {
-                            log.warn("Ошибка обновления трека {}: {}", trackParcelDTO.getNumber(), e.getMessage());
-                        } catch (Exception e) {
-                            log.error("Ошибка обработки трека {}: {}", trackParcelDTO.getNumber(), e.getMessage(), e);
-                        }
-                    }, taskExecutor))
+            List<TrackMeta> metas = parcelsToUpdate.stream()
+                    .map(dto -> new TrackMeta(dto.getNumber(), dto.getStoreId(), null, true))
                     .toList();
 
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
-                int updatedCount = successfulUpdates.get();
-                int totalCount = parcelsToUpdate.size();
+            List<TrackingResultAdd> results = trackUpdateCoordinatorService.process(metas, userId);
 
-                log.info("Итог обновления всех треков для userId={}: {} обновлено, {} не изменено",
-                        userId, updatedCount, totalCount - updatedCount);
+            int updatedCount = (int) results.stream()
+                    .filter(r -> !"Нет данных".equals(r.getStatus()))
+                    .count();
 
-                String message;
-                if (updatedCount == 0) {
-                    message = "Обновление завершено, но все треки уже были в финальном статусе.";
-                } else {
-                    message = "Обновление завершено! " + updatedCount + " из " + totalCount + " треков обновлено.";
-                }
+            int totalCount = parcelsToUpdate.size();
 
-                webSocketController.sendDetailUpdateStatus(
-                        userId,
-                        new UpdateResult(true, updatedCount, totalCount, message)
-                );
-            });
+            log.info("Итог обновления всех треков для userId={}: {} обновлено, {} не изменено",
+                    userId, updatedCount, totalCount - updatedCount);
+
+            String message;
+            if (updatedCount == 0) {
+                message = "Обновление завершено, но все треки уже были в финальном статусе.";
+            } else {
+                message = "Обновление завершено! " + updatedCount + " из " + totalCount + " треков обновлено.";
+            }
+
+            webSocketController.sendDetailUpdateStatus(
+                    userId,
+                    new UpdateResult(true, updatedCount, totalCount, message)
+            );
 
         } catch (Exception e) {
             log.error("Ошибка при обновлении всех треков для пользователя {}: {}", userId, e.getMessage());
@@ -203,50 +181,42 @@ public class TrackUpdateService {
     @Transactional
     public void processTrackUpdatesAsync(Long userId, List<TrackParcel> parcelsToUpdate, int totalRequested, int nonUpdatableCount) {
         try {
-            AtomicInteger successfulUpdates = new AtomicInteger(0);
-
             log.info("Начато обновление {} треков для userId={}", parcelsToUpdate.size(), userId);
 
-            List<CompletableFuture<Void>> futures = parcelsToUpdate.stream()
-                    .map(parcel -> CompletableFuture.runAsync(() -> {
-                        try {
-                            TrackInfoListDTO trackInfo = trackProcessingService.processTrack(parcel.getNumber(), parcel.getStore().getId(), userId, true);
-                            if (trackInfo != null && !trackInfo.getList().isEmpty()) {
-                                successfulUpdates.incrementAndGet();
-                            }
-                        } catch (Exception e) {
-                            log.error("Ошибка обновления трека {}: {}", parcel.getNumber(), e.getMessage());
-                        }
-                    }, taskExecutor))
+            List<TrackMeta> metas = parcelsToUpdate.stream()
+                    .map(parcel -> new TrackMeta(parcel.getNumber(), parcel.getStore().getId(), null, true))
                     .toList();
 
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
-                int updatedCount = successfulUpdates.get();
-                log.info("Итог обновления для userId={}: {} обновлено, {} в финальном статусе",
-                        userId, updatedCount, nonUpdatableCount);
+            List<TrackingResultAdd> results = trackUpdateCoordinatorService.process(metas, userId);
 
-                if (updatedCount > 0) {
-                    log.info("Финальное обновление updateCount для userId={}, добавляем={}", userId, updatedCount);
-                    trackParcelService.incrementUpdateCount(userId, updatedCount);
+            int updatedCount = (int) results.stream()
+                    .filter(r -> !"Нет данных".equals(r.getStatus()))
+                    .count();
+
+            log.info("Итог обновления для userId={}: {} обновлено, {} в финальном статусе",
+                    userId, updatedCount, nonUpdatableCount);
+
+            if (updatedCount > 0) {
+                log.info("Финальное обновление updateCount для userId={}, добавляем={}", userId, updatedCount);
+                trackParcelService.incrementUpdateCount(userId, updatedCount);
+            }
+
+            String message;
+            if (updatedCount == 0 && nonUpdatableCount == 0) {
+                message = "Все треки уже были обновлены ранее.";
+            } else if (updatedCount == 0) {
+                message = "Обновление завершено, но все треки уже в финальном статусе.";
+            } else {
+                message = "Обновление завершено! " + updatedCount + " из " + totalRequested + " треков обновлено.";
+                if (nonUpdatableCount > 0) {
+                    message += " " + nonUpdatableCount + " треков уже были в финальном статусе.";
                 }
+            }
 
-                String message;
-                if (updatedCount == 0 && nonUpdatableCount == 0) {
-                    message = "Все треки уже были обновлены ранее.";
-                } else if (updatedCount == 0) {
-                    message = "Обновление завершено, но все треки уже в финальном статусе.";
-                } else {
-                    message = "Обновление завершено! " + updatedCount + " из " + totalRequested + " треков обновлено.";
-                    if (nonUpdatableCount > 0) {
-                        message += " " + nonUpdatableCount + " треков уже были в финальном статусе.";
-                    }
-                }
-
-                webSocketController.sendDetailUpdateStatus(
-                        userId,
-                        new UpdateResult(true, updatedCount, totalRequested, message)
-                );
-            });
+            webSocketController.sendDetailUpdateStatus(
+                    userId,
+                    new UpdateResult(true, updatedCount, totalRequested, message)
+            );
 
         } catch (Exception e) {
             log.error("Ошибка при обновлении посылок для пользователя {}: {}", userId, e.getMessage());

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -1,7 +1,6 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackingResultAdd;
-import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.model.TrackingResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +9,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Координирует загрузку и обработку XLS-файла с треками.
@@ -22,8 +20,7 @@ public class TrackUploadProcessorService {
 
     private final TrackExcelParser trackExcelParser;
     private final TrackMetaValidator trackMetaValidator;
-    private final TrackUploadGroupingService trackUploadGroupingService;
-    private final TrackBatchProcessingService trackBatchProcessingService;
+    private final TrackUpdateCoordinatorService trackUpdateCoordinatorService;
 
     /**
      * Полный цикл загрузки файла: парсинг, валидация, группировка и отправка на обработку.
@@ -36,8 +33,8 @@ public class TrackUploadProcessorService {
     public TrackingResponse process(MultipartFile file, Long userId) throws IOException {
         List<TrackExcelRow> rows = trackExcelParser.parse(file);
         TrackMetaValidationResult validation = trackMetaValidator.validate(rows, userId);
-        Map<PostalServiceType, List<TrackMeta>> grouped = trackUploadGroupingService.group(validation.validTracks());
-        List<TrackingResultAdd> results = trackBatchProcessingService.processBatch(grouped, userId);
+        List<TrackingResultAdd> results =
+                trackUpdateCoordinatorService.process(validation.validTracks(), userId);
         return new TrackingResponse(results, validation.limitExceededMessage());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackUpdateCoordinatorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUpdateCoordinatorServiceTest.java
@@ -1,0 +1,49 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.entity.PostalServiceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link TrackUpdateCoordinatorService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackUpdateCoordinatorServiceTest {
+
+    @Mock
+    private TrackUploadGroupingService groupingService;
+    @Mock
+    private TrackBatchProcessingService batchProcessingService;
+
+    private TrackUpdateCoordinatorService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TrackUpdateCoordinatorService(groupingService, batchProcessingService);
+    }
+
+    @Test
+    void process_GroupsAndDelegates() {
+        TrackMeta meta = new TrackMeta("A1", 1L, null, true);
+        Map<PostalServiceType, List<TrackMeta>> grouped = Map.of(PostalServiceType.BELPOST, List.of(meta));
+        when(groupingService.group(anyList())).thenReturn(grouped);
+        List<TrackingResultAdd> expected = List.of(new TrackingResultAdd("A1", "ok"));
+        when(batchProcessingService.processBatch(grouped, 5L)).thenReturn(expected);
+
+        List<TrackingResultAdd> actual = service.process(List.of(meta), 5L);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -1,7 +1,6 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackingResultAdd;
-import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.model.TrackingResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +10,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
@@ -25,15 +23,13 @@ class TrackUploadProcessorServiceTest {
     @Mock
     private TrackMetaValidator validator;
     @Mock
-    private TrackUploadGroupingService groupingService;
-    @Mock
-    private TrackBatchProcessingService batchProcessingService;
+    private TrackUpdateCoordinatorService coordinator;
 
     private TrackUploadProcessorService processor;
 
     @BeforeEach
     void setUp() {
-        processor = new TrackUploadProcessorService(parser, validator, groupingService, batchProcessingService);
+        processor = new TrackUploadProcessorService(parser, validator, coordinator);
     }
 
     @Test
@@ -42,10 +38,8 @@ class TrackUploadProcessorServiceTest {
         when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", null, null)));
         TrackMeta meta = new TrackMeta("A1", null, null, true);
         when(validator.validate(anyList(), any())).thenReturn(new TrackMetaValidationResult(List.of(meta), null));
-        Map<PostalServiceType, List<TrackMeta>> grouped = Map.of(PostalServiceType.BELPOST, List.of(meta));
-        when(groupingService.group(anyList())).thenReturn(grouped);
         List<TrackingResultAdd> results = List.of(new TrackingResultAdd("A1", "ok"));
-        when(batchProcessingService.processBatch(grouped, 1L)).thenReturn(results);
+        when(coordinator.process(anyList(), eq(1L))).thenReturn(results);
 
         TrackingResponse response = processor.process(file, 1L);
 


### PR DESCRIPTION
## Summary
- create `TrackUpdateCoordinatorService` for grouping and batch processing
- use coordinator in `TrackUploadProcessorService`
- refactor manual update flows to delegate to coordinator
- update admin service to use new coordinator
- add unit tests for coordinator and adjust existing tests

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbf4ca510832d8776c58f1a78b3f9