### PR TITLE
Add dismissible tracking results

### DIFF
--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -64,6 +64,7 @@
         }
         const container = document.getElementById("progressContainer");
         progressPopup = document.getElementById("progressPopup");
+        attachResultsCloseHandler();
 
         fetch("/app/progress/latest", {cache: "no-store"})
             .then(r => r.ok ? r.json() : null)
@@ -342,6 +343,9 @@
         const table = ensureResultsTable();
         if (!table) return;
 
+        // При добавлении результатов показываем контейнер
+        document.getElementById("tracking-results-container")?.classList.remove("d-none");
+
         let row = table.querySelector(`tr[data-track-number="${trackNumber}"]`);
         if (!row) {
             row = table.insertRow(-1);
@@ -426,5 +430,25 @@
         if (!progressPopup) return;
         progressPopup.innerHTML = "";
         progressPopup.classList.add("d-none");
+    }
+
+    /**
+     * Назначает обработчик кнопки закрытия блока результатов трекинга.
+     * При нажатии очищает таблицу и скрывает контейнер.
+     */
+    function attachResultsCloseHandler() {
+        const container = document.getElementById("tracking-results-container");
+        if (!container) return;
+
+        const closeBtn = container.querySelector("#tracking-results-close");
+        if (!closeBtn) return;
+
+        closeBtn.addEventListener("click", () => {
+            const tbody = container.querySelector("#tracking-results-body");
+            if (tbody) {
+                tbody.innerHTML = "";
+            }
+            container.classList.add("d-none");
+        });
     }
 })();

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -129,8 +129,11 @@
 
                 <!-- Результаты загрузки -->
                 <div id="tracking-results-container"
-                     class="card shadow-sm p-4 rounded-4">
-                    <h4 class="text-center">Последние обновления</h4>
+                     class="card shadow-sm p-4 rounded-4 d-none">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h4 class="text-center flex-grow-1 mb-0">Последние обновления</h4>
+                        <button id="tracking-results-close" type="button" class="btn-close ms-2" aria-label="Закрыть"></button>
+                    </div>
                     <div class="table-responsive">
                         <!-- Таблица содержит последние обновления по загруженным трекам -->
                         <table id="tracking-results-table" class="table table-striped">


### PR DESCRIPTION
## Summary
- hide tracking results until data available
- add a small close button for tracking results
- show results container on new rows
- allow closing results and clear table via JS

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881357928b4832dbb067ddc6a573417