### PR TITLE
test: update invalid track cache test

### DIFF
--- a/src/test/java/com/project/tracking_system/service/track/InvalidTrackCacheServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/InvalidTrackCacheServiceTest.java
@@ -26,24 +26,37 @@ class InvalidTrackCacheServiceTest {
 
     @BeforeEach
     void setUp() {
+        // создаём сервис перед каждым тестом, передавая мок настроек
         service = new InvalidTrackCacheService(applicationSettingsService);
     }
 
+    /**
+     * Проверяет, что очистка кэша учитывает обновлённое значение TTL.
+     * TTL берётся из {@link ApplicationSettingsService} каждый раз при вызове {@link InvalidTrackCacheService#removeExpired()}.
+     */
     @Test
     void removeExpired_RespectsUpdatedSetting() {
-        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(100L);
+        // сначала возвращаем большое значение TTL, затем обнуляем его
+        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(100L, 0L);
 
         service.addInvalidTracks(1L, 1L, List.of(new InvalidTrack("A", InvalidTrackReason.WRONG_FORMAT)));
+        // первое обращение к кэшу запускает отсчёт времени жизни
+        service.getInvalidTracks(1L, 1L);
+
+        // при ненулевом TTL запись должна оставаться в кэше
         service.removeExpired();
         assertFalse(service.getInvalidTracks(1L, 1L).isEmpty());
 
-        when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(0L);
+        // после смены TTL на ноль запись должна быть удалена
         service.removeExpired();
         assertTrue(service.getInvalidTracks(1L, 1L).isEmpty());
 
         verify(applicationSettingsService, times(2)).getResultCacheExpirationMs();
     }
 
+    /**
+     * Проверяет, что возвращается список последнего загруженного батча.
+     */
     @Test
     void getLatestInvalidTracks_ReturnsNewestBatch() {
         service.addInvalidTracks(1L, 1L, List.of(new InvalidTrack("A", InvalidTrackReason.EMPTY_NUMBER)));
@@ -55,6 +68,9 @@ class InvalidTrackCacheServiceTest {
         assertEquals("B", list.get(0).number());
     }
 
+    /**
+     * Убеждаемся, что запись не удаляется, пока пользователь не откроет список ошибок.
+     */
     @Test
     void notViewed_EntriesIgnoredUntilFirstAccess() {
         when(applicationSettingsService.getResultCacheExpirationMs()).thenReturn(0L);
@@ -63,6 +79,7 @@ class InvalidTrackCacheServiceTest {
         service.removeExpired();
         assertFalse(service.getInvalidTracks(1L, 1L).isEmpty(), "Cache should persist until viewed");
 
+        // первое обращение помечает запись просмотренной
         service.getInvalidTracks(1L, 1L);
         service.removeExpired();
         assertTrue(service.getInvalidTracks(1L, 1L).isEmpty(), "Cache should expire after viewing when TTL elapsed");


### PR DESCRIPTION
## Summary
- refine invalid track cache test to respect TTL changes after first access
- document cache expiry tests with clearer comments

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68911df6e07c832d8e2c745c837f65bb