### PR TITLE
Add optimistic locking and indexes for customers

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import java.time.ZonedDateTime;
 
 /**
@@ -56,6 +57,13 @@ public class Customer {
     @Enumerated(EnumType.STRING)
     @Column(name = "reputation", nullable = false)
     private BuyerReputation reputation = BuyerReputation.NEW;
+
+    /**
+     * Версия записи для реализации оптимистичной блокировки.
+     */
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
 
     /**
      * Пересчитать репутацию покупателя на основе завершённых заказов.

--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -48,49 +48,52 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     int updateNotificationsEnabled(@Param("chatId") Long chatId, @Param("enabled") boolean enabled);
 
     /**
-     * Атомарно увеличить счётчик отправленных посылок.
+     * Атомарно увеличить счётчик отправленных посылок с проверкой версии.
      *
-     * @param id идентификатор покупателя
-     * @return количество обновлённых записей
+     * @param id      идентификатор покупателя
+     * @param version ожидаемая версия записи
+     * @return количество обновлённых записей (0 при конфликте версий)
      */
     @Modifying
     @Transactional
     @Query("""
         UPDATE Customer c
-        SET c.sentCount = c.sentCount + 1
-        WHERE c.id = :id
+        SET c.sentCount = c.sentCount + 1, c.version = c.version + 1
+        WHERE c.id = :id AND c.version = :version
         """)
-    int incrementSentCount(@Param("id") Long id);
+    int incrementSentCount(@Param("id") Long id, @Param("version") long version);
 
     /**
-     * Атомарно увеличить счётчик забранных посылок.
+     * Атомарно увеличить счётчик забранных посылок с учётом версии записи.
      *
-     * @param id идентификатор покупателя
+     * @param id      идентификатор покупателя
+     * @param version ожидаемая версия записи
      * @return количество обновлённых записей
      */
     @Modifying
     @Transactional
     @Query("""
         UPDATE Customer c
-        SET c.pickedUpCount = c.pickedUpCount + 1
-        WHERE c.id = :id
+        SET c.pickedUpCount = c.pickedUpCount + 1, c.version = c.version + 1
+        WHERE c.id = :id AND c.version = :version
         """)
-    int incrementPickedUpCount(@Param("id") Long id);
+    int incrementPickedUpCount(@Param("id") Long id, @Param("version") long version);
 
     /**
-     * Атомарно увеличить счётчик возвращённых посылок.
+     * Атомарно увеличить счётчик возвращённых посылок с проверкой версии.
      *
-     * @param id идентификатор покупателя
+     * @param id      идентификатор покупателя
+     * @param version ожидаемая версия записи
      * @return количество обновлённых записей
      */
     @Modifying
     @Transactional
     @Query("""
         UPDATE Customer c
-        SET c.returnedCount = c.returnedCount + 1
-        WHERE c.id = :id
+        SET c.returnedCount = c.returnedCount + 1, c.version = c.version + 1
+        WHERE c.id = :id AND c.version = :version
         """)
