### PR TITLE
Add latest batch progress endpoint

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProgressController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProgressController.java
@@ -5,6 +5,8 @@ import com.project.tracking_system.service.track.ProgressAggregatorService;
 import com.project.tracking_system.utils.ResponseBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import com.project.tracking_system.entity.User;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +29,26 @@ public class ProgressController {
     @GetMapping("/app/progress/{batchId}")
     public ResponseEntity<TrackProcessingProgressDTO> getProgress(@PathVariable Long batchId) {
         return ResponseBuilder.ok(progressAggregatorService.getProgress(batchId));
+    }
+
+    /**
+     * Возвращает прогресс последней активной партии текущего пользователя.
+     * <p>
+     * Если активных партий нет, возвращает пустой прогресс с total = 0.
+     * </p>
+     *
+     * @param user аутентифицированный пользователь
+     * @return прогресс в виде {@link TrackProcessingProgressDTO}
+     */
+    @GetMapping("/app/progress/latest")
+    public ResponseEntity<TrackProcessingProgressDTO> getLatestProgress(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            return ResponseBuilder.ok(new TrackProcessingProgressDTO(0L, 0, 0, "0:00"));
+        }
+        Long batchId = progressAggregatorService.getLatestBatchId(user.getId());
+        TrackProcessingProgressDTO dto = batchId != null
+                ? progressAggregatorService.getProgress(batchId)
+                : new TrackProcessingProgressDTO(0L, 0, 0, "0:00");
+        return ResponseBuilder.ok(dto);
     }
 }

--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -49,6 +49,8 @@
 
     /**
      * Точка входа: инициализируем соединение и отображение прогресса.
+     * Запрашиваем актуальный прогресс через REST до подключения к WebSocket,
+     * чтобы отобразить его сразу после загрузки страницы.
      */
     function initProgressTracking() {
         const userId = document.getElementById("userId")?.value;
@@ -56,7 +58,16 @@
             return; // Пользователь не авторизован
         }
         const container = document.getElementById("progressContainer");
-        connectSocket(userId, container);
+
+        fetch("/app/progress/latest", {cache: "no-store"})
+            .then(r => r.ok ? r.json() : null)
+            .then(data => {
+                if (data && data.total > 0) {
+                    lastBatchId = data.batchId;
+                    updateDisplay(data, container);
+                }
+            })
+            .finally(() => connectSocket(userId, container));
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/track/ProgressAggregatorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/ProgressAggregatorServiceTest.java
@@ -13,7 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for {@link ProgressAggregatorService}.
+ * Тесты для {@link ProgressAggregatorService}.
  */
 @ExtendWith(MockitoExtension.class)
 class ProgressAggregatorServiceTest {
@@ -44,5 +44,21 @@ class ProgressAggregatorServiceTest {
         verify(webSocketController, times(2)).sendProgress(eq(7L), any());
         TrackProcessingProgressDTO dto = service.getProgress(2L);
         assertEquals(0, dto.total());
+    }
+
+    @Test
+    void getLatestBatchId_ReturnsMostRecent() throws InterruptedException {
+        service.registerBatch(1L, 1, 5L);
+        Thread.sleep(2);
+        service.registerBatch(2L, 1, 5L);
+
+        Long latest = service.getLatestBatchId(5L);
+
+        assertEquals(2L, latest);
+    }
+
+    @Test
+    void getLatestBatchId_ReturnsNullWhenNothing() {
+        assertNull(service.getLatestBatchId(99L));
     }
 }


### PR DESCRIPTION
## Summary
- support retrieving latest batch id in `ProgressAggregatorService`
- add `/app/progress/latest` REST endpoint
- show progress bar immediately on page load by calling new endpoint
- test latest batch logic
- translate documentation comments to Russian

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880e5bc89b8832db3765298e1c4b549