### PR TITLE
Add validation DTO for contact form and update controller

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ContactController.java
+++ b/src/main/java/com/project/tracking_system/controller/ContactController.java
@@ -1,11 +1,15 @@
 package com.project.tracking_system.controller;
 
+import com.project.tracking_system.dto.ContactFormRequest;
 import com.project.tracking_system.service.contact.ContactService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
@@ -27,7 +31,9 @@ public class ContactController {
      * @return имя шаблона страницы контактов
      */
     @GetMapping("/contacts")
-    public String contactPage() {
+    public String contactPage(Model model) {
+        // Добавляем пустой объект формы в модель для привязки полей на странице
+        model.addAttribute("contactForm", new ContactFormRequest());
         return "marketing/contacts";
     }
 
@@ -41,11 +47,17 @@ public class ContactController {
      * @return редирект на страницу контактов
      */
     @PostMapping("/contacts/submit")
-    public String submitContactForm(@RequestParam String name,
-                                    @RequestParam String email,
-                                    @RequestParam String message,
-                                    RedirectAttributes redirectAttributes) {
-        contactService.processContactRequest(name, email, message);
+    public String submitContactForm(
+            @Valid @ModelAttribute("contactForm") ContactFormRequest contactForm,
+            BindingResult bindingResult,
+            RedirectAttributes redirectAttributes) {
+        // Если при валидации формы обнаружены ошибки - возвращаем пользователя на страницу контактов
+        if (bindingResult.hasErrors()) {
+            return "marketing/contacts";
+        }
+
+        // Передаём корректные данные в сервис для дальнейшей обработки
+        contactService.processContactRequest(contactForm);
         redirectAttributes.addFlashAttribute("success",
                 "Сообщение отправлено! Мы свяжемся с вами в ближайшее время.");
         return "redirect:/contacts";

--- a/src/main/java/com/project/tracking_system/dto/ContactFormRequest.java
+++ b/src/main/java/com/project/tracking_system/dto/ContactFormRequest.java
@@ -1,0 +1,39 @@
+package com.project.tracking_system.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO для передачи данных формы обратной связи.
+ * <p>
+ * Содержит имя, email и текст сообщения пользователя.
+ * Валидируется при получении в контроллере.
+ * </p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactFormRequest {
+
+    /** Имя отправителя сообщения. */
+    @NotBlank(message = "Введите имя")
+    @Size(max = 100, message = "Имя должно быть не длиннее 100 символов")
+    private String name;
+
+    /** Электронный адрес отправителя. */
+    @NotBlank(message = "Введите адрес электронной почты")
+    @Email(message = "Некорректный адрес электронной почты")
+    @Size(max = 100, message = "Email должен быть не длиннее 100 символов")
+    private String email;
+
+    /** Текст сообщения пользователя. */
+    @NotBlank(message = "Введите текст сообщения")
+    @Size(max = 1000, message = "Сообщение должно быть не длиннее 1000 символов")
+    private String message;
+}

--- a/src/main/java/com/project/tracking_system/service/contact/ContactService.java
+++ b/src/main/java/com/project/tracking_system/service/contact/ContactService.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.service.contact;
 
+import com.project.tracking_system.dto.ContactFormRequest;
 import com.project.tracking_system.service.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,16 +29,14 @@ public class ContactService {
     /**
      * Обрабатывает обращение пользователя, отправляя его содержимое по почте.
      *
-     * @param name    имя отправителя
-     * @param email   email отправителя
-     * @param message текст обращения
+     * @param request объект с данными обращения пользователя
      */
-    public void processContactRequest(String name, String email, String message) {
-        log.info("Получено обращение от {} <{}>", name, email);
+    public void processContactRequest(ContactFormRequest request) {
+        log.info("Получено обращение от {} <{}>", request.getName(), request.getEmail());
         emailService.sendContactEmail(recipientEmail, Map.of(
-                "name", name,
-                "email", email,
-                "message", message
+                "name", request.getName(),
+                "email", request.getEmail(),
+                "message", request.getMessage()
         ));
     }
 }

--- a/src/main/resources/templates/marketing/contacts.html
+++ b/src/main/resources/templates/marketing/contacts.html
@@ -34,19 +34,31 @@
                 <span th:text="${success}"></span>
             </div>
 
-            <form th:action="@{/contacts/submit}" method="post" class="row g-3">
+            <form th:action="@{/contacts/submit}" th:object="${contactForm}" method="post" class="row g-3">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="col-12">
                     <label for="name" class="form-label">Ваше имя</label>
-                    <input type="text" class="form-control" id="name" name="name" required>
+                    <input type="text" th:field="*{name}" class="form-control" id="name"
+                           th:classappend="${#fields.hasErrors('name')} ? 'is-invalid'">
+                    <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('name')}">
+                        <span th:errors="*{name}"></span>
+                    </div>
                 </div>
                 <div class="col-12">
                     <label for="email" class="form-label">Ваш Email</label>
-                    <input type="email" class="form-control" id="email" name="email" required>
+                    <input type="email" th:field="*{email}" class="form-control" id="email"
+                           th:classappend="${#fields.hasErrors('email')} ? 'is-invalid'">
+                    <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('email')}">
+                        <span th:errors="*{email}"></span>
+                    </div>
                 </div>
                 <div class="col-12">
                     <label for="message" class="form-label">Сообщение</label>
-                    <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+                    <textarea th:field="*{message}" class="form-control" id="message" rows="5"
+                              th:classappend="${#fields.hasErrors('message')} ? 'is-invalid'"></textarea>
+                    <div class="invalid-feedback d-block" th:if="${#fields.hasErrors('message')}">
+                        <span th:errors="*{message}"></span>
+                    </div>
                 </div>
                 <div class="col-12">
                     <button type="submit" class="btn btn-primary w-100">Отправить</button>

--- a/src/test/java/com/project/tracking_system/controller/ContactControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ContactControllerTest.java
@@ -1,0 +1,62 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.ContactFormRequest;
+import com.project.tracking_system.service.contact.ContactService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Тесты контроллера страницы контактов.
+ */
+@WebMvcTest(ContactController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ContactControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ContactService contactService;
+
+    /**
+     * Проверяет, что при ошибках валидации пользователь остаётся на странице формы.
+     */
+    @Test
+    void submitContactForm_whenValidationFails_returnsContactView() throws Exception {
+        mockMvc.perform(post("/contacts/submit")
+                        .param("name", "")
+                        .param("email", "invalid")
+                        .param("message", ""))
+                .andExpect(status().isOk())
+                .andExpect(view().name("marketing/contacts"));
+
+        verify(contactService, never()).processContactRequest(any(ContactFormRequest.class));
+    }
+
+    /**
+     * Проверяет, что при корректных данных происходит редирект и вызов сервиса.
+     */
+    @Test
+    void submitContactForm_whenValid_redirects() throws Exception {
+        mockMvc.perform(post("/contacts/submit")
+                        .param("name", "Иван")
+                        .param("email", "test@example.com")
+                        .param("message", "Сообщение"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/contacts"));
+
+        verify(contactService).processContactRequest(any(ContactFormRequest.class));
+    }
+}

--- a/src/test/java/com/project/tracking_system/dto/ContactFormRequestTest.java
+++ b/src/test/java/com/project/tracking_system/dto/ContactFormRequestTest.java
@@ -1,0 +1,46 @@
+package com.project.tracking_system.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты валидации {@link ContactFormRequest}.
+ */
+class ContactFormRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    /**
+     * Проверяет, что пустые и некорректные поля вызывают ошибки валидации.
+     */
+    @Test
+    void shouldFailValidationWhenFieldsInvalid() {
+        ContactFormRequest request = new ContactFormRequest("", "invalid", "");
+        Set<ConstraintViolation<ContactFormRequest>> violations = validator.validate(request);
+        assertEquals(3, violations.size(), "Ожидалось 3 ошибки валидации");
+    }
+
+    /**
+     * Проверяет, что корректно заполненная форма проходит валидацию.
+     */
+    @Test
+    void shouldPassValidationWithCorrectData() {
+        ContactFormRequest request = new ContactFormRequest("Иван", "test@example.com", "Сообщение");
+        Set<ConstraintViolation<ContactFormRequest>> violations = validator.validate(request);
+        assertTrue(violations.isEmpty(), "Не должно быть ошибок валидации");
+    }
+}


### PR DESCRIPTION
## Summary
- add `ContactFormRequest` DTO with validation annotations
- update `ContactController` and `ContactService` to use the DTO and handle validation errors
- display field validation messages in `contacts.html`
- introduce unit tests for the new DTO and controller

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fd927bee4832dae9cf423a7922674