### PR TITLE
feat: track customer name source

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import java.time.ZonedDateTime;
 
 /**
  * Покупатель, оформляющий заказы в системе.
@@ -23,6 +24,16 @@ public class Customer {
 
     @Column(name = "phone", nullable = false, unique = true)
     private String phone;
+
+    @Column(name = "full_name")
+    private String fullName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "name_source", nullable = false)
+    private NameSource nameSource = NameSource.MERCHANT_PROVIDED;
+
+    @Column(name = "name_updated_at")
+    private ZonedDateTime nameUpdatedAt;
 
     @Column(name = "sent_count", nullable = false)
     private int sentCount = 0;

--- a/src/main/java/com/project/tracking_system/entity/NameSource.java
+++ b/src/main/java/com/project/tracking_system/entity/NameSource.java
@@ -1,0 +1,11 @@
+package com.project.tracking_system.entity;
+
+/**
+ * Источник данных для имени покупателя.
+ */
+public enum NameSource {
+    /** Имя подтверждено пользователем. */
+    USER_CONFIRMED,
+    /** Имя передано магазином. */
+    MERCHANT_PROVIDED;
+}

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -14,6 +14,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
 import java.util.Optional;
@@ -81,6 +83,38 @@ public class CustomerService {
             throw new IllegalStateException("Покупатель не найден после ошибки сохранения");
         }
 
+    }
+
+    /**
+     * Обновляет ФИО покупателя с учётом источника данных.
+     * <p>
+     * Если имя подтверждено пользователем, попытки обновления от магазина
+     * игнорируются. При успешном изменении фиксируется время обновления.
+     * </p>
+     *
+     * @param customer изменяемый покупатель
+     * @param newName  новое ФИО
+     * @param source   источник данных имени
+     * @return {@code true}, если обновление было выполнено
+     */
+    @Transactional
+    public boolean updateCustomerName(Customer customer, String newName, NameSource source) {
+        if (customer == null || source == null || newName == null || newName.isBlank()) {
+            return false;
+        }
+        if (customer.getNameSource() == NameSource.USER_CONFIRMED
+                && source == NameSource.MERCHANT_PROVIDED) {
+            log.debug("🚫 Обновление ФИО отклонено: имя подтверждено пользователем");
+            return false;
+        }
+        if (newName.equals(customer.getFullName())) {
+            return false;
+        }
+        customer.setFullName(newName);
+        customer.setNameSource(source);
+        customer.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        customerRepository.save(customer);
+        return true;
     }
 
     /**

--- a/src/main/resources/db/migration/V6__customer_name_source.sql
+++ b/src/main/resources/db/migration/V6__customer_name_source.sql
@@ -1,0 +1,9 @@
+-- Добавление полей для хранения ФИО и источника имени покупателя
+ALTER TABLE tb_customers
+    ADD COLUMN full_name TEXT,
+    ADD COLUMN name_source VARCHAR(50) NOT NULL DEFAULT 'MERCHANT_PROVIDED',
+    ADD COLUMN name_updated_at TIMESTAMPTZ;
+
+-- Индекс для быстрого поиска по дате обновления имени
+CREATE INDEX IF NOT EXISTS idx_customers_name_updated_at
+    ON tb_customers(name_updated_at);


### PR DESCRIPTION
## Summary
- store customer full name along with source and update timestamp
- prevent merchant name changes once user confirms name
- add migration for new customer name fields

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dc967f0d8832db0591271236acf1a