### PR TITLE
Refine marketing page heading hierarchy

### DIFF
--- a/src/main/resources/templates/marketing/home.html
+++ b/src/main/resources/templates/marketing/home.html
@@ -26,28 +26,28 @@
         <p class="lead text-muted mt-2">Belivery автоматизирует трекинг, аналитику и упрощает контроль доставки.</p>
     </section>
 
-    <!-- Преимущества -->
+    <!-- Преимущества сервиса представлены карточками -->
     <section class="row text-center mt-5">
         <div class="col-md-4 mb-4">
             <i class="bi bi-bar-chart-line display-6 text-primary"></i>
-            <h5 class="mt-3">Аналитика по доставке</h5>
+            <h3 class="mt-3">Аналитика по доставке</h3>
             <p>Понимайте, где задержки и как быстро доходят ваши посылки</p>
         </div>
         <div class="col-md-4 mb-4">
             <i class="bi bi-robot display-6 text-primary"></i>
-            <h5 class="mt-3">Автоматизация трекинга</h5>
+            <h3 class="mt-3">Автоматизация трекинга</h3>
             <p>Обновление треков и напоминания клиентам — без ручной работы</p>
         </div>
         <div class="col-md-4 mb-4">
             <i class="bi bi-building display-6 text-primary"></i>
-            <h5 class="mt-3">Несколько магазинов</h5>
+            <h3 class="mt-3">Несколько магазинов</h3>
             <p>Создавайте и управляйте своими магазинами в одном аккаунте</p>
         </div>
     </section>
 
-    <!-- Как работает -->
+    <!-- Блок шагов использования сервиса -->
     <section class="mt-5">
-        <h3 class="text-center mb-4">Как это работает?</h3>
+        <h2 class="text-center mb-4">Как это работает?</h2>
         <div class="row text-center">
             <div class="col-md-4">
                 <span class="badge bg-primary rounded-circle p-3 fs-4">1</span>
@@ -64,7 +64,7 @@
         </div>
     </section>
 
-    <!-- Список отправлений -->
+    <!-- Раздел, демонстрирующий контроль над всеми отправлениями -->
     <section class="row align-items-center mt-5">
         <div class="col-md-6">
             <h3>Все отправления — под контролем</h3>
@@ -78,7 +78,7 @@
         </div>
     </section>
 
-    <!-- Аналитика по доставке -->
+    <!-- Раздел, описывающий аналитику по доставке и магазинам -->
     <section class="row align-items-center flex-md-row-reverse mt-5">
         <div class="col-md-6">
             <h3>Аналитика по доставке и магазинам</h3>
@@ -92,7 +92,7 @@
         </div>
     </section>
 
-    <!-- Аналитика по покупателям -->
+    <!-- Раздел, описывающий аналитику по покупателям -->
     <section class="row align-items-center mt-5">
         <div class="col-md-6">
             <h3>Аналитика по покупателям</h3>
@@ -106,7 +106,7 @@
         </div>
     </section>
 
-    <!-- Telegram уведомления -->
+    <!-- Раздел, посвященный Telegram-уведомлениям клиентам -->
     <section class="row align-items-center mt-5">
         <div class="col-md-6">
             <h3>Telegram-уведомления клиентам</h3>
@@ -120,9 +120,9 @@
         </div>
     </section>
 
-    <!-- CTA к тарифам -->
+    <!-- Призыв к переходу на страницу тарифов -->
     <section class="text-center mt-5">
-        <h4>Тарифы под любые задачи</h4>
+        <h2>Тарифы под любые задачи</h2>
         <p class="text-muted">От базового тестирования до расширенного бизнес-функционала</p>
         <a class="btn btn-outline-primary btn-lg mt-2" th:href="@{/tariffs}">Сравнить тарифы</a>
     </section>


### PR DESCRIPTION
## Summary
- elevate advantage cards from `h5` to `h3` and document each section
- promote "Как это работает?" and pricing headings to clarify page structure

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e7902b754832dbf65d56ca50d3766