### PR TITLE
Добавлено редактирование ФИО покупателя

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -181,6 +181,8 @@ function loadCustomerInfo(trackId) {
             initAssignCustomerFormHandler();
             initEditCustomerPhoneFormHandler();
             initPhoneEditToggle();
+            initEditCustomerNameFormHandler();
+            initNameEditToggle();
         })
         .catch(() => notifyUser('Ошибка при загрузке данных', 'danger'));
 }
@@ -461,6 +463,38 @@ function initEditCustomerPhoneFormHandler() {
 function initPhoneEditToggle() {
     const editBtn = document.getElementById('editPhoneBtn');
     const form = document.getElementById('edit-phone-form');
+
+    if (editBtn && form && !editBtn.dataset.initialized) {
+        editBtn.dataset.initialized = 'true';
+        editBtn.addEventListener('click', () => form.classList.toggle('hidden'));
+    }
+}
+
+/**
+ * Инициализирует отправку формы изменения ФИО покупателя.
+ * После успешного обновления перечитывает данные и
+ * повторно назначает обработчики.
+ */
+function initEditCustomerNameFormHandler() {
+    const reloadCallback = () => {
+        const idInput = document.querySelector('#edit-name-form input[name="trackId"]');
+        if (idInput) loadCustomerInfo(idInput.value);
+    };
+    ajaxSubmitForm('edit-name-form', 'customerInfoContainer', [
+        reloadCallback,
+        initEditCustomerNameFormHandler,
+        initAssignCustomerFormHandler,
+        initNameEditToggle
+    ]);
+}
+
+/**
+ * Назначает обработчик кнопке редактирования ФИО,
+ * отображающий или скрывающий форму ввода.
+ */
+function initNameEditToggle() {
+    const editBtn = document.getElementById('editNameBtn');
+    const form = document.getElementById('edit-name-form');
 
     if (editBtn && form && !editBtn.dataset.initialized) {
         editBtn.dataset.initialized = 'true';
@@ -1516,6 +1550,8 @@ document.addEventListener("DOMContentLoaded", function () {
     initAssignCustomerFormHandler();
     initEditCustomerPhoneFormHandler();
     initPhoneEditToggle();
+    initEditCustomerNameFormHandler();
+    initNameEditToggle();
     initTelegramForms();
     initTelegramToggle();
     initTelegramReminderBlocks();

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -32,6 +32,42 @@
                     </div>
                 </form>
             </li>
+            <li class="list-group-item">
+                <div th:if="${#strings.isEmpty(customerInfo.fullName)}">
+                    <strong>ФИО:</strong>
+                    <form id="edit-name-form" th:action="@{/app/customers/update-name}" method="post" class="mt-2">
+                        <input type="hidden" name="trackId" th:value="${trackId}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <div class="input-group mb-2">
+                            <input type="text" name="fullName" class="form-control" placeholder="Иванов Иван Иванович" required>
+                            <button type="submit" class="btn btn-primary">Сохранить</button>
+                        </div>
+                    </form>
+                </div>
+                <div th:unless="${#strings.isEmpty(customerInfo.fullName)}">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div>
+                            <strong>ФИО:</strong>
+                            <span th:text="${customerInfo.fullName}"></span>
+                            <span th:if="${customerInfo.nameSource == T(com.project.tracking_system.entity.NameSource).USER_CONFIRMED}"
+                                  class="badge bg-success ms-2">подтверждено</span>
+                        </div>
+                        <button th:if="${customerInfo.nameSource != T(com.project.tracking_system.entity.NameSource).USER_CONFIRMED}"
+                                id="editNameBtn" type="button" class="btn btn-link p-0 ms-2">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                    </div>
+                    <form th:if="${customerInfo.nameSource != T(com.project.tracking_system.entity.NameSource).USER_CONFIRMED}"
+                          id="edit-name-form" th:action="@{/app/customers/update-name}" method="post" class="mt-2 hidden">
+                        <input type="hidden" name="trackId" th:value="${trackId}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <div class="input-group mb-2">
+                            <input type="text" name="fullName" class="form-control" placeholder="Иванов Иван Иванович" required>
+                            <button type="submit" class="btn btn-primary">Сохранить</button>
+                        </div>
+                    </form>
+                </div>
+            </li>
             <li class="list-group-item"><strong>Отправлено:</strong> <span th:text="${customerInfo.sentCount}"></span></li>
             <li class="list-group-item"><strong>Забрано:</strong> <span th:text="${customerInfo.pickedUpCount}"></span></li>
             <li class="list-group-item"><strong>Процент выкупа:</strong> <span th:text="${customerInfo.pickupPercentage}"></span>%</li>


### PR DESCRIPTION
## Summary
- Добавлен вывод и редактирование ФИО покупателя в модальном окне, с формой ввода или бейджем подтверждения
- Реализован эндпоинт для обновления ФИО покупателя с проверкой источника имени
- Добавлены JavaScript-обработчики для переключения формы редактирования ФИО и её отправки

## Testing
- ⚠️ `mvn -q test` *(не удалось загрузить зависимости: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a04c003f80832d82446328222c2839