### PR TITLE
Add expiration mechanism for tracking results cache

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackingResultCacheService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackingResultCacheService.java
@@ -1,6 +1,8 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackStatusUpdateDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -19,8 +21,21 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 public class TrackingResultCacheService {
 
-    /** Карта вида userId -> (batchId -> список результатов). */
-    private final Map<Long, Map<Long, List<TrackStatusUpdateDTO>>> cache = new ConcurrentHashMap<>();
+    /** Время жизни результатов в кэше (мс). */
+    private final long expirationMs;
+
+    /**
+     * Конструктор, принимающий значение таймаута из конфигурации.
+     *
+     * @param expirationMs время жизни данных в миллисекундах
+     */
+    public TrackingResultCacheService(
+            @Value("${tracking.result-cache.expiration-ms:60000}") long expirationMs) {
+        this.expirationMs = expirationMs;
+    }
+
+    /** Карта вида userId -> (batchId -> результаты с отметкой времени). */
+    private final Map<Long, Map<Long, BatchEntry>> cache = new ConcurrentHashMap<>();
 
     /**
      * Добавляет один результат обработки в кэш.
@@ -34,7 +49,7 @@ public class TrackingResultCacheService {
         }
         cache
                 .computeIfAbsent(userId, id -> new ConcurrentHashMap<>())
-                .computeIfAbsent(dto.batchId(), id -> Collections.synchronizedList(new ArrayList<>()))
+                .computeIfAbsent(dto.batchId(), id -> new BatchEntry())
                 .add(dto);
     }
 
@@ -49,12 +64,12 @@ public class TrackingResultCacheService {
         if (userId == null || batchId == null) {
             return List.of();
         }
-        Map<Long, List<TrackStatusUpdateDTO>> byBatch = cache.get(userId);
+        Map<Long, BatchEntry> byBatch = cache.get(userId);
         if (byBatch == null) {
             return List.of();
         }
-        List<TrackStatusUpdateDTO> list = byBatch.get(batchId);
-        return list != null ? new ArrayList<>(list) : List.of();
+        BatchEntry entry = byBatch.get(batchId);
+        return entry != null ? entry.snapshot() : List.of();
     }
 
     /**
@@ -64,7 +79,7 @@ public class TrackingResultCacheService {
      * @return список результатов либо пустой список
      */
     public List<TrackStatusUpdateDTO> getLatestResults(Long userId) {
-        Map<Long, List<TrackStatusUpdateDTO>> byBatch = cache.get(userId);
+        Map<Long, BatchEntry> byBatch = cache.get(userId);
         if (byBatch == null || byBatch.isEmpty()) {
             return List.of();
         }
@@ -83,6 +98,50 @@ public class TrackingResultCacheService {
     public void clearResults(Long userId) {
         if (userId != null) {
             cache.remove(userId);
+        }
+    }
+
+    /**
+     * Периодически удаляет устаревшие записи из кэша.
+     * <p>Выполняется каждые 30 секунд.</p>
+     */
+    @Scheduled(fixedDelay = 30_000)
+    public void removeExpired() {
+        long threshold = System.currentTimeMillis() - expirationMs;
+        cache.entrySet().removeIf(userEntry -> {
+            Map<Long, BatchEntry> byBatch = userEntry.getValue();
+            byBatch.entrySet().removeIf(e -> e.getValue().expired(threshold));
+            return byBatch.isEmpty();
+        });
+    }
+
+    /**
+     * Контейнер для списка результатов одной партии и времени последнего доступа.
+     */
+    private static class BatchEntry {
+        private final List<TrackStatusUpdateDTO> results = Collections.synchronizedList(new ArrayList<>());
+        private volatile long lastAccess;
+
+        BatchEntry() {
+            refresh();
+        }
+
+        void add(TrackStatusUpdateDTO dto) {
+            results.add(dto);
+            refresh();
+        }
+
+        List<TrackStatusUpdateDTO> snapshot() {
+            refresh();
+            return new ArrayList<>(results);
+        }
+
+        void refresh() {
+            lastAccess = System.currentTimeMillis();
+        }
+
+        boolean expired(long threshold) {
+            return lastAccess < threshold;
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,9 @@ csp.allowed-form-action-origins=https://belivery.by
 
 security.remember-me-key=${REMEMBER_ME_KEY}
 
+# Время жизни результатов трекинга в кэше (мс)
+tracking.result-cache.expiration-ms=60000
+
 app.default-timezone=Europe/Minsk
 
 server.forward-headers-strategy=framework


### PR DESCRIPTION
## Summary
- add expiration for tracking results cached in `TrackingResultCacheService`
- schedule periodic cleanup of expired cache entries
- make cache timeout configurable via `tracking.result-cache.expiration-ms` property

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688155faa0c0832da1866f88445d6ea6