### PR TITLE
Fix customer stats for final parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -142,6 +142,17 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     List<String> findDistinctStoreNamesByCustomerId(@Param("customerId") Long customerId);
 
     /**
+     * Подсчитать количество посылок покупателя в указанном статусе.
+     *
+     * @param customerId идентификатор покупателя
+     * @param status     целевой статус
+     * @return количество посылок
+     */
+    @Query("SELECT COUNT(t) FROM TrackParcel t WHERE t.customer.id = :customerId AND t.status = :status")
+    int countByCustomerIdAndStatus(@Param("customerId") Long customerId,
+                                   @Param("status") GlobalStatus status);
+
+    /**
      * Поиск посылок по номеру или телефону покупателя.
      * <p>
      * Выполняется частичное совпадение номера трека и номера телефона

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerStatisticsFixService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerStatisticsFixService.java
@@ -1,0 +1,49 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Сервис пересчёта статистики покупателей.
+ * <p>
+ * Используется для исправления случаев, когда
+ * суммарное число полученных и возвращённых посылок
+ * превышает количество отправленных.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomerStatisticsFixService {
+
+    private final CustomerRepository customerRepository;
+    private final TrackParcelRepository trackParcelRepository;
+
+    /**
+     * Пересчитать счётчик отправленных посылок для всех покупателей.
+     * Если отправлено меньше, чем сумма полученных и возвращённых,
+     * значение отправленных корректируется.
+     */
+    @Transactional
+    public void recalculateSentCount() {
+        List<Customer> customers = customerRepository.findAll();
+        for (Customer customer : customers) {
+            int received = trackParcelRepository.countByCustomerIdAndStatus(customer.getId(), GlobalStatus.DELIVERED);
+            int returned = trackParcelRepository.countByCustomerIdAndStatus(customer.getId(), GlobalStatus.RETURNED);
+            int total = received + returned;
+            if (total > customer.getSentCount()) {
+                customer.setSentCount(total);
+                customerRepository.save(customer);
+                log.info("\uD83D\uDCC8 Обновлён sentCount для customerId={}: {}", customer.getId(), total);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update customer counters when phone is added to a parcel with a final status
- avoid duplicate analytics updates when repeating final status registration
- expose util service to recalc customer stats
- add repository method to count parcels by customer and status

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883a750eb18832d9c1d17a37af2dfb6