### PR TITLE
Add tests for customer services

### DIFF
--- a/src/test/java/com/project/tracking_system/service/customer/CustomerServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerServiceTest.java
@@ -1,0 +1,108 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.user.UserSettingsService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.project.tracking_system.service.customer.CustomerTransactionalService;
+import com.project.tracking_system.service.customer.CustomerStatsService;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link CustomerService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomerServiceTest {
+
+    @Mock
+    private CustomerRepository customerRepository; // not used in tests but required for service construction
+    @Mock
+    private TrackParcelRepository trackParcelRepository; // not used
+    @Mock
+    private CustomerTransactionalService transactionalService;
+    @Mock
+    private CustomerStatsService customerStatsService; // not used
+    @Mock
+    private SubscriptionService subscriptionService; // not used
+    @Mock
+    private UserSettingsService userSettingsService; // not used
+
+    @InjectMocks
+    private CustomerService service;
+
+    private Customer savedCustomer;
+
+    @BeforeEach
+    void setUp() {
+        savedCustomer = new Customer();
+        savedCustomer.setId(1L);
+        savedCustomer.setPhone("375291234567");
+    }
+
+    /**
+     * Проверяем нормализацию номера и сохранение нового покупателя.
+     */
+    @Test
+    void registerOrGetByPhone_NewCustomer_SavesWithNormalizedPhone() {
+        when(transactionalService.findByPhone("375291234567"))
+                .thenReturn(Optional.empty());
+        when(transactionalService.saveCustomer(any(Customer.class)))
+                .thenReturn(savedCustomer);
+
+        Customer result = service.registerOrGetByPhone("+375 (29) 123-45-67");
+
+        assertSame(savedCustomer, result);
+        verify(transactionalService).findByPhone("375291234567");
+        verify(transactionalService).saveCustomer(argThat(c -> "375291234567".equals(c.getPhone())));
+    }
+
+    /**
+     * Проверяем повторный поиск после ошибки сохранения из-за дубликата.
+     */
+    @Test
+    void registerOrGetByPhone_DuplicateRetry_ReturnsExisting() {
+        when(transactionalService.findByPhone("375291234567"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(savedCustomer));
+        when(transactionalService.saveCustomer(any(Customer.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        Customer result = service.registerOrGetByPhone("375291234567");
+
+        assertSame(savedCustomer, result);
+        verify(transactionalService, times(2)).findByPhone("375291234567");
+        verify(transactionalService).saveCustomer(any(Customer.class));
+    }
+
+    /**
+     * Если поиск не удаётся после нескольких попыток, бросается исключение.
+     */
+    @Test
+    void registerOrGetByPhone_RetriesExhausted_Throws() {
+        when(transactionalService.findByPhone("375291234567"))
+                .thenReturn(Optional.empty());
+        when(transactionalService.saveCustomer(any(Customer.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+        when(transactionalService.findByPhone("375291234567"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class,
+                () -> service.registerOrGetByPhone("375291234567"));
+
+        verify(transactionalService, times(4)).findByPhone("375291234567");
+
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerStatsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerStatsServiceTest.java
@@ -1,0 +1,127 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link CustomerStatsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomerStatsServiceTest {
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @InjectMocks
+    private CustomerStatsService service;
+
+    private Customer customer;
+
+    @BeforeEach
+    void setUp() {
+        customer = new Customer();
+        customer.setId(1L);
+    }
+
+    /**
+     * Успешное атомарное увеличение отправленных посылок.
+     */
+    @Test
+    void incrementSent_AtomicSuccess() {
+        when(customerRepository.incrementSentCount(1L)).thenReturn(1);
+
+        service.incrementSent(customer);
+
+        assertEquals(1, customer.getSentCount());
+        verify(customerRepository).incrementSentCount(1L);
+        verify(customerRepository).save(customer);
+    }
+
+    /**
+     * Падение атомарного обновления приводит к ручному увеличению.
+     */
+    @Test
+    void incrementSent_FallbackManual() {
+        when(customerRepository.incrementSentCount(1L)).thenReturn(0);
+        Customer fresh = new Customer();
+        fresh.setId(1L);
+        when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
+
+        service.incrementSent(customer);
+
+        assertEquals(1, customer.getSentCount());
+        verify(customerRepository).save(fresh);
+    }
+
+    /**
+     * Успешное атомарное увеличение забранных посылок.
+     */
+    @Test
+    void incrementPickedUp_AtomicSuccess() {
+        when(customerRepository.incrementPickedUpCount(1L)).thenReturn(1);
+
+        service.incrementPickedUp(customer);
+
+        assertEquals(1, customer.getPickedUpCount());
+        verify(customerRepository).incrementPickedUpCount(1L);
+        verify(customerRepository).save(customer);
+    }
+
+    /**
+     * Ошибка атомарного обновления забранных переключает на ручной режим.
+     */
+    @Test
+    void incrementPickedUp_FallbackManual() {
+        when(customerRepository.incrementPickedUpCount(1L)).thenReturn(0);
+        Customer fresh = new Customer();
+        fresh.setId(1L);
+        when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
+
+        service.incrementPickedUp(customer);
+
+        assertEquals(1, customer.getPickedUpCount());
+        verify(customerRepository).save(fresh);
+    }
+
+    /**
+     * Успешное атомарное увеличение возвратов.
+     */
+    @Test
+    void incrementReturned_AtomicSuccess() {
+        when(customerRepository.incrementReturnedCount(1L)).thenReturn(1);
+
+        service.incrementReturned(customer);
+
+        assertEquals(1, customer.getReturnedCount());
+        verify(customerRepository).incrementReturnedCount(1L);
+        verify(customerRepository).save(customer);
+    }
+
+    /**
+     * Ошибка атомарного увеличения возвратов обрабатывается вручную.
+     */
+    @Test
+    void incrementReturned_FallbackManual() {
+        when(customerRepository.incrementReturnedCount(1L)).thenReturn(0);
+        Customer fresh = new Customer();
+        fresh.setId(1L);
+        when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
+
+        service.incrementReturned(customer);
+
+        assertEquals(1, customer.getReturnedCount());
+        verify(customerRepository).save(fresh);
+    }
+}


### PR DESCRIPTION
## Summary
- add CustomerServiceTest verifying phone normalization and retry logic
- add CustomerStatsServiceTest covering atomic and manual updates

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc8256720832da69fa78e89e8884e