### PR TITLE
Add contact page with feedback form

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -87,7 +87,7 @@ public class SecurityConfiguration {
                         .requestMatchers("/", "/features", "/pricing", "/terms", "/privacy",
                                 "/auth/**", "/favicon.ico",
                                 "/css/**", "/js/**", "/bootstrap/**", "/images/**",
-                                "/ws/**", "/wss/**", "/faq", "/about", "/contacts").permitAll()
+                                "/ws/**", "/wss/**", "/faq", "/about", "/contacts", "/contacts/submit").permitAll()
                         // Доступ к административному разделу только для ROLE_ADMIN
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         // Требуется аутентификация для пользовательской части приложения

--- a/src/main/java/com/project/tracking_system/controller/ContactController.java
+++ b/src/main/java/com/project/tracking_system/controller/ContactController.java
@@ -1,0 +1,53 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.service.contact.ContactService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+/**
+ * Контроллер страницы "Контакты".
+ * <p>
+ * Отображает форму обратной связи и обрабатывает её отправку.
+ * </p>
+ */
+@RequiredArgsConstructor
+@Controller
+public class ContactController {
+
+    /** Сервис обработки сообщений обратной связи. */
+    private final ContactService contactService;
+
+    /**
+     * Отображает страницу с формой обратной связи.
+     *
+     * @return имя шаблона страницы контактов
+     */
+    @GetMapping("/contacts")
+    public String contactPage() {
+        return "marketing/contacts";
+    }
+
+    /**
+     * Обрабатывает отправку формы обратной связи.
+     *
+     * @param name  имя отправителя
+     * @param email email отправителя
+     * @param message текст сообщения
+     * @param redirectAttributes контейнер для передачи flash-сообщений
+     * @return редирект на страницу контактов
+     */
+    @PostMapping("/contacts/submit")
+    public String submitContactForm(@RequestParam String name,
+                                    @RequestParam String email,
+                                    @RequestParam String message,
+                                    RedirectAttributes redirectAttributes) {
+        contactService.processContactRequest(name, email, message);
+        redirectAttributes.addFlashAttribute("success",
+                "Сообщение отправлено! Мы свяжемся с вами в ближайшее время.");
+        return "redirect:/contacts";
+    }
+}

--- a/src/main/java/com/project/tracking_system/controller/MarketingController.java
+++ b/src/main/java/com/project/tracking_system/controller/MarketingController.java
@@ -163,13 +163,4 @@ public class MarketingController {
         return "marketing/about";
     }
 
-    /**
-     * Отображает страницу с контактной информацией.
-     *
-     * @return имя представления страницы с контактами
-     */
-    @GetMapping("contacts")
-    public String contacts() {
-        return "marketing/contacts";
-    }
 }

