### PR TITLE
Add customer change endpoint

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/CustomerController.java
+++ b/src/main/java/com/project/tracking_system/controller/CustomerController.java
@@ -51,6 +51,34 @@ public class CustomerController {
     public String assignCustomer(@RequestParam Long trackId,
                                  @RequestParam String phone,
                                  Model model) {
+        return updateCustomer(trackId, phone, model);
+    }
+
+    /**
+     * Изменяет номер телефона покупателя, связанного с посылкой.
+     * <p>
+     * Метод используется при редактировании существующей привязки. После
+     * сохранения возвращается тот же Thymeleaf-фрагмент с обновлёнными данными.
+     * </p>
+     *
+     * @param trackId идентификатор посылки
+     * @param phone   новый номер телефона
+     * @param model   модель для передачи данных во фрагмент
+     * @return HTML-фрагмент с актуальной информацией о покупателе
+     */
+    @PostMapping("/change")
+    public String changeCustomer(@RequestParam Long trackId,
+                                 @RequestParam String phone,
+                                 Model model) {
+        return updateCustomer(trackId, phone, model);
+    }
+
+    /**
+     * Выполняет привязку покупателя к посылке и формирует модель представления.
+     * Выделено в отдельный метод для повторного использования в разных
+     * обработчиках.
+     */
+    private String updateCustomer(Long trackId, String phone, Model model) {
         CustomerInfoDTO dto = customerService.assignCustomerToParcel(trackId, phone);
         model.addAttribute("customerInfo", dto);
         model.addAttribute("notFound", dto == null);

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -22,7 +22,7 @@
                         <i class="bi bi-pencil"></i>
                     </button>
                 </div>
-                <form id="edit-phone-form" th:action="@{/app/customers/assign}" method="post"
+                <form id="edit-phone-form" th:action="@{/app/customers/change}" method="post"
                       class="mt-2 hidden">
                     <input type="hidden" name="trackId" th:value="${trackId}">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">


### PR DESCRIPTION
## Summary
- add endpoint `/change` to modify a parcel's linked customer
- reuse same logic for `/assign` and `/change`
- adjust HTML form to post to the new endpoint

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e13e35cd8832d91ae7707dfc42aed