### PR TITLE
Implement invalid track collection

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/InvalidTrack.java
+++ b/src/main/java/com/project/tracking_system/service/track/InvalidTrack.java
@@ -1,0 +1,13 @@
+package com.project.tracking_system.service.track;
+
+/**
+ * Информация о некорректной строке из файла с треками.
+ * <p>
+ * Хранит номер и причину, по которой строка признана некорректной.
+ * </p>
+ *
+ * @param number исходный номер трека (может быть {@code null})
+ * @param reason текстовое описание причины
+ */
+public record InvalidTrack(String number, String reason) {
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidationResult.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidationResult.java
@@ -6,8 +6,10 @@ import java.util.List;
  * Результат валидации и нормализации треков.
  *
  * @param validTracks список корректных треков
+ * @param invalidTracks список некорректных строк
  * @param limitExceededMessage сообщение о превышении лимитов (может быть null)
  */
 public record TrackMetaValidationResult(List<TrackMeta> validTracks,
+                                        List<InvalidTrack> invalidTracks,
                                         String limitExceededMessage) {
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -78,7 +78,7 @@ class TrackUploadProcessorServiceTest {
         TrackMeta meta = new TrackMeta("A1", 1L, "p", true, PostalServiceType.BELPOST);
         when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p")));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
-                .thenReturn(new TrackMetaValidationResult(List.of(meta), null));
+                .thenReturn(new TrackMetaValidationResult(List.of(meta), List.of(), null));
         when(trackUpdateEligibilityService.canUpdate(anyString(), any())).thenReturn(true);
         when(groupingService.group(List.of(meta)))
                 .thenReturn(java.util.Map.of(PostalServiceType.BELPOST, List.of(meta)));
@@ -108,7 +108,7 @@ class TrackUploadProcessorServiceTest {
         when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p")));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
                 .thenReturn(new TrackMetaValidationResult(
-                        List.of(new TrackMeta("A1", 1L, "p", true)), null));
+                        List.of(new TrackMeta("A1", 1L, "p", true)), List.of(), null));
         when(trackUpdateEligibilityService.canUpdate(anyString(), any())).thenReturn(false);
 
         processor.process(file, 1L);


### PR DESCRIPTION
## Summary
- add `InvalidTrack` to represent skipped track rows
- include invalid tracks in `TrackMetaValidationResult`
- collect invalid rows in `TrackMetaValidator`
- update tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68851b4a0f68832d9f3076705b84c425