### PR TITLE
Add invalid track caching and API

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ProgressController.java
+++ b/src/main/java/com/project/tracking_system/controller/ProgressController.java
@@ -3,6 +3,8 @@ package com.project.tracking_system.controller;
 import com.project.tracking_system.dto.TrackProcessingProgressDTO;
 import com.project.tracking_system.service.track.ProgressAggregatorService;
 import com.project.tracking_system.service.track.TrackingResultCacheService;
+import com.project.tracking_system.service.track.InvalidTrackCacheService;
+import com.project.tracking_system.service.track.InvalidTrack;
 import com.project.tracking_system.dto.TrackStatusUpdateDTO;
 import com.project.tracking_system.utils.ResponseBuilder;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class ProgressController {
 
     private final ProgressAggregatorService progressAggregatorService;
     private final TrackingResultCacheService trackingResultCacheService;
+    private final InvalidTrackCacheService invalidTrackCacheService;
 
     /**
      * Возвращает актуальный прогресс обработки партии.
@@ -72,12 +75,37 @@ public class ProgressController {
     }
 
     /**
+     * Возвращает сохранённые некорректные строки последней партии пользователя.
+     *
+     * @param user аутентифицированный пользователь
+     * @return список некорректных треков
+     */
+    @GetMapping("/app/invalid/latest")
+    public ResponseEntity<List<InvalidTrack>> getLatestInvalid(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            return ResponseBuilder.ok(List.of());
+        }
+        return ResponseBuilder.ok(invalidTrackCacheService.getLatestInvalidTracks(user.getId()));
+    }
+
+    /**
      * Очищает кэш результатов текущего пользователя.
      */
     @PostMapping("/app/results/clear")
     public ResponseEntity<String> clearResults(@AuthenticationPrincipal User user) {
         if (user != null) {
             trackingResultCacheService.clearResults(user.getId());
+        }
+        return ResponseBuilder.ok("cleared");
+    }
+
+    /**
+     * Очищает кэш некорректных треков текущего пользователя.
+     */
+    @PostMapping("/app/invalid/clear")
+    public ResponseEntity<String> clearInvalid(@AuthenticationPrincipal User user) {
+        if (user != null) {
+            invalidTrackCacheService.clearInvalidTracks(user.getId());
         }
         return ResponseBuilder.ok("cleared");
     }

--- a/src/main/java/com/project/tracking_system/service/track/InvalidTrackCacheService.java
+++ b/src/main/java/com/project/tracking_system/service/track/InvalidTrackCacheService.java
@@ -1,0 +1,144 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache service for storing invalid track rows grouped by user and batch.
+ * <p>
+ * Allows restoring the table with errors after page reload.
+ * Entries expire after a configurable TTL obtained from
+ * {@link ApplicationSettingsService}.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class InvalidTrackCacheService {
+
+    /** Application settings provider. */
+    private final ApplicationSettingsService applicationSettingsService;
+
+    /** Map userId -> (batchId -> cached entry). */
+    private final Map<Long, Map<Long, BatchEntry>> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Stores invalid tracks for the specified batch.
+     *
+     * @param userId  owner identifier
+     * @param batchId batch identifier
+     * @param tracks  list of invalid tracks
+     */
+    public void addInvalidTracks(Long userId, Long batchId, List<InvalidTrack> tracks) {
+        if (userId == null || batchId == null || tracks == null || tracks.isEmpty()) {
+            return;
+        }
+        cache
+                .computeIfAbsent(userId, id -> new ConcurrentHashMap<>())
+                .computeIfAbsent(batchId, id -> new BatchEntry())
+                .addAll(tracks);
+    }
+
+    /**
+     * Returns invalid tracks for a user's batch.
+     *
+     * @param userId  user identifier
+     * @param batchId batch identifier
+     * @return list of invalid tracks or empty list
+     */
+    public List<InvalidTrack> getInvalidTracks(Long userId, Long batchId) {
+        if (userId == null || batchId == null) {
+            return List.of();
+        }
+        Map<Long, BatchEntry> byBatch = cache.get(userId);
+        if (byBatch == null) {
+            return List.of();
+        }
+        BatchEntry entry = byBatch.get(batchId);
+        return entry != null ? entry.snapshot() : List.of();
+    }
+
+    /**
+     * Returns the invalid tracks from the latest batch of the user.
+     *
+     * @param userId user identifier
+     * @return list of invalid tracks or empty list
+     */
+    public List<InvalidTrack> getLatestInvalidTracks(Long userId) {
+        Map<Long, BatchEntry> byBatch = cache.get(userId);
+        if (byBatch == null || byBatch.isEmpty()) {
+            return List.of();
+        }
+        Long latestBatchId = byBatch.keySet().stream().max(Long::compareTo).orElse(null);
+        if (latestBatchId == null) {
+            return List.of();
+        }
+        return getInvalidTracks(userId, latestBatchId);
+    }
+
+    /**
+     * Clears all cached invalid tracks of the user.
+     *
+     * @param userId identifier of the user
+     */
+    public void clearInvalidTracks(Long userId) {
+        if (userId != null) {
+            cache.remove(userId);
+        }
+    }
+
+    /**
+     * Removes expired cache entries based on configured TTL.
+     * Executed every 30 seconds.
+     */
+    @Scheduled(fixedDelay = 30_000)
+    public void removeExpired() {
+        long expiration = applicationSettingsService.getResultCacheExpirationMs();
+        long threshold = System.currentTimeMillis() - expiration;
+        cache.entrySet().removeIf(userEntry -> {
+            Map<Long, BatchEntry> byBatch = userEntry.getValue();
+            byBatch.entrySet().removeIf(e -> e.getValue().expired(threshold));
+            return byBatch.isEmpty();
+        });
+    }
+
+    /**
+     * Container storing invalid tracks of a batch and last access time.
+     */
+    private static class BatchEntry {
+        /** Stored invalid tracks. */
+        private final List<InvalidTrack> tracks = Collections.synchronizedList(new ArrayList<>());
+        /** Last access timestamp. */
+        private volatile long lastAccess;
+
+        BatchEntry() {
+            refresh();
+        }
+
+        void addAll(List<InvalidTrack> list) {
+            tracks.addAll(list);
+            refresh();
+        }
+
+        List<InvalidTrack> snapshot() {
+            refresh();
+            return new ArrayList<>(tracks);
+        }
+
+        void refresh() {
+            lastAccess = System.currentTimeMillis();
+        }
+
+        boolean expired(long threshold) {
+            return lastAccess < threshold;
+        }
+    }
+}
+

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.service.track.TrackUpdateEligibilityService;
 import com.project.tracking_system.service.track.TrackUploadGroupingService;
 import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
 import com.project.tracking_system.service.track.TrackingResultCacheService;
