### PR TITLE
Add websocket events for Belpost queue

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/WebSocketController.java
+++ b/src/main/java/com/project/tracking_system/controller/WebSocketController.java
@@ -2,6 +2,9 @@ package com.project.tracking_system.controller;
 
 import com.project.tracking_system.entity.UpdateResult;
 import com.project.tracking_system.dto.TrackProcessingStartedDTO;
+import com.project.tracking_system.dto.BelPostBatchStartedDTO;
+import com.project.tracking_system.dto.BelPostTrackProcessedDTO;
+import com.project.tracking_system.dto.BelPostBatchFinishedDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -57,6 +60,39 @@ public class WebSocketController {
     public void sendTrackProcessingStarted(Long userId, TrackProcessingStartedDTO startedDto) {
         log.debug("\uD83D\uDCE1 WebSocket старт обработки для {}: {}", userId, startedDto);
         messagingTemplate.convertAndSend("/topic/track-processing-started/" + userId, startedDto);
+    }
+
+    /**
+     * Отправляет событие о начале обработки партии треков Белпочты.
+     *
+     * @param userId идентификатор пользователя
+     * @param dto    данные о партии
+     */
+    public void sendBelPostBatchStarted(Long userId, BelPostBatchStartedDTO dto) {
+        log.debug("\uD83D\uDCE1 WebSocket партия {} начата для {}: {}", dto.batchId(), userId, dto);
+        messagingTemplate.convertAndSend("/topic/belpost/batch-started/" + userId, dto);
+    }
+
+    /**
+     * Отправляет информацию о результате обработки одного трека Белпочты.
+     *
+     * @param userId идентификатор пользователя
+     * @param dto    информация об обработанном треке
+     */
+    public void sendBelPostTrackProcessed(Long userId, BelPostTrackProcessedDTO dto) {
+        log.debug("\uD83D\uDCE1 WebSocket обработан трек {} партии {}: {}", dto.trackNumber(), dto.batchId(), dto);
+        messagingTemplate.convertAndSend("/topic/belpost/track-processed/" + userId, dto);
+    }
+
+    /**
+     * Отправляет сообщение о завершении обработки партии треков Белпочты.
+     *
+     * @param userId идентификатор пользователя
+     * @param dto    финальная статистика по партии
+     */
+    public void sendBelPostBatchFinished(Long userId, BelPostBatchFinishedDTO dto) {
+        log.debug("\uD83D\uDCE1 WebSocket партия {} завершена для {}: {}", dto.batchId(), userId, dto);
+        messagingTemplate.convertAndSend("/topic/belpost/batch-finished/" + userId, dto);
     }
 
     private static void getDebug(Long userId, UpdateResult updateResult) {

--- a/src/main/java/com/project/tracking_system/dto/BelPostBatchFinishedDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/BelPostBatchFinishedDTO.java
@@ -1,0 +1,15 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Сообщение о завершении обработки партии треков Белпочты.
+ *
+ * @param batchId   идентификатор партии
+ * @param processed обработано треков
+ * @param success   количество успешных
+ * @param failed    количество неуспешных
+ */
+public record BelPostBatchFinishedDTO(long batchId,
+                                      int processed,
+                                      int success,
+                                      int failed) {
+}

--- a/src/main/java/com/project/tracking_system/dto/BelPostBatchStartedDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/BelPostBatchStartedDTO.java
@@ -1,0 +1,10 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Сообщение о начале обработки партии треков Белпочты.
+ *
+ * @param batchId   идентификатор партии
+ * @param totalCount количество треков в партии
+ */
+public record BelPostBatchStartedDTO(long batchId, int totalCount) {
+}

--- a/src/main/java/com/project/tracking_system/dto/BelPostTrackProcessedDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/BelPostTrackProcessedDTO.java
@@ -1,0 +1,17 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Сообщение о результатах обработки одного трека Белпочты.
+ *
+ * @param batchId    идентификатор партии
+ * @param trackNumber номер трека
+ * @param processed  сколько треков обработано
+ * @param success    количество успешных
+ * @param failed     количество неуспешных
+ */
+public record BelPostTrackProcessedDTO(long batchId,
+                                       String trackNumber,
+                                       int processed,
+                                       int success,
+                                       int failed) {
+}


### PR DESCRIPTION
## Summary
- emit websocket messages for Belpost batch start, track processed and batch finished
- hold totals for batches and dispatch events from BelPostTrackQueueService
- provide DTOs for new events

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f76afe1d4832d9ce8536e8d99002b