### PR TITLE
Mask PII in logging

### DIFF
--- a/src/main/java/com/project/tracking_system/logging/PiiMaskingFilter.java
+++ b/src/main/java/com/project/tracking_system/logging/PiiMaskingFilter.java
@@ -1,0 +1,56 @@
+package com.project.tracking_system.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import com.project.tracking_system.utils.EmailUtils;
+import com.project.tracking_system.utils.PhoneUtils;
+
+import java.util.regex.Pattern;
+
+/**
+ * Фильтр Logback, маскирующий персональные данные в логах.
+ * <p>
+ * Перед записью сообщения фильтр заменяет телефоны и email на маскированные значения.
+ * Это снижает риск утечки PII даже при забытых масках в коде.
+ * </p>
+ */
+public class PiiMaskingFilter extends Filter<ILoggingEvent> {
+
+    /** Паттерн распознавания телефонного номера. */
+    private static final Pattern PHONE_PATTERN = Pattern.compile("\\+?\\d{10,15}");
+    /** Паттерн распознавания email-адреса. */
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}");
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        if (!(event instanceof LoggingEvent loggingEvent)) {
+            return FilterReply.NEUTRAL;
+        }
+        String formatted = loggingEvent.getFormattedMessage();
+        String masked = mask(formatted);
+        if (!formatted.equals(masked)) {
+            loggingEvent.setMessage(masked);
+            loggingEvent.setArgumentArray(null);
+        }
+        return FilterReply.NEUTRAL;
+    }
+
+    /**
+     * Маскирует телефоны и email в переданном сообщении.
+     *
+     * @param message исходное сообщение
+     * @return сообщение с маскированными персональными данными
+     */
+    private String mask(String message) {
+        if (message == null) {
+            return null;
+        }
+        String result = PHONE_PATTERN.matcher(message)
+                .replaceAll(m -> PhoneUtils.maskPhone(m.group()));
+        result = EMAIL_PATTERN.matcher(result)
+                .replaceAll(m -> EmailUtils.maskEmail(m.group()));
+        return result;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerNameService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerNameService.java
@@ -43,7 +43,8 @@ public class CustomerNameService {
             Customer customer = customerService.registerOrGetByPhone(phone);
             customerService.updateCustomerName(customer, fullName, NameSource.MERCHANT_PROVIDED, Role.ROLE_USER);
         } catch (Exception e) {
-            log.warn("Не удалось обновить ФИО для телефона {}: {}", rawPhone, e.getMessage());
+            log.warn("Не удалось обновить ФИО для телефона {}: {}",
+                    PhoneUtils.maskPhone(rawPhone), e.getMessage());
         }
     }
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -9,7 +9,9 @@ import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.user.UserSettingsService;
 import com.project.tracking_system.service.customer.CustomerNameEventService;
 import com.project.tracking_system.model.subscription.FeatureKey;
+import com.project.tracking_system.utils.NameUtils;
 import com.project.tracking_system.utils.PhoneUtils;
+import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -42,6 +44,10 @@ public class CustomerService {
     private final CustomerNameEventService customerNameEventService;
     /** Клиент Telegram для отправки уведомлений. */
     private final TelegramClient telegramClient;
+
+    /** Фича-флаг для вывода маскированных ФИО в DEBUG. */
+    @Value("${debug.log-masked-fio:false}")
+    private boolean debugLogMaskedFio;
 
     /**
      * Зарегистрировать нового покупателя или получить существующего по телефону.
@@ -132,7 +138,11 @@ public class CustomerService {
                 log.warn("🚫 Попытка магазина изменить подтверждённое имя клиента ID={}", customer.getId());
                 throw new ConfirmedNameChangeException("Имя подтверждено пользователем");
             } else {
-                log.info("⚠️ Администратор изменяет подтверждённое имя клиента ID={} на '{}'", customer.getId(), newName);
+                log.info("⚠️ Администратор изменяет подтверждённое имя клиента ID={}", customer.getId());
+                if (debugLogMaskedFio && log.isDebugEnabled()) {
+                    log.debug("⚠️ Администратор изменяет подтверждённое имя клиента ID={} на '{}'",
+                            customer.getId(), NameUtils.maskName(newName));
+                }
                 notifyCustomer(customer, newName);
             }
         }

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
@@ -184,7 +184,7 @@ public class TrackMetaValidator {
         try {
             return PhoneUtils.normalizePhone(phone);
         } catch (Exception e) {
-            log.warn("Некорректный телефон '{}' пропущен", phone);
+            log.warn("Некорректный телефон '{}' пропущен", PhoneUtils.maskPhone(phone));
             return null;
         }
     }

--- a/src/main/java/com/project/tracking_system/utils/NameUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/NameUtils.java
@@ -1,0 +1,39 @@
+package com.project.tracking_system.utils;
+
+/**
+ * Утилиты для работы с ФИО.
+ * <p>
+ * Предоставляет методы для маскирования персональных данных.
+ * </p>
+ */
+public final class NameUtils {
+
+    private NameUtils() {
+    }
+
+    /**
+     * Маскирует ФИО, оставляя только первую букву каждого слова.
+     * Остальные символы заменяются на символ '*'.
+     *
+     * @param name исходное ФИО
+     * @return маскированное ФИО либо {@code null}, если входные данные пусты
+     */
+    public static String maskName(String name) {
+        if (name == null || name.isBlank()) {
+            return name;
+        }
+        String[] parts = name.trim().split("\\s+");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
+            sb.append(part.charAt(0));
+            if (part.length() > 1) {
+                sb.append("*".repeat(part.length() - 1));
+            }
+            if (i < parts.length - 1) {
+                sb.append(' ');
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,3 +63,6 @@ recaptcha.verify-url=https://www.google.com/recaptcha/api/siteverify
 # Rate limiting for contact form
 contact.rate-limit.max=5
 contact.rate-limit.window-ms=60000
+
+# Разрешить вывод маскированного ФИО в DEBUG-логах
+debug.log-masked-fio=false

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,12 +3,14 @@
     <property name="LOG_DIR" value="${LOG_DIR:-/default/path/to/logs}" />
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="com.project.tracking_system.logging.PiiMaskingFilter" />
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="fileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="com.project.tracking_system.logging.PiiMaskingFilter" />
         <file>${LOG_DIR}/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/application-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
@@ -29,6 +31,7 @@
 
     <!-- Логирование только ошибок в отдельный файл -->
     <appender name="errorFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="com.project.tracking_system.logging.PiiMaskingFilter" />
         <file>${LOG_DIR}/error.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/errors-%d{yyyy-MM-dd}.%i.log</fileNamePattern>


### PR DESCRIPTION
## Summary
- mask raw phone numbers in customer name handling and track validation
- prevent unmasked full names in INFO logs and gate masked DEBUG output behind a feature flag
- add Logback filter to sanitize phone and email patterns and provide name masking utility

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a079603de0832d93e4590e3bdf97e7