### PR TITLE
Queue Belpost tracks

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -1,12 +1,16 @@
 package com.project.tracking_system.controller;
 
 import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.track.TrackFacade;
 import com.project.tracking_system.service.track.TrackMeta;
 import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
+import com.project.tracking_system.service.track.TrackServiceClassifier;
+import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
+import com.project.tracking_system.service.belpost.QueuedTrack;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,6 +38,10 @@ public class HomeController {
     private final TrackFacade trackFacade;
     private final StoreService storeService;
     private final TrackUpdateDispatcherService trackUpdateDispatcherService;
+    /** Сервис классификации трек-номеров по типу почтовой службы. */
+    private final TrackServiceClassifier trackServiceClassifier;
+    /** Очередь асинхронной обработки треков Белпочты. */
+    private final BelPostTrackQueueService belPostTrackQueueService;
 
     /**
      * Обрабатывает запросы на главной странице. Отображает домашнюю страницу.
@@ -53,7 +61,13 @@ public class HomeController {
     /**
      * Обрабатывает POST-запросы на главной странице.
      * <p>
-     * Выполняет отслеживание посылки по номеру, а также связывает её с покупателем при указании телефона.
+     * Выполняет отслеживание посылки по номеру.
+     * <p>
+     * Номера Белпочты помещаются в очередь {@link BelPostTrackQueueService} и
+     * обрабатываются асинхронно. Для остальных номеров информация
+     * загружается синхронно через {@link TrackUpdateDispatcherService}.
+     * При указании телефона трек связывается с покупателем.
+     * </p>
      * </p>
      *
      * @param number  номер посылки
@@ -81,6 +95,21 @@ public class HomeController {
         model.addAttribute("stores", stores);
 
         try {
+            PostalServiceType type = trackServiceClassifier.detect(number);
+
+            if (type == PostalServiceType.BELPOST && userId != null) {
+                // Для номеров Белпочты выполняем асинхронную обработку через очередь
+                belPostTrackQueueService.enqueue(new QueuedTrack(
+                        number,
+                        userId,
+                        storeId,
+                        "MANUAL",
+                        System.currentTimeMillis()
+                ));
+                model.addAttribute("successMessage", "Номер добавлен в очередь обработки.");
+                return "app/home";
+            }
+
             TrackMeta meta = new TrackMeta(number, storeId, phone, canSave);
             TrackInfoListDTO trackInfo = trackUpdateDispatcherService.dispatch(meta).getTrackInfo();
 

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -31,6 +31,9 @@
                 <div th:if="${generalError}" class="alert alert-danger mb-4">
                     <p th:text="${generalError}" class="mb-0"></p>
                 </div>
+                <div th:if="${successMessage}" class="alert alert-success mb-4">
+                    <p th:text="${successMessage}" class="mb-0"></p>
+                </div>
 
                 <!-- Форма поиска посылки и загрузка файла -->
                 <div class="card shadow-sm p-4 rounded-4">


### PR DESCRIPTION
## Summary
- enqueue Belpost numbers via `BelPostTrackQueueService`
- show success alert on home page when a track is queued

## Testing
- `./mvnw test` *(fails: cannot open `.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_687f6f2b3424832dbececb79db23deba