### PR TITLE
Enable phone editing in customer info modal

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -100,6 +100,10 @@ function loadCustomerInfo(trackId) {
             document.querySelector('#customerModal .modal-body').innerHTML = data;
             let modal = new bootstrap.Modal(document.getElementById('customerModal'));
             modal.show();
+            // После загрузки контента назначаем обработчики форм
+            initAssignCustomerFormHandler();
+            initEditCustomerPhoneFormHandler();
+            initPhoneEditToggle();
         })
         .catch(() => notifyUser('Ошибка при загрузке данных', 'danger'));
 }
@@ -315,6 +319,38 @@ function initializePhoneToggle() {
 // Инициализация формы привязки покупателя к посылке
 function initAssignCustomerFormHandler() {
     ajaxSubmitForm('assign-customer-form', 'customerInfoContainer', [initAssignCustomerFormHandler]);
+}
+
+/**
+ * Инициализирует отправку формы изменения телефона покупателя.
+ * После успешного запроса перечитывает данные покупателя и
+ * повторно настраивает обработчики формы и кнопки редактирования.
+ */
+function initEditCustomerPhoneFormHandler() {
+    const reloadCallback = () => {
+        const idInput = document.querySelector('#edit-phone-form input[name="trackId"]');
+        if (idInput) loadCustomerInfo(idInput.value);
+    };
+    ajaxSubmitForm('edit-phone-form', 'customerInfoContainer', [
+        reloadCallback,
+        initEditCustomerPhoneFormHandler,
+        initAssignCustomerFormHandler,
+        initPhoneEditToggle
+    ]);
+}
+
+/**
+ * Назначает обработчик кнопке редактирования телефона,
+ * который показывает или скрывает форму ввода номера.
+ */
+function initPhoneEditToggle() {
+    const editBtn = document.getElementById('editPhoneBtn');
+    const form = document.getElementById('edit-phone-form');
+
+    if (editBtn && form && !editBtn.dataset.initialized) {
+        editBtn.dataset.initialized = 'true';
+        editBtn.addEventListener('click', () => form.classList.toggle('hidden'));
+    }
 }
 
 // Инициализация форм настроек Telegram
@@ -1347,6 +1383,8 @@ document.addEventListener("DOMContentLoaded", function () {
     initBulkButtonToggle();
     initializePhoneToggle();
     initAssignCustomerFormHandler();
+    initEditCustomerPhoneFormHandler();
+    initPhoneEditToggle();
     initTelegramForms();
     initTelegramToggle();
     initTelegramReminderBlocks();

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -12,7 +12,26 @@
     </div>
     <div th:unless="${notFound}">
         <ul class="list-group">
-            <li class="list-group-item"><strong>Телефон:</strong> <span th:text="${customerInfo.phone}"></span></li>
+            <li class="list-group-item">
+                <div class="d-flex justify-content-between align-items-center">
+                    <div>
+                        <strong>Телефон:</strong>
+                        <span th:text="${customerInfo.phone}"></span>
+                    </div>
+                    <button id="editPhoneBtn" type="button" class="btn btn-link p-0 ms-2">
+                        <i class="bi bi-pencil"></i>
+                    </button>
+                </div>
+                <form id="edit-phone-form" th:action="@{/app/customers/assign}" method="post"
+                      class="mt-2 hidden">
+                    <input type="hidden" name="trackId" th:value="${trackId}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <div class="input-group mb-2">
+                        <input type="text" name="phone" class="form-control" placeholder="375XXXXXXXXX" required>
+                        <button type="submit" class="btn btn-primary">Сохранить</button>
+                    </div>
+                </form>
+            </li>
             <li class="list-group-item"><strong>Отправлено:</strong> <span th:text="${customerInfo.sentCount}"></span></li>
             <li class="list-group-item"><strong>Забрано:</strong> <span th:text="${customerInfo.pickedUpCount}"></span></li>
             <li class="list-group-item"><strong>Процент выкупа:</strong> <span th:text="${customerInfo.pickupPercentage}"></span>%</li>


### PR DESCRIPTION
## Summary
- add phone editing form in customer info modal
- support toggling phone edit form in JS and reload modal after update

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1135d000832dbd92969f2de0322a