### PR TITLE
Handle individual errors in TrackAutoUpdateScheduler

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
@@ -45,11 +45,20 @@ public class TrackAutoUpdateScheduler {
 
         for (Long userId : userIds) {
             if (userService.isAutoUpdateEnabled(userId)) {
-                updateUserTracks(userId);
+                try {
+                    updateUserTracks(userId);
+                } catch (Exception e) {
+                    log.error("Не удалось автообновить треки для userId={}", userId, e);
+                }
             }
         }
     }
 
+    /**
+     * Обновляет треки для одного пользователя.
+     *
+     * @param userId идентификатор пользователя
+     */
     private void updateUserTracks(Long userId) {
         List<TrackParcel> parcels = trackParcelRepository.findByUserId(userId);
         List<TrackParcel> toUpdate = parcels.stream()


### PR DESCRIPTION
## Summary
- log errors per user when auto update fails
- continue processing remaining users
- test that failure for one user doesn't stop others

## Testing
- `mvn -version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687bc81f7d50832d85730fe1a337094c