### PR TITLE
Add invalid track handling

### DIFF
--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -169,6 +169,25 @@
                     </div>
 
                 </div>
+
+                <!-- Контейнер для некорректных треков, наполняемый через WebSocket -->
+                <div id="invalid-tracks-container" class="card shadow-sm p-4 rounded-4 d-none mt-3">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h4 class="text-center flex-grow-1 mb-0">Некорректные строки</h4>
+                        <button id="invalid-tracks-close" type="button" class="btn-close ms-2" aria-label="Закрыть"></button>
+                    </div>
+                    <div class="table-responsive">
+                        <table id="invalid-tracks-table" class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>Номер посылки</th>
+                                <th>Причина</th>
+                            </tr>
+                            </thead>
+                            <tbody id="invalid-tracks-body"></tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show separate container for invalid tracks
- fill invalid track table from WebSocket
- stop progress bar when total is 0

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688520a2bf80832d998458e408f75f35