### PR TITLE
Refactor track services to use constant for no data status

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
@@ -83,7 +83,7 @@ public class TrackAutoUpdateScheduler {
         List<TrackingResultAdd> results = trackUpdateCoordinatorService.process(metas, userId);
 
         long updated = results.stream()
-                .filter(r -> !"Нет данных".equals(r.getStatus()))
+                .filter(r -> !TrackConstants.NO_DATA_STATUS.equals(r.getStatus()))
                 .count();
 
         if (updated > 0) {

--- a/src/main/java/com/project/tracking_system/service/track/TrackBatchProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackBatchProcessingService.java
@@ -99,7 +99,7 @@ public class TrackBatchProcessingService {
                     TrackInfoListDTO info = trackFacade.processTrack(
                             meta.number(), meta.storeId(), userId, meta.canSave(), meta.phone());
                     String status = info.getList().isEmpty()
-                            ? "Нет данных"
+                            ? TrackConstants.NO_DATA_STATUS
                             : info.getList().get(0).getInfoTrack();
                     return new TrackingResultAdd(meta.number(), status);
                 }, batchUploadExecutor))
@@ -132,7 +132,7 @@ public class TrackBatchProcessingService {
                 trackFacade.saveTrackInfo(meta.number(), info, meta.storeId(), userId, meta.phone());
             }
             String status = info.getList().isEmpty()
-                    ? "Нет данных"
+                    ? TrackConstants.NO_DATA_STATUS
                     : info.getList().get(0).getInfoTrack();
             results.add(new TrackingResultAdd(meta.number(), status));
         }

--- a/src/main/java/com/project/tracking_system/service/track/TrackConstants.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackConstants.java
@@ -1,0 +1,17 @@
+package com.project.tracking_system.service.track;
+
+/**
+ * Набор общих констант для сервисов работы с треками.
+ * <p>Используется различными сервисами для избежания дублирования строк.</p>
+ */
+public final class TrackConstants {
+
+    /**
+     * Статус, который означает отсутствие данных по треку.
+     */
+    public static final String NO_DATA_STATUS = "Нет данных";
+
+    private TrackConstants() {
+        // предотвращаем создание экземпляров
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -105,7 +105,7 @@ public class TrackUpdateService {
             List<TrackingResultAdd> results = trackUpdateCoordinatorService.process(metas, userId);
 
             int updatedCount = (int) results.stream()
-                    .filter(r -> !"Нет данных".equals(r.getStatus()))
+                    .filter(r -> !TrackConstants.NO_DATA_STATUS.equals(r.getStatus()))
                     .count();
 
             int totalCount = parcelsToUpdate.size();
@@ -190,7 +190,7 @@ public class TrackUpdateService {
             List<TrackingResultAdd> results = trackUpdateCoordinatorService.process(metas, userId);
 
             int updatedCount = (int) results.stream()
-                    .filter(r -> !"Нет данных".equals(r.getStatus()))
+                    .filter(r -> !TrackConstants.NO_DATA_STATUS.equals(r.getStatus()))
                     .count();
 
             log.info("Итог обновления для userId={}: {} обновлено, {} в финальном статусе",


### PR DESCRIPTION
## Summary
- add `TrackConstants` with `NO_DATA_STATUS`
- replace hard-coded "Нет данных" occurrences in track services

## Testing
- `mvn -version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687bcd38e124832d98da94b65886cd1f