### PR TITLE
feat: import customer names from excel uploads

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerNameService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerNameService.java
@@ -1,0 +1,48 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.utils.PhoneUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Сервис управления ФИО покупателя, полученного от магазина.
+ * <p>
+ * Обновляет профиль покупателя и фиксирует событие {@code PENDING},
+ * которое может быть подтверждено пользователем в дальнейшем.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerNameService {
+
+    private final CustomerService customerService;
+
+    /**
+     * Обновить или добавить ФИО покупателя на основании данных из магазина.
+     * <p>
+     * При отсутствии покупателя он создаётся автоматически. Для успешных
+     * обновлений в журнал записывается событие со статусом {@code PENDING}.
+     * </p>
+     *
+     * @param rawPhone  телефон покупателя в произвольном формате
+     * @param fullName  предложенное магазином ФИО
+     */
+    @Transactional
+    public void upsertFromStore(String rawPhone, String fullName) {
+        if (rawPhone == null || rawPhone.isBlank() || fullName == null || fullName.isBlank()) {
+            return;
+        }
+        try {
+            String phone = PhoneUtils.normalizePhone(rawPhone);
+            Customer customer = customerService.registerOrGetByPhone(phone);
+            customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED);
+        } catch (Exception e) {
+            log.warn("Не удалось обновить ФИО для телефона {}: {}", rawPhone, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackExcelParser.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackExcelParser.java
@@ -56,7 +56,13 @@ public class TrackExcelParser {
                 if (phoneCell != null) {
                     phone = readCell(phoneCell).trim();
                 }
-                rows.add(new TrackExcelRow(number, store, phone));
+                String fullName = null;
+                Cell nameCell = row.getCell(3);
+                if (nameCell != null) {
+                    fullName = readCell(nameCell).trim();
+                }
+                // Сохраняем значения строки без нормализации
+                rows.add(new TrackExcelRow(number, store, phone, fullName));
             }
         }
         log.info("Разобрано {} строк из файла", rows.size());

--- a/src/main/java/com/project/tracking_system/service/track/TrackExcelRow.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackExcelRow.java
@@ -7,8 +7,9 @@ package com.project.tracking_system.service.track;
  * </p>
  *
  * @param number номер трека
- * @param store  значение ячейки магазина
- * @param phone  значение ячейки телефона
+ * @param store    значение ячейки магазина
+ * @param phone    значение ячейки телефона
+ * @param fullName значение ячейки ФИО
  */
-public record TrackExcelRow(String number, String store, String phone) {
+public record TrackExcelRow(String number, String store, String phone, String fullName) {
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.customer.CustomerNameService;
 import com.project.tracking_system.utils.PhoneUtils;
 import com.project.tracking_system.utils.TrackNumberUtils;
 import com.project.tracking_system.entity.PostalServiceType;
@@ -51,6 +52,8 @@ public class TrackMetaValidator {
     private final StoreService storeService;
     /** Сервис определения почтовой службы трека. */
     private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+    /** Сервис обновления ФИО покупателя. */
+    private final CustomerNameService customerNameService;
 
 /**
  * Валидирует сырые строки и преобразует их в {@link TrackMeta}.
@@ -107,6 +110,11 @@ public class TrackMetaValidator {
             String number = TrackNumberUtils.normalize(row.number());
             Long storeId = parseStoreId(row.store(), defaultStoreId, userId);
             String phone = normalizePhone(row.phone());
+            String fullName = row.fullName();
+            if (phone != null && fullName != null && !fullName.isBlank()) {
+                // При наличии телефона и ФИО обновляем данные покупателя
+                customerNameService.upsertFromStore(phone, fullName);
+            }
 
             boolean isNew = trackParcelService.isNewTrack(number, storeId);
             tempMetaList.add(new TempMeta(number, storeId, phone, isNew));

--- a/src/test/java/com/project/tracking_system/service/track/TrackExcelParserTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackExcelParserTest.java
@@ -20,6 +20,7 @@ class TrackExcelParserTest {
         row1.createCell(0).setCellValue("AA111");
         row1.createCell(1).setCellValue("1");
         row1.createCell(2).setCellValue("+375291234567");
+        row1.createCell(3).setCellValue("Иван Иванов");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         wb.write(out);
         MockMultipartFile file = new MockMultipartFile("f", out.toByteArray());
@@ -31,5 +32,6 @@ class TrackExcelParserTest {
         assertEquals("AA111", rows.get(0).number());
         assertEquals("1", rows.get(0).store());
         assertEquals("+375291234567", rows.get(0).phone());
+        assertEquals("Иван Иванов", rows.get(0).fullName());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
+import com.project.tracking_system.service.customer.CustomerNameService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +15,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Тесты для {@link TrackMetaValidator}.
@@ -34,6 +35,8 @@ class TrackMetaValidatorTest {
     private StoreService storeService;
     @Mock
     private TypeDefinitionTrackPostService typeDefinitionTrackPostService;
+    @Mock
+    private CustomerNameService customerNameService;
 
     private TrackMetaValidator validator;
 
@@ -43,7 +46,8 @@ class TrackMetaValidatorTest {
                 trackParcelService,
                 subscriptionService,
                 storeService,
-                typeDefinitionTrackPostService
+                typeDefinitionTrackPostService,
+                customerNameService
         );
     }
 
@@ -60,8 +64,8 @@ class TrackMetaValidatorTest {
         when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
 
         List<TrackExcelRow> rows = List.of(
-                new TrackExcelRow("A1", "1", "375291111111"),
-                new TrackExcelRow("A2", "1", "375291111112")
+                new TrackExcelRow("A1", "1", "375291111111", null),
+                new TrackExcelRow("A2", "1", "375291111112", null)
         );
 
         TrackMetaValidationResult result = validator.validate(rows, 1L);
@@ -87,7 +91,7 @@ class TrackMetaValidatorTest {
         when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
 
         List<TrackExcelRow> rows = List.of(
-                new TrackExcelRow("A1", "Shop", "375291111111")
+                new TrackExcelRow("A1", "Shop", "375291111111", null)
         );
 
         TrackMetaValidationResult result = validator.validate(rows, 1L);
@@ -109,7 +113,7 @@ class TrackMetaValidatorTest {
         when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
 
         List<TrackExcelRow> rows = List.of(
-                new TrackExcelRow("A1", "1", "+375 (29) 111-11-11")
+                new TrackExcelRow("A1", "1", "+375 (29) 111-11-11", null)
         );
 
         TrackMetaValidationResult result = validator.validate(rows, 1L);
@@ -135,14 +139,35 @@ class TrackMetaValidatorTest {
                 });
 
         List<TrackExcelRow> rows = List.of(
-                new TrackExcelRow("A1", "1", null),
-                new TrackExcelRow("BAD", "1", null),
-                new TrackExcelRow("A1", "1", null)
+                new TrackExcelRow("A1", "1", null, null),
+                new TrackExcelRow("BAD", "1", null, null),
+                new TrackExcelRow("A1", "1", null, null)
         );
 
         TrackMetaValidationResult result = validator.validate(rows, 1L);
 
         assertEquals(1, result.validTracks().size());
         assertEquals(2, result.invalidTracks().size());
+    }
+
+    /**
+     * При наличии корректного телефона и имени вызывается сервис обновления ФИО.
+     */
+    @Test
+    void validate_UpdatesCustomerName() {
+        when(subscriptionService.canUploadTracks(anyLong(), anyInt())).thenReturn(1);
+        when(subscriptionService.canSaveMoreTracks(anyLong(), anyInt())).thenReturn(1);
+        when(storeService.getDefaultStoreId(1L)).thenReturn(1L);
+        when(storeService.userOwnsStore(1L, 1L)).thenReturn(true);
+        when(trackParcelService.isNewTrack(anyString(), any())).thenReturn(true);
+        when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
+
+        List<TrackExcelRow> rows = List.of(
+                new TrackExcelRow("A1", "1", "+375291111111", "Иван")
+        );
+
+        validator.validate(rows, 1L);
+
+        verify(customerNameService).upsertFromStore("375291111111", "Иван");
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -83,7 +83,7 @@ class TrackUploadProcessorServiceTest {
     void process_EnqueuesTracks() throws Exception {
         MockMultipartFile file = new MockMultipartFile("f", new byte[0]);
         TrackMeta meta = new TrackMeta("A1", 1L, "p", true, PostalServiceType.BELPOST);
-        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p")));
+        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p", null)));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
                 .thenReturn(new TrackMetaValidationResult(List.of(meta), List.of(), null));
         when(trackUpdateEligibilityService.canUpdate(anyString(), any())).thenReturn(true);
@@ -117,7 +117,7 @@ class TrackUploadProcessorServiceTest {
     @Test
     void process_NoEligibleTracks_ReturnsEarly() throws Exception {
         MockMultipartFile file = new MockMultipartFile("f", new byte[0]);
-        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p")));
+        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("A1", "1", "p", null)));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
                 .thenReturn(new TrackMetaValidationResult(
                         List.of(new TrackMeta("A1", 1L, "p", true)), List.of(), null));
@@ -143,7 +143,7 @@ class TrackUploadProcessorServiceTest {
     @Test
     void process_AllInvalid_SendsErrorAndProgress() throws Exception {
         MockMultipartFile file = new MockMultipartFile("f", new byte[0]);
-        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("bad", null, null)));
+        when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow("bad", null, null, null)));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
                 .thenReturn(new TrackMetaValidationResult(
                         List.of(),


### PR DESCRIPTION
## Summary
- parse `full_name` column from track Excel files
- update TrackMetaValidator to upsert customer names and log issues per row
- add CustomerNameService for creating `PENDING` name events

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent 3.4.3 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a06f700720832d88b2aac3a14a16c2