### PR TITLE
Expose single-track parsing

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
@@ -52,6 +52,21 @@ public class WebBelPostBatchService {
         return result;
     }
 
+    /**
+     * Загружает информацию по одному трек-номеру.
+     * <p>
+     * Для каждого вызова создаётся отдельный {@link WebDriver},
+     * который закрывается после завершения парсинга.
+     * </p>
+     *
+     * @param trackNumber номер Белпочты
+     * @return данные о треке или пустой DTO при ошибке
+     */
+    public TrackInfoListDTO parseTrack(String trackNumber) {
+        Map<String, TrackInfoListDTO> map = processBatch(List.of(trackNumber));
+        return map.getOrDefault(trackNumber, new TrackInfoListDTO());
+    }
+
     private TrackInfoListDTO parseTrack(WebDriver driver, String number) {
         for (int attempt = 1; attempt <= 2; attempt++) {
             try {

--- a/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
@@ -4,7 +4,7 @@ import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.mapper.JsonEvroTrackingResponseMapper;
 import com.project.tracking_system.model.evropost.jsonResponseModel.JsonEvroTrackingResponse;
-import com.project.tracking_system.service.belpost.BelPostSessionParser;
+import com.project.tracking_system.service.belpost.WebBelPostBatchService;
 import com.project.tracking_system.service.jsonEvropostService.JsonEvroTrackingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +20,8 @@ import java.util.concurrent.ExecutionException;
  * Сервис для получения информации о статусе почтовых отправлений.
  * <p>
  * Этот сервис предоставляет методы для получения информации о посылках на основе номера отслеживания.
- * Включает асинхронную обработку запросов для различных типов кодов посылок и интеграцию с сервисами BelPostSessionParser и EuroPost.
+ * Включает асинхронную обработку запросов для различных типов кодов посылок и
+ * интеграцию с сервисами WebBelPostBatchService и EuroPost.
  * </p>
  *
  * @author Dmitriy Anisimov
@@ -31,7 +32,7 @@ import java.util.concurrent.ExecutionException;
 @Service
 public class TypeDefinitionTrackPostService {
 
-    private final BelPostSessionParser belPostSessionParser;
+    private final WebBelPostBatchService webBelPostBatchService;
     private final JsonEvroTrackingService jsonEvroTrackingService;
     private final JsonEvroTrackingResponseMapper jsonEvroTrackingResponseMapper;
 
@@ -71,7 +72,7 @@ public class TypeDefinitionTrackPostService {
             switch (postalService) {
                 case BELPOST:
                     log.info("📨 Запрос к Белпочте для номера: {}", number);
-                    result = belPostSessionParser.parseTrack(number);
+                    result = webBelPostBatchService.parseTrack(number);
                     break;
                 case EVROPOST:
                     log.info("📨 Запрос к Европочте для номера: {}", number);

--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceTest.java
@@ -1,0 +1,53 @@
+package com.project.tracking_system.service.belpost;
+
+import com.project.tracking_system.webdriver.WebDriverFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Проверка того, что для каждого вызова {@link WebBelPostBatchService#parseTrack(String)}
+ * создаётся новый экземпляр {@link WebDriver}.
+ */
+@ExtendWith(MockitoExtension.class)
+class WebBelPostBatchServiceTest {
+
+    @Mock
+    private WebDriverFactory factory;
+    @Mock
+    private WebDriver driver1;
+    @Mock
+    private WebDriver driver2;
+
+    private WebBelPostBatchService service;
+
+    @BeforeEach
+    void init() {
+        when(factory.create()).thenReturn(driver1, driver2);
+        doNothing().when(driver1).get(anyString());
+        doNothing().when(driver2).get(anyString());
+        when(driver1.findElement(any(By.class))).thenThrow(new NoSuchElementException("mock"));
+        when(driver2.findElement(any(By.class))).thenThrow(new NoSuchElementException("mock"));
+
+        service = new WebBelPostBatchService(factory);
+    }
+
+    @Test
+    void parseTrack_CreatesNewDriverEachCall() {
+        service.parseTrack("111");
+        service.parseTrack("222");
+
+        verify(factory, times(2)).create();
+        verify(driver1).quit();
+        verify(driver2).quit();
+    }
+}


### PR DESCRIPTION
## Summary
- allow parsing a single Belpost track with `WebBelPostBatchService`
- use the new method from `TypeDefinitionTrackPostService`
- add unit test for the new method

## Testing
- `mvn -v` *(fails: command not found)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687c2f983ef0832d83113baaaf88fd43