### PR TITLE
Handle empty track uploads

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -65,6 +65,16 @@ public class TrackUploadProcessorService {
                 .filter(q -> trackUpdateEligibilityService.canUpdate(q.trackNumber(), q.userId()))
                 .toList();
 
+        // Если после фильтрации не осталось треков, уведомляем пользователя и завершаем обработку
+        if (queued.isEmpty()) {
+            webSocketController.sendUpdateStatus(
+                    userId,
+                    "Файл не содержит подходящих треков для обработки",
+                    false
+            );
+            return;
+        }
+
         progressAggregatorService.registerBatch(batchId, queued.size(), userId);
         belPostTrackQueueService.enqueue(queued);
 


### PR DESCRIPTION
## Summary
- early return from TrackUploadProcessorService when no tracks remain after filtering
- adjust TrackUploadProcessorServiceTest for new behavior and dependency

## Testing
- `mvn -q -Dtest=TrackUploadProcessorServiceTest test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68822feb8280832d88003423759f6b6f