### PR TITLE
Validate update interval

### DIFF
--- a/src/main/java/com/project/tracking_system/service/admin/ApplicationSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/ApplicationSettingsService.java
@@ -35,10 +35,14 @@ public class ApplicationSettingsService {
     /**
      * Обновить интервал автообновления треков.
      *
-     * @param hours новое значение интервала в часах
+     * @param hours новое значение интервала в часах. Значение должно быть больше нуля,
+     *              иначе будет сгенерировано {@link IllegalArgumentException}.
      */
     @Transactional
     public void updateTrackUpdateIntervalHours(int hours) {
+        if (hours <= 0) {
+            throw new IllegalArgumentException("Interval must be positive");
+        }
         ApplicationSettings settings = repository
                 .findById(SETTINGS_ID)
                 .orElseGet(() -> {

--- a/src/main/java/com/project/tracking_system/service/admin/ApplicationSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/ApplicationSettingsService.java
@@ -24,6 +24,7 @@ public class ApplicationSettingsService {
 
     /**
      * Получить текущий интервал автообновления треков в часах.
+     * Если запись отсутствует, возвращается значение по умолчанию.
      */
     @Transactional(readOnly = true)
     public int getTrackUpdateIntervalHours() {
@@ -42,7 +43,7 @@ public class ApplicationSettingsService {
     @Transactional
     public void updateTrackUpdateIntervalHours(int hours) {
         if (hours <= 0) {
-            throw new IllegalArgumentException("Interval must be positive");
+            throw new IllegalArgumentException("Интервал должен быть положительным");
         }
         ApplicationSettings settings = repository
                 .findById(SETTINGS_ID)

--- a/src/main/java/com/project/tracking_system/service/admin/ApplicationSettingsService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/ApplicationSettingsService.java
@@ -37,6 +37,7 @@ public class ApplicationSettingsService {
      *
      * @param hours новое значение интервала в часах. Значение должно быть больше нуля,
      *              иначе будет сгенерировано {@link IllegalArgumentException}.
+     * @throws IllegalArgumentException если значение {@code hours} не положительно
      */
     @Transactional
     public void updateTrackUpdateIntervalHours(int hours) {

--- a/src/test/java/com/project/tracking_system/service/admin/ApplicationSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/admin/ApplicationSettingsServiceTest.java
@@ -1,0 +1,40 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.repository.ApplicationSettingsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Проверки {@link ApplicationSettingsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ApplicationSettingsServiceTest {
+
+    @Mock
+    private ApplicationSettingsRepository repository;
+
+    @InjectMocks
+    private ApplicationSettingsService service;
+
+    @Test
+    void updateTrackUpdateIntervalHours_ZeroValue_ThrowsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.updateTrackUpdateIntervalHours(0));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateTrackUpdateIntervalHours_NegativeValue_ThrowsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.updateTrackUpdateIntervalHours(-5));
+        verify(repository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- validate update interval value when modifying app settings
- test invalid intervals for ApplicationSettingsService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68814f8cbfe4832d94cade98cdbbf982