### PR TITLE
Fix Mockito thenReturn chaining

### DIFF
--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceTest.java
@@ -32,7 +32,12 @@ class WebBelPostBatchServiceTest {
 
     @BeforeEach
     void init() {
-        when(factory.create()).thenReturn(driver1, driver2);
+        // Возвращаем разные драйверы при последовательных вызовах
+        // фабрики, имитируя создание нового экземпляра для каждого
+        // парсинга треков.
+        when(factory.create())
+                .thenReturn(driver1)
+                .thenReturn(driver2);
         doNothing().when(driver1).get(anyString());
         doNothing().when(driver2).get(anyString());
         when(driver1.findElement(any(By.class))).thenThrow(new NoSuchElementException("mock"));


### PR DESCRIPTION
## Summary
- split varargs `thenReturn` for WebBelPostBatchService test
- add explanatory comments

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688026ea7974832da3e5d61e2f644aa1