### PR TITLE
Add styles for history page badges and animation

### DIFF
--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -221,6 +221,11 @@
     border-bottom: 1px solid ui.$light;
   }
 
+  /* Добавляем анимацию появления строк истории */
+  tbody tr {
+    animation: fadeSlideIn 0.5s ease forwards;
+  }
+
   tbody tr:hover {
     background: rgba(ui.$primary, 0.1);
     cursor: pointer;
@@ -251,6 +256,14 @@
   display: inline-flex; // Позволяет корректно выровнять иконку
   align-items: center; // Центрируем содержимое по вертикали
   margin-left: 0.25rem; // Небольшой отступ слева от номера посылки
+  color: ui.$primary;
+  cursor: pointer;
+  @include ui.transition(color, 0.3s);
+
+  &:hover {
+    color: color.scale(ui.$primary, $lightness: -10%);
+    transform: scale(1.1);
+  }
 }
 
 
@@ -399,5 +412,39 @@
 
   .table-responsive {
     overflow-x: auto;
+  }
+}
+
+/* === Отображение статуса посылки и номера === */
+.parcel-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: ui.$white;
+  background-color: ui.$info;
+  padding: 2px 6px;
+  border-radius: ui.$border-radius;
+}
+
+/* Стили для номера посылки */
+.track-number {
+  font-weight: 600;
+  color: ui.$dark;
+  text-decoration: none;
+  @include ui.transition(color);
+
+  &:hover {
+    color: ui.$primary;
+  }
+}
+
+/* Анимация появления строк в таблице */
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }


### PR DESCRIPTION
## Summary
- style customer icon interaction and track numbers
- add parcel badge styling
- animate history table rows with `fadeSlideIn`
- define `fadeSlideIn` keyframes in SCSS

## Testing
- `npm run build:css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_688949fd26d4832d98eeb133b5f5e5b7