### PR TITLE
Обработка предварительно зарегистрированных треков

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.service.track.TrackConstants;
 import com.project.tracking_system.service.track.TrackProcessingService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
 
     /**
@@ -55,9 +57,12 @@ public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
                 .map(meta -> CompletableFuture.supplyAsync(() -> {
                     TrackInfoListDTO info = trackProcessingService.processTrack(
                             meta.number(), meta.storeId(), userId, meta.canSave(), meta.phone());
-                    String status = info.getList().isEmpty()
-                            ? TrackConstants.NO_DATA_STATUS
-                            : info.getList().get(0).getInfoTrack();
+                    boolean hasStatus = !info.getList().isEmpty();
+                    // Информируем о результате обработки без персональных данных
+                    log.debug(hasStatus ? "Статусы получены" : "Статусы отсутствуют");
+                    String status = hasStatus
+                            ? info.getList().get(0).getInfoTrack()
+                            : TrackConstants.NO_DATA_STATUS;
                     return new TrackingResultAdd(meta.number(), status);
                 }, batchUploadExecutor))
                 .toList();
@@ -78,9 +83,12 @@ public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
         }
         TrackInfoListDTO info = trackProcessingService.processTrack(
                 meta.number(), meta.storeId(), null, meta.canSave(), meta.phone());
-        String status = info.getList().isEmpty()
-                ? TrackConstants.NO_DATA_STATUS
-                : info.getList().get(0).getInfoTrack();
+        boolean hasStatus = !info.getList().isEmpty();
+        // Информируем о результате обработки без персональных данных
+        log.debug(hasStatus ? "Статусы получены" : "Статусы отсутствуют");
+        String status = hasStatus
+                ? info.getList().get(0).getInfoTrack()
+                : TrackConstants.NO_DATA_STATUS;
         return new TrackingResultAdd(meta.number(), status, info);
     }
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -80,22 +80,22 @@ public class TrackProcessingService {
         }
         number = TrackNumberUtils.normalize(number); // Приводим к единообразному виду
 
-        log.info("Обработка трека: {} (Пользователь ID={}, Магазин ID={})", number, userId, storeId);
+        log.debug("Начата обработка трека");
 
         // Получаем данные о треке
         TrackInfoListDTO trackInfo = typeDefinitionTrackPostService.getTypeDefinitionTrackPostService(userId, number);
 
         if (trackInfo == null || trackInfo.getList().isEmpty()) {
-            log.warn("Данных по треку {} не найдено", number);
+            log.debug("Информация по треку отсутствует");
             return trackInfo;
         }
 
         // Сохраняем трек, если пользователь авторизован и разрешено сохранять
         if (userId != null && canSave) {
             save(number, trackInfo, storeId, userId, phone);
-            log.debug("✅ Посылка сохранена: {} (UserID={}, StoreID={})", number, userId, storeId);
+            log.debug("Посылка сохранена");
         } else {
-            log.info("⏳ Трек '{}' обработан, но не сохранён.", number);
+            log.debug("Трек обработан без сохранения");
         }
 
         return trackInfo;
@@ -134,7 +134,7 @@ public class TrackProcessingService {
                      Long storeId,
                      Long userId,
                      String phone) {
-        log.info("Начало сохранения трека {} для пользователя ID={}", number, userId);
+        log.debug("Начало сохранения трека");
         if (number == null || trackInfoListDTO == null) {
             throw new IllegalArgumentException("Отсутствует посылка");
         }
@@ -166,7 +166,7 @@ public class TrackProcessingService {
             trackParcel.setNumber(number);
             trackParcel.setStore(store);
             trackParcel.setUser(user);
-            log.info("Создан новый трек {} для пользователя ID={}", number, userId);
+            log.debug("Создан новый трек");
 
         } else {
             // Запоминаем предыдущие значения для корректировки статистики
@@ -181,7 +181,13 @@ public class TrackProcessingService {
 
             // Обновляем магазин у трека
             trackParcel.setStore(newStore);
-            log.info("Обновление магазина для трека {}: с магазина {} на магазин {}", number, oldStoreId, storeId);
+            log.debug("Обновлён магазин трека");
+        }
+
+        // Для предварительно зарегистрированного трека без статусов сохраняем текущее состояние
+        if (!isNewParcel && trackParcel.isPreRegistered() && trackInfoListDTO.getList().isEmpty()) {
+            log.debug("Статусы не получены, изменения не применены");
+            return;
         }
 
         // Обновляем статус и дату трека на основе нового содержимого
@@ -222,8 +228,7 @@ public class TrackProcessingService {
         // Обновляем историю доставки
         deliveryHistoryService.updateDeliveryHistory(trackParcel, oldStatus, newStatus, trackInfoListDTO);
 
-        log.info("Обновлено: userId={}, storeId={}, трек={}, новый статус={}",
-                userId, storeId, trackParcel.getNumber(), newStatus);
+        log.debug("Трек обновлён");
     }
 
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackProcessingServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackProcessingServiceTest.java
@@ -1,0 +1,133 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.repository.StoreRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.analytics.DeliveryHistoryService;
+import com.project.tracking_system.service.analytics.TrackStatisticsUpdater;
+import com.project.tracking_system.service.customer.CustomerService;
+import com.project.tracking_system.service.customer.CustomerStatsService;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты сервиса {@link TrackProcessingService} для проверки обработки
+ * предварительно зарегистрированных треков.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackProcessingServiceTest {
+
+    @Mock
+    private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+    @Mock
+    private StatusTrackService statusTrackService;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private DeliveryHistoryService deliveryHistoryService;
+    @Mock
+    private CustomerService customerService;
+    @Mock
+    private CustomerStatsService customerStatsService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private TrackStatisticsUpdater trackStatisticsUpdater;
+
+    private TrackProcessingService trackProcessingService;
+
+    @BeforeEach
+    void init() {
+        trackProcessingService = new TrackProcessingService(
+                typeDefinitionTrackPostService,
+                statusTrackService,
+                subscriptionService,
+                deliveryHistoryService,
+                customerService,
+                customerStatsService,
+                userService,
+                storeRepository,
+                userRepository,
+                trackParcelRepository,
+                trackStatisticsUpdater
+        );
+    }
+
+    /**
+     * Убеждаемся, что при отсутствии статусов
+     * предварительно зарегистрированный трек остаётся без изменений.
+     */
+    @Test
+    void preRegisteredWithoutStatuses_noChanges() {
+        // подготавливаем трек
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber("AB123");
+        parcel.setStatus(GlobalStatus.PRE_REGISTERED);
+        Store store = new Store();
+        store.setId(1L);
+        parcel.setStore(store);
+        when(trackParcelRepository.findByNumberAndUserId("AB123", 5L)).thenReturn(parcel);
+
+        TrackInfoListDTO info = new TrackInfoListDTO();
+
+        trackProcessingService.save("AB123", info, 1L, 5L, null);
+
+        assertEquals(GlobalStatus.PRE_REGISTERED, parcel.getStatus());
+        assertTrue(parcel.isPreRegistered());
+        verify(trackParcelRepository, never()).save(any());
+        verify(statusTrackService, never()).setStatus(any());
+    }
+
+    /**
+     * Проверяем, что при наличии статусов
+     * предварительно зарегистрированный трек обновляется,
+     * а флаг preRegistered снимается.
+     */
+    @Test
+    void preRegisteredWithStatuses_updatesTrack() {
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber("AB123");
+        parcel.setStatus(GlobalStatus.PRE_REGISTERED);
+        Store store = new Store();
+        store.setId(1L);
+        parcel.setStore(store);
+        when(trackParcelRepository.findByNumberAndUserId("AB123", 5L)).thenReturn(parcel);
+
+        TrackInfoDTO dto = new TrackInfoDTO("07.01.2025, 12:00", "Вручено");
+        TrackInfoListDTO info = new TrackInfoListDTO(List.of(dto));
+        when(statusTrackService.setStatus(any())).thenReturn(GlobalStatus.DELIVERED);
+        when(userService.getUserZone(5L)).thenReturn(ZoneId.of("UTC"));
+        when(trackParcelRepository.save(any())).thenReturn(parcel);
+        when(deliveryHistoryService.hasFinalStatus(any())).thenReturn(false);
+
+        trackProcessingService.save("AB123", info, 1L, 5L, null);
+
+        assertEquals(GlobalStatus.DELIVERED, parcel.getStatus());
+        assertFalse(parcel.isPreRegistered());
+        verify(trackParcelRepository).save(parcel);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Обновлён TrackProcessingService: предрег треки теперь обновляются только при наличии статусов, логирование переведено на DEBUG
- Добавлены отладочные сообщения в процессорах Belpost/Evropost без персональных данных
- Добавлены тесты обработки предрег треков

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fb7304120832dbee808daf6c30025