### PR TITLE
Add elapsed time to Belpost completion DTO

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/WebSocketController.java
+++ b/src/main/java/com/project/tracking_system/controller/WebSocketController.java
@@ -90,7 +90,7 @@ public class WebSocketController {
      * Отправляет сообщение о завершении обработки партии треков Белпочты.
      *
      * @param userId идентификатор пользователя
-     * @param dto    финальная статистика по партии
+     * @param dto    финальная статистика по партии, включая время обработки
      */
     public void sendBelPostBatchFinished(Long userId, BelPostBatchFinishedDTO dto) {
         log.debug("\uD83D\uDCE1 WebSocket партия {} завершена для {}: {}", dto.batchId(), userId, dto);

--- a/src/main/java/com/project/tracking_system/dto/BelPostBatchFinishedDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/BelPostBatchFinishedDTO.java
@@ -7,9 +7,11 @@ package com.project.tracking_system.dto;
  * @param processed обработано треков
  * @param success   количество успешных
  * @param failed    количество неуспешных
+ * @param elapsed   время обработки партии в формате mm:ss
  */
 public record BelPostBatchFinishedDTO(long batchId,
                                       int processed,
                                       int success,
-                                      int failed) {
+                                      int failed,
+                                      String elapsed) {
 }

--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
@@ -175,7 +175,8 @@ public class BelPostTrackQueueService {
                             task.batchId(),
                             progress.getProcessed(),
                             progress.getSuccess(),
-                            progress.getFailed()));
+                            progress.getFailed(),
+                            progress.getElapsed()));
             progressMap.remove(task.batchId());
         }
     }
@@ -208,7 +209,7 @@ public class BelPostTrackQueueService {
         }
 
         /**
-         * Возвращает строковое представление прошедшего времени с начала партии.
+         * Возвращает прошедшее время с начала обработки в формате mm:ss.
          */
         public String getElapsed() {
             Duration d = Duration.ofMillis(System.currentTimeMillis() - startTime);


### PR DESCRIPTION
## Summary
- extend `BelPostBatchFinishedDTO` with an `elapsed` field
- send elapsed processing time when notifying about batch completion
- clarify documentation in `WebSocketController`

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688227888ebc832db68e799c6ed8dbf5