### PR TITLE
Handle PRE_REGISTERED parcels without statistics

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/DeliveryHistory.java
+++ b/src/main/java/com/project/tracking_system/entity/DeliveryHistory.java
@@ -36,6 +36,12 @@ public class DeliveryHistory {
     @Column(name = "postal_service", nullable = false)
     private PostalServiceType postalService;
 
+    /**
+     * Дата предварительной регистрации посылки.
+     */
+    @Column(name = "registration_date")
+    private ZonedDateTime registrationDate;
+
     @Column(name = "send_date")
     private ZonedDateTime sendDate;
 
@@ -48,11 +54,17 @@ public class DeliveryHistory {
     @Column(name = "returned_date")
     private ZonedDateTime returnedDate;
 
-    public DeliveryHistory(TrackParcel trackParcel, Store store, PostalServiceType postalService,
-                           ZonedDateTime sendDate, ZonedDateTime receivedDate, ZonedDateTime returnedDate) {
+    public DeliveryHistory(TrackParcel trackParcel,
+                           Store store,
+                           PostalServiceType postalService,
+                           ZonedDateTime registrationDate,
+                           ZonedDateTime sendDate,
+                           ZonedDateTime receivedDate,
+                           ZonedDateTime returnedDate) {
         this.trackParcel = trackParcel;
         this.store = store;
         this.postalService = postalService;
+        this.registrationDate = registrationDate;
         this.sendDate = sendDate;
         this.receivedDate = receivedDate;
         this.returnedDate = returnedDate;


### PR DESCRIPTION
## Summary
- add registrationDate to delivery history and handle pre-registered creation
- skip statistics increments for PRE_REGISTERED status
- handle EuroPost: penultimate status is send date; single status counts as registration only

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dd0c1050c832db26c0717abb94100