### PR TITLE
Center store IDs

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -32,3 +32,8 @@
     padding: 0.25rem 0.75rem;
   }
 }
+
+// Выравнивание ID магазинов по центру
+.store-id {
+  text-align: center;
+}

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -897,8 +897,9 @@ async function loadStores() {
 
     stores.forEach(store => {
         const row = document.createElement("tr");
+        // Первый столбец содержит идентификатор магазина и выравнивается по центру
         row.innerHTML = `
-            <td>${store.id}</td>
+            <td class="text-center store-id">${store.id}</td>
             <td class="d-flex align-items-center">
                 <input type="radio" name="defaultStore"
                        class="default-store-radio me-2"
@@ -1075,8 +1076,9 @@ function addNewStore() {
     const tempId = `new-${Date.now()}`; // Уникальный ID для нового магазина
 
     const row = document.createElement("tr");
+    // Строка новой записи с центровкой ID для согласованности с таблицей
     row.innerHTML = `
-        <td>—</td>
+        <td class="text-center store-id">—</td>
         <td>
             <input type="text" class="form-control store-name-input" id="store-name-${tempId}" placeholder="Введите название">
         </td>

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -155,7 +155,7 @@
                             <table class="table">
                                 <thead>
                                 <tr>
-                                    <th>ID</th>
+                                    <th class="text-center store-id">ID</th>
                                     <th>Название магазина</th>
                                     <th>Действия</th>
                                 </tr>


### PR DESCRIPTION
## Summary
- center IDs in profile store table
- apply same class in JS when rendering store rows
- add SCSS for store id

## Testing
- `npm run build:css` *(fails: blocked)*
- `./mvnw -q test` *(fails: blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ff9727830832dad0136cc87ed4d25