### PR TITLE
Add cache for tracking results

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProgressController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProgressController.java
@@ -2,6 +2,8 @@ package com.project.tracking_system.controller;
 
 import com.project.tracking_system.dto.TrackProcessingProgressDTO;
 import com.project.tracking_system.service.track.ProgressAggregatorService;
+import com.project.tracking_system.service.track.TrackingResultCacheService;
+import com.project.tracking_system.dto.TrackStatusUpdateDTO;
 import com.project.tracking_system.utils.ResponseBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PostMapping;
+import java.util.List;
 
 /**
  * REST-контроллер для получения прогресса обработки треков.
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProgressController {
 
     private final ProgressAggregatorService progressAggregatorService;
+    private final TrackingResultCacheService trackingResultCacheService;
 
     /**
      * Возвращает актуальный прогресс обработки партии.
@@ -50,5 +55,30 @@ public class ProgressController {
                 ? progressAggregatorService.getProgress(batchId)
                 : new TrackProcessingProgressDTO(0L, 0, 0, "0:00");
         return ResponseBuilder.ok(dto);
+    }
+
+    /**
+     * Returns cached tracking results for the latest batch of the current user.
+     *
+     * @param user authenticated user
+     * @return list of cached updates
+     */
+    @GetMapping("/app/results/latest")
+    public ResponseEntity<List<TrackStatusUpdateDTO>> getLatestResults(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            return ResponseBuilder.ok(List.of());
+        }
+        return ResponseBuilder.ok(trackingResultCacheService.getLatestResults(user.getId()));
+    }
+
+    /**
+     * Clears cached results for the current user.
+     */
+    @PostMapping("/app/results/clear")
+    public ResponseEntity<String> clearResults(@AuthenticationPrincipal User user) {
+        if (user != null) {
+            trackingResultCacheService.clearResults(user.getId());
+        }
+        return ResponseBuilder.ok("cleared");
     }
 }

