### PR TITLE
Исправление очереди Белпочты

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
@@ -1,0 +1,39 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
+import com.project.tracking_system.service.belpost.QueuedTrack;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Сервис постановки в очередь треков Белпочты, добавленных вручную.
+ */
+@Service
+@RequiredArgsConstructor
+public class BelPostManualService {
+
+    private final BelPostTrackQueueService belPostTrackQueueService;
+    private final TrackUpdateEligibilityService trackUpdateEligibilityService;
+
+    /**
+     * Добавляет трек в очередь, если разрешено его обновлять.
+     *
+     * @param number номер трека
+     * @param storeId идентификатор магазина
+     * @param userId идентификатор пользователя
+     * @return {@code true}, если трек был поставлен в очередь
+     */
+    public boolean enqueueIfAllowed(String number, Long storeId, Long userId) {
+        if (trackUpdateEligibilityService.canUpdate(number, userId)) {
+            belPostTrackQueueService.enqueue(new QueuedTrack(
+                    number,
+                    userId,
+                    storeId,
+                    "MANUAL",
+                    System.currentTimeMillis()
+            ));
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateEligibilityService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateEligibilityService.java
@@ -1,0 +1,48 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * Сервис проверки возможности обновления трека.
+ * <p>
+ * Решение основывается на времени последнего обновления и текущем статусе
+ * посылки. Треки с финальным статусом никогда не ставятся в очередь.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class TrackUpdateEligibilityService {
+
+    private final TrackParcelService trackParcelService;
+    private final ApplicationSettingsService applicationSettingsService;
+
+    /**
+     * Проверяет, можно ли обновлять трек.
+     *
+     * @param number номер трека
+     * @param userId идентификатор владельца
+     * @return {@code true}, если трек новый либо его обновление было
+     *         раньше установленного интервала
+     */
+    public boolean canUpdate(String number, Long userId) {
+        if (userId == null || number == null) {
+            return false;
+        }
+        TrackParcel parcel = trackParcelService.findByNumberAndUserId(number.toUpperCase(), userId);
+        if (parcel == null) {
+            return true;
+        }
+        if (parcel.getStatus().isFinal()) {
+            return false;
+        }
+        int interval = applicationSettingsService.getTrackUpdateIntervalHours();
+        ZonedDateTime threshold = ZonedDateTime.now(ZoneOffset.UTC).minusHours(interval);
+        return parcel.getLastUpdate() == null || parcel.getLastUpdate().isBefore(threshold);
+    }
+}


### PR DESCRIPTION
## Summary
- перенос логики постановки в очередь Белпочты в сервис
- сервис проверки допустимости обновления описан на русском
- фильтрация треков при загрузке из Excel

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68815da13804832d9fde131b4a47396e