### PR TITLE
Add progress popup for progress tracking

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1567,4 +1567,16 @@ body.loading {
   }
 }
 
+.progress-popup {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1250;
+  min-width: 220px;
+  padding: 1rem;
+  background-color: #0d6efd;
+  color: #fff;
+  border-radius: 0.25rem;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -44,6 +44,11 @@
      * @type {HTMLElement|null}
      */
     let progressContainer = null;
+    /**
+     * DOM-элемент всплывающего окна с прогрессом.
+     * @type {HTMLElement|null}
+     */
+    let progressPopup = null;
 
     document.addEventListener("DOMContentLoaded", initProgressTracking);
 
@@ -58,6 +63,7 @@
             return; // Пользователь не авторизован
         }
         const container = document.getElementById("progressContainer");
+        progressPopup = document.getElementById("progressPopup");
 
         fetch("/app/progress/latest", {cache: "no-store"})
             .then(r => r.ok ? r.json() : null)
@@ -171,7 +177,7 @@
         if (container) {
             renderBar(container, data);
         } else {
-            showProgressToast(data);
+            renderPopup(data);
         }
     }
 
@@ -198,6 +204,22 @@
         bar.style.width = percent + "%";
         bar.setAttribute("aria-valuenow", String(data.processed));
         info.textContent = `Обработано ${data.processed} из ${data.total} | ${data.elapsed}`;
+    }
+
+    /**
+     * Отображает прогресс во всплывающем окне, не создавая новые toast.
+     * @param {{processed:number,total:number,elapsed:string}} data данные прогресса
+     */
+    function renderPopup(data) {
+        if (!progressPopup) return;
+        progressPopup.classList.remove("d-none");
+
+        const percent = Math.floor(data.processed / data.total * 100);
+        progressPopup.innerHTML =
+            `<div class="progress">
+                 <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="${data.total}" style="width: ${percent}%" aria-valuenow="${data.processed}"></div>
+             </div>
+             <div class="progress-info small text-center mt-1">Обработано ${data.processed} из ${data.total} | ${data.elapsed}</div>`;
     }
 
     /**
@@ -245,6 +267,7 @@
         stopTimer();
         showBatchFinishedToast();
         hideDisplay(container);
+        hidePopup();
     }
 
     /**
@@ -394,5 +417,14 @@
             container.innerHTML = "";
             container.classList.add("d-none");
         }
+    }
+
+    /**
+     * Скрывает всплывающий блок прогресса и очищает его содержимое.
+     */
+    function hidePopup() {
+        if (!progressPopup) return;
+        progressPopup.innerHTML = "";
+        progressPopup.classList.add("d-none");
     }
 })();

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -58,6 +58,7 @@
 
 <!-- Контейнер для Toast (глобальные уведомления) -->
 <div class="toast-container position-fixed top-0 end-0 p-3" id="globalToastContainer" style="z-index: 1200;"></div>
+<div id="progressPopup" class="progress-popup d-none"></div>
 
 <div id="loadingOverlay" class="hidden">
     <div class="spinner-border text-primary" role="status">


### PR DESCRIPTION
## Summary
- add progressPopup element in layout
- style progress popup in CSS
- display progress updates in popup instead of toast when bar absent
- hide popup once batch processing is complete
- adjust popup position to top-right per review comment

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880fd9ad74c832da1e918573be9a9be