### PR TITLE
feat: add pre-registration flag for parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
@@ -22,6 +22,7 @@ public enum GlobalStatus {
     RETURN_IN_PROGRESS("Возврат в пути", "<i class='bi bi-truck status-icon return-progress'></i>"),
     RETURN_PENDING_PICKUP("Возврат ожидает забора", "<i class='bi bi-box-arrow-in-down-right status-icon return-pending'></i>"),
     RETURNED("Возврат забран", "<i class='bi bi-check2-circle status-icon returned'></i>"),
+    PRE_REGISTERED("Предрегистрация", "<i class='bi bi-hourglass status-icon preregistered'></i>"),
     REGISTERED("Заявка зарегистрирована", "<i class='bi bi-file-earmark-text status-icon registered'></i>"),
     UNKNOWN_STATUS("Неизвестный статус", "<i class='bi bi-question-circle status-icon unknown'></i>");
 

--- a/src/main/java/com/project/tracking_system/entity/TrackParcel.java
+++ b/src/main/java/com/project/tracking_system/entity/TrackParcel.java
@@ -31,6 +31,12 @@ public class TrackParcel {
     @Column(name = "status", nullable = false)
     private GlobalStatus status;
 
+    /**
+     * Флаг предварительной регистрации посылки.
+     */
+    @Column(name = "pre_registered", nullable = false)
+    private boolean preRegistered = false;
+
     @Column(name = "timestamp", nullable = false)
     private ZonedDateTime timestamp;
 

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -45,6 +45,23 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     // Поиск одной посылки по номеру в рамках конкретного магазина
     TrackParcel findByNumberAndStoreId(String number, Long storeId);
 
+    /**
+     * Найти все предзарегистрированные посылки.
+     *
+     * @param pageable настройки пагинации
+     * @return страница предзарегистрированных посылок
+     */
+    Page<TrackParcel> findByPreRegisteredTrue(Pageable pageable);
+
+    /**
+     * Найти посылки по статусу с пагинацией.
+     *
+     * @param status   статус посылки
+     * @param pageable настройки пагинации
+     * @return страница посылок с указанным статусом
+     */
+    Page<TrackParcel> findByStatus(GlobalStatus status, Pageable pageable);
+
     // Поиск посылок по статусу для конкретного магазина (с пагинацией)
     @Query("SELECT t FROM TrackParcel t WHERE t.store.id IN :storeIds AND t.status = :status")
     Page<TrackParcel> findByStoreIdInAndStatus(@Param("storeIds") List<Long> storeIds, @Param("status") GlobalStatus status, Pageable pageable);

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -112,6 +112,50 @@ public class TrackParcelService {
     }
 
     /**
+     * Возвращает страницу предзарегистрированных посылок.
+     *
+     * @param page      номер страницы
+     * @param size      размер страницы
+     * @param sortOrder порядок сортировки: {@code "asc"} или {@code "desc"}
+     * @return страница предзарегистрированных посылок
+     */
+    @Transactional(readOnly = true)
+    public Page<TrackParcelDTO> findPreRegistered(int page,
+                                                  int size,
+                                                  String sortOrder) {
+        Sort sort = Sort.by("timestamp");
+        sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<TrackParcel> parcels = trackParcelRepository.findByPreRegisteredTrue(pageable);
+        return parcels.map(track -> new TrackParcelDTO(
+                track,
+                userService.getUserZone(track.getUser().getId())));
+    }
+
+    /**
+     * Возвращает посылки в указанном статусе без учёта магазина.
+     *
+     * @param status    статус посылки
+     * @param page      номер страницы
+     * @param size      размер страницы
+     * @param sortOrder порядок сортировки: {@code "asc"} или {@code "desc"}
+     * @return страница посылок в заданном статусе
+     */
+    @Transactional(readOnly = true)
+    public Page<TrackParcelDTO> findByStatus(GlobalStatus status,
+                                             int page,
+                                             int size,
+                                             String sortOrder) {
+        Sort sort = Sort.by("timestamp");
+        sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<TrackParcel> parcels = trackParcelRepository.findByStatus(status, pageable);
+        return parcels.map(track -> new TrackParcelDTO(
+                track,
+                userService.getUserZone(track.getUser().getId())));
+    }
+
+    /**
      * Выполняет поиск посылок по номеру или номеру телефона покупателя.
      *
      * @param storeIds список магазинов

--- a/src/main/resources/db/migration/V6__track_pre_registration.sql
+++ b/src/main/resources/db/migration/V6__track_pre_registration.sql
@@ -1,0 +1,6 @@
+-- Добавление флага предварительной регистрации
+ALTER TABLE tb_track_parcels
+    ADD COLUMN pre_registered BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Индекс для быстрого поиска предзарегистрированных посылок
+CREATE INDEX idx_parcels_prereg ON tb_track_parcels(pre_registered);


### PR DESCRIPTION
## Summary
- track pre-registration flag on parcels
- support fetching pre-registered parcels and parcels by status
- add migration for pre-registration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dcaa675c8832db7d4de6bcbf72249