### PR TITLE
Add pagination URL fragment

### DIFF
--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -162,7 +162,7 @@
                             <li class="page-item" th:classappend="${currentPage == 0} ? 'disabled'">
                                 <!-- При наличии поискового запроса добавляем его к ссылке -->
                                 <a class="page-link"
-                                   th:href="${query != null} ? @{/app/departures(storeId=${storeId}, status=${statusString}, page=${currentPage > 0 ? currentPage - 1 : 0}, size=${size}, query=${query})} : @{/app/departures(storeId=${storeId}, status=${statusString}, page=${currentPage > 0 ? currentPage - 1 : 0}, size=${size})}"
+                                   th:href="~{partials/pagination-url :: departuresUrl(storeId=${storeId}, status=${statusString}, page=${currentPage > 0 ? currentPage - 1 : 0}, size=${size}, query=${query})}"
                                    aria-label="Предыдущая страница">
                                     <i class="bi bi-chevron-left"></i>
                                 </a>
@@ -173,7 +173,7 @@
                                 th:classappend="${i == currentPage} ? 'active'">
                                 <!-- Ссылка на определённую страницу, учитывающая поисковый запрос -->
                                 <a class="page-link"
-                                   th:href="${query != null} ? @{/app/departures(storeId=${storeId}, status=${statusString}, page=${i}, size=${size}, query=${query})} : @{/app/departures(storeId=${storeId}, status=${statusString}, page=${i}, size=${size})}"
+                                   th:href="~{partials/pagination-url :: departuresUrl(storeId=${storeId}, status=${statusString}, page=${i}, size=${size}, query=${query})}"
                                    th:text="${i + 1}" aria-label="Страница ${i + 1}">
                                 </a>
                             </li>
@@ -182,7 +182,7 @@
                             <li class="page-item" th:classappend="${currentPage == totalPages - 1} ? 'disabled'">
                                 <!-- Кнопка перехода вперёд: добавляем параметр query при его наличии -->
                                 <a class="page-link"
-                                   th:href="${query != null} ? @{/app/departures(storeId=${storeId}, status=${statusString}, page=${currentPage + 1 < totalPages ? currentPage + 1 : totalPages - 1}, size=${size}, query=${query})} : @{/app/departures(storeId=${storeId}, status=${statusString}, page=${currentPage + 1 < totalPages ? currentPage + 1 : totalPages - 1}, size=${size})}"
+                                   th:href="~{partials/pagination-url :: departuresUrl(storeId=${storeId}, status=${statusString}, page=${currentPage + 1 < totalPages ? currentPage + 1 : totalPages - 1}, size=${size}, query=${query})}"
                                    aria-label="Следующая страница">
                                     <i class="bi bi-chevron-right"></i>
                                 </a>

--- a/src/main/resources/templates/partials/pagination-url.html
+++ b/src/main/resources/templates/partials/pagination-url.html
@@ -1,0 +1,15 @@
+<!--
+    Фрагмент формирует URL для пагинации отправлений.
+    Он принимает параметры storeId, status, page, size и необязательный query.
+    Если query отсутствует или пуст, он не добавляется к ссылке.
+    Использование фрагмента позволяет избежать дублирования логики построения ссылок.
+-->
+<th:block th:fragment="departuresUrl(storeId, status, page, size, query)" th:remove="tag">
+    <!-- Вычисляем URL один раз, выбирая вариант с query или без него -->
+    <th:block th:with="paginationUrl=${#strings.isEmpty(query) ?
+            @{/app/departures(storeId=${storeId}, status=${status}, page=${page}, size=${size})} :
+            @{/app/departures(storeId=${storeId}, status=${status}, page=${page}, size=${size}, query=${query})}">
+        <!-- Возвращаем URL без лишней обёртки -->
+        <th:block th:text="${paginationUrl}"></th:block>
+    </th:block>
+</th:block>


### PR DESCRIPTION
## Summary
- add fragment to build departures pagination URLs
- reuse fragment in departures.html
- refactor fragment to compute URL once and avoid duplication

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883d7d8c084832db69897aa250c7054