### PR TITLE
Add configurable result cache TTL

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -556,6 +556,7 @@ public class AdminController {
         model.addAttribute("appVersion", appInfoService.getApplicationVersion());
         model.addAttribute("webhookEnabled", appInfoService.isTelegramWebhookEnabled());
         model.addAttribute("interval", applicationSettingsService.getTrackUpdateIntervalHours());
+        model.addAttribute("cacheTtl", applicationSettingsService.getResultCacheExpirationMs());
         // для таблицы тарифов используем DTO с лимитами и признаками функций
         model.addAttribute("plans", tariffService.getAllPlans());
 
@@ -574,6 +575,7 @@ public class AdminController {
     @GetMapping("/settings/track-interval")
     public String trackIntervalForm(Model model) {
         model.addAttribute("interval", applicationSettingsService.getTrackUpdateIntervalHours());
+        model.addAttribute("cacheTtl", applicationSettingsService.getResultCacheExpirationMs());
         List<BreadcrumbItemDTO> breadcrumbs = List.of(
                 new BreadcrumbItemDTO("Админ Панель", "/admin"),
                 new BreadcrumbItemDTO("Интервал обновления", "")
@@ -588,6 +590,30 @@ public class AdminController {
     @PostMapping("/settings/track-interval")
     public String updateTrackInterval(@RequestParam int interval) {
         applicationSettingsService.updateTrackUpdateIntervalHours(interval);
+        return "redirect:/admin/settings";
+    }
+
+    /**
+     * Страница изменения времени хранения результатов в кэше.
+     */
+    @GetMapping("/settings/cache-ttl")
+    public String cacheTtlForm(Model model) {
+        model.addAttribute("interval", applicationSettingsService.getTrackUpdateIntervalHours());
+        model.addAttribute("cacheTtl", applicationSettingsService.getResultCacheExpirationMs());
+        List<BreadcrumbItemDTO> breadcrumbs = List.of(
+                new BreadcrumbItemDTO("Админ Панель", "/admin"),
+                new BreadcrumbItemDTO("TTL кэша", "")
+        );
+        model.addAttribute("breadcrumbs", breadcrumbs);
+        return "admin/settings";
+    }
+
+    /**
+     * Сохранение нового TTL для кэша результатов.
+     */
+    @PostMapping("/settings/cache-ttl")
+    public String updateCacheTtl(@RequestParam("ttl") long ttl) {
+        applicationSettingsService.updateResultCacheExpirationMs(ttl);
         return "redirect:/admin/settings";
     }
 

--- a/src/main/java/com/project/tracking_system/entity/ApplicationSettings.java
+++ b/src/main/java/com/project/tracking_system/entity/ApplicationSettings.java
@@ -30,4 +30,10 @@ public class ApplicationSettings {
      */
     @Column(name = "track_update_interval_hours", nullable = false)
     private int trackUpdateIntervalHours;
+
+    /**
+     * Время хранения результатов обработки в кэше в миллисекундах.
+     */
+    @Column(name = "result_cache_expiration_ms", nullable = false)
+    private long resultCacheExpirationMs;
 }

--- a/src/main/resources/db/migration/V4__add_cache_ttl.sql
+++ b/src/main/resources/db/migration/V4__add_cache_ttl.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tb_application_settings
+    ADD COLUMN result_cache_expiration_ms BIGINT NOT NULL DEFAULT 60000;
+
+UPDATE tb_application_settings
+SET result_cache_expiration_ms = 60000
+WHERE id = 1;

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -71,5 +71,16 @@
             <button type="submit" class="btn btn-primary">Сохранить</button>
         </div>
     </form>
+
+    <h4 class="mt-4">TTL кэша результатов (мс)</h4>
+    <form th:action="@{/admin/settings/cache-ttl}" method="post" class="row g-2">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <div class="col-auto">
+            <input type="number" min="1" class="form-control" name="ttl" th:value="${cacheTtl}" required>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Сохранить</button>
+        </div>
+    </form>
 </main>
 </html>

--- a/src/test/java/com/project/tracking_system/service/admin/ApplicationSettingsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/admin/ApplicationSettingsServiceTest.java
@@ -37,4 +37,18 @@ class ApplicationSettingsServiceTest {
                 () -> service.updateTrackUpdateIntervalHours(-5));
         verify(repository, never()).save(any());
     }
+
+    @Test
+    void updateResultCacheExpirationMs_ZeroValue_ThrowsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.updateResultCacheExpirationMs(0));
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateResultCacheExpirationMs_NegativeValue_ThrowsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.updateResultCacheExpirationMs(-10));
+        verify(repository, never()).save(any());
+    }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackingResultCacheServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackingResultCacheServiceTest.java
@@ -1,0 +1,44 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackStatusUpdateDTO;
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link TrackingResultCacheService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackingResultCacheServiceTest {
+
+    @Mock
+    private ApplicationSettingsService applicationSettingsService;
+
+    private TrackingResultCacheService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TrackingResultCacheService(applicationSettingsService);
+    }
+
+    @Test
+    void removeExpired_RespectsUpdatedSetting() {
+        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(100L);
+
+        service.addResult(1L, new TrackStatusUpdateDTO(1L, "A1", "ok", 1, 1));
+        service.removeExpired();
+        assertFalse(service.getResults(1L, 1L).isEmpty());
+
+        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(0L);
+        service.removeExpired();
+        assertTrue(service.getResults(1L, 1L).isEmpty());
+
+        verify(applicationSettingsService, times(2)).getResultCacheExpirationMs();
+    }
+}


### PR DESCRIPTION
## Summary
- add Flyway migration for result cache expiration time
- extend `ApplicationSettings` with TTL column
- expose TTL getters/setters in `ApplicationSettingsService`
- inject `ApplicationSettingsService` into `TrackingResultCacheService`
- make TTL editable from admin UI
- add service/controller tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881585162b0832db3a72a5b4ae09127