### PR TITLE
Add parcel sorting

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -54,13 +54,15 @@ public class DeparturesController {
     private final TrackViewService trackViewService;
 
     /**
-     * Метод для отображения списка отслеживаемых посылок пользователя с возможностью фильтрации по магазину и статусу.
+     * Метод для отображения списка отслеживаемых посылок пользователя с
+     * возможностью фильтрации по магазину, статусу и сортировки по дате.
      *
      * @param storeId      (опционально) ID магазина, если нужно показать посылки только из одного магазина.
      * @param statusString строковое представление статуса для фильтрации.
      * @param query        строка поиска по номеру посылки или телефону.
      * @param page         номер страницы для пагинации.
      * @param size         размер страницы.
+     * @param sortOrder    порядок сортировки по дате (asc/desc).
      * @param model        модель для передачи данных на представление.
      * @param user         текущий пользователь.
      * @return имя представления для отображения истории.
@@ -72,6 +74,7 @@ public class DeparturesController {
             @RequestParam(value = "query", required = false) String query, // Поиск по номеру или телефону
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "20") int size,
+            @RequestParam(value = "sortOrder", defaultValue = "desc") String sortOrder,
             Model model,
             @AuthenticationPrincipal User user) {
 
@@ -141,6 +144,9 @@ public class DeparturesController {
             dto.setIconHtml(statusTrackService.getIcon(statusEnum)); // Передаем Enum в сервис для получения иконки
         });
 
+        // Получаем полный список посылок, отсортированный по дате
+        List<TrackParcelDTO> sortedParcels = trackParcelService.getParcelsSortedByDate(userId, sortOrder);
+
         log.debug("Передача атрибутов в модель: stores={}, storeId={}, trackParcelDTO={}, currentPage={}, totalPages={}, size={}", stores, storeId, trackParcelPage.getContent(), trackParcelPage.getNumber(), trackParcelPage.getTotalPages(), size);
 
         // Добавляем атрибуты в модель
@@ -155,6 +161,8 @@ public class DeparturesController {
         model.addAttribute("trackParcelNotification", trackParcelPage.isEmpty() ? "Отслеживаемых посылок нет" : null);
         model.addAttribute("bulkUpdateButtonDTO",
                 new BulkUpdateButtonDTO(userService.isShowBulkUpdateButton(user.getId())));
+        model.addAttribute("sortedParcels", sortedParcels);
+        model.addAttribute("sortOrder", sortOrder);
 
         return "app/departures";
     }

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.GlobalStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,15 @@ import java.util.List;
 public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> {
 
     List<TrackParcel> findByUserId(Long userId);
+
+    /**
+     * Найти все посылки пользователя с указанным порядком сортировки по дате.
+     *
+     * @param userId идентификатор пользователя
+     * @param sort   настройка порядка сортировки
+     * @return отсортированный список посылок
+     */
+    List<TrackParcel> findByUserId(Long userId, Sort sort);
 
     TrackParcel findByNumberAndUserId(String number, Long userId);
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -201,6 +202,30 @@ public class TrackParcelService {
         List<TrackParcel> trackParcels = trackParcelRepository.findByUserId(userId);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.stream()
+                .map(track -> new TrackParcelDTO(track, userZone))
+                .toList();
+    }
+
+    /**
+     * Получить все посылки пользователя, отсортированные по дате создания.
+     * <p>
+     * Порядок сортировки задаётся параметром {@code sortOrder} и может быть
+     * восходящим ({@code "asc"}) или нисходящим ({@code "desc"}).
+     * </p>
+     *
+     * @param userId    идентификатор пользователя
+     * @param sortOrder порядок сортировки: {@code "asc"} или {@code "desc"}
+     * @return список отсортированных посылок
+     */
+    @Transactional(readOnly = true)
+    public List<TrackParcelDTO> getParcelsSortedByDate(Long userId, String sortOrder) {
+        Sort sort = Sort.by("timestamp");
+        sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
+
+        List<TrackParcel> parcels = trackParcelRepository.findByUserId(userId, sort);
+        ZoneId userZone = userService.getUserZone(userId);
+
+        return parcels.stream()
                 .map(track -> new TrackParcelDTO(track, userZone))
                 .toList();
     }


### PR DESCRIPTION
## Summary
- allow sorting of user parcels by date
- implement service layer for date-based sorting
- expose sorting in departures controller

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888c16b7f7c832d80fcb67425d1fe62