### PR TITLE
Refine footer bottom layout and styling

### DIFF
--- a/src/main/resources/assets/scss/components/_footer.scss
+++ b/src/main/resources/assets/scss/components/_footer.scss
@@ -105,6 +105,13 @@
         display: flex;
         justify-content: center; // Центрируем содержимое
         align-items: center;
+        flex-wrap: wrap; // Элементы могут переноситься
+        gap: 8px; // Отступы между элементами
+
+        .footer-links {
+          display: flex;
+          gap: 4px; // Расстояние между ссылками
+        }
 
         a {
           text-decoration: none;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -451,6 +451,12 @@ header .mobile-nav.active {
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.footer .footer-contacts .contact-group .footer-bottom .footer-links {
+  display: flex;
+  gap: 4px;
 }
 .footer .footer-contacts .contact-group .footer-bottom a {
   text-decoration: none;

--- a/src/main/resources/templates/partials/footer.html
+++ b/src/main/resources/templates/partials/footer.html
@@ -55,12 +55,19 @@
             </div>
         </div>
 
-        <!-- Нижняя часть футера -->
+        <!-- Нижняя часть футера: копирайт, версия и ссылки -->
         <div class="footer-bottom text-center">
-            <span class="text-muted">
+            <!-- Копирайт -->
+            <span class="text-muted footer-bottom__copyright">
                 &copy; 2025 Belivery. Все права защищены.
-                <span th:text="'Версия ' + ${appVersion}"></span>
-                <a href="/privacy" class="text-muted">Политика конфиденциальности</a> |
+            </span>
+            <!-- Версия приложения -->
+            <span class="text-muted footer-bottom__version"
+                  th:text="'Версия ' + ${appVersion}"></span>
+            <!-- Ссылки на политику и соглашение -->
+            <span class="footer-links">
+                <a href="/privacy" class="text-muted">Политика конфиденциальности</a>
+                |
                 <a href="/terms" class="text-muted">Пользовательское соглашение</a>
             </span>
         </div>


### PR DESCRIPTION
## Summary
- separate the footer bottom section into copyright, version, and legal links
- style the new footer fragments for better alignment

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800931ae54832d92bf1be4cb0aa6fb