### PR TITLE
Update tests for track modules

### DIFF
--- a/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
@@ -2,6 +2,8 @@ package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +16,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
+/**
+ * Тесты для {@link TrackMetaValidator}.
+ * <p>
+ * Проверяется корректность нормализации данных и применение
+ * пользовательских лимитов при валидации списка треков.
+ * </p>
+ */
 @ExtendWith(MockitoExtension.class)
 class TrackMetaValidatorTest {
 
@@ -23,14 +32,24 @@ class TrackMetaValidatorTest {
     private SubscriptionService subscriptionService;
     @Mock
     private StoreService storeService;
+    @Mock
+    private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
 
     private TrackMetaValidator validator;
 
     @BeforeEach
     void setUp() {
-        validator = new TrackMetaValidator(trackParcelService, subscriptionService, storeService);
+        validator = new TrackMetaValidator(
+                trackParcelService,
+                subscriptionService,
+                storeService,
+                typeDefinitionTrackPostService
+        );
     }
 
+    /**
+     * Проверяет применение лимита на сохранение новых треков.
+     */
     @Test
     void validate_RespectsSaveLimit() {
         when(subscriptionService.canUploadTracks(anyLong(), anyInt())).thenReturn(2);
@@ -38,6 +57,7 @@ class TrackMetaValidatorTest {
         when(storeService.getDefaultStoreId(1L)).thenReturn(1L);
         when(storeService.userOwnsStore(1L, 1L)).thenReturn(true);
         when(trackParcelService.isNewTrack(anyString(), any())).thenReturn(true);
+        when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
 
         List<TrackExcelRow> rows = List.of(
                 new TrackExcelRow("A1", "1", "375291111111"),
@@ -52,6 +72,9 @@ class TrackMetaValidatorTest {
         assertNotNull(result.limitExceededMessage());
     }
 
+    /**
+     * Убеждаемся, что имя магазина корректно преобразуется в идентификатор.
+     */
     @Test
     void validate_ParsesStoreName() {
         when(subscriptionService.canUploadTracks(anyLong(), anyInt())).thenReturn(1);
@@ -60,6 +83,7 @@ class TrackMetaValidatorTest {
         when(storeService.findStoreIdByName("Shop", 1L)).thenReturn(2L);
         when(storeService.userOwnsStore(2L, 1L)).thenReturn(true);
         when(trackParcelService.isNewTrack(anyString(), any())).thenReturn(true);
+        when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
 
         List<TrackExcelRow> rows = List.of(
                 new TrackExcelRow("A1", "Shop", "375291111111")
@@ -70,6 +94,9 @@ class TrackMetaValidatorTest {
         assertEquals(2L, result.validTracks().get(0).storeId());
     }
 
+    /**
+     * Телефон клиента должен быть нормализован к цифровому формату.
+     */
     @Test
     void validate_NormalizesPhone() {
         when(subscriptionService.canUploadTracks(anyLong(), anyInt())).thenReturn(1);
@@ -77,6 +104,7 @@ class TrackMetaValidatorTest {
         when(storeService.getDefaultStoreId(1L)).thenReturn(1L);
         when(storeService.userOwnsStore(1L, 1L)).thenReturn(true);
         when(trackParcelService.isNewTrack(anyString(), any())).thenReturn(true);
+        when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
 
         List<TrackExcelRow> rows = List.of(
                 new TrackExcelRow("A1", "1", "+375 (29) 111-11-11")

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -9,6 +9,10 @@ import com.project.tracking_system.service.track.TrackExcelParser;
 import com.project.tracking_system.service.track.TrackExcelRow;
 import com.project.tracking_system.service.track.TrackMeta;
 import com.project.tracking_system.service.track.TrackMetaValidationResult;
+import com.project.tracking_system.service.track.TrackUploadGroupingService;
+import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
+import com.project.tracking_system.service.track.TrackingResultCacheService;
+import com.project.tracking_system.entity.PostalServiceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +25,11 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Тесты для {@link TrackUploadProcessorService}.
+ * Проверяется корректная постановка треков в очередь и обработка
+ * случаев отсутствия подходящих номеров.
+ */
 @ExtendWith(MockitoExtension.class)
 class TrackUploadProcessorServiceTest {
 
@@ -36,33 +45,63 @@ class TrackUploadProcessorServiceTest {
     private ProgressAggregatorService progressAggregatorService;
     @Mock
     private TrackUpdateEligibilityService trackUpdateEligibilityService;
+    @Mock
+    private TrackUploadGroupingService groupingService;
+    @Mock
+    private TrackUpdateDispatcherService dispatcherService;
+    @Mock
+    private TrackingResultCacheService trackingResultCacheService;
 
     private TrackUploadProcessorService processor;
 
     @BeforeEach
     void setUp() {
-        processor = new TrackUploadProcessorService(parser, queueService, webSocketController,
-                trackMetaValidator, progressAggregatorService, trackUpdateEligibilityService);
+        processor = new TrackUploadProcessorService(
+                parser,
+                queueService,
+                webSocketController,
+                trackMetaValidator,
+                progressAggregatorService,
+                trackUpdateEligibilityService,
+                groupingService,
+                dispatcherService,
+                trackingResultCacheService
+        );
     }
 
+    /**
+     * Проверяет, что валидные треки ставятся в очередь и обрабатываются.
+     */
     @Test
     void process_EnqueuesTracks() throws Exception {
         MockMultipartFile file = new MockMultipartFile("f", new byte[0]);
+        TrackMeta meta = new TrackMeta("A1", 1L, "p", true, PostalServiceType.BELPOST);
         when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p")));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
-                .thenReturn(new TrackMetaValidationResult(
-                        List.of(new TrackMeta("A1", 1L, "p", true)), null));
+                .thenReturn(new TrackMetaValidationResult(List.of(meta), null));
         when(trackUpdateEligibilityService.canUpdate(anyString(), any())).thenReturn(true);
+        when(groupingService.group(List.of(meta)))
+                .thenReturn(java.util.Map.of(PostalServiceType.BELPOST, List.of(meta)));
+        when(dispatcherService.dispatch(anyMap(), eq(1L)))
+                .thenReturn(List.of(new com.project.tracking_system.dto.TrackingResultAdd("A1", "ok")));
+        when(progressAggregatorService.getProgress(anyLong()))
+                .thenReturn(new com.project.tracking_system.dto.TrackProcessingProgressDTO(1L, 1, 1, "0:00"));
         when(queueService.estimateWaitTime(1L)).thenReturn(java.time.Duration.ofSeconds(4));
 
         processor.process(file, 1L);
 
         verify(queueService).enqueue(anyList());
+        verify(dispatcherService).dispatch(anyMap(), eq(1L));
+        verify(trackingResultCacheService).addResult(eq(1L), any());
         verify(webSocketController, times(2)).sendUpdateStatus(eq(1L), contains("Белпочты"), eq(true));
         verify(webSocketController).sendTrackProcessingStarted(eq(1L), any());
         verify(progressAggregatorService).registerBatch(anyLong(), eq(1), eq(1L));
+        verify(progressAggregatorService).trackProcessed(anyLong());
     }
 
+    /**
+     * Если подходящих для обновления треков нет, метод завершается без действий.
+     */
     @Test
     void process_NoEligibleTracks_ReturnsEarly() throws Exception {
         MockMultipartFile file = new MockMultipartFile("f", new byte[0]);


### PR DESCRIPTION
## Summary
- update TrackMetaValidatorTest with new dependency
- update TrackUploadProcessorServiceTest with new services
- document tests with Javadoc comments

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68840f974cf8832d9923d976c0bbddbb