### PR TITLE
Add phone propagation through queue

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
@@ -143,7 +143,7 @@ public class BelPostTrackQueueService {
         try {
             info = webBelPostBatchService.parseTrack(task.trackNumber());
             if (!info.getList().isEmpty()) {
-                trackProcessingService.save(task.trackNumber(), info, task.storeId(), task.userId());
+                trackProcessingService.save(task.trackNumber(), info, task.storeId(), task.userId(), task.phone());
                 progress.success.incrementAndGet();
             } else {
                 progress.failed.incrementAndGet();

--- a/src/main/java/com/project/tracking_system/service/belpost/QueuedTrack.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/QueuedTrack.java
@@ -12,9 +12,20 @@ import com.project.tracking_system.service.track.TrackSource;
  *                    (см. {@link TrackSource})
  * @param batchId     идентификатор партии, объединяющей несколько треков
  */
+/**
+ * Представляет элемент очереди для поэтапной обработки трек-номеров Белпочты.
+ *
+ * @param trackNumber номер отправления
+ * @param userId      идентификатор пользователя
+ * @param storeId     идентификатор магазина
+ * @param source      источник добавления трека {@link TrackSource}
+ * @param batchId     идентификатор партии обработки
+ * @param phone       номер телефона получателя (может быть {@code null})
+ */
 public record QueuedTrack(String trackNumber,
                           Long userId,
                           Long storeId,
                           TrackSource source,
-                          Long batchId) {
+                          Long batchId,
+                          String phone) {
 }

--- a/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
@@ -35,7 +35,8 @@ public class BelPostManualService {
                     userId,
                     storeId,
                     TrackSource.MANUAL,
-                    System.currentTimeMillis()
+                    System.currentTimeMillis(),
+                    null
             ));
 
             webSocketController.sendUpdateStatus(

--- a/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateScheduler.java
@@ -118,7 +118,8 @@ public class TrackAutoUpdateScheduler {
                         userId,
                         parcel.getStore().getId(),
                         TrackSource.AUTO,
-                        batchId
+                        batchId,
+                        null
                 ));
             } else {
                 others.add(new TrackMeta(

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -317,7 +317,8 @@ public class TrackUpdateService {
                             userId,
                             m.storeId(),
                             TrackSource.UPDATE,
-                            batchId))
+                            batchId,
+                            m.phone()))
                     .toList();
             belPostTrackQueueService.enqueue(queued);
         }

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -61,7 +61,8 @@ public class TrackUploadProcessorService {
                         userId,
                         parseStoreId(r.store(), defaultStoreId, userId),
                         TrackSource.EXCEL,
-                        batchId))
+                        batchId,
+                        r.phone()))
                 .filter(q -> trackUpdateEligibilityService.canUpdate(q.trackNumber(), q.userId()))
                 .toList();
 


### PR DESCRIPTION
## Summary
- carry phone number in queued tracks
- include phone when creating queued tracks from Excel uploads
- include phone in manual, auto and update queue entries
- pass phone to track processing service when handling queue

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68835d242500832d817077e9b577c9c8