### PR TITLE
feat: expose customer info in departures

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
@@ -1,5 +1,7 @@
 package com.project.tracking_system.dto;
 
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.NameSource;
 import com.project.tracking_system.entity.TrackParcel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +22,20 @@ public class TrackParcelDTO {
     private String timestamp;
     private transient String iconHtml;
     private Long storeId;
+    private String customerName;
+    private String customerPhone;
+    private NameSource nameSource;
 
+    /**
+     * Конструктор DTO на основе сущности TrackParcel.
+     * <p>
+     * Преобразует дату в часовую зону пользователя и извлекает
+     * данные о покупателе, если они связаны с посылкой.
+     * </p>
+     *
+     * @param trackParcel сущность посылки
+     * @param userZone    часовой пояс пользователя
+     */
     public TrackParcelDTO(TrackParcel trackParcel, ZoneId userZone) {
         this.id = trackParcel.getId();
         this.number = trackParcel.getNumber();
@@ -29,5 +44,12 @@ public class TrackParcelDTO {
         this.timestamp = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss")
                 .withZone(userZone)
                 .format(trackParcel.getTimestamp());
+
+        Customer customer = trackParcel.getCustomer();
+        if (customer != null) {
+            this.customerName = customer.getFullName();
+            this.customerPhone = customer.getPhone();
+            this.nameSource = customer.getNameSource();
+        }
     }
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.TrackParcelDTO;
+import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.PostalServiceType;
@@ -87,7 +88,7 @@ public class TrackParcelService {
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<TrackParcel> trackParcels = trackParcelRepository.findByStoreIdIn(storeIds, pageable);
         ZoneId userZone = userService.getUserZone(userId);
-        return trackParcels.map(track -> new TrackParcelDTO(track, userZone));
+        return trackParcels.map(track -> toDto(track, userZone));
     }
 
     /**
@@ -113,7 +114,7 @@ public class TrackParcelService {
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<TrackParcel> trackParcels = trackParcelRepository.findByStoreIdInAndStatus(storeIds, status, pageable);
         ZoneId userZone = userService.getUserZone(userId);
-        return trackParcels.map(track -> new TrackParcelDTO(track, userZone));
+        return trackParcels.map(track -> toDto(track, userZone));
     }
 
     /**
@@ -132,7 +133,7 @@ public class TrackParcelService {
         sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<TrackParcel> parcels = trackParcelRepository.findByPreRegisteredTrue(pageable);
-        return parcels.map(track -> new TrackParcelDTO(
+        return parcels.map(track -> toDto(
                 track,
                 userService.getUserZone(track.getUser().getId())));
     }
@@ -195,7 +196,7 @@ public class TrackParcelService {
         ZoneId userZone = userService.getUserZone(userId);
         List<TrackParcelDTO> content = merged.subList(start, end)
                 .stream()
-                .map(track -> new TrackParcelDTO(track, userZone))
+                .map(track -> toDto(track, userZone))
                 .toList();
 
         return new PageImpl<>(content, PageRequest.of(page, size, sort), merged.size());
@@ -219,7 +220,7 @@ public class TrackParcelService {
         sort = "asc".equalsIgnoreCase(sortOrder) ? sort.ascending() : sort.descending();
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<TrackParcel> parcels = trackParcelRepository.findByStatus(status, pageable);
-        return parcels.map(track -> new TrackParcelDTO(
+        return parcels.map(track -> toDto(
                 track,
                 userService.getUserZone(track.getUser().getId())));
     }
@@ -251,7 +252,7 @@ public class TrackParcelService {
         Page<TrackParcel> parcels = trackParcelRepository.searchByNumberOrPhone(
                 storeIds, userId, status, query, phoneDigits, pageable);
         ZoneId userZone = userService.getUserZone(userId);
-        return parcels.map(track -> new TrackParcelDTO(track, userZone));
+        return parcels.map(track -> toDto(track, userZone));
     }
 
     /**
@@ -319,7 +320,7 @@ public class TrackParcelService {
         List<TrackParcel> trackParcels = trackParcelRepository.findByStoreId(storeId);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.stream()
-                .map(track -> new TrackParcelDTO(track, userZone))
+                .map(track -> toDto(track, userZone))
                 .toList();
     }
 
@@ -334,7 +335,7 @@ public class TrackParcelService {
         List<TrackParcel> trackParcels = trackParcelRepository.findByUserId(userId);
         ZoneId userZone = userService.getUserZone(userId);
         return trackParcels.stream()
-                .map(track -> new TrackParcelDTO(track, userZone))
+                .map(track -> toDto(track, userZone))
                 .toList();
     }
 
@@ -358,8 +359,25 @@ public class TrackParcelService {
         ZoneId userZone = userService.getUserZone(userId);
 
         return parcels.stream()
-                .map(track -> new TrackParcelDTO(track, userZone))
+                .map(track -> toDto(track, userZone))
                 .toList();
     }
 
+    /**
+     * Преобразует сущность TrackParcel в DTO с данными покупателя.
+     *
+     * @param track    исходная сущность
+     * @param userZone часовой пояс пользователя
+     * @return заполненный {@link TrackParcelDTO}
+     */
+    private TrackParcelDTO toDto(TrackParcel track, ZoneId userZone) {
+        TrackParcelDTO dto = new TrackParcelDTO(track, userZone);
+        Customer customer = track.getCustomer();
+        if (customer != null) {
+            dto.setCustomerName(customer.getFullName());
+            dto.setCustomerPhone(customer.getPhone());
+            dto.setNameSource(customer.getNameSource());
+        }
+        return dto;
+    }
 }

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -117,6 +117,7 @@
                                             <input type="checkbox" id="selectAllCheckbox" aria-label="Выделить все посылки">
                                         </th>
                                         <th scope="col">№ посылки</th>
+                                        <th scope="col">Покупатель</th>
                                         <th scope="col">Статус</th>
                                         <th scope="col">
                                             <a href="#" id="sortDateBtn" class="link-dark text-decoration-none">
@@ -142,10 +143,23 @@
                                                         th:data-itemnumber="${item.number}"
                                                         aria-label="Открыть детали посылки">
                                                 </button>
-                                                <span class="customer-icon" role="button"
-                                                      th:data-trackid="${item.id}" aria-label="Информация о покупателе">
-                                                    <i class="bi bi-person-circle"></i>
-                                                </span>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <div class="d-flex flex-column">
+                                                <div class="d-flex align-items-center">
+                                                    <button type="button" class="btn btn-link p-0 customer-icon ms-0"
+                                                            th:text="${item.customerName != null ? item.customerName : '-'}"
+                                                            th:data-trackid="${item.id}"
+                                                            aria-label="Информация о покупателе">
+                                                    </button>
+                                                    <span th:if="${item.nameSource == T(com.project.tracking_system.entity.NameSource).USER_CONFIRMED}"
+                                                          class="badge bg-success ms-2">подтверждено</span>
+                                                    <span th:if="${item.nameSource == T(com.project.tracking_system.entity.NameSource).MERCHANT_PROVIDED}"
+                                                          class="badge bg-secondary ms-2">магазин</span>
+                                                </div>
+                                                <span class="text-muted"
+                                                      th:text="${item.customerPhone != null ? item.customerPhone : '-'}"></span>
                                             </div>
                                         </td>
                                         <td th:text="${item.status}" class="status-text"></td>


### PR DESCRIPTION
## Summary
- show customer name, phone and source in TrackParcelDTO
- map customer data when building track parcel DTOs
- display customer info in departures table with confirmation badges

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd8b773c832d902086d65013cd3c