### PR TITLE
Add Bucket4j rate limiting for customer API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
             <version>1.9.0</version>
         </dependency>
         <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.7.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.configuration;
 
 import com.project.tracking_system.service.user.LoginAttemptService;
+import com.project.tracking_system.utils.ApiRateLimitFilter;
 import com.project.tracking_system.utils.CspNonceFilter;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -57,18 +58,22 @@ public class SecurityConfiguration {
      * Метод конфигурирует фильтры и основные параметры Spring Security.
      * </p>
      *
-     * @param http           объект {@link HttpSecurity} для настройки безопасности
-     * @param cspNonceFilter фильтр добавления nonce для CSP
+     * @param http             объект {@link HttpSecurity} для настройки безопасности
+     * @param cspNonceFilter   фильтр добавления nonce для CSP
+     * @param apiRateLimitFilter фильтр ограничения частоты запросов
      * @return цепочка фильтров {@link SecurityFilterChain}
      * @throws Exception при ошибках конфигурации
      */
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, CspNonceFilter cspNonceFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   CspNonceFilter cspNonceFilter,
+                                                   ApiRateLimitFilter apiRateLimitFilter) throws Exception {
         // Если ключ не переопределён в конфигурации, выводим предупреждение
         if ("defaultKey".equals(rememberMeKey)) {
             log.warn("Используется значение по умолчанию для security.remember-me-key. Задайте уникальное значение в application.properties!");
         }
         http
+                .addFilterBefore(apiRateLimitFilter, SecurityContextPersistenceFilter.class)
                 .addFilterBefore(cspNonceFilter, SecurityContextPersistenceFilter.class)
                 .headers(h -> h
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)

--- a/src/main/java/com/project/tracking_system/service/ratelimit/Bucket4jRateLimiter.java
+++ b/src/main/java/com/project/tracking_system/service/ratelimit/Bucket4jRateLimiter.java
@@ -1,0 +1,82 @@
+package com.project.tracking_system.service.ratelimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Сервис ограничения частоты запросов на основе Bucket4j.
+ * <p>
+ * Поддерживает отдельные наборы лимитов для API покупателей и Telegram-хука,
+ * что упрощает расширение и настройку.
+ * </p>
+ */
+@Service
+public class Bucket4jRateLimiter {
+
+    /**
+     * Хранилище бакетов для операций над покупателями.
+     */
+    private final Map<String, Bucket> customerBuckets = new ConcurrentHashMap<>();
+
+    /**
+     * Хранилище бакетов для Telegram-хука.
+     */
+    private final Map<String, Bucket> telegramBuckets = new ConcurrentHashMap<>();
+
+    /**
+     * Лимит для стандартных запросов.
+     */
+    private final Bandwidth customerLimit;
+
+    /**
+     * Лимит для Telegram-хука.
+     */
+    private final Bandwidth telegramLimit;
+
+    /**
+     * Создает сервис с настраиваемыми параметрами лимитов.
+     *
+     * @param customerCapacity максимальное количество запросов к API покупателей
+     * @param customerInterval интервал восстановления лимита для покупателей
+     * @param telegramCapacity максимальное количество запросов Telegram-хука
+     * @param telegramInterval интервал восстановления лимита Telegram-хука
+     */
+    public Bucket4jRateLimiter(
+            @Value("${rate-limit.customers.capacity:50}") long customerCapacity,
+            @Value("${rate-limit.customers.interval-seconds:60}") long customerInterval,
+            @Value("${rate-limit.telegram.capacity:100}") long telegramCapacity,
+            @Value("${rate-limit.telegram.interval-seconds:60}") long telegramInterval
+    ) {
+        this.customerLimit = Bandwidth.simple(customerCapacity, Duration.ofSeconds(customerInterval));
+        this.telegramLimit = Bandwidth.simple(telegramCapacity, Duration.ofSeconds(telegramInterval));
+    }
+
+    /**
+     * Возвращает бакет для ключа покупателя, создавая его при необходимости.
+     *
+     * @param key идентификатор магазина или пользователя
+     * @return бакет с лимитом для операций над покупателями
+     */
+    public Bucket resolveCustomerBucket(String key) {
+        return customerBuckets.computeIfAbsent(key, k ->
+                Bucket4j.builder().addLimit(customerLimit).build());
+    }
+
+    /**
+     * Возвращает бакет для Telegram-хука.
+     *
+     * @param key произвольный ключ (например, IP источника)
+     * @return бакет с лимитом для Telegram-хука
+     */
+    public Bucket resolveTelegramBucket(String key) {
+        return telegramBuckets.computeIfAbsent(key, k ->
+                Bucket4j.builder().addLimit(telegramLimit).build());
+    }
+}

--- a/src/main/java/com/project/tracking_system/utils/ApiRateLimitFilter.java
+++ b/src/main/java/com/project/tracking_system/utils/ApiRateLimitFilter.java
@@ -1,0 +1,87 @@
+package com.project.tracking_system.utils;
+
+import com.project.tracking_system.service.ratelimit.Bucket4jRateLimiter;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Фильтр ограничения частоты запросов для API покупателей.
+ * <p>
+ * Проверяет POST-запросы к {@code /api/customers/**} по идентификаторам
+ * магазина или пользователя. Для Telegram-хука применяется отдельный,
+ * более мягкий лимит.
+ * </p>
+ */
+@Component
+@RequiredArgsConstructor
+public class ApiRateLimitFilter extends OncePerRequestFilter {
+
+    private static final String CUSTOMERS_PATH = "/api/customers";
+    private static final String TELEGRAM_HOOK_PATH = "/telegram/hook";
+
+    private final Bucket4jRateLimiter rateLimiter;
+
+    /**
+     * Определяет, нужно ли применять фильтр к текущему запросу.
+     * <p>
+     * Фильтр активен только для POST-запросов к путям {@code /api/customers/**}
+     * и {@code /telegram/hook}.
+     * </p>
+     *
+     * @param request обрабатываемый запрос
+     * @return {@code true}, если фильтр можно пропустить
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+        String uri = request.getRequestURI();
+        return !(uri.startsWith(CUSTOMERS_PATH) || uri.equals(TELEGRAM_HOOK_PATH));
+    }
+
+    /**
+     * Выполняет проверку лимита и либо продолжает цепочку, либо возвращает 429.
+     *
+     * @param request     обрабатываемый запрос
+     * @param response    ответ, в который при необходимости пишется ошибка
+     * @param filterChain дальнейшая цепочка фильтров
+     * @throws ServletException если произошла ошибка фильтрации
+     * @throws IOException      при ошибках ввода-вывода
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        Bucket bucket;
+        if (uri.equals(TELEGRAM_HOOK_PATH)) {
+            bucket = rateLimiter.resolveTelegramBucket("telegram");
+        } else {
+            String key = Optional.ofNullable(request.getParameter("storeId"))
+                    .orElse(request.getParameter("userId"));
+            if (key == null) {
+                key = request.getRemoteAddr();
+            }
+            bucket = rateLimiter.resolveCustomerBucket(key);
+        }
+
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        response.setStatus(HttpServletResponse.SC_TOO_MANY_REQUESTS);
+        response.setContentType("text/plain;charset=UTF-8");
+        response.getWriter().write("Превышен лимит запросов.");
+    }
+}


### PR DESCRIPTION
## Summary
- add Bucket4j dependency and service to manage buckets
- implement ApiRateLimitFilter for POST /api/customers/** and Telegram hook with 429 response
- wire filter into Spring Security chain

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a07383c300832d8c97744a9150f668