### PR TITLE
Remove legacy invalid track list

### DIFF
--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -158,15 +158,6 @@
                         <strong th:text="${limitExceededMessage}"></strong>
                     </div>
 
-                    <!-- Некорректные строки -->
-                    <div th:if="${invalidTracks != null and not #lists.isEmpty(invalidTracks)}"
-                         class="alert alert-warning mt-3">
-                        <p class="mb-1">Некорректные строки файла:</p>
-                        <ul class="mb-0">
-                            <li th:each="it : ${invalidTracks}"
-                                th:text="${it.number} + ' - ' + ${it.reason}"></li>
-                        </ul>
-                    </div>
 
                 </div>
 


### PR DESCRIPTION
## Summary
- drop server-side invalid track list from home page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68853ee5f60c832da73f85efe66b18c7