### PR TITLE
Fix Belpost arrival status handling

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostSessionParser.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostSessionParser.java
@@ -78,7 +78,8 @@ public class BelPostSessionParser {
             List<WebElement> trackItems = trackDetails.findElements(By.cssSelector("div.track-details__item"));
 
             for (WebElement trackItemElement : trackItems) {
-                String title = trackItemElement.findElement(By.cssSelector("dt")).getText();
+                // Тримим пробелы, чтобы регулярные выражения корректно распознавали статус
+                String title = trackItemElement.findElement(By.cssSelector("dt")).getText().trim();
                 WebElement contentElement = trackItemElement.findElement(By.cssSelector("dd"));
                 WebElement dateElement = contentElement.findElement(By.cssSelector("li.text-secondary"));
                 String dateContent = dateElement.getText();

--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -4,7 +4,7 @@ import com.project.tracking_system.dto.TrackInfoDTO;
 import com.project.tracking_system.entity.GlobalStatus;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -23,7 +23,9 @@ public class StatusTrackService {
     /**
      * Карта, которая сопоставляет регулярные выражения для статусов с их соответствующими значениями.
      */
-    private static final Map<Pattern, GlobalStatus> statusPatterns = new HashMap<>();
+    // LinkedHashMap обеспечивает стабильный порядок перебора,
+    // поэтому специфичные шаблоны должны добавляться первыми
+    private static final Map<Pattern, GlobalStatus> statusPatterns = new LinkedHashMap<>();
 
     /**
      * Шаблон для промежуточных статусов, после которых возможен возврат отправителю.
@@ -37,7 +39,7 @@ public class StatusTrackService {
         // Инициализация карты регулярных выражений и статусов
         statusPatterns.put(Pattern.compile("^Почтовое отправление выдано|^Вручено"), GlobalStatus.DELIVERED);
         statusPatterns.put(Pattern.compile("^Почтовое отправление прибыло на ОПС выдачи|^Добрый день\\. Срок бесплатного хранения|" +
-                "^Поступило в учреждение доставки"), GlobalStatus.WAITING_FOR_CUSTOMER);
+                "^Поступило в учреждение доставки.*"), GlobalStatus.WAITING_FOR_CUSTOMER);
         statusPatterns.put(Pattern.compile("^Почтовое отправление принято на ОПС|" +
                         "^Оплачено на ОПС|^Отправлено|^Принято от отправителя|" +
                         "^Поступило в обработку|" +

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -1,0 +1,47 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.entity.GlobalStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link StatusTrackService} verifying correct mapping
+ * of raw status strings to {@link GlobalStatus} values.
+ */
+class StatusTrackServiceTest {
+
+    private final StatusTrackService service = new StatusTrackService();
+
+    /**
+     * Arrival status from Belpost should map to {@link GlobalStatus#WAITING_FOR_CUSTOMER}.
+     * Leading and trailing spaces must not affect the result.
+     */
+    @Test
+    void setStatus_MapsArrivalToWaiting() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO("18.07.2025, 10:36", " Поступило в учреждение доставки ")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.WAITING_FOR_CUSTOMER, status);
+    }
+
+    /**
+     * Status text about delivery must result in {@link GlobalStatus#DELIVERED}.
+     */
+    @Test
+    void setStatus_MapsDelivered() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO("19.07.2025, 11:00", "Почтовое отправление выдано")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.DELIVERED, status);
+    }
+}


### PR DESCRIPTION
## Summary
- trim whitespace from Belpost statuses when parsing
- iterate status patterns in deterministic order
- allow extra text after "Поступило в учреждение доставки" when mapping statuses
- test `StatusTrackService` mappings for Belpost statuses

## Testing
- `mvn -q test` *(fails: command not found)*
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_687d148779e8832daee70e1bfab5e202