### PR TITLE
Добавлены имя и источник в DTO покупателя

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/CustomerInfoDTO.java
@@ -1,10 +1,11 @@
 package com.project.tracking_system.dto;
 
 import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.NameSource;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Информация о покупателе, связанная с посылкой.
@@ -15,11 +16,49 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CustomerInfoDTO {
     private String phone;
+    private String fullName;
+    private NameSource nameSource;
     private int sentCount;
     private int pickedUpCount;
     private int returnedCount;
     private double pickupPercentage;
     private BuyerReputation reputation;
+
+    /**
+     * Получить полное имя покупателя.
+     *
+     * @return ФИО покупателя
+     */
+    public String getFullName() {
+        return fullName;
+    }
+
+    /**
+     * Установить полное имя покупателя.
+     *
+     * @param fullName ФИО покупателя
+     */
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    /**
+     * Получить источник имени покупателя.
+     *
+     * @return источник данных имени
+     */
+    public NameSource getNameSource() {
+        return nameSource;
+    }
+
+    /**
+     * Установить источник имени покупателя.
+     *
+     * @param nameSource источник данных имени
+     */
+    public void setNameSource(NameSource nameSource) {
+        this.nameSource = nameSource;
+    }
 
     /**
      * Получить отображаемое название репутации покупателя.

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -203,6 +203,7 @@ public class CustomerService {
                             parcelId);
                     return track.getCustomer();
                 })
+                // Источник имени возвращаем, чтобы клиент мог блокировать редактирование подтверждённого имени
                 .map(this::toInfoDto)
                 .orElseGet(() -> {
                     log.debug("ℹ️ Покупатель для посылки ID={} не найден", parcelId);
@@ -255,6 +256,7 @@ public class CustomerService {
 
         log.debug("📈 Статистика покупателя ID={} обновлена после привязки посылки ID={}",
                 newCustomer.getId(), parcelId);
+        // Возвращаем имя и его источник, чтобы при подтверждённом имени запретить дальнейшее редактирование
         return toInfoDto(newCustomer);
     }
 
@@ -302,6 +304,8 @@ public class CustomerService {
                 : 0.0;
         return new CustomerInfoDTO(
                 customer.getPhone(),
+                customer.getFullName(),
+                customer.getNameSource(),
                 customer.getSentCount(),
                 customer.getPickedUpCount(),
                 customer.getReturnedCount(),

--- a/src/test/java/com/project/tracking_system/controller/CustomerControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/CustomerControllerTest.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.controller;
 
 import com.project.tracking_system.dto.CustomerInfoDTO;
 import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.NameSource;
 import com.project.tracking_system.service.customer.CustomerService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,14 @@ class CustomerControllerTest {
     @Test
     void getCustomerByParcelId_ReturnsCustomerInfoFragment() {
         CustomerInfoDTO dto = new CustomerInfoDTO(
-                "375291234567", 1, 1, 0, 100.0, BuyerReputation.RELIABLE
+                "375291234567",
+                "Иван Иванов",
+                NameSource.MERCHANT_PROVIDED,
+                1,
+                1,
+                0,
+                100.0,
+                BuyerReputation.RELIABLE
         );
         when(customerService.getCustomerInfoByParcelId(7L)).thenReturn(dto);
         Model model = new ExtendedModelMap();
@@ -58,7 +66,14 @@ class CustomerControllerTest {
     @Test
     void changeCustomer_UpdatesPhoneAndDelegatesToService() {
         CustomerInfoDTO dto = new CustomerInfoDTO(
-                "375299999999", 2, 1, 0, 50.0, BuyerReputation.RELIABLE
+                "375299999999",
+                "Пётр Петров",
+                NameSource.USER_CONFIRMED,
+                2,
+                1,
+                0,
+                50.0,
+                BuyerReputation.RELIABLE
         );
         when(customerService.assignCustomerToParcel(7L, "375299999999"))
                 .thenReturn(dto);


### PR DESCRIPTION
## Summary
- Добавлены поля `fullName` и `nameSource` в DTO покупателя с JavaDoc
- Сервис заполняет новые поля и комментирует использование источника имени для блокировки редактирования
- Обновлены тесты контроллера под новые поля

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a04adf3788832db4df20071e14dd60