### PR TITLE
refactor: elevate faq section headings

### DIFF
--- a/src/main/resources/templates/marketing/faq.html
+++ b/src/main/resources/templates/marketing/faq.html
@@ -21,9 +21,10 @@
         </ul>
     </div>
 
-    <!-- Раздел: Работа с отправлениями -->
+    <!-- Раздел: Работа с отправлениями — ответы по добавлению и отслеживанию отправлений -->
     <section class="mb-5" id="faq-shipping">
-        <h3 class="fw-bold mb-4 text-primary">Работа с отправлениями</h3>
+        <!-- Заголовок основного раздела FAQ о работе с отправлениями -->
+        <h2 class="fw-bold mb-4 text-primary">Работа с отправлениями</h2>
 
         <div class="faq-item mb-3">
             <div class="faq-question">
@@ -76,9 +77,10 @@
         </div>
     </section>
 
-    <!-- Раздел: Telegram и уведомления -->
+    <!-- Раздел: Telegram и уведомления — информация о клиентских уведомлениях через мессенджер -->
     <section class="mb-5" id="faq-telegram">
-        <h3 class="fw-bold mb-4 text-primary">Telegram и уведомления</h3>
+        <!-- Заголовок раздела, описывающего интеграцию с Telegram и уведомления -->
+        <h2 class="fw-bold mb-4 text-primary">Telegram и уведомления</h2>
 
         <div class="faq-item mb-3">
             <div class="faq-question">
@@ -115,9 +117,10 @@
         </div>
     </section>
 
-    <!-- Раздел: Управление аккаунтом -->
+    <!-- Раздел: Управление аккаунтом — управление магазинами и аналитикой пользователя -->
     <section class="mb-5" id="faq-account">
-        <h3 class="fw-bold mb-4 text-primary">Управление аккаунтом</h3>
+        <!-- Заголовок раздела по настройкам аккаунта и работе с данными пользователя -->
+        <h2 class="fw-bold mb-4 text-primary">Управление аккаунтом</h2>
 
         <div class="faq-item mb-3">
             <div class="faq-question">
@@ -160,9 +163,10 @@
         </div>
     </section>
 
-    <!-- Раздел: Тарифы и оплата -->
+    <!-- Раздел: Тарифы и оплата — описание возможностей тарифных планов и способов оплаты -->
     <section class="mb-5" id="faq-pricing">
-        <h3 class="fw-bold mb-4 text-primary">Тарифы и оплата</h3>
+        <!-- Заголовок раздела с ответами по тарифам и оплате -->
+        <h2 class="fw-bold mb-4 text-primary">Тарифы и оплата</h2>
 
         <div class="faq-item mb-3">
             <div class="faq-question">
@@ -195,9 +199,10 @@
         </div>
     </section>
 
-    <!-- Раздел: Безопасность и данные -->
+    <!-- Раздел: Безопасность и данные — сведения о хранении и защите пользовательской информации -->
     <section class="mb-5" id="faq-security">
-        <h3 class="fw-bold mb-4 text-primary">Безопасность и данные</h3>
+        <!-- Заголовок раздела, посвящённого вопросам безопасности и конфиденциальности -->
+        <h2 class="fw-bold mb-4 text-primary">Безопасность и данные</h2>
 
         <div class="faq-item mb-3">
             <div class="faq-question">


### PR DESCRIPTION
## Summary
- refactor FAQ page to use `<h2>` for main sections
- document each section with explanatory comments

## Testing
- `mvn test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e7a2ce0b0832d806435707c3c1767