### PR TITLE
Убрать отдельную дату регистрации и заполнить timestamp при создании

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/TrackParcel.java
+++ b/src/main/java/com/project/tracking_system/entity/TrackParcel.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 /**
  * Представляет посылку с трек-номером в системе.
@@ -37,6 +38,11 @@ public class TrackParcel {
     @Column(name = "pre_registered", nullable = false)
     private boolean preRegistered = false;
 
+    /**
+     * Дата последнего статуса либо время предварительной регистрации.
+     * Заполняется автоматически при создании записи.
+     */
+    @CreationTimestamp
     @Column(name = "timestamp", nullable = false)
     private ZonedDateTime timestamp;
 

--- a/src/main/resources/db/migration/V7__track_preregistration_details.sql
+++ b/src/main/resources/db/migration/V7__track_preregistration_details.sql
@@ -1,0 +1,3 @@
+-- Значение по умолчанию для времени статуса/предрегистрации
+ALTER TABLE tb_track_parcels
+    ALTER COLUMN timestamp SET DEFAULT now() AT TIME ZONE 'UTC';


### PR DESCRIPTION
## Summary
- заполнение времени регистрации через поле `timestamp` вместо отдельной колонки
- добавлен дефолт для `timestamp` в миграции

## Testing
- `mvn -q test` *(fail: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689df46d23ac832dae5b09d5c2be533e