--- a/src/main/java/com/project/tracking_system/service/contact/ContactService.java
+++ b/src/main/java/com/project/tracking_system/service/contact/ContactService.java
@@ -1,0 +1,43 @@
+package com.project.tracking_system.service.contact;
+
+import com.project.tracking_system.service.email.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * Сервис обработки сообщений с формы обратной связи.
+ * <p>
+ * При получении обращения отправляет письмо на адрес поддержки.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ContactService {
+
+    private final EmailService emailService;
+
+    /** Адрес получателя обращений. */
+    @Value("${contact.recipient:support@belivery.by}")
+    private String recipientEmail;
+
+    /**
+     * Обрабатывает обращение пользователя, отправляя его содержимое по почте.
+     *
+     * @param name    имя отправителя
+     * @param email   email отправителя
+     * @param message текст обращения
+     */
+    public void processContactRequest(String name, String email, String message) {
+        log.info("Получено обращение от {} <{}>", name, email);
+        emailService.sendContactEmail(recipientEmail, Map.of(
+                "name", name,
+                "email", email,
+                "message", message
+        ));
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/email/EmailService.java
+++ b/src/main/java/com/project/tracking_system/service/email/EmailService.java
@@ -84,6 +84,32 @@ public class EmailService {
     }
 
     /**
+     * Отправляет письмо из формы обратной связи.
+     *
+     * @param to        адрес получателя
+     * @param variables карта данных формы (имя, email, сообщение)
+     */
+    public void sendContactEmail(String to, Map<String, Object> variables) {
+        if (!isValidEmail(to)) {
+            log.warn("⚠ Неверный формат email получателя: {}", EmailUtils.maskEmail(to));
+            return;
+        }
+
+        Object emailObj = variables.get("email");
+        if (emailObj instanceof String sender && !isValidEmail(sender)) {
+            log.warn("⚠ Неверный формат email отправителя: {}", EmailUtils.maskEmail(sender));
+            return;
+        }
+
+        try {
+            String htmlContent = templateService.generateEmail("contact-email", variables);
+            sendHtmlEmailAsync(to, "Обращение через форму обратной связи", htmlContent);
+        } catch (Exception e) {
+            log.error("❌ Ошибка при генерации email-шаблона обращения: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
      * Асинхронно отправляет HTML email сообщение.
      *
      * @param to      адрес получателя.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,6 +47,9 @@ app.default-timezone=Europe/Minsk
 server.forward-headers-strategy=framework
 webdriver.chrome.driver=${CHROMEDRIVER_PATH:/usr/local/bin/chromedriver}
 
+# Email получателя формы "Контакты"
+contact.recipient=support@belivery.by
+
 belpost.queue.delay-ms=100
 
 # Minimal interval between progress updates in milliseconds

--- a/src/main/resources/templates/email/contact-email.html
+++ b/src/main/resources/templates/email/contact-email.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ru" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Новое обращение</title>
+</head>
+<body style="font-family: Arial, sans-serif; background-color: #f8f9fa; color: #333333; padding: 30px;">
+<div style="max-width: 600px; margin: 0 auto; background: #ffffff; padding: 20px; border-radius: 10px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #007bff; text-align: center;">Новое обращение с сайта</h2>
+    <p><strong>Имя:</strong> <span th:text="${name}"></span></p>
+    <p><strong>Email:</strong> <span th:text="${email}"></span></p>
+    <p><strong>Сообщение:</strong></p>
+    <p th:text="${message}"></p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/marketing/contacts.html
+++ b/src/main/resources/templates/marketing/contacts.html
@@ -8,8 +8,39 @@
      th:replace="~{partials/header-marketing :: header}">
 </div>
 
-<main layout:fragment="content" class="container mt-4">
-    <h1 class="text-center">Контакты</h1>
-    <p class="text-center">Страница в разработке.</p>
+<main layout:fragment="content" class="container py-5">
+    <h2 class="mb-4">Связаться с нами</h2>
+    <p>Если у вас возникли вопросы или предложения — напишите нам через форму ниже. Мы ответим в течение 1 рабочего дня.</p>
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <h5>📧 Электронная почта</h5>
+            <p><strong>Техническая поддержка:</strong> <a href="mailto:support@belivery.by">support@belivery.by</a></p>
+            <p><strong>Общие вопросы:</strong> <a href="mailto:info@belivery.by">info@belivery.by</a></p>
+        </div>
+    </div>
+
+    <div th:if="${success}" class="alert alert-success mt-3" role="alert">
+        <span th:text="${success}"></span>
+    </div>
+
+    <form th:action="@{/contacts/submit}" method="post" class="row g-3">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <div class="col-md-6">
+            <label for="name" class="form-label">Ваше имя</label>
+            <input type="text" class="form-control" id="name" name="name" required>
+        </div>
+        <div class="col-md-6">
+            <label for="email" class="form-label">Ваш Email</label>
+            <input type="email" class="form-control" id="email" name="email" required>
+        </div>
+        <div class="col-12">
+            <label for="message" class="form-label">Сообщение</label>
+            <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Отправить</button>
+        </div>
+    </form>
 </main>
 </html>

--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -242,7 +242,7 @@
 
     <div class="text-center mt-5">
         <p class="fw-semibold">Не нашли ответа на свой вопрос?</p>
-        <a href="marketing/contacts" class="btn btn-outline-primary">Связаться с нами</a>
+        <a href="/contacts" class="btn btn-outline-primary">Связаться с нами</a>
     </div>
 
     <script th:attr="nonce=${nonce}">


### PR DESCRIPTION
## Summary
- replace placeholder contacts page with full feedback form
- route `/contacts` to new `ContactController`
- add `ContactService` and email sending method
- configure security for contact form submission
- support contact email template and property
- update FAQ link to new contacts page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688a7a75f37c832db6c99f0c0c333c83