### PR TITLE
Add date sort toggle control

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -162,6 +162,7 @@ public class DeparturesController {
         model.addAttribute("bulkUpdateButtonDTO",
                 new BulkUpdateButtonDTO(userService.isShowBulkUpdateButton(user.getId())));
         model.addAttribute("sortedParcels", sortedParcels);
+        // Передаём текущий порядок сортировки во вью, чтобы отобразить правильную стрелку на кнопке
         model.addAttribute("sortOrder", sortOrder);
 
         return "app/departures";

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -103,6 +103,17 @@
                                     th:classappend="${size == 100} ? 'active'">100</button>
                         </div>
 
+                        <!--
+                            Кнопка переключения порядка сортировки отправлений по дате.
+                            При нажатии меняет значение параметра sortOrder и перезагружает страницу.
+                            Значок стрелки отображает текущий порядок: восходящий или нисходящий.
+                        -->
+                        <a th:href="@{/app/departures(sortOrder=${sortOrder == 'asc' ? 'desc' : 'asc'})}"
+                           class="btn btn-outline-primary btn-sm">
+                            <i class="bi" th:classappend="${sortOrder == 'asc'} ? 'bi-arrow-down' : 'bi-arrow-up'"></i>
+                            <span th:text="${sortOrder == 'asc'} ? 'Старые вначале' : 'Новые вначале'"></span>
+                        </a>
+
                     </div>
 
                     <!-- Таблица истории -->


### PR DESCRIPTION
## Summary
- add button to toggle sorting in departures page
- pass current sort order to the view with explanatory comment

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6888c2f002c4832dbd9b296021b25586