### PR TITLE
Switch update processors to TrackProcessingService

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessor.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.service.belpost.WebBelPostBatchService;
 import com.project.tracking_system.service.track.TrackConstants;
+import com.project.tracking_system.service.track.TrackProcessingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,14 +20,35 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class BelpostTrackUpdateProcessor implements TrackUpdateProcessor {
 
-    private final TrackFacade trackFacade;
+    /**
+     * Сервис низкого уровня, отвечающий за обработку и сохранение треков.
+     */
+    private final TrackProcessingService trackProcessingService;
+
+    /**
+     * Клиент для групповой загрузки данных с сайта Белпочты.
+     * <p>
+     * Реализует парсинг веб-страницы через Selenium и ChromeDriver,
+     * а не обращается к какому-либо официальному API.
+     * </p>
+     */
     private final WebBelPostBatchService webBelPostBatchService;
 
+    /**
+     * Возвращает тип почтового сервиса, который поддерживает данный процессор.
+     */
     @Override
     public PostalServiceType supportedType() {
         return PostalServiceType.BELPOST;
     }
 
+    /**
+     * Обновляет список треков пользователя одной пачкой.
+     *
+     * @param tracks список трек-метаданных
+     * @param userId идентификатор пользователя, которому принадлежат треки
+     * @return список результатов обновления
+     */
     @Override
     public List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId) {
         List<TrackingResultAdd> results = new ArrayList<>();
@@ -38,7 +60,7 @@ public class BelpostTrackUpdateProcessor implements TrackUpdateProcessor {
         for (TrackMeta meta : tracks) {
             TrackInfoListDTO info = infoMap.getOrDefault(meta.number(), new TrackInfoListDTO());
             if (userId != null && meta.canSave()) {
-                trackFacade.saveTrackInfo(meta.number(), info, meta.storeId(), userId, meta.phone());
+                trackProcessingService.save(meta.number(), info, meta.storeId(), userId, meta.phone());
             }
             String status = info.getList().isEmpty()
                     ? TrackConstants.NO_DATA_STATUS
@@ -48,6 +70,12 @@ public class BelpostTrackUpdateProcessor implements TrackUpdateProcessor {
         return results;
     }
 
+    /**
+     * Загружает и сохраняет информацию по одному треку.
+     *
+     * @param meta метаданные трек-номера
+     * @return результат обработки
+     */
     @Override
     public TrackingResultAdd process(TrackMeta meta) {
         if (meta == null) {
@@ -56,7 +84,7 @@ public class BelpostTrackUpdateProcessor implements TrackUpdateProcessor {
         Map<String, TrackInfoListDTO> infoMap = webBelPostBatchService.processBatch(List.of(meta.number()));
         TrackInfoListDTO info = infoMap.getOrDefault(meta.number(), new TrackInfoListDTO());
         if (meta.canSave()) {
-            trackFacade.saveTrackInfo(meta.number(), info, meta.storeId(), null, meta.phone());
+            trackProcessingService.save(meta.number(), info, meta.storeId(), null, meta.phone());
         }
         String status = info.getList().isEmpty()
                 ? TrackConstants.NO_DATA_STATUS

--- a/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
@@ -4,8 +4,8 @@ import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.service.track.TrackConstants;
+import com.project.tracking_system.service.track.TrackProcessingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
@@ -20,14 +20,31 @@ import java.util.concurrent.CompletableFuture;
 @RequiredArgsConstructor
 public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
 
-    private final TrackFacade trackFacade;
+    /**
+     * Сервис низкого уровня, выполняющий обработку и сохранение треков.
+     */
+    private final TrackProcessingService trackProcessingService;
+
+    /**
+     * Асинхронный исполнитель для отправки запросов к сервису Европочты.
+     */
     private final TaskExecutor batchUploadExecutor;
 
+    /**
+     * Возвращает тип почтовой службы, поддерживаемой данным процессором.
+     */
     @Override
     public PostalServiceType supportedType() {
         return PostalServiceType.EVROPOST;
     }
 
+    /**
+     * Обрабатывает список треков асинхронно, используя европейский сервис.
+     *
+     * @param tracks список треков
+     * @param userId идентификатор пользователя, инициировавшего обработку
+     * @return список результатов обработки
+     */
     @Override
     public List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId) {
         List<TrackingResultAdd> results = new ArrayList<>();
@@ -36,7 +53,7 @@ public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
         }
         List<CompletableFuture<TrackingResultAdd>> futures = tracks.stream()
                 .map(meta -> CompletableFuture.supplyAsync(() -> {
-                    TrackInfoListDTO info = trackFacade.processTrack(
+                    TrackInfoListDTO info = trackProcessingService.processTrack(
                             meta.number(), meta.storeId(), userId, meta.canSave(), meta.phone());
                     String status = info.getList().isEmpty()
                             ? TrackConstants.NO_DATA_STATUS
@@ -48,12 +65,18 @@ public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
         return results;
     }
 
+    /**
+     * Обрабатывает один трек синхронно.
+     *
+     * @param meta метаданные трек-номера
+     * @return результат обработки
+     */
     @Override
     public TrackingResultAdd process(TrackMeta meta) {
         if (meta == null) {
             return new TrackingResultAdd(null, TrackConstants.NO_DATA_STATUS, new TrackInfoListDTO());
         }
-        TrackInfoListDTO info = trackFacade.processTrack(
+        TrackInfoListDTO info = trackProcessingService.processTrack(
                 meta.number(), meta.storeId(), null, meta.canSave(), meta.phone());
         String status = info.getList().isEmpty()
                 ? TrackConstants.NO_DATA_STATUS

--- a/src/test/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessorTest.java
@@ -4,7 +4,7 @@ import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.service.belpost.WebBelPostBatchService;
 import com.project.tracking_system.service.track.TrackMeta;
-import com.project.tracking_system.service.track.TrackFacade;
+import com.project.tracking_system.service.track.TrackProcessingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
 class BelpostTrackUpdateProcessorTest {
 
     @Mock
-    private TrackFacade trackFacade;
+    private TrackProcessingService trackProcessingService;
     @Mock
     private WebBelPostBatchService webService;
 
@@ -32,7 +32,7 @@ class BelpostTrackUpdateProcessorTest {
 
     @BeforeEach
     void setUp() {
-        processor = new BelpostTrackUpdateProcessor(trackFacade, webService);
+        processor = new BelpostTrackUpdateProcessor(trackProcessingService, webService);
     }
 
     @Test
@@ -43,7 +43,7 @@ class BelpostTrackUpdateProcessorTest {
 
         TrackingResultAdd result = processor.process(meta);
 
-        verify(trackFacade).saveTrackInfo("B1", info, 1L, null, null);
+        verify(trackProcessingService).save("B1", info, 1L, null, null);
         assertEquals(info, result.getTrackInfo());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessorTest.java
@@ -2,7 +2,7 @@ package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.TrackingResultAdd;
-import com.project.tracking_system.service.track.TrackFacade;
+import com.project.tracking_system.service.track.TrackProcessingService;
 import com.project.tracking_system.service.track.TrackMeta;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,24 +21,24 @@ import static org.mockito.Mockito.*;
 class EvropostTrackUpdateProcessorTest {
 
     @Mock
-    private TrackFacade trackFacade;
+    private TrackProcessingService trackProcessingService;
 
     private EvropostTrackUpdateProcessor processor;
 
     @BeforeEach
     void setUp() {
-        processor = new EvropostTrackUpdateProcessor(trackFacade, new SyncTaskExecutor());
+        processor = new EvropostTrackUpdateProcessor(trackProcessingService, new SyncTaskExecutor());
     }
 
     @Test
     void processSingle_ReturnsInfo() {
         TrackMeta meta = new TrackMeta("E1", 1L, null, false);
         TrackInfoListDTO info = new TrackInfoListDTO();
-        when(trackFacade.processTrack("E1", 1L, null, false, null)).thenReturn(info);
+        when(trackProcessingService.processTrack("E1", 1L, null, false, null)).thenReturn(info);
 
         TrackingResultAdd result = processor.process(meta);
 
-        verify(trackFacade).processTrack("E1", 1L, null, false, null);
+        verify(trackProcessingService).processTrack("E1", 1L, null, false, null);
         assertEquals(info, result.getTrackInfo());
     }
 }


### PR DESCRIPTION
## Summary
- refactor Belpost and Evropost processors to use `TrackProcessingService`
- update unit tests accordingly
- document purpose of low-level services and methods
- fix Belpost comment to mention Selenium/ChromeDriver site parsing

## Testing
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687c2086ba10832d8aac06322aa73a02