### PR TITLE
Add force update result to admin parcel view

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -516,8 +516,10 @@ public class AdminController {
      * @return редирект на страницу деталей
      */
     @PostMapping("/parcels/{id}/force-update")
-    public String forceUpdateParcel(@PathVariable Long id) {
-        adminService.forceUpdateParcel(id);
+    public String forceUpdateParcel(@PathVariable Long id,
+                                    org.springframework.web.servlet.mvc.support.RedirectAttributes redirectAttributes) {
+        var result = adminService.forceUpdateParcel(id);
+        redirectAttributes.addFlashAttribute("updateStatus", result.getStatus());
         return "redirect:/admin/parcels/" + id;
     }
 

--- a/src/main/resources/templates/admin/parcel-details.html
+++ b/src/main/resources/templates/admin/parcel-details.html
@@ -28,6 +28,10 @@
             </div>
         </div>
 
+        <div th:if="${updateStatus}" class="alert alert-info">
+            Статус обновлён: <span th:text="${updateStatus}"></span>
+        </div>
+
         <form th:action="@{/admin/parcels/{id}/force-update(id=${parcel.id})}" method="post" class="mb-3">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
             <button type="submit" class="btn btn-success">Обновить статус</button>

--- a/src/test/java/com/project/tracking_system/controller/AdminControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/AdminControllerTest.java
@@ -1,0 +1,40 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.service.admin.AdminService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link AdminController} force update flow.
+ */
+@ExtendWith(MockitoExtension.class)
+class AdminControllerTest {
+
+    @Mock
+    private AdminService adminService;
+
+    @InjectMocks
+    private AdminController controller;
+
+    @Test
+    void forceUpdateParcel_AddsFlashAttribute() {
+        TrackingResultAdd result = new TrackingResultAdd("A1", "ok");
+        when(adminService.forceUpdateParcel(1L)).thenReturn(result);
+
+        RedirectAttributes attrs = new RedirectAttributesModelMap();
+        String view = controller.forceUpdateParcel(1L, attrs);
+
+        assertEquals("redirect:/admin/parcels/1", view);
+        assertEquals("ok", attrs.getFlashAttributes().get("updateStatus"));
+        verify(adminService).forceUpdateParcel(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- return `TrackingResultAdd` from `AdminService.forceUpdateParcel`
- add flash message with update status in `AdminController`
- show update status on parcel details page
- test controller flow with new flash attribute

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd1f82f18832db7fa818a3cd6cc29