### PR TITLE
feat: include pre-registered parcels in departures

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -113,8 +113,14 @@ public class DeparturesController {
             trackParcelPage = trackParcelService.searchByNumberOrPhone(
                     filteredStoreIds, status, query.trim(), page, size, userId, sortOrder);
         } else if (status != null) {
-            trackParcelPage = trackParcelService.findByStoreTracksAndStatus(
-                    filteredStoreIds, status, page, size, userId, sortOrder);
+            if (status == GlobalStatus.PRE_REGISTERED) {
+                // При фильтрации по PRE_REGISTERED добавляем также предзарегистрированные посылки
+                trackParcelPage = trackParcelService.findByStoreTracksWithPreRegistered(
+                        filteredStoreIds, page, size, userId, sortOrder);
+            } else {
+                trackParcelPage = trackParcelService.findByStoreTracksAndStatus(
+                        filteredStoreIds, status, page, size, userId, sortOrder);
+            }
         } else {
             trackParcelPage = trackParcelService.findByStoreTracks(
                     filteredStoreIds, page, size, userId, sortOrder);


### PR DESCRIPTION
## Summary
- include parcels with `preRegistered=true` when filtering by `PRE_REGISTERED`
- expose service method to merge status and pre-registered parcels

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689dd9cefe04832db5198a21ef452e52