### PR TITLE
Add phone to manual Belpost queue

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -97,7 +97,7 @@ public class HomeController {
             PostalServiceType type = trackServiceClassifier.detect(number);
 
             if (type == PostalServiceType.BELPOST && userId != null) {
-                boolean queued = belPostManualService.enqueueIfAllowed(number, storeId, userId);
+                boolean queued = belPostManualService.enqueueIfAllowed(number, storeId, userId, phone);
                 if (queued) {
                     model.addAttribute("successMessage", "Номер добавлен в очередь обработки.");
                 } else {

--- a/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
@@ -26,9 +26,10 @@ public class BelPostManualService {
      * @param number номер трека
      * @param storeId идентификатор магазина
      * @param userId идентификатор пользователя
+     * @param phone телефон покупателя (может быть {@code null})
      * @return {@code true}, если трек был поставлен в очередь
      */
-    public boolean enqueueIfAllowed(String number, Long storeId, Long userId) {
+    public boolean enqueueIfAllowed(String number, Long storeId, Long userId, String phone) {
         if (trackUpdateEligibilityService.canUpdate(number, userId)) {
             belPostTrackQueueService.enqueue(new QueuedTrack(
                     number,
@@ -36,7 +37,7 @@ public class BelPostManualService {
                     storeId,
                     TrackSource.MANUAL,
                     System.currentTimeMillis(),
-                    null
+                    phone
             ));
 
             webSocketController.sendUpdateStatus(


### PR DESCRIPTION
## Summary
- pass phone number when enqueuing Belpost tracks
- forward phone to queue and track processing

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68836a89d56c832daaa81ae1f890fee9