### PR TITLE
Add track status push via WebSocket

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/WebSocketController.java
+++ b/src/main/java/com/project/tracking_system/controller/WebSocketController.java
@@ -3,7 +3,7 @@ package com.project.tracking_system.controller;
 import com.project.tracking_system.entity.UpdateResult;
 import com.project.tracking_system.dto.TrackProcessingStartedDTO;
 import com.project.tracking_system.dto.BelPostBatchStartedDTO;
-import com.project.tracking_system.dto.BelPostTrackProcessedDTO;
+import com.project.tracking_system.dto.TrackStatusUpdateDTO;
 import com.project.tracking_system.dto.BelPostBatchFinishedDTO;
 import com.project.tracking_system.dto.TrackProcessingProgressDTO;
 import lombok.RequiredArgsConstructor;
@@ -80,8 +80,8 @@ public class WebSocketController {
      * @param userId идентификатор пользователя
      * @param dto    информация об обработанном треке
      */
-    public void sendBelPostTrackProcessed(Long userId, BelPostTrackProcessedDTO dto) {
-        log.debug("\uD83D\uDCE1 WebSocket обработан трек {} партии {}: {}", dto.trackNumber(), dto.batchId(), dto);
+    public void sendBelPostTrackProcessed(Long userId, TrackStatusUpdateDTO dto) {
+        log.debug("\uD83D\uDCE1 WebSocket обработан трек {} партии {}: {}", dto.trackingNumber(), dto.batchId(), dto);
         messagingTemplate.convertAndSend("/topic/belpost/track-processed/" + userId, dto);
     }
 

--- a/src/main/java/com/project/tracking_system/dto/TrackStatusUpdateDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackStatusUpdateDTO.java
@@ -1,0 +1,21 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Сообщение о текущем статусе обработки трека Белпочты.
+ * <p>
+ * Отправляется после обработки каждого трек-номера для обновления
+ * прогресса у пользователя в реальном времени.
+ * </p>
+ *
+ * @param batchId        идентификатор партии
+ * @param trackingNumber номер трека
+ * @param status         последний известный статус трека
+ * @param completed      сколько треков уже обработано
+ * @param total          общее количество треков в партии
+ */
+public record TrackStatusUpdateDTO(long batchId,
+                                   String trackingNumber,
+                                   String status,
+                                   int completed,
+                                   int total) {
+}

--- a/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -76,7 +77,8 @@ class BelPostTrackQueueServiceTest {
         assertEquals(1, p.getSuccess());
         assertEquals(0, p.getFailed());
         verify(webSocketController).sendBelPostBatchStarted(eq(1L), any());
-        verify(webSocketController).sendBelPostTrackProcessed(eq(1L), any());
+        verify(webSocketController).sendBelPostTrackProcessed(eq(1L), argThat(dto ->
+                "info".equals(dto.status()) && dto.completed() == 1 && dto.total() == 2));
         verify(webSocketController).sendProgress(eq(1L), any());
 
         queueService.processQueue();


### PR DESCRIPTION
## Summary
- add `TrackStatusUpdateDTO` for progress message with current status
- send new DTO from `BelPostTrackQueueService.processQueue`
- update `WebSocketController.sendBelPostTrackProcessed` to use new DTO
- adjust unit test to validate status sending

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880b857ae58832daa2c0bd82e8ca06d