### PR TITLE
feat: add section heading for pricing plans

### DIFF
--- a/src/main/resources/assets/scss/base/_typography.scss
+++ b/src/main/resources/assets/scss/base/_typography.scss
@@ -1,7 +1,7 @@
 @use '../ui' as ui;
 
-// Общие стили для заголовков
-h1, h3, h4, h5 {
+/* Общие стили для заголовков (включая h2) */
+h1, h2, h3, h4, h5 {
   color: ui.$dark;
   font-weight: bold;
   margin-bottom: 15px;
@@ -28,6 +28,13 @@ h1 {
   @include ui.respond-to(sm) {
     font-size: 1.5rem;
   }
+}
+
+/* Заголовки второго уровня для внутренних секций */
+h2 {
+  font-size: 2rem;
+  text-align: center;
+  margin-bottom: 1.25rem;
 }
 
 h3 {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -90,7 +90,8 @@ footer {
     margin-right: 5px;
   }
 }
-h1, h3, h4, h5 {
+/* Общие стили для заголовков (включая h2) */
+h1, h2, h3, h4, h5 {
   color: #343a40;
   font-weight: bold;
   margin-bottom: 15px;
@@ -120,6 +121,13 @@ h1 {
   h1 {
     font-size: 1.5rem;
   }
+}
+
+/* Заголовки второго уровня для внутренних секций */
+h2 {
+  font-size: 2rem;
+  text-align: center;
+  margin-bottom: 1.25rem;
 }
 
 h3 {
@@ -1765,5 +1773,3 @@ body.loading {
   border-style: solid;
   border-color: #ddd transparent transparent transparent;
 }
-
-/*# sourceMappingURL=style.css.map */

--- a/src/main/resources/templates/marketing/pricing.html
+++ b/src/main/resources/templates/marketing/pricing.html
@@ -25,12 +25,15 @@
             </div>
         </div>
 
+        <!-- 🧭 Заголовок секции тарифов -->
+        <h2 class="text-center mb-4">Тарифные планы</h2>
+
         <div class="row justify-content-center g-4">
 
             <div class="col-12 col-sm-6 col-md-4 col-lg-3" th:each="plan : ${plans}">
                 <div class="card h-100 shadow-sm border-0 rounded-4 d-flex flex-column position-relative">
                     <div th:if="${plan.recommended}" class="recommended-label">Рекомендуем</div>
-                    <!-- Название -->
+                    <!-- Название тарифа (уровень h3 следует за общим h2) -->
                     <h3 class="text-center fw-bold fs-3 mt-3 mb-1" th:text="${plan.name}">Premium</h3>
                     <div class="text-center mb-2" th:if="${plan.recommended}">
                         <span class="recommended-label">Рекомендуем</span>


### PR DESCRIPTION
## Summary
- introduce section heading before pricing cards
- document heading levels and styling for consistency

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3)*

------
https://chatgpt.com/codex/tasks/task_e_688e7a37d1f8832da270a1e3ec3ca65e