--- a/src/main/java/com/project/tracking_system/controller/ProgressController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProgressController.java
@@ -58,10 +58,10 @@ public class ProgressController {
     }
 
     /**
-     * Returns cached tracking results for the latest batch of the current user.
+     * Возвращает сохранённые результаты последней партии текущего пользователя.
      *
-     * @param user authenticated user
-     * @return list of cached updates
+     * @param user аутентифицированный пользователь
+     * @return список сохранённых обновлений
      */
     @GetMapping("/app/results/latest")
     public ResponseEntity<List<TrackStatusUpdateDTO>> getLatestResults(@AuthenticationPrincipal User user) {
@@ -72,7 +72,7 @@ public class ProgressController {
     }
 
     /**
-     * Clears cached results for the current user.
+     * Очищает кэш результатов текущего пользователя.
      */
     @PostMapping("/app/results/clear")
     public ResponseEntity<String> clearResults(@AuthenticationPrincipal User user) {

--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
@@ -8,6 +8,7 @@ import com.project.tracking_system.dto.BelPostBatchFinishedDTO;
 import com.project.tracking_system.service.track.TrackProcessingService;
 import com.project.tracking_system.service.track.TrackConstants;
 import com.project.tracking_system.service.track.ProgressAggregatorService;
+import com.project.tracking_system.service.track.TrackingResultCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.WebDriverException;
@@ -42,6 +43,8 @@ public class BelPostTrackQueueService {
     private final WebSocketController webSocketController;
     /** Aggregates overall progress from different services. */
     private final ProgressAggregatorService progressAggregatorService;
+    /** Cache for tracking results to restore page state. */
+    private final TrackingResultCacheService trackingResultCacheService;
 
     /** Хранилище заданий на обработку. */
     private final BlockingQueue<QueuedTrack> queue = new LinkedBlockingQueue<>();
@@ -129,14 +132,14 @@ public class BelPostTrackQueueService {
         String status = info.getList().isEmpty()
                 ? TrackConstants.NO_DATA_STATUS
                 : info.getList().get(0).getInfoTrack();
-        webSocketController.sendBelPostTrackProcessed(
-                task.userId(),
-                new TrackStatusUpdateDTO(
-                        task.batchId(),
-                        task.trackNumber(),
-                        status,
-                        progress.getProcessed(),
-                        progress.getTotal()));
+        TrackStatusUpdateDTO dto = new TrackStatusUpdateDTO(
+                task.batchId(),
+                task.trackNumber(),
+                status,
+                progress.getProcessed(),
+                progress.getTotal());
+        webSocketController.sendBelPostTrackProcessed(task.userId(), dto);
+        trackingResultCacheService.addResult(task.userId(), dto);
 
         progressAggregatorService.trackProcessed(task.batchId());
 

--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
@@ -41,9 +41,9 @@ public class BelPostTrackQueueService {
     private final WebBelPostBatchService webBelPostBatchService;
     private final TrackProcessingService trackProcessingService;
     private final WebSocketController webSocketController;
-    /** Aggregates overall progress from different services. */
+    /** Сервис агрегирования прогресса из различных источников. */
     private final ProgressAggregatorService progressAggregatorService;
-    /** Cache for tracking results to restore page state. */
+    /** Кэш результатов трекинга для восстановления состояния страницы. */
     private final TrackingResultCacheService trackingResultCacheService;
 
     /** Хранилище заданий на обработку. */

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -45,7 +45,7 @@ public class TrackUpdateService {
     private final BelPostTrackQueueService belPostTrackQueueService;
     /** Сервис агрегации прогресса обработки. */
     private final ProgressAggregatorService progressAggregatorService;
-    /** Cache storing tracking results for restoring page state. */
+    /** Кэш результатов трекинга для восстановления состояния страницы. */
     private final TrackingResultCacheService trackingResultCacheService;
 
     /**

--- a/src/main/java/com/project/tracking_system/service/track/TrackingResultCacheService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingResultCacheService.java
@@ -10,23 +10,23 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * In-memory cache for storing tracking results per user and batch.
+ * Сервис-кэш для временного хранения результатов обработки по пользователям и партиям.
  * <p>
- * The cache is used to restore the table of processed tracks on page reload.
- * Results are grouped by user id and batch id.
+ * Используется для восстановления таблицы результатов после перезагрузки страницы.
+ * Результаты группируются по идентификатору пользователя и идентификатору партии.
  * </p>
  */
 @Service
 public class TrackingResultCacheService {
 
-    /** Map userId -&gt; (batchId -&gt; list of results). */
+    /** Карта вида userId -> (batchId -> список результатов). */
     private final Map<Long, Map<Long, List<TrackStatusUpdateDTO>>> cache = new ConcurrentHashMap<>();
 
     /**
-     * Adds a single tracking result to the cache.
+     * Добавляет один результат обработки в кэш.
      *
-     * @param userId identifier of the user
-     * @param dto    result of track processing
+     * @param userId идентификатор пользователя
+     * @param dto    результат обработки трека
      */
     public void addResult(Long userId, TrackStatusUpdateDTO dto) {
         if (userId == null || dto == null) {
@@ -39,11 +39,11 @@ public class TrackingResultCacheService {
     }
 
     /**
-     * Returns stored results for the given batch of the user.
+     * Возвращает сохранённые результаты для указанной партии пользователя.
      *
-     * @param userId  user identifier
-     * @param batchId batch identifier
-     * @return list of results, possibly empty
+     * @param userId  идентификатор пользователя
+     * @param batchId идентификатор партии
+     * @return список результатов, может быть пустым
      */
     public List<TrackStatusUpdateDTO> getResults(Long userId, Long batchId) {
         if (userId == null || batchId == null) {
@@ -58,10 +58,10 @@ public class TrackingResultCacheService {
     }
 
     /**
-     * Returns results of the latest batch for the user.
+     * Получает результаты последней партии пользователя.
      *
-     * @param userId user identifier
-     * @return list of results or empty list if none
+     * @param userId идентификатор пользователя
+     * @return список результатов либо пустой список
      */
     public List<TrackStatusUpdateDTO> getLatestResults(Long userId) {
         Map<Long, List<TrackStatusUpdateDTO>> byBatch = cache.get(userId);
@@ -76,9 +76,9 @@ public class TrackingResultCacheService {
     }
 
     /**
-     * Clears cached results for a user.
+     * Очищает кэш результатов пользователя.
      *
-     * @param userId user identifier
+     * @param userId идентификатор пользователя
      */
     public void clearResults(Long userId) {
         if (userId != null) {

--- a/src/main/java/com/project/tracking_system/service/track/TrackingResultCacheService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingResultCacheService.java
@@ -1,0 +1,88 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackStatusUpdateDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory cache for storing tracking results per user and batch.
+ * <p>
+ * The cache is used to restore the table of processed tracks on page reload.
+ * Results are grouped by user id and batch id.
+ * </p>
+ */
+@Service
+public class TrackingResultCacheService {
+
+    /** Map userId -&gt; (batchId -&gt; list of results). */
+    private final Map<Long, Map<Long, List<TrackStatusUpdateDTO>>> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Adds a single tracking result to the cache.
+     *
+     * @param userId identifier of the user
+     * @param dto    result of track processing
+     */
+    public void addResult(Long userId, TrackStatusUpdateDTO dto) {
+        if (userId == null || dto == null) {
+            return;
+        }
+        cache
+                .computeIfAbsent(userId, id -> new ConcurrentHashMap<>())
+                .computeIfAbsent(dto.batchId(), id -> Collections.synchronizedList(new ArrayList<>()))
+                .add(dto);
+    }
+
+    /**
+     * Returns stored results for the given batch of the user.
+     *
+     * @param userId  user identifier
+     * @param batchId batch identifier
+     * @return list of results, possibly empty
+     */
+    public List<TrackStatusUpdateDTO> getResults(Long userId, Long batchId) {
+        if (userId == null || batchId == null) {
+            return List.of();
+        }
+        Map<Long, List<TrackStatusUpdateDTO>> byBatch = cache.get(userId);
+        if (byBatch == null) {
+            return List.of();
+        }
+        List<TrackStatusUpdateDTO> list = byBatch.get(batchId);
+        return list != null ? new ArrayList<>(list) : List.of();
+    }
+
+    /**
+     * Returns results of the latest batch for the user.
+     *
+     * @param userId user identifier
+     * @return list of results or empty list if none
+     */
+    public List<TrackStatusUpdateDTO> getLatestResults(Long userId) {
+        Map<Long, List<TrackStatusUpdateDTO>> byBatch = cache.get(userId);
+        if (byBatch == null || byBatch.isEmpty()) {
+            return List.of();
+        }
+        Long latestBatchId = byBatch.keySet().stream().max(Long::compareTo).orElse(null);
+        if (latestBatchId == null) {
+            return List.of();
+        }
+        return getResults(userId, latestBatchId);
+    }
+
+    /**
+     * Clears cached results for a user.
+     *
+     * @param userId user identifier
+     */
+    public void clearResults(Long userId) {
+        if (userId != null) {
+            cache.remove(userId);
+        }
+    }
+}

--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -460,7 +460,7 @@
     }
 
     /**
-     * Sends a request to clear cached results when the user leaves the page.
+     * Отправляет запрос на очистку кэша результатов при уходе со страницы.
      */
     function attachUnloadHandler() {
         window.addEventListener("beforeunload", () => {

--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -65,6 +65,7 @@
         const container = document.getElementById("progressContainer");
         progressPopup = document.getElementById("progressPopup");
         attachResultsCloseHandler();
+        attachUnloadHandler();
 
         fetch("/app/progress/latest", {cache: "no-store"})
             .then(r => r.ok ? r.json() : null)
@@ -75,6 +76,11 @@
                 }
             })
             .finally(() => connectSocket(userId, container));
+
+        // Загружаем сохранённые результаты последней партии
+        fetch("/app/results/latest", {cache: "no-store"})
+            .then(r => r.ok ? r.json() : [])
+            .then(list => list.forEach(item => updateTrackingRow(item.trackingNumber, item.status)));
     }
 
     /**
@@ -449,6 +455,16 @@
                 tbody.innerHTML = "";
             }
             container.classList.add("d-none");
+            fetch("/app/results/clear", {method: "POST"});
+        });
+    }
+
+    /**
+     * Sends a request to clear cached results when the user leaves the page.
+     */
+    function attachUnloadHandler() {
+        window.addEventListener("beforeunload", () => {
+            navigator.sendBeacon("/app/results/clear");
         });
     }
 })();


### PR DESCRIPTION
## Summary
- add TrackingResultCacheService to store per-user results
- push BelPost updates and synchronous processor results into the cache
- expose latest results endpoint and clear endpoint
- fetch cached results on page load and clear them when closing the table

## Testing
- `mvn test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881367ffd38832d998ed7d2aa11bde2