### PR TITLE
Unify track processing via dispatcher

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -8,9 +8,10 @@ import com.project.tracking_system.entity.UpdateResult;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.service.track.StatusTrackService;
-import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackFacade;
+import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
+import com.project.tracking_system.service.track.TrackMeta;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,7 @@ public class DeparturesController {
     private final TrackFacade trackFacade;
     private final StatusTrackService statusTrackService;
     private final StoreService storeService;
-    private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+    private final TrackUpdateDispatcherService trackUpdateDispatcherService;
     private final WebSocketController webSocketController;
     private final UserService userService;
 
@@ -163,8 +164,10 @@ public class DeparturesController {
             throw new RuntimeException("Ошибка доступа: Посылка не принадлежит пользователю.");
         }
 
-        // Получаем информацию о посылке
-        TrackInfoListDTO trackInfo = typeDefinitionTrackPostService.getTypeDefinitionTrackPostService(userId, itemNumber);
+        // Собираем метаданные и передаём в общий диспетчер
+        TrackMeta meta = new TrackMeta(itemNumber, null, null, false,
+                trackParcelService.getPostalServiceType(itemNumber));
+        TrackInfoListDTO trackInfo = trackUpdateDispatcherService.dispatch(meta).getTrackInfo();
         log.info("🎯 Передача в шаблон: {} записей для трека {}", trackInfo.getList().size(), itemNumber);
 
         model.addAttribute("trackInfo", trackInfo);

--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -5,6 +5,8 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.track.TrackFacade;
+import com.project.tracking_system.service.track.TrackMeta;
+import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,6 +33,7 @@ public class HomeController {
 
     private final TrackFacade trackFacade;
     private final StoreService storeService;
+    private final TrackUpdateDispatcherService trackUpdateDispatcherService;
 
     /**
      * Обрабатывает запросы на главной странице. Отображает домашнюю страницу.
@@ -78,8 +81,8 @@ public class HomeController {
         model.addAttribute("stores", stores);
 
         try {
-            // trackParcelService реализует логику с посылкой!
-            TrackInfoListDTO trackInfo = trackFacade.processTrack(number, storeId, userId, canSave, phone);
+            TrackMeta meta = new TrackMeta(number, storeId, phone, canSave);
+            TrackInfoListDTO trackInfo = trackUpdateDispatcherService.dispatch(meta).getTrackInfo();
 
             if (trackInfo == null || trackInfo.getList().isEmpty()) {
                 model.addAttribute("customError", "Нет данных для указанного номера посылки.");

--- a/src/main/java/com/project/tracking_system/dto/TrackingResultAdd.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackingResultAdd.java
@@ -1,17 +1,55 @@
 package com.project.tracking_system.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 
+/**
+ * Результат обработки одного трек-номера.
+ * <p>Содержит номер, итоговый статус, подробную информацию
+ * и сообщение об ошибке, если она возникла.</p>
+ */
+
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
 public class TrackingResultAdd {
 
+    /**
+     * Номер отслеживания посылки.
+     */
     private String trackingNumber;
+
+    /**
+     * Статус после обработки.
+     */
     private String status;
 
+    /**
+     * Детальная информация о посылке.
+     */
+    private TrackInfoListDTO trackInfo;
+
+    /**
+     * Сообщение об ошибке, если обработка завершилась неуспешно.
+     */
+    private String error;
+
+    public TrackingResultAdd(String trackingNumber, String status) {
+        this.trackingNumber = trackingNumber;
+        this.status = status;
+    }
+
+    public TrackingResultAdd(String trackingNumber, String status, TrackInfoListDTO trackInfo) {
+        this.trackingNumber = trackingNumber;
+        this.status = status;
+        this.trackInfo = trackInfo;
+    }
+
+    public TrackingResultAdd(String trackingNumber, String status, TrackInfoListDTO trackInfo, String error) {
+        this.trackingNumber = trackingNumber;
+        this.status = status;
+        this.trackInfo = trackInfo;
+        this.error = error;
+    }
 }

--- a/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.track;
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.service.track.TrackConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
@@ -45,5 +46,18 @@ public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
                 .toList();
         futures.forEach(f -> results.add(f.join()));
         return results;
+    }
+
+    @Override
+    public TrackingResultAdd process(TrackMeta meta) {
+        if (meta == null) {
+            return new TrackingResultAdd(null, TrackConstants.NO_DATA_STATUS, new TrackInfoListDTO());
+        }
+        TrackInfoListDTO info = trackFacade.processTrack(
+                meta.number(), meta.storeId(), null, meta.canSave(), meta.phone());
+        String status = info.getList().isEmpty()
+                ? TrackConstants.NO_DATA_STATUS
+                : info.getList().get(0).getInfoTrack();
+        return new TrackingResultAdd(meta.number(), status, info);
     }
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.track;
 import com.project.tracking_system.dto.TrackParcelDTO;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import com.project.tracking_system.service.user.UserService;
@@ -30,6 +31,21 @@ public class TrackParcelService {
     private final UserService userService;
     private final TrackParcelRepository trackParcelRepository;
     private final UserSubscriptionRepository userSubscriptionRepository;
+
+    /**
+     * Возвращает тип почтовой службы для сохранённой посылки.
+     *
+     * @param number номер посылки
+     * @return тип службы или {@code null}, если посылка не найдена
+     */
+    @Transactional(readOnly = true)
+    public PostalServiceType getPostalServiceType(String number) {
+        TrackParcel parcel = trackParcelRepository.findByNumberWithStoreAndUser(number);
+        if (parcel != null && parcel.getDeliveryHistory() != null) {
+            return parcel.getDeliveryHistory().getPostalService();
+        }
+        return null;
+    }
 
     /**
      * Проверяет, принадлежит ли посылка пользователю.

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateProcessor.java
@@ -23,4 +23,12 @@ public interface TrackUpdateProcessor {
      * @return список результатов обработки
      */
     List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId);
+
+    /**
+     * Обрабатывает один трек без привязки к пользователю.
+     *
+     * @param meta метаданные трека
+     * @return результат обработки
+     */
+    TrackingResultAdd process(TrackMeta meta);
 }

