### PR TITLE
Add progress tracking UI

### DIFF
--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -1,0 +1,169 @@
+(function() {
+    "use strict";
+
+    /**
+     * Клиент STOMP для получения уведомлений по WebSocket.
+     * @type {StompJs.Client|null}
+     */
+    let stompClient = null;
+
+    /**
+     * Идентификатор таймера опроса REST контроллера.
+     * @type {number|null}
+     */
+    let pollingTimer = null;
+
+    /**
+     * Последний известный batchId. Используется при падении WebSocket
+     * и переходе на опрос REST контроллера.
+     * @type {number|null}
+     */
+    let lastBatchId = null;
+
+    document.addEventListener("DOMContentLoaded", initProgressTracking);
+
+    /**
+     * Точка входа: инициализируем соединение и отображение прогресса.
+     */
+    function initProgressTracking() {
+        const userId = document.getElementById("userId")?.value;
+        if (!userId) {
+            return; // Пользователь не авторизован
+        }
+        const placeholder = document.getElementById("progressPlaceholder");
+        connectSocket(userId, placeholder);
+    }
+
+    /**
+     * Подключается к WebSocket и подписывается на канал прогресса.
+     * В случае ошибки запускает периодический опрос REST.
+     *
+     * @param {string} userId идентификатор пользователя
+     * @param {HTMLElement|null} placeholder блок для прогресс-бара
+     */
+    function connectSocket(userId, placeholder) {
+        const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+        stompClient = new StompJs.Client({
+            brokerURL: `${protocol}://${window.location.host}/ws`,
+            reconnectDelay: 0
+        });
+
+        stompClient.onConnect = () => {
+            stompClient.subscribe(`/topic/progress/${userId}`, message => {
+                const data = JSON.parse(message.body);
+                lastBatchId = data.batchId;
+                updateDisplay(data, placeholder);
+            });
+        };
+
+        const fallback = () => startPolling(placeholder);
+        stompClient.onWebSocketError = fallback;
+        stompClient.onStompError = fallback;
+
+        stompClient.activate();
+    }
+
+    /**
+     * Запускает циклический опрос REST контроллера.
+     * Используется, если WebSocket недоступен.
+     *
+     * @param {HTMLElement|null} placeholder блок для прогресс-бара
+     */
+    function startPolling(placeholder) {
+        if (pollingTimer || !lastBatchId) {
+            return; // Уже запущено или неизвестен batchId
+        }
+        pollingTimer = setInterval(() => {
+            fetch(`/app/progress/${lastBatchId}`, {cache: "no-store"})
+                .then(r => r.ok ? r.json() : Promise.reject(r.status))
+                .then(data => {
+                    updateDisplay(data, placeholder);
+                    if (data.processed >= data.total) {
+                        stopPolling();
+                    }
+                })
+                .catch(err => console.error("Progress polling error", err));
+        }, 5000);
+    }
+
+    /** Останавливает опрос REST контроллера. */
+    function stopPolling() {
+        if (pollingTimer) {
+            clearInterval(pollingTimer);
+            pollingTimer = null;
+        }
+    }
+
+    /**
+     * Обновляет отображение прогресса: прогресс-бар или toast.
+     * Также скрывает элементы при завершении.
+     *
+     * @param {{batchId:number,processed:number,total:number,elapsed:string}} data
+     * @param {HTMLElement|null} placeholder контейнер прогресс-бара
+     */
+    function updateDisplay(data, placeholder) {
+        if (!data || data.total === 0) return;
+        if (placeholder) {
+            renderBar(placeholder, data);
+        } else {
+            showProgressToast(data);
+        }
+        if (data.processed >= data.total) {
+            hideDisplay(placeholder);
+        }
+    }
+
+    /**
+     * Создаёт или обновляет полоску прогресса.
+     *
+     * @param {HTMLElement} container блок для прогресс-бара
+     * @param {{processed:number,total:number,elapsed:string}} data данные прогресса
+     */
+    function renderBar(container, data) {
+        let bar = container.querySelector(".progress-bar");
+        let info = container.querySelector(".progress-info");
+        if (!bar) {
+            container.innerHTML =
+                `<div class="progress my-3">
+                     <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="${data.total}"></div>
+                 </div>
+                 <div class="progress-info small text-center"></div>`;
+            bar = container.querySelector(".progress-bar");
+            info = container.querySelector(".progress-info");
+        }
+        const percent = Math.floor(data.processed / data.total * 100);
+        bar.style.width = percent + "%";
+        bar.setAttribute("aria-valuenow", String(data.processed));
+        info.textContent = `Обработано ${data.processed} из ${data.total} | ${data.elapsed}`;
+    }
+
+    /**
+     * Показывает уведомление в виде toast с информацией о прогрессе.
+     * @param {{processed:number,total:number,elapsed:string}} data
+     */
+    function showProgressToast(data) {
+        const container = document.getElementById("globalToastContainer");
+        if (!container) return;
+        const toastId = `progress-toast-${Date.now()}`;
+        const message = `Обработано ${data.processed}/${data.total} | ${data.elapsed}`;
+        container.insertAdjacentHTML("beforeend",
+            `<div id="${toastId}" class="toast align-items-center text-bg-info border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
+                <div class="d-flex">
+                    <div class="toast-body">${message}</div>
+                    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+                </div>
+             </div>`);
+        const toastEl = document.getElementById(toastId);
+        const toast = new bootstrap.Toast(toastEl, {delay: 5000});
+        toast.show();
+        toastEl.addEventListener("hidden.bs.toast", () => toastEl.remove());
+    }
+
+    /** Скрывает прогресс-бар и прекращает опрос. */
+    function hideDisplay(placeholder) {
+        stopPolling();
+        if (placeholder) {
+            placeholder.innerHTML = "";
+        }
+    }
+})();

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -40,6 +40,7 @@
 
                     <!-- Контейнер для уведомлений -->
                     <div id="notificationContainer"></div>
+                    <div id="progressPlaceholder" class="my-3"></div>
 
                     <div class="card shadow-sm p-4 rounded-4 mb-4">
 
@@ -212,6 +213,6 @@
             </div>
         </div>
     </div>
+<script src="/js/progress-tracking.js"></script>
 </div>
-
 </html>

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -103,6 +103,7 @@
                     </form>
 
                 </div>
+                <div id="progressPlaceholder" class="my-3"></div>
 
                 <!-- Информация о посылке -->
                 <div th:if="${trackInfo}" class="card shadow-sm p-4 rounded-4 mb-4">
@@ -157,5 +158,8 @@
         </div>
     </div>
 </main>
+<div layout:fragment="afterFooter">
+    <script src="/js/progress-tracking.js"></script>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `progress-tracking.js` module to show WebSocket progress
- display progress bar in home and departures pages
- include module via `afterFooter` fragment on relevant pages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880afdfa268832d8fb4de30cacade1f