### PR TITLE
Fix TempMeta scope

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
@@ -22,6 +22,16 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class TrackMetaValidator {
 
+    /**
+     * Временное представление трека в процессе валидации.
+     * <p>
+     * Хранит данные, необходимые для проверки и нормализации,
+     * до применения лимитов на сохранение новых треков.
+     * </p>
+     */
+    private static record TempMeta(String number, Long storeId, String phone, boolean isNew) {
+    }
+
     private final TrackParcelService trackParcelService;
     private final SubscriptionService subscriptionService;
     private final StoreService storeService;
@@ -49,8 +59,6 @@ public class TrackMetaValidator {
         int maxLimit = subscriptionService.canUploadTracks(userId, validRows.size());
 
         // Временная структура для подготовки данных
-        record TempMeta(String number, Long storeId, String phone, boolean isNew) {}
-
         List<TempMeta> tempMetaList = new ArrayList<>();
         int processed = 0;
 


### PR DESCRIPTION
## Summary
- move `TempMeta` record outside of `validate` so it is visible to other methods
- document the record

## Testing
- `mvn -q -DskipTests=false test` *(fails: `command not found: mvn`)*
- `./mvnw -q -DskipTests=false test` *(fails: cannot open wrapper properties)*

------
https://chatgpt.com/codex/tasks/task_e_687be1cd89d8832db4ee22d1cff4ed33