### PR TITLE
Refactor track grouping into classifier

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackServiceClassifier.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackServiceClassifier.java
@@ -1,0 +1,45 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.PostalServiceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Определяет почтовую службу для каждого трек-номера и
+ * группирует метаданные треков по типу почтовой службы.
+ * <p>
+ * Треки, отнесённые к {@link PostalServiceType#UNKNOWN},
+ * не включаются в результирующее отображение, что исключает
+ * дальнейшую обработку неподдерживаемых номеров.
+ * </p>
+ */
+@Component
+@RequiredArgsConstructor
+public class TrackServiceClassifier {
+
+    private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+
+    /**
+     * Классифицирует список треков по почтовым службам.
+     *
+     * @param tracks список валидированных трек-метаданных
+     * @return карта «служба → список треков» без UNKNOWN
+     */
+    public Map<PostalServiceType, List<TrackMeta>> classify(List<TrackMeta> tracks) {
+        Map<PostalServiceType, List<TrackMeta>> grouped = new EnumMap<>(PostalServiceType.class);
+        for (TrackMeta meta : tracks) {
+            PostalServiceType type = typeDefinitionTrackPostService.detectPostalService(meta.number());
+            if (type == PostalServiceType.UNKNOWN) {
+                // Номера с неопределённым форматом пропускаем
+                continue;
+            }
+            grouped.computeIfAbsent(type, k -> new ArrayList<>()).add(meta);
+        }
+        return grouped;
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackServiceClassifierTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackServiceClassifierTest.java
@@ -14,21 +14,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+/**
+ * Тесты для {@link TrackServiceClassifier}.
+ */
 @ExtendWith(MockitoExtension.class)
-class TrackUploadGroupingServiceTest {
+class TrackServiceClassifierTest {
 
     @Mock
     private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
 
-    private TrackUploadGroupingService service;
+    private TrackServiceClassifier classifier;
 
     @BeforeEach
     void setUp() {
-        service = new TrackUploadGroupingService(typeDefinitionTrackPostService);
+        classifier = new TrackServiceClassifier(typeDefinitionTrackPostService);
     }
 
     @Test
-    void group_SplitsByService() {
+    void classify_SplitsByService() {
         when(typeDefinitionTrackPostService.detectPostalService(anyString()))
                 .thenReturn(PostalServiceType.BELPOST)
                 .thenReturn(PostalServiceType.EVROPOST);
@@ -38,14 +41,14 @@ class TrackUploadGroupingServiceTest {
                 new TrackMeta("E1", 1L, null, true)
         );
 
-        Map<PostalServiceType, List<TrackMeta>> map = service.group(list);
+        Map<PostalServiceType, List<TrackMeta>> map = classifier.classify(list);
 
         assertEquals(1, map.get(PostalServiceType.BELPOST).size());
         assertEquals(1, map.get(PostalServiceType.EVROPOST).size());
     }
 
     @Test
-    void group_SkipsUnknownService() {
+    void classify_SkipsUnknownService() {
         when(typeDefinitionTrackPostService.detectPostalService(anyString()))
                 .thenReturn(PostalServiceType.BELPOST)
                 .thenReturn(PostalServiceType.UNKNOWN);
@@ -55,7 +58,7 @@ class TrackUploadGroupingServiceTest {
                 new TrackMeta("U1", 1L, null, true)
         );
 
-        Map<PostalServiceType, List<TrackMeta>> map = service.group(list);
+        Map<PostalServiceType, List<TrackMeta>> map = classifier.classify(list);
 
         assertEquals(1, map.get(PostalServiceType.BELPOST).size());
         // Для UNKNOWN не должно быть записей


### PR DESCRIPTION
## Summary
- extract classification logic into new `TrackServiceClassifier`
- delegate `TrackUploadGroupingService` to the classifier
- add unit tests for classification results

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687bc613c650832db19e19e85b346cf9