### PR TITLE
fix: handle surrounding spaces in status parsing

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -60,18 +60,20 @@ public class StatusTrackService {
     }
 
     /**
-     * Устанавливает статус для списка треков посылок.
+     * Определяет итоговый статус для списка трекинговых записей.
+     * Метод анализирует последний статус, игнорируя пробелы в начале
+     * и в конце строки, и проверяет его соответствие известным шаблонам.
      *
-     * @param trackInfoDTOList Список объектов с информацией о трекинге.
-     * @return Статус, который соответствует последнему трекинговому событию.
+     * @param trackInfoDTOList список событий трекинга в обратном хронологическом порядке
+     * @return статус, соответствующий последнему событию
      */
     public GlobalStatus setStatus(List<TrackInfoDTO> trackInfoDTOList) {
         if (trackInfoDTOList.isEmpty()) {
             return GlobalStatus.UNKNOWN_STATUS; // Если список пустой, статус неизвестен
         }
 
-        // Получаем последний статус
-        String lastStatus = trackInfoDTOList.get(0).getInfoTrack();
+        // Получаем последний статус и убираем лишние пробелы
+        String lastStatus = trackInfoDTOList.get(0).getInfoTrack().trim();
 
         // Проверяем последний статус
         for (Map.Entry<Pattern, GlobalStatus> entry : statusPatterns.entrySet()) {
@@ -81,7 +83,8 @@ public class StatusTrackService {
                 if (RETURN_PATTERN.matcher(lastStatus).find()) {
                     // Проверяем историю на наличие статуса возврата
                     for (TrackInfoDTO trackInfoDTO : trackInfoDTOList) {
-                        if (trackInfoDTO.getInfoTrack().equals("Почтовое отправление готово к возврату")) {
+                        String status = trackInfoDTO.getInfoTrack().trim();
+                        if (status.equals("Почтовое отправление готово к возврату")) {
                             return GlobalStatus.RETURN_IN_PROGRESS;
                         }
                     }

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -9,16 +9,17 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Unit tests for {@link StatusTrackService} verifying correct mapping
- * of raw status strings to {@link GlobalStatus} values.
+ * Юнит-тесты для {@link StatusTrackService}, проверяющие корректное
+ * сопоставление сырых строк статуса значениям {@link GlobalStatus}.
  */
 class StatusTrackServiceTest {
 
     private final StatusTrackService service = new StatusTrackService();
 
     /**
-     * Arrival status from Belpost should map to {@link GlobalStatus#WAITING_FOR_CUSTOMER}.
-     * Leading and trailing spaces must not affect the result.
+     * Статус прибытия от Белпочты должен преобразовываться в
+     * {@link GlobalStatus#WAITING_FOR_CUSTOMER}. Наличие пробелов в начале
+     * и конце строки не должно влиять на результат.
      */
     @Test
     void setStatus_MapsArrivalToWaiting() {
@@ -32,7 +33,8 @@ class StatusTrackServiceTest {
     }
 
     /**
-     * Status text about delivery must result in {@link GlobalStatus#DELIVERED}.
+     * Строка со статусом о выдаче должна приводить к статусу
+     * {@link GlobalStatus#DELIVERED}.
      */
     @Test
     void setStatus_MapsDelivered() {


### PR DESCRIPTION
## Summary
- trim incoming track statuses before pattern matching
- document tests in Russian for StatusTrackService

## Testing
- `mvn -q -Dtest=StatusTrackServiceTest test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689288c06bd8832d8b14fcda8d5544d9