### PR TITLE
Fix TrackViewService test stubbing

### DIFF
--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -77,7 +77,6 @@ class TrackViewServiceTest {
         when(trackParcelService.findByNumberAndUserId("A1", 1L)).thenReturn(parcel);
         when(applicationSettingsService.getTrackUpdateIntervalHours()).thenReturn(3);
         when(trackParcelService.getPostalServiceType("A1")).thenReturn(PostalServiceType.BELPOST);
-        when(userService.getUserZone(1L)).thenReturn(ZoneId.systemDefault());
         TrackInfoListDTO info = new TrackInfoListDTO();
         when(trackUpdateDispatcherService.dispatch(any(TrackMeta.class)))
                 .thenReturn(new TrackingResultAdd("A1", "ok", info));


### PR DESCRIPTION
## Summary
- remove unused user zone mocking in TrackViewServiceTest to avoid UnnecessaryStubbingException

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892892f3ac4832daaa6803c10570383