### PR TITLE
Ensure tracking table is shown after upload

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/UploadController.java
+++ b/src/main/java/com/project/tracking_system/controller/UploadController.java
@@ -59,6 +59,11 @@ public class UploadController {
         try {
             if (contentType.equals("application/vnd.ms-excel") || contentType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
                 trackUploadProcessorService.process(file, userId);
+                // После успешной передачи файла и запуска обработки
+                // инициализируем пустую коллекцию для отображения результатов
+                // отслеживания. Это позволяет отрисовать таблицу и наполнять
+                // её данными по WebSocket.
+                model.addAttribute("trackingResults", java.util.Collections.emptyList());
                 model.addAttribute("successMessage", "Файл принят, обработка начата.");
             } else {
                 model.addAttribute("customError", "Неподдерживаемый тип файла. Загрузите XLS или XLSX.");

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -128,7 +128,7 @@
                 </div>
 
                 <!-- Результаты загрузки -->
-                <div th:if="${trackingResults}" class="card shadow-sm p-4 rounded-4">
+                <div class="card shadow-sm p-4 rounded-4">
                     <h4 class="text-center">Последние обновления</h4>
                     <div class="table-responsive">
                         <!-- Таблица содержит последние обновления по загруженным трекам -->


### PR DESCRIPTION
## Summary
- populate empty `trackingResults` after upload
- always render results table on home page

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880df749f8c832d8c838ce64fbfadbc