### PR TITLE
Fix password eye icon initial state

### DIFF
--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -344,7 +344,7 @@
                         <input type="password" class="form-control password-input" id="evropostPassword" name="evropostPassword" th:field="*{evropostPassword}" placeholder="Password" autocomplete="off">
                         <label for="evropostPassword">Password</label>
                         <span class="toggle-password" data-target="evropostPassword">
-                            <i class="bi bi-eye"></i>
+                            <i class="bi bi-eye-slash"></i>
                         </span>
                         <div th:errors="*{evropostPassword}" class="text-danger"></div>
                     </div>
@@ -352,7 +352,7 @@
                         <input type="password" class="form-control password-input" id="serviceNumber" name="serviceNumber" th:field="*{serviceNumber}" placeholder="ServiceNumber" autocomplete="off">
                         <label for="serviceNumber">ServiceNumber</label>
                         <span class="toggle-password" data-target="serviceNumber">
-                            <i class="bi bi-eye"></i>
+                            <i class="bi bi-eye-slash"></i>
                         </span>
                         <div th:errors="*{serviceNumber}" class="text-danger"></div>
                     </div>
@@ -379,7 +379,7 @@
                     <input type="password" class="form-control password-input" id="currentPassword" name="currentPassword" th:field="*{currentPassword}" placeholder="Текущий пароль" autocomplete="off">
                     <label for="currentPassword">Текущий пароль</label>
                     <span class="toggle-password" data-target="currentPassword">
-                        <i class="bi bi-eye"></i>
+                        <i class="bi bi-eye-slash"></i>
                     </span>
                     <div th:errors="*{currentPassword}" class="text-danger"></div>
                 </div>
@@ -387,7 +387,7 @@
                     <input type="password" class="form-control password-input" id="newPassword" name="newPassword" th:field="*{newPassword}" placeholder="Новый пароль" autocomplete="off">
                     <label for="newPassword">Новый пароль</label>
                     <span class="toggle-password" data-target="newPassword">
-                        <i class="bi bi-eye"></i>
+                        <i class="bi bi-eye-slash"></i>
                     </span>
                     <div th:errors="*{newPassword}" class="text-danger"></div>
                 </div>
@@ -395,7 +395,7 @@
                     <input type="password" class="form-control password-input" id="confirmPassword" name="confirmPassword" th:field="*{confirmPassword}" placeholder="Подтвердите пароль" autocomplete="off">
                     <label for="confirmPassword">Подтвердите пароль</label>
                     <span class="toggle-password" data-target="confirmPassword">
-                        <i class="bi bi-eye"></i>
+                        <i class="bi bi-eye-slash"></i>
                     </span>
                     <div th:errors="*{confirmPassword}" class="text-danger"></div>
                 </div>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -40,7 +40,7 @@
             <input type="password" class="form-control password-input" id="password" name="password" placeholder="Пароль" required>
             <label for="password">Пароль</label>
             <span class="toggle-password" data-target="password">
-                <i class="bi bi-eye"></i>
+                <i class="bi bi-eye-slash"></i>
             </span>
         </div>
 

--- a/src/main/resources/templates/auth/registration.html
+++ b/src/main/resources/templates/auth/registration.html
@@ -38,7 +38,7 @@
                 <input type="password" class="form-control password-input" id="password" th:field="*{password}" placeholder="Пароль" required>
                 <label for="password">Пароль</label>
                 <span class="toggle-password" data-target="password">
-                    <i class="bi bi-eye"></i>
+                    <i class="bi bi-eye-slash"></i>
                 </span>
                 <div th:if="${#fields.hasErrors('password')}" class="text-danger small" th:errors="*{password}"></div>
             </div>
@@ -47,9 +47,9 @@
                 <input type="password" class="form-control password-input" id="confirmPassword" th:field="*{confirmPassword}" placeholder="Подтвердите пароль" required>
                 <label for="confirmPassword">Подтвердите пароль</label>
                 <span class="toggle-password" data-target="confirmPassword">
-                    <i class="bi bi-eye"></i>
+                    <i class="bi bi-eye-slash"></i>
                 </span>
-                <div th:if="${#fields.hasErrors('confirmPassword')}" class="text-danger small" th:errors="*{confirmPassword}"></div>
+            <div th:if="${#fields.hasErrors('confirmPassword')}" class="text-danger small" th:errors="*{confirmPassword}"></div>
             </div>
 
             <!-- Чекбокс "Согласен с условиями" -->

--- a/src/main/resources/templates/auth/reset-password.html
+++ b/src/main/resources/templates/auth/reset-password.html
@@ -32,7 +32,7 @@
                 <input type="password" class="form-control password-input" id="newPassword" th:field="*{newPassword}" placeholder="Новый пароль">
                 <label for="newPassword">Новый пароль</label>
                 <span class="toggle-password" data-target="newPassword">
-                    <i class="bi bi-eye"></i>
+                    <i class="bi bi-eye-slash"></i>
                 </span>
                 <div th:if="${#fields.hasErrors('newPassword')}" th:errors="*{newPassword}" class="text-danger small"></div>
             </div>
@@ -41,9 +41,9 @@
                 <input type="password" class="form-control password-input" id="confirmPassword" th:field="*{confirmPassword}" placeholder="Подтверждение пароля">
                 <label for="confirmPassword">Подтвердите пароль</label>
                 <span class="toggle-password" data-target="confirmPassword">
-                    <i class="bi bi-eye"></i>
+                    <i class="bi bi-eye-slash"></i>
                 </span>
-                <div th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}" class="text-danger small"></div>
+            <div th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}" class="text-danger small"></div>
             </div>
 
             <button class="btn btn-primary w-100 py-2" type="submit">


### PR DESCRIPTION
## Summary
- align password visibility icon with hidden state across login, registration, reset, and profile forms

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68945f604e10832d858eb67505c9eaef