### PR TITLE
Handle sorting in track parcel pagination

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -111,13 +111,13 @@ public class DeparturesController {
         Page<TrackParcelDTO> trackParcelPage;
         if (query != null && !query.isBlank()) {
             trackParcelPage = trackParcelService.searchByNumberOrPhone(
-                    filteredStoreIds, status, query.trim(), page, size, userId);
+                    filteredStoreIds, status, query.trim(), page, size, userId, sortOrder);
         } else if (status != null) {
             trackParcelPage = trackParcelService.findByStoreTracksAndStatus(
-                    filteredStoreIds, status, page, size, userId);
+                    filteredStoreIds, status, page, size, userId, sortOrder);
         } else {
             trackParcelPage = trackParcelService.findByStoreTracks(
-                    filteredStoreIds, page, size, userId);
+                    filteredStoreIds, page, size, userId, sortOrder);
         }
 
         // Если запрошенная страница больше допустимой, загружаем первую страницу
@@ -128,13 +128,13 @@ public class DeparturesController {
             page = 0;
             if (query != null && !query.isBlank()) {
                 trackParcelPage = trackParcelService.searchByNumberOrPhone(
-                        filteredStoreIds, status, query.trim(), page, size, userId);
+                        filteredStoreIds, status, query.trim(), page, size, userId, sortOrder);
             } else if (status != null) {
                 trackParcelPage = trackParcelService.findByStoreTracksAndStatus(
-                        filteredStoreIds, status, page, size, userId);
+                        filteredStoreIds, status, page, size, userId, sortOrder);
             } else {
                 trackParcelPage = trackParcelService.findByStoreTracks(
-                        filteredStoreIds, page, size, userId);
+                        filteredStoreIds, page, size, userId, sortOrder);
             }
         }
 
@@ -143,9 +143,6 @@ public class DeparturesController {
             GlobalStatus statusEnum = GlobalStatus.fromDescription(dto.getStatus()); // Конвертация строки в Enum
             dto.setIconHtml(statusTrackService.getIcon(statusEnum)); // Передаем Enum в сервис для получения иконки
         });
-
-        // Получаем полный список посылок, отсортированный по дате
-        List<TrackParcelDTO> sortedParcels = trackParcelService.getParcelsSortedByDate(userId, sortOrder);
 
         log.debug("Передача атрибутов в модель: stores={}, storeId={}, trackParcelDTO={}, currentPage={}, totalPages={}, size={}", stores, storeId, trackParcelPage.getContent(), trackParcelPage.getNumber(), trackParcelPage.getTotalPages(), size);
 
@@ -161,7 +158,6 @@ public class DeparturesController {
         model.addAttribute("trackParcelNotification", trackParcelPage.isEmpty() ? "Отслеживаемых посылок нет" : null);
         model.addAttribute("bulkUpdateButtonDTO",
                 new BulkUpdateButtonDTO(userService.isShowBulkUpdateButton(user.getId())));
-        model.addAttribute("sortedParcels", sortedParcels);
         // Передаём текущий порядок сортировки во вью, чтобы отобразить правильную стрелку на кнопке
         model.addAttribute("sortOrder", sortOrder);
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -67,12 +67,19 @@ public class TrackParcelService {
      * @param storeIds список идентификаторов магазинов
      * @param page     номер страницы
      * @param size     размер страницы
-     * @param userId   идентификатор пользователя
+     * @param userId    идентификатор пользователя
+     * @param sortOrder порядок сортировки: {@code "asc"} или {@code "desc"}
      * @return страница посылок указанного пользователя
      */
     @Transactional(readOnly = true)
-    public Page<TrackParcelDTO> findByStoreTracks(List<Long> storeIds, int page, int size, Long userId) {
-        Pageable pageable = PageRequest.of(page, size);
+    public Page<TrackParcelDTO> findByStoreTracks(List<Long> storeIds,
+                                                  int page,
+                                                  int size,
+                                                  Long userId,
+                                                  String sortOrder) {
+        Sort sort = Sort.by("timestamp");
+        sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
         Page<TrackParcel> trackParcels = trackParcelRepository.findByStoreIdIn(storeIds, pageable);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.map(track -> new TrackParcelDTO(track, userZone));
@@ -85,12 +92,20 @@ public class TrackParcelService {
      * @param status   статус посылки
      * @param page     номер страницы
      * @param size     размер страницы
-     * @param userId   идентификатор пользователя
+     * @param userId    идентификатор пользователя
+     * @param sortOrder порядок сортировки: {@code "asc"} или {@code "desc"}
      * @return страница посылок
      */
     @Transactional(readOnly = true)
-    public Page<TrackParcelDTO> findByStoreTracksAndStatus(List<Long> storeIds, GlobalStatus status, int page, int size, Long userId) {
-        Pageable pageable = PageRequest.of(page, size);
+    public Page<TrackParcelDTO> findByStoreTracksAndStatus(List<Long> storeIds,
+                                                          GlobalStatus status,
+                                                          int page,
+                                                          int size,
+                                                          Long userId,
+                                                          String sortOrder) {
+        Sort sort = Sort.by("timestamp");
+        sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
         Page<TrackParcel> trackParcels = trackParcelRepository.findByStoreIdInAndStatus(storeIds, status, pageable);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.map(track -> new TrackParcelDTO(track, userZone));
@@ -104,7 +119,8 @@ public class TrackParcelService {
      * @param query    строка поиска
      * @param page     номер страницы
      * @param size     размер страницы
-     * @param userId   идентификатор пользователя
+     * @param userId    идентификатор пользователя
+     * @param sortOrder порядок сортировки: {@code "asc"} или {@code "desc"}
      * @return страница найденных посылок
      */
     @Transactional(readOnly = true)
@@ -113,8 +129,11 @@ public class TrackParcelService {
                                                       String query,
                                                       int page,
                                                       int size,
-                                                      Long userId) {
-        Pageable pageable = PageRequest.of(page, size);
+                                                      Long userId,
+                                                      String sortOrder) {
+        Sort sort = Sort.by("timestamp");
+        sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
         String phoneDigits = PhoneUtils.extractDigits(query);
         Page<TrackParcel> parcels = trackParcelRepository.searchByNumberOrPhone(
                 storeIds, userId, status, query, phoneDigits, pageable);


### PR DESCRIPTION
## Summary
- add `sortOrder` parameter to TrackParcelService queries
- update DeparturesController to pass sorting preference
- remove redundant sortedParcels attribute

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688937725148832d896af0f36c3fbde9