### PR TITLE
Fix modal track update interval

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TrackViewResult.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackViewResult.java
@@ -1,0 +1,10 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Результат получения информации о треке для отображения.
+ *
+ * @param trackInfo      список статусов посылки
+ * @param nextUpdateTime строка с датой и временем следующего допустимого обновления
+ */
+public record TrackViewResult(TrackInfoListDTO trackInfo, String nextUpdateTime) {
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -132,6 +132,22 @@ public class TrackParcelService {
     }
 
     /**
+     * Возвращает посылку по номеру и пользователю.
+     * <p>
+     * Используется для проверки времени последнего обновления
+     * и извлечения связанных данных.
+     * </p>
+     *
+     * @param number номер посылки
+     * @param userId идентификатор пользователя
+     * @return посылка или {@code null}, если не найдена
+     */
+    @Transactional(readOnly = true)
+    public TrackParcel findByNumberAndUserId(String number, Long userId) {
+        return trackParcelRepository.findByNumberAndUserId(number, userId);
+    }
+
+    /**
      * Возвращает все посылки указанного магазина.
      *
      * @param storeId идентификатор магазина

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -1,0 +1,88 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.dto.TrackViewResult;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import com.project.tracking_system.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Сервис получения детальной информации о посылке.
+ * <p>
+ * Проверяет, можно ли обновлять трек прямо сейчас,
+ * при необходимости обновляет его и сохраняет изменения.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrackViewService {
+
+    private final TrackParcelService trackParcelService;
+    private final TrackUpdateDispatcherService trackUpdateDispatcherService;
+    private final TrackProcessingService trackProcessingService;
+    private final UserService userService;
+    private final ApplicationSettingsService applicationSettingsService;
+
+    /**
+     * Возвращает информацию о посылке для отображения в интерфейсе.
+     * <p>
+     * Если последнее обновление было достаточно давно, трек будет
+     * обновлён и сохранён. В противном случае вернётся текущее состояние
+     * и время следующего допустимого обновления.
+     * </p>
+     *
+     * @param itemNumber номер посылки
+     * @param userId     идентификатор пользователя
+     * @return объект с историей трека и возможным временем следующего обновления
+     */
+    @Transactional
+    public TrackViewResult getTrackDetails(String itemNumber, Long userId) {
+        // Проверяем принадлежность посылки
+        if (!trackParcelService.userOwnsParcel(itemNumber, userId)) {
+            log.warn("❌ Пользователь ID={} попытался получить чужой трек {}", userId, itemNumber);
+            throw new RuntimeException("Ошибка доступа: Посылка не принадлежит пользователю.");
+        }
+
+        TrackParcel parcel = trackParcelService.findByNumberAndUserId(itemNumber, userId);
+        if (parcel == null) {
+            throw new RuntimeException("Посылка не найдена");
+        }
+
+        int interval = applicationSettingsService.getTrackUpdateIntervalHours();
+        ZonedDateTime nowUtc = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime nextAllowed = parcel.getLastUpdate().plusHours(interval);
+        boolean canUpdate = !parcel.getStatus().isFinal() && parcel.getLastUpdate() != null
+                ? parcel.getLastUpdate().isBefore(nowUtc.minusHours(interval))
+                : true;
+
+        TrackInfoListDTO trackInfo;
+        String nextUpdateTime = null;
+        if (canUpdate) {
+            TrackMeta meta = new TrackMeta(itemNumber, null, null, false,
+                    trackParcelService.getPostalServiceType(itemNumber));
+            trackInfo = trackUpdateDispatcherService.dispatch(meta).getTrackInfo();
+            trackProcessingService.save(itemNumber, trackInfo, parcel.getStore().getId(), userId);
+            log.info("🎯 Передано {} записей для трека {}", trackInfo.getList().size(), itemNumber);
+        } else {
+            trackInfo = new TrackInfoListDTO();
+            String ts = parcel.getTimestamp()
+                    .withZoneSameInstant(userService.getUserZone(userId))
+                    .format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss"));
+            trackInfo.addTrackInfo(new TrackInfoDTO(ts, parcel.getStatus().getDescription()));
+            nextUpdateTime = nextAllowed.withZoneSameInstant(userService.getUserZone(userId))
+                    .format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss"));
+        }
+
+        return new TrackViewResult(trackInfo, nextUpdateTime);
+    }
+}

--- a/src/main/resources/templates/partials/track-info-departures.html
+++ b/src/main/resources/templates/partials/track-info-departures.html
@@ -1,5 +1,8 @@
 <div>
     <a th:text="${itemNumber}"></a>
+    <p th:if="${nextUpdateTime}" class="text-warning">
+        Следующее обновление возможно после <span th:text="${nextUpdateTime}"></span>
+    </p>
     <table class="table mt-3 table-striped">
         <thead>
         <tr>


### PR DESCRIPTION
## Summary
- respect track update interval when viewing parcel details
- expose TrackParcel lookup helper
- note next allowed update time in the modal
- delegate track detail retrieval to TrackViewService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_688154cf38bc832dacaaef4932f66c73