### PR TITLE
test: expand contact controller coverage

### DIFF
--- a/src/test/java/com/project/tracking_system/controller/ContactControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ContactControllerTest.java
@@ -12,10 +12,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -37,6 +40,28 @@ class ContactControllerTest {
     private CaptchaService captchaService;
 
     /**
+     * Проверяет, что GET-запрос отображает форму с пустыми данными и ключом reCAPTCHA.
+     * <p>
+     * Данный тест демонстрирует ответственность контроллера за подготовку данных,
+     * необходимых представлению, не затрагивая работу других слоев приложения.
+     * </p>
+     */
+    @Test
+    void contactPage_returnsViewWithCaptchaKey() throws Exception {
+        // Возвращаем тестовый ключ сайта для рендеринга виджета
+        when(captchaService.getSiteKey()).thenReturn("site-key");
+
+        mockMvc.perform(get("/contacts"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("marketing/contacts"))
+                .andExpect(model().attributeExists("contactForm", "recaptchaSiteKey"))
+                .andExpect(model().attribute("recaptchaSiteKey", "site-key"));
+
+        // Убеждаемся, что ключ действительно был запрошен у сервиса
+        verify(captchaService).getSiteKey();
+    }
+
+    /**
      * Проверяет, что при ошибках валидации пользователь остаётся на странице формы.
      */
     @Test
@@ -51,6 +76,7 @@ class ContactControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("marketing/contacts"));
 
+        verify(captchaService).verifyToken(anyString(), anyString());
         verify(contactService, never()).processContactRequest(any(ContactFormRequest.class), anyString());
     }
 
@@ -69,6 +95,7 @@ class ContactControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/contacts"));
 
+        verify(captchaService).verifyToken(anyString(), anyString());
         verify(contactService).processContactRequest(any(ContactFormRequest.class), anyString());
     }
 
@@ -87,6 +114,7 @@ class ContactControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("marketing/contacts"));
 
+        verify(captchaService).verifyToken(anyString(), anyString());
         verify(contactService, never()).processContactRequest(any(ContactFormRequest.class), anyString());
     }
 
@@ -104,5 +132,27 @@ class ContactControllerTest {
 
         verify(captchaService, never()).verifyToken(anyString(), anyString());
         verify(contactService, never()).processContactRequest(any(ContactFormRequest.class), anyString());
+    }
+
+    /**
+     * Проверяет, что при превышении лимита запросов отображается форма с ошибкой.
+     */
+    @Test
+    void submitContactForm_whenRateLimitExceeded_returnsContactView() throws Exception {
+        when(captchaService.verifyToken(anyString(), anyString())).thenReturn(true);
+        doThrow(new com.project.tracking_system.exception.RateLimitExceededException("too many"))
+                .when(contactService).processContactRequest(any(ContactFormRequest.class), anyString());
+
+        mockMvc.perform(post("/contacts/submit")
+                        .param("name", "Иван")
+                        .param("email", "test@example.com")
+                        .param("message", "Сообщение")
+                        .param("g-recaptcha-response", "token"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("marketing/contacts"))
+                .andExpect(model().attributeHasErrors("contactForm"));
+
+        verify(captchaService).verifyToken(anyString(), anyString());
+        verify(contactService).processContactRequest(any(ContactFormRequest.class), anyString());
     }
 }


### PR DESCRIPTION
## Summary
- broaden `ContactController` test suite for GET endpoint and rate-limit handling
- assert captcha service interactions in existing contact form scenarios

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68911835bb44832dbfcaa6ccd2bd0a28