### PR TITLE
Add clock injection for progress service

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import java.time.Clock;
 
 /**
  * Конфигурационный класс для приложения.
@@ -99,6 +100,20 @@ public class AppConfiguration {
     @Bean
     public WebDriverFactory webDriverFactory() {
         return new ChromeWebDriverFactory(chromeDriverPath);
+    }
+
+    /**
+     * Создает бин {@link Clock} для получения текущего времени.
+     * <p>
+     * Используется в сервисах, где требуется абстракция времени,
+     * что упрощает тестирование и соблюдает принципы SOLID.
+     * </p>
+     *
+     * @return системные часы по умолчанию
+     */
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
     }
 
 }


### PR DESCRIPTION
## Summary
- inject `Clock` bean and field for `ProgressAggregatorService`
- use the injected clock when registering batches and formatting duration
- provide clock bean in `AppConfiguration`
- improve `ProgressAggregatorServiceTest` to use a mutable clock

## Testing
- `mvn -q -DskipTests=false test` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6882aed2407c832dbc0715fb8f69546f