### PR TITLE
feat: restrict editing confirmed customer name

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/CustomerController.java
+++ b/src/main/java/com/project/tracking_system/controller/CustomerController.java
@@ -3,9 +3,11 @@ package com.project.tracking_system.controller;
 import com.project.tracking_system.dto.CustomerInfoDTO;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.service.customer.CustomerNameEventService;
 import com.project.tracking_system.service.customer.CustomerService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -91,13 +93,15 @@ public class CustomerController {
     @PostMapping("/update-name")
     public String updateName(@RequestParam Long trackId,
                              @RequestParam String fullName,
-                             Model model) {
+                             Model model,
+                             @AuthenticationPrincipal User user) {
         Customer customer = trackParcelRepository.findById(trackId)
                 .map(track -> track.getCustomer())
                 .orElse(null);
         if (customer != null) {
             // Имя, подтверждённое пользователем, сервис не позволит изменить
-            customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED);
+            customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED,
+                    user != null ? user.getRole() : null);
         }
         CustomerInfoDTO dto = customerService.getCustomerInfoByParcelId(trackId);
         populateModel(trackId, dto, model);

--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.entity.Role;
 import com.project.tracking_system.service.store.StoreService;
 import com.project.tracking_system.service.track.TrackFacade;
 import com.project.tracking_system.service.track.TrackServiceClassifier;
@@ -116,7 +117,7 @@ public class HomeController {
             } else {
                 model.addAttribute("successMessage", "Предрегистрация выполнена.");
             }
-            updateCustomerName(phone, fullName);
+            updateCustomerName(phone, fullName, user != null ? user.getRole() : null);
             return "app/home";
         }
 
@@ -146,7 +147,7 @@ public class HomeController {
             model.addAttribute("trackInfo", trackInfo);
 
             // Обновляем ФИО покупателя при наличии телефона
-            updateCustomerName(phone, fullName);
+            updateCustomerName(phone, fullName, user != null ? user.getRole() : null);
         } catch (IllegalArgumentException e) {
             model.addAttribute("customError", e.getMessage());
             log.warn("Ошибка: {}", e.getMessage());
@@ -186,11 +187,11 @@ public class HomeController {
      * @param phone    номер телефона покупателя
      * @param fullName новое ФИО
      */
-    private void updateCustomerName(String phone, String fullName) {
+    private void updateCustomerName(String phone, String fullName, Role role) {
         if (phone == null || phone.isBlank() || fullName == null || fullName.isBlank()) {
             return;
         }
         Customer customer = customerService.registerOrGetByPhone(phone);
-        customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED);
+        customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED, role);
     }
 }

--- a/src/main/java/com/project/tracking_system/exception/ConfirmedNameChangeException.java
+++ b/src/main/java/com/project/tracking_system/exception/ConfirmedNameChangeException.java
@@ -1,0 +1,15 @@
+package com.project.tracking_system.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Исключение, выбрасываемое при попытке магазина изменить подтверждённое имя.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConfirmedNameChangeException extends RuntimeException {
+
+    public ConfirmedNameChangeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerNameService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerNameService.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.service.customer;
 
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.entity.Role;
 import com.project.tracking_system.utils.PhoneUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +41,7 @@ public class CustomerNameService {
         try {
             String phone = PhoneUtils.normalizePhone(rawPhone);
             Customer customer = customerService.registerOrGetByPhone(phone);
-            customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED);
+            customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED, Role.ROLE_USER);
         } catch (Exception e) {
             log.warn("Не удалось обновить ФИО для телефона {}: {}", rawPhone, e.getMessage());
         }

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerAssignServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerAssignServiceTest.java
@@ -8,11 +8,13 @@ import com.project.tracking_system.repository.CustomerRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.user.UserSettingsService;
+import com.project.tracking_system.service.customer.CustomerNameEventService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
 
 import java.util.Optional;
 
@@ -39,6 +41,10 @@ class CustomerAssignServiceTest {
     private SubscriptionService subscriptionService;
     @Mock
     private UserSettingsService userSettingsService;
+    @Mock
+    private CustomerNameEventService customerNameEventService;
+    @Mock
+    private TelegramClient telegramClient;
 
     private CustomerStatsService customerStatsService;
     private CustomerService service;
@@ -52,7 +58,9 @@ class CustomerAssignServiceTest {
                 transactionalService,
                 customerStatsService,
                 subscriptionService,
-                userSettingsService
+                userSettingsService,
+                customerNameEventService,
+                telegramClient
         );
 
         when(customerRepository.save(any(Customer.class))).thenAnswer(inv -> inv.getArgument(0));

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerServiceTest.java
@@ -1,12 +1,18 @@
 package com.project.tracking_system.service.customer;
 
 import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.user.UserSettingsService;
+import com.project.tracking_system.service.customer.CustomerNameEventService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
@@ -22,7 +28,19 @@ import static org.mockito.Mockito.*;
 class CustomerServiceTest {
 
     @Mock
+    private CustomerRepository customerRepository;
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private UserSettingsService userSettingsService;
+    @Mock
+    private CustomerNameEventService customerNameEventService;
+    @Mock
     private CustomerTransactionalService transactionalService;
+    @Mock
+    private TelegramClient telegramClient;
 
     @InjectMocks
     private CustomerService service;


### PR DESCRIPTION
## Summary
- prevent stores from overriding user-confirmed customer names
- log and notify when admin changes confirmed name
- wire role checks through controllers and services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a07130e094832dad70bed084fd0391