### PR TITLE
Add progress updates for Belpost batch processing

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProgressController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProgressController.java
@@ -1,0 +1,41 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.TrackProcessingProgressDTO;
+import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
+import com.project.tracking_system.utils.ResponseBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST-контроллер для получения прогресса обработки треков.
+ */
+@RequiredArgsConstructor
+@RestController
+public class ProgressController {
+
+    private final BelPostTrackQueueService belPostTrackQueueService;
+
+    /**
+     * Возвращает актуальный прогресс обработки партии.
+     *
+     * @param batchId идентификатор партии
+     * @return прогресс в виде {@link TrackProcessingProgressDTO}
+     */
+    @GetMapping("/app/progress/{batchId}")
+    public ResponseEntity<TrackProcessingProgressDTO> getProgress(@PathVariable Long batchId) {
+        BelPostTrackQueueService.BatchProgress progress = belPostTrackQueueService.getProgress(batchId);
+        if (progress == null) {
+            return ResponseBuilder.ok(new TrackProcessingProgressDTO(batchId, 0, 0, "0:00"));
+        }
+        TrackProcessingProgressDTO dto = new TrackProcessingProgressDTO(
+                batchId,
+                progress.getProcessed(),
+                progress.getTotal(),
+                progress.getElapsed()
+        );
+        return ResponseBuilder.ok(dto);
+    }
+}

--- a/src/main/java/com/project/tracking_system/controller/WebSocketController.java
+++ b/src/main/java/com/project/tracking_system/controller/WebSocketController.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.dto.TrackProcessingStartedDTO;
 import com.project.tracking_system.dto.BelPostBatchStartedDTO;
 import com.project.tracking_system.dto.BelPostTrackProcessedDTO;
 import com.project.tracking_system.dto.BelPostBatchFinishedDTO;
+import com.project.tracking_system.dto.TrackProcessingProgressDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -93,6 +94,17 @@ public class WebSocketController {
     public void sendBelPostBatchFinished(Long userId, BelPostBatchFinishedDTO dto) {
         log.debug("\uD83D\uDCE1 WebSocket партия {} завершена для {}: {}", dto.batchId(), userId, dto);
         messagingTemplate.convertAndSend("/topic/belpost/batch-finished/" + userId, dto);
+    }
+
+    /**
+     * Передаёт текущий прогресс обработки партии треков.
+     *
+     * @param userId идентификатор пользователя
+     * @param dto    данные о прогрессе обработки
+     */
+    public void sendProgress(Long userId, TrackProcessingProgressDTO dto) {
+        log.debug("\uD83D\uDCE1 WebSocket прогресс партии {} для {}: {}", dto.batchId(), userId, dto);
+        messagingTemplate.convertAndSend("/topic/progress/" + userId, dto);
     }
 
     private static void getDebug(Long userId, UpdateResult updateResult) {

--- a/src/main/java/com/project/tracking_system/dto/TrackProcessingProgressDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackProcessingProgressDTO.java
@@ -1,0 +1,15 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Данные о текущем прогрессе обработки партии треков.
+ *
+ * @param batchId   идентификатор партии
+ * @param processed сколько треков уже обработано
+ * @param total     общее количество треков
+ * @param elapsed   время с начала обработки в формате mm:ss
+ */
+public record TrackProcessingProgressDTO(long batchId,
+                                         int processed,
+                                         int total,
+                                         String elapsed) {
+}

--- a/src/test/java/com/project/tracking_system/controller/ProgressControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ProgressControllerTest.java
@@ -1,0 +1,46 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.TrackProcessingProgressDTO;
+import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link ProgressController}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProgressControllerTest {
+
+    @Mock
+    private BelPostTrackQueueService queueService;
+    @Mock
+    private BelPostTrackQueueService.BatchProgress progress;
+
+    @InjectMocks
+    private ProgressController controller;
+
+    @Test
+    void getProgress_ReturnsDto() {
+        when(queueService.getProgress(5L)).thenReturn(progress);
+        when(progress.getProcessed()).thenReturn(2);
+        when(progress.getTotal()).thenReturn(3);
+        when(progress.getElapsed()).thenReturn("0:05");
+
+        ResponseEntity<TrackProcessingProgressDTO> response = controller.getProgress(5L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        TrackProcessingProgressDTO body = response.getBody();
+        assertEquals(5L, body.batchId());
+        assertEquals(2, body.processed());
+        assertEquals(3, body.total());
+        assertEquals("0:05", body.elapsed());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
@@ -77,10 +77,12 @@ class BelPostTrackQueueServiceTest {
         assertEquals(0, p.getFailed());
         verify(webSocketController).sendBelPostBatchStarted(eq(1L), any());
         verify(webSocketController).sendBelPostTrackProcessed(eq(1L), any());
+        verify(webSocketController).sendProgress(eq(1L), any());
 
         queueService.processQueue();
         assertNull(queueService.getProgress(10L));
         verify(webSocketController).sendBelPostBatchFinished(eq(1L), any());
+        verify(webSocketController, times(2)).sendProgress(eq(1L), any());
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `TrackProcessingProgressDTO` to report batch progress
- expose `/app/progress/{batchId}` REST endpoint
- extend `WebSocketController` with `sendProgress`
- update `BelPostTrackQueueService` to send progress via websocket
- test new progress endpoint and service behavior

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880ae4cc794832d81a28f5a0cb285d9