### PR TITLE
Fix progress aggregation across services

### DIFF
--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -177,6 +177,13 @@
      */
     function updateDisplay(data, container) {
         if (!data || data.total === 0) return;
+        // Сохраняем контейнер и последние значения,
+        // чтобы таймер корректно обновлял полосу прогресса
+        if (container) {
+            progressContainer = container;
+        }
+        lastCompleted = data.processed;
+        lastTotal = data.total;
         // Первое сообщение задаёт базовую точку времени для локального таймера
         if (timerStart === null && typeof data.elapsed === "string") {
             timerStart = Date.now() - parseElapsed(data.elapsed);


### PR DESCRIPTION
## Summary
- persist latest global progress data in progress tracking UI

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883f1f232d4832d812a42f973a8ba44