### PR TITLE
style: add spacing before tracking results table

### DIFF
--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -127,9 +127,9 @@
                     </div>
                 </div>
 
-                <!-- Результаты загрузки -->
+                <!-- Результаты загрузки. mt-4 добавляет отступ сверху, чтобы отделить карточку от предыдущего блока -->
                 <div id="tracking-results-container"
-                     class="card shadow-sm p-4 rounded-4 d-none">
+                     class="card shadow-sm p-4 rounded-4 d-none mt-4">
                     <div class="d-flex justify-content-between align-items-center mb-2">
                         <h4 class="text-center flex-grow-1 mb-0">Последние обновления</h4>
                         <button id="tracking-results-close" type="button" class="btn-close ms-2" aria-label="Закрыть"></button>


### PR DESCRIPTION
## Summary
- add top margin to tracking results container for visual separation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b816cd3c832db8c1d1ba38563cb6