### PR TITLE
Add BelPost track queue

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
@@ -1,0 +1,130 @@
+package com.project.tracking_system.service.belpost;
+
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.service.track.TrackProcessingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.WebDriverException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Очередь последовательной обработки трек-номеров Белпочты.
+ * <p>
+ * Предназначена для единообразного использования различными модулями
+ * приложения: ручной ввод, импорт из Excel и автоматическое обновление.
+ * Очередь обеспечивает потокобезопасность и ведёт статистику по каждой
+ * партии треков.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BelPostTrackQueueService {
+
+    private final WebBelPostBatchService webBelPostBatchService;
+    private final TrackProcessingService trackProcessingService;
+    private final WebSocketController webSocketController;
+
+    /** Хранилище заданий на обработку. */
+    private final BlockingQueue<QueuedTrack> queue = new LinkedBlockingQueue<>();
+
+    /** Прогресс по каждой пачке треков. */
+    private final Map<Long, BatchProgress> progressMap = new ConcurrentHashMap<>();
+
+    /** Время до которого обработка приостановлена (millis). */
+    private volatile long pauseUntil = 0L;
+
+    /** Добавляет один трек в очередь. */
+    public void enqueue(QueuedTrack track) {
+        if (track == null) {
+            return;
+        }
+        queue.offer(track);
+        progressMap.computeIfAbsent(track.batchId(), id -> new BatchProgress());
+    }
+
+    /** Добавляет список треков в очередь. */
+    public void enqueue(List<QueuedTrack> tracks) {
+        if (tracks == null || tracks.isEmpty()) {
+            return;
+        }
+        tracks.forEach(this::enqueue);
+    }
+
+    /** Возвращает текущий прогресс для указанной пачки. */
+    public BatchProgress getProgress(long batchId) {
+        return progressMap.get(batchId);
+    }
+
+    /**
+     * Периодически извлекает из очереди один трек и обрабатывает его.
+     * Между итерациями выдерживается пауза 15 секунд.
+     */
+    @Scheduled(fixedDelay = 15000)
+    public void processQueue() {
+        if (Instant.now().toEpochMilli() < pauseUntil) {
+            return; // временно приостановлено
+        }
+
+        QueuedTrack task = queue.poll();
+        if (task == null) {
+            return; // очередь пуста
+        }
+
+        BatchProgress progress = progressMap.computeIfAbsent(task.batchId(), id -> new BatchProgress());
+        progress.processed.incrementAndGet();
+
+        try {
+            TrackInfoListDTO info = webBelPostBatchService.parseTrack(task.trackNumber());
+            if (!info.getList().isEmpty()) {
+                trackProcessingService.save(task.trackNumber(), info, task.storeId(), task.userId());
+                progress.success.incrementAndGet();
+            } else {
+                progress.failed.incrementAndGet();
+            }
+        } catch (WebDriverException e) {
+            log.error("\uD83D\uDEA7 Ошибка Selenium при обработке {}: {}", task.trackNumber(), e.getMessage());
+            progress.failed.incrementAndGet();
+            pauseUntil = Instant.now().plusSeconds(60).toEpochMilli();
+            webSocketController.sendUpdateStatus(task.userId(), "Белпочта временно недоступна", false);
+        } catch (Exception e) {
+            log.error("\u274C Не удалось обработать {}: {}", task.trackNumber(), e.getMessage());
+            progress.failed.incrementAndGet();
+        }
+
+        String msg = String.format("Пакет %d: обработано %d, успех %d, ошибок %d", task.batchId(),
+                progress.processed.get(), progress.success.get(), progress.failed.get());
+        webSocketController.sendUpdateStatus(task.userId(), msg, true);
+    }
+
+    /**
+     * Контейнер статистики выполнения для одной партии треков.
+     */
+    public static class BatchProgress {
+        private final AtomicInteger processed = new AtomicInteger();
+        private final AtomicInteger success = new AtomicInteger();
+        private final AtomicInteger failed = new AtomicInteger();
+
+        public int getProcessed() {
+            return processed.get();
+        }
+
+        public int getSuccess() {
+            return success.get();
+        }
+
+        public int getFailed() {
+            return failed.get();
+        }
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/belpost/QueuedTrack.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/QueuedTrack.java
@@ -1,0 +1,17 @@
+package com.project.tracking_system.service.belpost;
+
+/**
+ * Модель элемента очереди для пакетной обработки треков Белпочты.
+ *
+ * @param trackNumber номер отправления
+ * @param userId      идентификатор пользователя
+ * @param storeId     идентификатор магазина
+ * @param source      источник поступления трека (ручной ввод, файл и т.п.)
+ * @param batchId     идентификатор партии, объединяющей несколько треков
+ */
+public record QueuedTrack(String trackNumber,
+                          Long userId,
+                          Long storeId,
+                          String source,
+                          Long batchId) {
+}


### PR DESCRIPTION
## Summary
- queue Belpost tracks with new `QueuedTrack` record
- process queued tracks with scheduled `BelPostTrackQueueService`

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper properties)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687e589d76dc832db284a26954c7c822