### PR TITLE
feat: add track number editing for preregistered parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -230,6 +230,23 @@ public class DeparturesController {
     }
 
     /**
+     * Сохраняет трек-номер для предварительно зарегистрированной посылки.
+     *
+     * @param id     идентификатор посылки
+     * @param number новый трек-номер
+     * @param user   текущий пользователь
+     * @return результат операции
+     */
+    @PostMapping("/set-number")
+    public ResponseEntity<?> setNumber(
+            @RequestParam Long id,
+            @RequestParam String number,
+            @AuthenticationPrincipal User user) {
+        trackParcelService.assignTrackNumber(id, number, user.getId());
+        return ResponseBuilder.ok("Трек-номер добавлен");
+    }
+
+    /**
      * Метод для удаления выбранных посылок.
      * <p>
      * Удаляются посылки, выбранные пользователем в интерфейсе. В случае успеха отображается сообщение об успешном удалении.

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.utils.PhoneUtils;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -361,6 +362,27 @@ public class TrackParcelService {
         return parcels.stream()
                 .map(track -> toDto(track, userZone))
                 .toList();
+    }
+
+    /**
+     * Присваивает трек-номер предварительно зарегистрированной посылке пользователя.
+     * <p>
+     * Метод проверяет принадлежность посылки пользователю и наличие статуса
+     * предварительной регистрации. В случае отсутствия посылки или
+     * несоответствия владельца выбрасывается {@link EntityNotFoundException}.
+     * </p>
+     *
+     * @param parcelId идентификатор посылки
+     * @param number   трек-номер
+     * @param userId   идентификатор пользователя
+     */
+    @Transactional
+    public void assignTrackNumber(Long parcelId, String number, Long userId) {
+        TrackParcel parcel = trackParcelRepository.findByIdAndPreRegisteredTrue(parcelId);
+        if (parcel == null || !parcel.getUser().getId().equals(userId)) {
+            throw new EntityNotFoundException("Посылка не найдена");
+        }
+        trackParcelRepository.updatePreRegisteredNumber(parcelId, number);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -403,9 +403,8 @@ public class TrackUpdateService {
                     .append(" треков недавно обновлялись и пропущены");
         }
         if (preRegistered > 0) {
-            sb.append("\n▪ ")
-                    .append(preRegistered)
-                    .append(" предрегистраций без номера пропущено");
+            sb.append("\n▪ Пропущено предрегистраций без номера: ")
+                    .append(preRegistered);
         }
         return sb.toString();
     }

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -129,20 +129,29 @@
                                     </thead>
                                     <tbody>
                                     <tr th:each="item : ${trackParcelDTO}" th:attr="data-track-number=${item.number},data-track-id=${item.id}">
-                                    <td class="checkbox-column">
-                                            <input type="checkbox" class="selectCheckbox" th:value="${item.number}" name="selectedNumbers">
+                                        <td class="checkbox-column">
+                                            <input type="checkbox" class="selectCheckbox" th:value="${item.number}" name="selectedNumbers"
+                                                   th:disabled="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}">
+                                            <span th:if="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}"
+                                                  class="badge bg-warning ms-2">Пропущено: нет трека</span>
                                         </td>
                                         <td>
                                             <div class="d-flex align-items-center">
                                                 <!-- Изменено: выводим готовое значение iconHtml из DTO -->
-                                                <span th:if="${item.iconHtml != null}" th:utext="${item.iconHtml}" class="status-icon"></span>
-                                                <span th:unless="${item.iconHtml != null}" th:utext="${T(com.project.tracking_system.entity.GlobalStatus).UNKNOWN_STATUS.getIconHtml()}" class="status-icon"></span>
+                                                <span th:if="${item.iconHtml != null}" th:utext="${item.iconHtml}" class="status-icon"
+                                                      th:attr="title=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'Добавьте трек-номер, чтобы начать обновлять' : null}, data-bs-toggle=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'tooltip' : null}"></span>
+                                                <span th:unless="${item.iconHtml != null}" th:utext="${T(com.project.tracking_system.entity.GlobalStatus).UNKNOWN_STATUS.getIconHtml()}" class="status-icon"
+                                                      th:attr="title=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'Добавьте трек-номер, чтобы начать обновлять' : null}, data-bs-toggle=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'tooltip' : null}"></span>
 
-                                                <button type="button" class="btn btn-link parcel-number open-modal"
+                                                <button th:if="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}" type="button" class="btn btn-link parcel-number"
+                                                        th:data-id="${item.id}"
+                                                        title="Добавьте трек-номер, чтобы начать обновлять"
+                                                        data-bs-toggle="tooltip"
+                                                        onclick="promptTrackNumber(this.dataset.id)">Указать трек</button>
+                                                <button th:unless="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}" type="button" class="btn btn-link parcel-number open-modal"
                                                         th:text="${item.number}"
                                                         th:data-itemnumber="${item.number}"
-                                                        aria-label="Открыть детали посылки">
-                                                </button>
+                                                        aria-label="Открыть детали посылки"></button>
                                             </div>
                                         </td>
                                         <td>
@@ -242,5 +251,30 @@
             </div>
         </div>
     </div>
+
+    <script>
+        function promptTrackNumber(id) {
+            const number = prompt('Введите трек-номер');
+            if (!number) {
+                return;
+            }
+            const data = new URLSearchParams();
+            data.append('id', id);
+            data.append('number', number);
+            fetch('/app/departures/set-number', {
+                method: 'POST',
+                headers: { [csrfHeader]: csrfToken },
+                body: data
+            })
+                .then(r => {
+                    if (!r.ok) {
+                        return r.text().then(t => { throw new Error(t); });
+                    }
+                    notifyUser('Трек-номер добавлен', 'success');
+                    setTimeout(() => window.location.reload(), 500);
+                })
+                .catch(e => notifyUser('Ошибка: ' + e.message, 'danger'));
+        }
+    </script>
 </div>
 </html>


### PR DESCRIPTION
## Summary
- allow assigning tracking numbers to pre-registered parcels via new controller endpoint
- show "Указать трек" button for pre-registrations without numbers and disable their checkboxes
- include count of pre-registrations without numbers in update notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689fc13713e8832d8811cc22cce5c68c