### PR TITLE
Implement track pre-registration service

### DIFF
--- a/src/main/java/com/project/tracking_system/service/registration/PreRegistrationService.java
+++ b/src/main/java/com/project/tracking_system/service/registration/PreRegistrationService.java
@@ -1,27 +1,89 @@
 package com.project.tracking_system.service.registration;
 
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.utils.TrackNumberUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Сервис обработки предрегистрации отправлений.
  * <p>
- * Отвечает за сохранение данных, полученных от пользователя при предрегистрации.
- * Текущая реализация выступает заглушкой и может быть расширена в будущем.
+ * Сохраняет минимальную информацию о посылке, полученную от пользователя,
+ * позволяя позже дополнить данные трека.
  * </p>
  */
+@Slf4j
+@RequiredArgsConstructor
 @Service
 public class PreRegistrationService {
 
+    private final TrackParcelRepository trackParcelRepository;
+    private final UserRepository userRepository;
+    private final StoreService storeService;
+
     /**
-     * Выполняет предрегистрацию номера.
+     * Выполняет предрегистрацию номера и сохраняет базовые данные о посылке.
      *
-     * @param number  основной трек-номер
+     * @param number  основной трек-номер (может быть пустым)
      * @param storeId идентификатор магазина
      * @param userId  идентификатор пользователя
+     * @return созданная сущность {@link TrackParcel}
      */
-    public void preRegister(String number,
-                            Long storeId,
-                            Long userId) {
-        // Заглушка. Реализация зависит от интеграции с внешними системами.
+    @Transactional
+    public TrackParcel preRegister(String number,
+                                   Long storeId,
+                                   Long userId) {
+        String normalized = normalizeNumber(number);
+        Store store = loadStore(storeId, userId);
+        User user = loadUser(userId);
+
+        TrackParcel parcel = buildPreRegisteredParcel(normalized, store, user);
+        TrackParcel saved = trackParcelRepository.save(parcel);
+        log.debug("Предрегистрация посылки ID={} выполнена", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Нормализует переданный номер трека.
+     * Возвращает {@code null}, если номер отсутствует либо пуст.
+     */
+    private String normalizeNumber(String number) {
+        String normalized = TrackNumberUtils.normalize(number);
+        return (normalized == null || normalized.isBlank()) ? null : normalized;
+    }
+
+    /**
+     * Загружает магазин и проверяет его принадлежность пользователю.
+     */
+    private Store loadStore(Long storeId, Long userId) {
+        return storeService.getStore(storeId, userId);
+    }
+
+    /**
+     * Получает пользователя по идентификатору.
+     */
+    private User loadUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Пользователь не найден"));
+    }
+
+    /**
+     * Формирует сущность посылки со статусом предрегистрации.
+     */
+    private TrackParcel buildPreRegisteredParcel(String number, Store store, User user) {
+        TrackParcel parcel = new TrackParcel();
+        parcel.setStatus(GlobalStatus.PRE_REGISTERED); // флаг preRegistered выставится автоматически
+        parcel.setNumber(number);
+        parcel.setStore(store);
+        parcel.setUser(user);
+        return parcel;
     }
 }


### PR DESCRIPTION
## Summary
- implement PreRegistrationService to save preliminary TrackParcel entities
- normalize optional track numbers and link parcel to user and store

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa6121ea0832dae5bfee2b5836ce7