### PR TITLE
Ensure empty results table after upload

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/UploadController.java
+++ b/src/main/java/com/project/tracking_system/controller/UploadController.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.project.tracking_system.entity.User;
 
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Контроллер для загрузки файлов и распознавания номеров посылок.
@@ -59,6 +60,10 @@ public class UploadController {
         try {
             if (contentType.equals("application/vnd.ms-excel") || contentType.equals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
                 trackUploadProcessorService.process(file, userId);
+                // После успешной передачи файла и запуска обработки
+                // добавляем пустой список результатов, чтобы таблица могла
+                // появиться на странице и наполняться через WebSocket.
+                model.addAttribute("trackingResults", Collections.emptyList());
                 // Таблица с результатами появится после получения первых данных
                 // по WebSocket. На этом этапе её не заполняем.
                 model.addAttribute("successMessage", "Файл принят, обработка начата.");

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -129,8 +129,7 @@
 
                 <!-- Результаты загрузки -->
                 <div id="tracking-results-container"
-                     class="card shadow-sm p-4 rounded-4"
-                     th:classappend="${trackingResults}? '' : ' d-none'">
+                     class="card shadow-sm p-4 rounded-4">
                     <h4 class="text-center">Последние обновления</h4>
                     <div class="table-responsive">
                         <!-- Таблица содержит последние обновления по загруженным трекам -->


### PR DESCRIPTION
## Summary
- prefill `trackingResults` with an empty list after file upload succeeds
- keep tracking results table on the page at all times

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68812698b2f4832d825ae69369da0fc9