### PR TITLE
Normalize track numbers before classification

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.service.belpost.QueuedTrack;
 import com.project.tracking_system.service.track.TrackSource;
 import com.project.tracking_system.controller.WebSocketController;
 import com.project.tracking_system.utils.DurationUtils;
+import com.project.tracking_system.utils.TrackNumberUtils;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,9 +31,10 @@ public class BelPostManualService {
      * @return {@code true}, если трек был поставлен в очередь
      */
     public boolean enqueueIfAllowed(String number, Long storeId, Long userId, String phone) {
-        if (trackUpdateEligibilityService.canUpdate(number, userId)) {
+        String normalized = TrackNumberUtils.normalize(number);
+        if (trackUpdateEligibilityService.canUpdate(normalized, userId)) {
             belPostTrackQueueService.enqueue(new QueuedTrack(
-                    number,
+                    normalized,
                     userId,
                     storeId,
                     TrackSource.MANUAL,
@@ -42,7 +44,7 @@ public class BelPostManualService {
 
             webSocketController.sendUpdateStatus(
                     userId,
-                    "Трек '" + number + "' поставлен в очередь Белпочты",
+                    "Трек '" + normalized + "' поставлен в очередь Белпочты",
                     true
             );
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.track;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.utils.PhoneUtils;
+import com.project.tracking_system.utils.TrackNumberUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -65,7 +66,7 @@ public class TrackMetaValidator {
         for (TrackExcelRow row : validRows) {
             if (processed >= maxLimit) break;
 
-            String number = row.number().toUpperCase();
+            String number = TrackNumberUtils.normalize(row.number());
             Long storeId = parseStoreId(row.store(), defaultStoreId, userId);
             String phone = normalizePhone(row.phone());
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -10,6 +10,7 @@ import com.project.tracking_system.service.customer.CustomerService;
 import com.project.tracking_system.service.customer.CustomerStatsService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.utils.DateParserUtils;
+import com.project.tracking_system.utils.TrackNumberUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -77,7 +78,7 @@ public class TrackProcessingService {
         if (number == null) {
             throw new IllegalArgumentException("Номер посылки не может быть null");
         }
-        number = number.toUpperCase(); // Приводим к верхнему регистру
+        number = TrackNumberUtils.normalize(number); // Приводим к единообразному виду
 
         log.info("Обработка трека: {} (Пользователь ID={}, Магазин ID={})", number, userId, storeId);
 
@@ -139,7 +140,7 @@ public class TrackProcessingService {
         }
 
         // Приведение номера к единому виду
-        number = number.toUpperCase().trim();
+        number = TrackNumberUtils.normalize(number);
 
         // Ищем трек по номеру и пользователю независимо от магазина
         TrackParcel trackParcel = trackParcelRepository.findByNumberAndUserId(number, userId);

--- a/src/main/java/com/project/tracking_system/service/track/TrackServiceClassifier.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackServiceClassifier.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.utils.TrackNumberUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -50,6 +51,7 @@ public class TrackServiceClassifier {
      * @return detected postal service type
      */
     public PostalServiceType detect(String number) {
-        return typeDefinitionTrackPostService.detectPostalService(number);
+        String normalized = TrackNumberUtils.normalize(number);
+        return typeDefinitionTrackPostService.detectPostalService(normalized);
     }
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateEligibilityService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateEligibilityService.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import com.project.tracking_system.utils.TrackNumberUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -34,7 +35,8 @@ public class TrackUpdateEligibilityService {
         if (userId == null || number == null) {
             return false;
         }
-        TrackParcel parcel = trackParcelService.findByNumberAndUserId(number.toUpperCase(), userId);
+        String normalized = TrackNumberUtils.normalize(number);
+        TrackParcel parcel = trackParcelService.findByNumberAndUserId(normalized, userId);
         if (parcel == null) {
             return true;
         }

--- a/src/main/java/com/project/tracking_system/utils/TrackNumberUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/TrackNumberUtils.java
@@ -1,0 +1,24 @@
+package com.project.tracking_system.utils;
+
+/**
+ * Utility methods for track number normalization.
+ */
+public final class TrackNumberUtils {
+
+    private TrackNumberUtils() {
+    }
+
+    /**
+     * Normalizes a track number by trimming whitespace and converting
+     * the string to upper case.
+     *
+     * @param input raw track number, may be {@code null}
+     * @return normalized track number or {@code null} if input was null
+     */
+    public static String normalize(String input) {
+        if (input == null) {
+            return null;
+        }
+        return input.toUpperCase().trim();
+    }
+}


### PR DESCRIPTION
## Summary
- add `TrackNumberUtils` with normalization logic
- normalize track numbers before classification
- use normalized numbers when creating `TrackMeta` and queuing Belpost items
- reuse normalization in validation and eligibility checks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68836b5c4820832d988dfd43eda2673b