--- a/src/test/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessorTest.java
@@ -1,0 +1,49 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.service.belpost.WebBelPostBatchService;
+import com.project.tracking_system.service.track.TrackMeta;
+import com.project.tracking_system.service.track.TrackFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link BelpostTrackUpdateProcessor} single track processing.
+ */
+@ExtendWith(MockitoExtension.class)
+class BelpostTrackUpdateProcessorTest {
+
+    @Mock
+    private TrackFacade trackFacade;
+    @Mock
+    private WebBelPostBatchService webService;
+
+    private BelpostTrackUpdateProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new BelpostTrackUpdateProcessor(trackFacade, webService);
+    }
+
+    @Test
+    void processSingle_SavesWhenAllowed() {
+        TrackMeta meta = new TrackMeta("B1", 1L, null, true);
+        TrackInfoListDTO info = new TrackInfoListDTO();
+        when(webService.processBatch(List.of("B1"))).thenReturn(Map.of("B1", info));
+
+        TrackingResultAdd result = processor.process(meta);
+
+        verify(trackFacade).saveTrackInfo("B1", info, 1L, null, null);
+        assertEquals(info, result.getTrackInfo());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessorTest.java
@@ -1,0 +1,44 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.service.track.TrackFacade;
+import com.project.tracking_system.service.track.TrackMeta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link EvropostTrackUpdateProcessor} single track processing.
+ */
+@ExtendWith(MockitoExtension.class)
+class EvropostTrackUpdateProcessorTest {
+
+    @Mock
+    private TrackFacade trackFacade;
+
+    private EvropostTrackUpdateProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new EvropostTrackUpdateProcessor(trackFacade, new SyncTaskExecutor());
+    }
+
+    @Test
+    void processSingle_ReturnsInfo() {
+        TrackMeta meta = new TrackMeta("E1", 1L, null, false);
+        TrackInfoListDTO info = new TrackInfoListDTO();
+        when(trackFacade.processTrack("E1", 1L, null, false, null)).thenReturn(info);
+
+        TrackingResultAdd result = processor.process(meta);
+
+        verify(trackFacade).processTrack("E1", 1L, null, false, null);
+        assertEquals(info, result.getTrackInfo());
+    }
+}


### PR DESCRIPTION
## Summary
- support single-track dispatching in `TrackUpdateDispatcherService`
- add single-track processing to Belpost and Evropost processors
- include postal service lookup in `TrackParcelService`
- use dispatcher for manual and modal tracking info
- extend `TrackingResultAdd` to expose fetched info
- add unit tests for new dispatcher and processors

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be3321f3c832d908e0ba59ab1d001