### PR TITLE
Fix admin Telegram date formatting

### DIFF
--- a/src/main/resources/templates/admin/telegram.html
+++ b/src/main/resources/templates/admin/telegram.html
@@ -48,7 +48,8 @@
             <td th:text="${log.customer.phone}"></td>
             <td th:text="${log.parcel.number}"></td>
             <td th:text="${log.notificationType}"></td>
-            <td th:text="${#dates.format(log.sentAt,'dd.MM.yyyy HH:mm')}"></td>
+            <!-- Форматируем дату отправки уведомления с помощью #temporals -->
+            <td th:text="${#temporals.format(log.sentAt,'dd.MM.yyyy HH:mm')}"></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- fix Telegram admin page by using `#temporals.format` for ZonedDateTime

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68815cd13b74832d8dde058a9e8a330c