### PR TITLE
Ensure tracking table appears with progress

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/UploadController.java
+++ b/src/main/java/com/project/tracking_system/controller/UploadController.java
@@ -59,6 +59,8 @@ public class UploadController {
         try {
             if (contentType.equals("application/vnd.ms-excel") || contentType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
                 trackUploadProcessorService.process(file, userId);
+                // Таблица с результатами появится после получения первых данных
+                // по WebSocket. На этом этапе её не заполняем.
                 model.addAttribute("successMessage", "Файл принят, обработка начата.");
             } else {
                 model.addAttribute("customError", "Неподдерживаемый тип файла. Загрузите XLS или XLSX.");

--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -252,12 +252,13 @@
 
     /**
      * Обновляет или создаёт строку в таблице результатов трекинга.
+     * Таблица создаётся динамически при первом обращении.
      *
      * @param {string} trackNumber номер трек-отправления
      * @param {string} statusText текст статуса
      */
     function updateTrackingRow(trackNumber, statusText) {
-        const table = document.getElementById("tracking-results-table");
+        const table = ensureResultsTable();
         if (!table) return;
 
         let row = table.querySelector(`tr[data-track-number="${trackNumber}"]`);
@@ -269,6 +270,33 @@
         } else {
             row.cells[1].textContent = statusText;
         }
+    }
+
+    /**
+     * Гарантирует наличие таблицы результатов на странице и показывает её.
+     * Если таблицы нет, она создаётся вместе с контейнером.
+     *
+     * @returns {HTMLTableElement|null} найденная или созданная таблица
+     */
+    function ensureResultsTable() {
+        const container = document.getElementById("tracking-results-container");
+        if (!container) return null;
+
+        container.classList.remove("d-none");
+        let table = container.querySelector("#tracking-results-table");
+        if (!table) {
+            container.innerHTML =
+                `<div class="table-responsive">
+                     <table id="tracking-results-table" class="table table-striped">
+                         <thead>
+                         <tr><th>Номер посылки</th><th>Статус</th></tr>
+                         </thead>
+                         <tbody id="tracking-results-body"></tbody>
+                     </table>
+                 </div>`;
+            table = container.querySelector("#tracking-results-table");
+        }
+        return table;
     }
 
     /**

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -128,7 +128,9 @@
                 </div>
 
                 <!-- Результаты загрузки -->
-                <div th:if="${trackingResults}" class="card shadow-sm p-4 rounded-4">
+                <div id="tracking-results-container"
+                     class="card shadow-sm p-4 rounded-4"
+                     th:classappend="${trackingResults}? '' : ' d-none'">
                     <h4 class="text-center">Последние обновления</h4>
                     <div class="table-responsive">
                         <!-- Таблица содержит последние обновления по загруженным трекам -->


### PR DESCRIPTION
## Summary
- hide results card until there are tracking updates
- update progress script to create/show the table dynamically
- clarify upload flow comments

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880df749f8c832d8c838ce64fbfadbc