-    int incrementReturnedCount(@Param("id") Long id);
+    int incrementReturnedCount(@Param("id") Long id, @Param("version") long version);
 
     /**
      * Подсчитать количество покупателей с указанной репутацией.

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerStatsService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerStatsService.java
@@ -29,7 +29,7 @@ public class CustomerStatsService {
             return;
         }
         log.debug("🔄 Попытка атомарного увеличения отправленных для customerId={}", customer.getId());
-        int updated = customerRepository.incrementSentCount(customer.getId());
+        int updated = customerRepository.incrementSentCount(customer.getId(), customer.getVersion());
         if (updated == 0) {
             log.warn("⚠️ Не удалось атомарно обновить отправленные для customerId={}, переключаемся на ручной режим", customer.getId());
             // При неудаче загружаем сущность и обновляем вручную
@@ -41,11 +41,13 @@ public class CustomerStatsService {
             // Синхронизируем переданный объект
             customer.setSentCount(fresh.getSentCount());
             customer.setReputation(fresh.getReputation());
+            customer.setVersion(fresh.getVersion());
             log.debug("✅ Счётчик отправленных вручную увеличен для customerId={}", customer.getId());
         } else {
             log.debug("✅ Атомарное увеличение отправленных успешно для customerId={}", customer.getId());
             customer.setSentCount(customer.getSentCount() + 1);
             customer.recalculateReputation();
+            customer.setVersion(customer.getVersion() + 1);
             // Сохраняем репутацию для согласованности с БД
             customerRepository.save(customer);
         }
@@ -62,7 +64,7 @@ public class CustomerStatsService {
             return;
         }
         log.debug("🔄 Попытка атомарного увеличения забранных для customerId={}", customer.getId());
-        int updated = customerRepository.incrementPickedUpCount(customer.getId());
+        int updated = customerRepository.incrementPickedUpCount(customer.getId(), customer.getVersion());
         if (updated == 0) {
             log.warn("⚠️ Не удалось атомарно обновить забранные для customerId={}, переключаемся на ручной режим", customer.getId());
             // При неудаче читаем и обновляем вручную
@@ -74,11 +76,13 @@ public class CustomerStatsService {
             // Обновляем переданный экземпляр
             customer.setPickedUpCount(fresh.getPickedUpCount());
             customer.setReputation(fresh.getReputation());
+            customer.setVersion(fresh.getVersion());
             log.debug("✅ Счётчик забранных вручную увеличен для customerId={}", customer.getId());
         } else {
             log.debug("✅ Атомарное увеличение забранных успешно для customerId={}", customer.getId());
             customer.setPickedUpCount(customer.getPickedUpCount() + 1);
             customer.recalculateReputation();
+            customer.setVersion(customer.getVersion() + 1);
             // Сохраняем репутацию для согласованности с БД
             customerRepository.save(customer);
         }
@@ -95,7 +99,7 @@ public class CustomerStatsService {
             return;
         }
         log.debug("🔄 Попытка атомарного увеличения возвратов для customerId={}", customer.getId());
-        int updated = customerRepository.incrementReturnedCount(customer.getId());
+        int updated = customerRepository.incrementReturnedCount(customer.getId(), customer.getVersion());
         if (updated == 0) {
             log.warn("⚠️ Не удалось атомарно обновить возвраты для customerId={}, переключаемся на ручной режим", customer.getId());
             Customer fresh = customerRepository.findById(customer.getId())
@@ -105,11 +109,13 @@ public class CustomerStatsService {
             customerRepository.save(fresh);
             customer.setReturnedCount(fresh.getReturnedCount());
             customer.setReputation(fresh.getReputation());
+            customer.setVersion(fresh.getVersion());
             log.debug("✅ Счётчик возвратов вручную увеличен для customerId={}", customer.getId());
         } else {
             log.debug("✅ Атомарное увеличение возвратов успешно для customerId={}", customer.getId());
             customer.setReturnedCount(customer.getReturnedCount() + 1);
             customer.recalculateReputation();
+            customer.setVersion(customer.getVersion() + 1);
             customerRepository.save(customer);
         }
     }

--- a/src/main/resources/db/migration/V9__customer_version_indexes.sql
+++ b/src/main/resources/db/migration/V9__customer_version_indexes.sql
@@ -1,0 +1,11 @@
+-- Добавление колонки версии и индексов для покупателей
+ALTER TABLE tb_customers
+    ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+
+-- Индекс для быстрого поиска по идентификатору Telegram-чата
+CREATE INDEX IF NOT EXISTS idx_customers_telegram_chat_id
+    ON tb_customers(telegram_chat_id);
+
+-- Индекс для фильтрации по репутации покупателя
+CREATE INDEX IF NOT EXISTS idx_customers_reputation
+    ON tb_customers(reputation);

--- a/src/test/java/com/project/tracking_system/repository/CustomerRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/CustomerRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.Customer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Проверка оптимистичной блокировки для {@link CustomerRepository}.
+ */
+@DataJpaTest
+class CustomerRepositoryTest {
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    /**
+     * Попытка сохранить устаревшую версию сущности должна завершаться ошибкой.
+     */
+    @Test
+    void savingStaleEntityThrowsOptimisticLockingFailure() {
+        Customer customer = new Customer();
+        customer.setPhone("375000000000");
+        customerRepository.saveAndFlush(customer);
+
+        Customer first = customerRepository.findById(customer.getId()).orElseThrow();
+        Customer second = customerRepository.findById(customer.getId()).orElseThrow();
+
+        first.setFullName("Первый");
+        customerRepository.saveAndFlush(first);
+
+        second.setFullName("Второй");
+        assertThrows(OptimisticLockingFailureException.class,
+                () -> customerRepository.saveAndFlush(second));
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerAssignServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerAssignServiceTest.java
@@ -74,8 +74,8 @@ class CustomerAssignServiceTest {
 
         when(trackParcelRepository.findById(10L)).thenReturn(Optional.of(parcel));
         when(transactionalService.findByPhone("375111111111")).thenReturn(Optional.of(newCustomer));
-        when(customerRepository.incrementSentCount(2L)).thenReturn(1);
-        when(customerRepository.incrementPickedUpCount(2L)).thenReturn(1);
+        when(customerRepository.incrementSentCount(2L, 0L)).thenReturn(1);
+        when(customerRepository.incrementPickedUpCount(2L, 1L)).thenReturn(1);
 
         service.assignCustomerToParcel(10L, "375111111111");
 
@@ -107,8 +107,8 @@ class CustomerAssignServiceTest {
 
         when(trackParcelRepository.findById(11L)).thenReturn(Optional.of(parcel));
         when(transactionalService.findByPhone("375222222222")).thenReturn(Optional.of(newCustomer));
-        when(customerRepository.incrementSentCount(2L)).thenReturn(1);
-        when(customerRepository.incrementReturnedCount(2L)).thenReturn(1);
+        when(customerRepository.incrementSentCount(2L, 0L)).thenReturn(1);
+        when(customerRepository.incrementReturnedCount(2L, 1L)).thenReturn(1);
 
         service.assignCustomerToParcel(11L, "375222222222");
 
@@ -131,6 +131,7 @@ class CustomerAssignServiceTest {
         c.setSentCount(sent);
         c.setPickedUpCount(picked);
         c.setReturnedCount(returned);
+        c.setVersion(0);
         c.recalculateReputation();
         return c;
     }

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerStatsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerStatsServiceTest.java
@@ -33,6 +33,7 @@ class CustomerStatsServiceTest {
     void setUp() {
         customer = new Customer();
         customer.setId(1L);
+        customer.setVersion(0);
     }
 
     /**
@@ -40,12 +41,12 @@ class CustomerStatsServiceTest {
      */
     @Test
     void incrementSent_AtomicSuccess() {
-        when(customerRepository.incrementSentCount(1L)).thenReturn(1);
+        when(customerRepository.incrementSentCount(1L, 0L)).thenReturn(1);
 
         service.incrementSent(customer);
 
         assertEquals(1, customer.getSentCount());
-        verify(customerRepository).incrementSentCount(1L);
+        verify(customerRepository).incrementSentCount(1L, 0L);
         verify(customerRepository).save(customer);
     }
 
@@ -54,9 +55,10 @@ class CustomerStatsServiceTest {
      */
     @Test
     void incrementSent_FallbackManual() {
-        when(customerRepository.incrementSentCount(1L)).thenReturn(0);
+        when(customerRepository.incrementSentCount(1L, 0L)).thenReturn(0);
         Customer fresh = new Customer();
         fresh.setId(1L);
+        fresh.setVersion(1);
         when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
 
         service.incrementSent(customer);
@@ -70,12 +72,12 @@ class CustomerStatsServiceTest {
      */
     @Test
     void incrementPickedUp_AtomicSuccess() {
-        when(customerRepository.incrementPickedUpCount(1L)).thenReturn(1);
+        when(customerRepository.incrementPickedUpCount(1L, 0L)).thenReturn(1);
 
         service.incrementPickedUp(customer);
 
         assertEquals(1, customer.getPickedUpCount());
-        verify(customerRepository).incrementPickedUpCount(1L);
+        verify(customerRepository).incrementPickedUpCount(1L, 0L);
         verify(customerRepository).save(customer);
     }
 
@@ -84,9 +86,10 @@ class CustomerStatsServiceTest {
      */
     @Test
     void incrementPickedUp_FallbackManual() {
-        when(customerRepository.incrementPickedUpCount(1L)).thenReturn(0);
+        when(customerRepository.incrementPickedUpCount(1L, 0L)).thenReturn(0);
         Customer fresh = new Customer();
         fresh.setId(1L);
+        fresh.setVersion(1);
         when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
 
         service.incrementPickedUp(customer);
@@ -100,12 +103,12 @@ class CustomerStatsServiceTest {
      */
     @Test
     void incrementReturned_AtomicSuccess() {
-        when(customerRepository.incrementReturnedCount(1L)).thenReturn(1);
+        when(customerRepository.incrementReturnedCount(1L, 0L)).thenReturn(1);
 
         service.incrementReturned(customer);
 
         assertEquals(1, customer.getReturnedCount());
-        verify(customerRepository).incrementReturnedCount(1L);
+        verify(customerRepository).incrementReturnedCount(1L, 0L);
         verify(customerRepository).save(customer);
     }
 
@@ -114,9 +117,10 @@ class CustomerStatsServiceTest {
      */
     @Test
     void incrementReturned_FallbackManual() {
-        when(customerRepository.incrementReturnedCount(1L)).thenReturn(0);
+        when(customerRepository.incrementReturnedCount(1L, 0L)).thenReturn(0);
         Customer fresh = new Customer();
         fresh.setId(1L);
+        fresh.setVersion(1);
         when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
 
         service.incrementReturned(customer);


### PR DESCRIPTION
## Summary
- add migration with version column and new indexes for customers
- implement optimistic locking on Customer entity and repository
- cover optimistic locking with repository test and adjust services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a05b374a80832da517a603c99a00d2