### PR TITLE
Исключение предрегистраций без номера при обновлении треков

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TrackUpdateResponse.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackUpdateResponse.java
@@ -11,11 +11,13 @@ package com.project.tracking_system.dto;
  * @param readyToUpdate        сколько треков будет обновлено
  * @param finalStatusCount     сколько треков пропущено из-за финального статуса
  * @param recentlyUpdatedCount сколько треков пропущено из-за ограничения по времени
+ * @param preRegisteredCount   сколько предрегистраций без номера пропущено
  * @param message              человекочитаемое сообщение о запуске
  */
 public record TrackUpdateResponse(int totalRequested,
                                   int readyToUpdate,
                                   int finalStatusCount,
                                   int recentlyUpdatedCount,
+                                  int preRegisteredCount,
                                   String message) {
 }


### PR DESCRIPTION
## Summary
- исключены из обновления предзарегистрированные посылки без номера
- добавлен учет количества таких пропусков в TrackUpdateResponse
- добавлены отладочные сообщения о пропущенных предрегистрациях

## Testing
- `mvn test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa8152db0832da8696b2c3e95e9e1