### PR TITLE
Update progress bar handling

### DIFF
--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -115,11 +115,11 @@
             });
 
             // Подписка на события обработки трека Белпочты
+            // Глобальный прогресс обновляется через канал /topic/progress,
+            // поэтому здесь обновляем только информацию по конкретному треку
             stompClient.subscribe(`/topic/belpost/track-processed/${userId}`, message => {
                 progressContainer = container;
                 const data = JSON.parse(message.body);
-                // Progress updates come with elapsed time, timer is started in updateDisplay
-                updateProgressBar(data.completed, data.total);
                 updateTrackingRow(data.trackingNumber, data.status);
             });
 


### PR DESCRIPTION
## Summary
- stop updating progress bar on individual track events

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883fa1dbb54832d9c26ac75f789d58f