### PR TITLE
Ensure results cleanup uses CSRF token

### DIFF
--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -455,7 +455,12 @@
                 tbody.innerHTML = "";
             }
             container.classList.add("d-none");
-            fetch("/app/results/clear", {method: "POST"});
+            // Отправляем запрос на очистку сохранённых результатов трекинга
+            // Используем глобально заданные CSRF-заголовок и токен из app.js
+            fetch("/app/results/clear", {
+                method: "POST",
+                headers: { [window.csrfHeader]: window.csrfToken }
+            });
         });
     }
 
@@ -464,7 +469,13 @@
      */
     function attachUnloadHandler() {
         window.addEventListener("beforeunload", () => {
-            navigator.sendBeacon("/app/results/clear");
+            // Используем fetch с keepalive, чтобы гарантировать отправку запроса
+            // даже при закрытии страницы
+            fetch("/app/results/clear", {
+                method: "POST",
+                headers: { [window.csrfHeader]: window.csrfToken },
+                keepalive: true
+            });
         });
     }
 })();


### PR DESCRIPTION
## Summary
- use fetch with CSRF header to clear results table and on page unload
- rely on globally defined `window.csrfHeader` and `window.csrfToken` from `app.js`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881552af0b0832d995df2d534a8e804