+import com.project.tracking_system.service.track.InvalidTrackCacheService;
 import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.dto.TrackStatusUpdateDTO;
 import com.project.tracking_system.dto.TrackProcessingProgressDTO;
@@ -55,6 +56,8 @@ public class TrackUploadProcessorService {
     private final TrackUpdateDispatcherService dispatcherService;
     /** Кэш результатов обработки для восстановления таблицы. */
     private final TrackingResultCacheService trackingResultCacheService;
+    /** Кэш некорректных треков для восстановления таблицы. */
+    private final InvalidTrackCacheService invalidTrackCacheService;
 
     /**
      * Принимает Excel-файл, валидирует строки и конвертирует их
@@ -89,6 +92,8 @@ public class TrackUploadProcessorService {
             TrackMetaValidationResult validationResult = trackMetaValidator.validate(rows, userId);
             invalid = validationResult.invalidTracks();
             limitMessage = validationResult.limitExceededMessage();
+            // Сохраняем список некорректных строк для возможного восстановления таблицы
+            invalidTrackCacheService.addInvalidTracks(userId, batchId, invalid);
 
             metas = validationResult.validTracks().stream()
                     .filter(m -> trackUpdateEligibilityService.canUpdate(m.number(), userId))

--- a/src/main/resources/static/js/progress-tracking.js
+++ b/src/main/resources/static/js/progress-tracking.js
@@ -142,6 +142,11 @@
         fetch("/app/results/latest", {cache: "no-store"})
             .then(r => r.ok ? r.json() : [])
             .then(list => list.forEach(item => updateTrackingRow(item.trackingNumber, item.status)));
+
+        // Загружаем сохранённые некорректные строки
+        fetch("/app/invalid/latest", {cache: "no-store"})
+            .then(r => r.ok ? r.json() : [])
+            .then(list => list.forEach(item => updateInvalidTrackRow(item.number, item.reason)));
     }
 
     /**
@@ -699,6 +704,11 @@
                 tbody.innerHTML = "";
             }
             container.classList.add("d-none");
+            // Очищаем кэш сохранённых некорректных треков
+            fetch("/app/invalid/clear", {
+                method: "POST",
+                headers: { [window.csrfHeader]: window.csrfToken }
+            });
         });
     }
 
@@ -710,6 +720,11 @@
             // Используем fetch с keepalive, чтобы гарантировать отправку запроса
             // даже при закрытии страницы
             fetch("/app/results/clear", {
+                method: "POST",
+                headers: { [window.csrfHeader]: window.csrfToken },
+                keepalive: true
+            });
+            fetch("/app/invalid/clear", {
                 method: "POST",
                 headers: { [window.csrfHeader]: window.csrfToken },
                 keepalive: true

--- a/src/test/java/com/project/tracking_system/service/track/InvalidTrackCacheServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/InvalidTrackCacheServiceTest.java
@@ -1,0 +1,57 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link InvalidTrackCacheService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class InvalidTrackCacheServiceTest {
+
+    @Mock
+    private ApplicationSettingsService applicationSettingsService;
+
+    private InvalidTrackCacheService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InvalidTrackCacheService(applicationSettingsService);
+    }
+
+    @Test
+    void removeExpired_RespectsUpdatedSetting() {
+        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(100L);
+
+        service.addInvalidTracks(1L, 1L, List.of(new InvalidTrack("A", "BAD")));
+        service.removeExpired();
+        assertFalse(service.getInvalidTracks(1L, 1L).isEmpty());
+
+        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(0L);
+        service.removeExpired();
+        assertTrue(service.getInvalidTracks(1L, 1L).isEmpty());
+
+        verify(applicationSettingsService, times(2)).getResultCacheExpirationMs();
+    }
+
+    @Test
+    void getLatestInvalidTracks_ReturnsNewestBatch() {
+        service.addInvalidTracks(1L, 1L, List.of(new InvalidTrack("A", "x")));
+        service.addInvalidTracks(1L, 2L, List.of(new InvalidTrack("B", "y")));
+
+        List<InvalidTrack> list = service.getLatestInvalidTracks(1L);
+
+        assertEquals(1, list.size());
+        assertEquals("B", list.get(0).number());
+    }
+}
+

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.service.track.InvalidTrack;
 import com.project.tracking_system.service.track.TrackUploadGroupingService;
 import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
 import com.project.tracking_system.service.track.TrackingResultCacheService;
+import com.project.tracking_system.service.track.InvalidTrackCacheService;
 import com.project.tracking_system.entity.PostalServiceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,8 @@ class TrackUploadProcessorServiceTest {
     private TrackUpdateDispatcherService dispatcherService;
     @Mock
     private TrackingResultCacheService trackingResultCacheService;
+    @Mock
+    private InvalidTrackCacheService invalidTrackCacheService;
 
     private TrackUploadProcessorService processor;
 
@@ -67,7 +70,8 @@ class TrackUploadProcessorServiceTest {
                 trackUpdateEligibilityService,
                 groupingService,
                 dispatcherService,
-                trackingResultCacheService
+                trackingResultCacheService,
+                invalidTrackCacheService
         );
     }
 
@@ -98,6 +102,7 @@ class TrackUploadProcessorServiceTest {
         verify(queueService).enqueue(anyList());
         verify(dispatcherService).dispatch(anyMap(), eq(1L));
         verify(trackingResultCacheService).addResult(eq(1L), any());
+        verify(invalidTrackCacheService).addInvalidTracks(eq(1L), anyLong(), anyList());
         verify(webSocketController, times(2)).sendUpdateStatus(eq(1L), contains("Белпочты"), eq(true));
         verify(webSocketController).sendTrackProcessingStarted(eq(1L), any());
         verify(progressAggregatorService).registerBatch(anyLong(), eq(1), eq(1L));
@@ -125,6 +130,7 @@ class TrackUploadProcessorServiceTest {
         verify(queueService, never()).enqueue(anyList());
         verify(webSocketController, never()).sendTrackProcessingStarted(anyLong(), any());
         verify(webSocketController).sendUpdateStatus(eq(1L), contains("нет"), eq(false));
+        verify(invalidTrackCacheService).addInvalidTracks(eq(1L), anyLong(), anyList());
     }
 
     /**
@@ -147,5 +153,6 @@ class TrackUploadProcessorServiceTest {
         verify(webSocketController).sendUpdateStatus(eq(1L), contains("невалидны"), eq(false));
         verify(queueService, never()).enqueue(anyList());
         verify(dispatcherService, never()).dispatch(anyMap(), any());
+        verify(invalidTrackCacheService).addInvalidTracks(eq(1L), anyLong(), anyList());
     }
 }


### PR DESCRIPTION
## Summary
- store invalid track lists by user with new `InvalidTrackCacheService`
- expose latest/clear endpoints in `ProgressController`
- persist invalid tracks during upload processing
- show saved invalid tracks on page load and allow clearing via JS
- cover cache service with unit tests and adjust processor tests

## Testing
- `mvn test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68852983bf6c832daecf2ccfa25f32b5