### PR TITLE
Fix TrackUploadProcessorServiceTest

### DIFF
--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -88,7 +88,7 @@ class TrackUploadProcessorServiceTest {
                 .thenReturn(new TrackMetaValidationResult(List.of(meta), List.of(), null));
         when(trackUpdateEligibilityService.canUpdate(anyString(), any())).thenReturn(true);
         when(groupingService.group(List.of(meta)))
-                .thenReturn(java.util.Map.of(PostalServiceType.BELPOST, List.of(meta)));
+                .thenReturn(new java.util.HashMap<>(java.util.Map.of(PostalServiceType.BELPOST, List.of(meta))));
         when(dispatcherService.dispatch(anyMap(), eq(1L)))
                 .thenReturn(List.of(new com.project.tracking_system.dto.TrackingResultAdd("A1", "ok")));
         when(progressAggregatorService.getProgress(anyLong()))
@@ -111,7 +111,8 @@ class TrackUploadProcessorServiceTest {
     }
 
     /**
-     * Если подходящих для обновления треков нет, метод завершается без действий.
+     * Если подходящих для обновления треков нет, метод регистрирует пустую партию
+     * и завершает обработку без постановки треков в очередь.
      */
     @Test
     void process_NoEligibleTracks_ReturnsEarly() throws Exception {
@@ -127,7 +128,7 @@ class TrackUploadProcessorServiceTest {
         assertTrue(result.validTracks().isEmpty());
         assertTrue(result.invalidTracks().isEmpty());
 
-        verify(progressAggregatorService, never()).registerBatch(anyLong(), anyInt(), any());
+        verify(progressAggregatorService).registerBatch(anyLong(), eq(0), eq(1L));
         verify(queueService, never()).enqueue(anyList());
         verify(webSocketController, never()).sendTrackProcessingStarted(anyLong(), any());
         verify(webSocketController).sendUpdateStatus(eq(1L), contains("нет"), eq(false));


### PR DESCRIPTION
## Summary
- fix test to return mutable grouping map for processing
- expect empty progress batch registration when no eligible tracks

## Testing
- `mvn -q -Dtest=TrackUploadProcessorServiceTest test` *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_689282979c2c832dbc5833204be8e99c