### PR TITLE
feat: handle pre-registered rows in Excel imports

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/PreRegistrationMeta.java
+++ b/src/main/java/com/project/tracking_system/service/track/PreRegistrationMeta.java
@@ -1,0 +1,15 @@
+package com.project.tracking_system.service.track;
+
+/**
+ * Данные для предрегистрации из Excel-файла.
+ * <p>
+ * Содержит нормализованный (при наличии) номер и идентификатор магазина,
+ * по которым {@link com.project.tracking_system.service.registration.PreRegistrationService}
+ * создаёт запись с флагом предрегистрации.
+ * </p>
+ *
+ * @param number  нормализованный номер трека, может быть {@code null}
+ * @param storeId идентификатор магазина
+ */
+public record PreRegistrationMeta(String number, Long storeId) {
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackExcelRow.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackExcelRow.java
@@ -6,10 +6,15 @@ package com.project.tracking_system.service.track;
  * Используется для хранения значений ячеек без предварительной обработки.
  * </p>
  *
- * @param number номер трека
- * @param store    значение ячейки магазина
- * @param phone    значение ячейки телефона
- * @param fullName значение ячейки ФИО
+ * @param number        номер трека
+ * @param store         значение ячейки магазина
+ * @param phone         значение ячейки телефона
+ * @param fullName      значение ячейки ФИО
+ * @param preRegistered признак предрегистрации
  */
-public record TrackExcelRow(String number, String store, String phone, String fullName) {
+public record TrackExcelRow(String number,
+                            String store,
+                            String phone,
+                            String fullName,
+                            boolean preRegistered) {
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidationResult.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidationResult.java
@@ -14,8 +14,10 @@ import java.util.List;
  * @param validTracks           список успешно прошедших проверку треков
  * @param invalidTracks         собранные некорректные строки из исходного файла
  * @param limitExceededMessage  сообщение о превышении лимитов (может быть {@code null})
+ * @param preRegistered         список данных для предрегистрации
  */
 public record TrackMetaValidationResult(List<TrackMeta> validTracks,
                                         List<InvalidTrack> invalidTracks,
-                                        String limitExceededMessage) {
+                                        String limitExceededMessage,
+                                        List<PreRegistrationMeta> preRegistered) {
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -21,6 +21,8 @@ import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.service.track.TrackMeta;
 import com.project.tracking_system.service.track.TrackMetaValidationResult;
 import com.project.tracking_system.service.track.InvalidTrack;
+import com.project.tracking_system.service.track.PreRegistrationMeta;
+import com.project.tracking_system.service.registration.PreRegistrationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -58,6 +60,8 @@ public class TrackUploadProcessorService {
     private final TrackingResultCacheService trackingResultCacheService;
     /** Кэш некорректных треков для восстановления таблицы. */
     private final InvalidTrackCacheService invalidTrackCacheService;
+    /** Сервис предрегистрации отправлений. */
+    private final PreRegistrationService preRegistrationService;
 
     /**
      * Принимает Excel-файл, валидирует строки и конвертирует их
@@ -85,15 +89,22 @@ public class TrackUploadProcessorService {
 
         List<TrackMeta> metas;
         List<InvalidTrack> invalid = List.of();
+        List<PreRegistrationMeta> preRegistered = List.of();
         String limitMessage = null;
 
         if (userId != null) {
             // Валидация данных и применение лимитов
             TrackMetaValidationResult validationResult = trackMetaValidator.validate(rows, userId);
             invalid = validationResult.invalidTracks();
+            preRegistered = validationResult.preRegistered();
             limitMessage = validationResult.limitExceededMessage();
             // Сохраняем список некорректных строк для возможного восстановления таблицы
             invalidTrackCacheService.addInvalidTracks(userId, batchId, invalid);
+
+            for (PreRegistrationMeta pr : preRegistered) {
+                // Передаём строки предрегистрации отдельному сервису
+                preRegistrationService.preRegister(pr.number(), pr.storeId(), userId);
+            }
 
             metas = validationResult.validTracks().stream()
                     .filter(m -> trackUpdateEligibilityService.canUpdate(m.number(), userId))
@@ -105,12 +116,20 @@ public class TrackUploadProcessorService {
         if (metas.isEmpty()) {
             // отправляем пустой прогресс, чтобы скрыть статусбар
             progressAggregatorService.registerBatch(batchId, 0, userId);
-            webSocketController.sendUpdateStatus(
-                    userId,
-                    "Ошибка — все треки невалидны",
-                    false
-            );
-            return new TrackMetaValidationResult(List.of(), invalid, limitMessage);
+            if (preRegistered.isEmpty()) {
+                webSocketController.sendUpdateStatus(
+                        userId,
+                        "Ошибка — все треки невалидны",
+                        false
+                );
+            } else {
+                webSocketController.sendUpdateStatus(
+                        userId,
+                        "Предрегистрации выполнены, треков для проверки нет",
+                        true
+                );
+            }
+            return new TrackMetaValidationResult(List.of(), invalid, limitMessage, preRegistered);
         }
 
         progressAggregatorService.registerBatch(batchId, metas.size(), userId);
@@ -168,7 +187,7 @@ public class TrackUploadProcessorService {
         String eta = DurationUtils.formatMinutesSeconds(duration);
         webSocketController.sendTrackProcessingStarted(userId,
                 new TrackProcessingStartedDTO(metas.size(), eta, waitEta));
-        return new TrackMetaValidationResult(metas, invalid, limitMessage);
+        return new TrackMetaValidationResult(metas, invalid, limitMessage, preRegistered);
     }
 
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackExcelParserTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackExcelParserTest.java
@@ -21,6 +21,7 @@ class TrackExcelParserTest {
         row1.createCell(1).setCellValue("1");
         row1.createCell(2).setCellValue("+375291234567");
         row1.createCell(3).setCellValue("Иван Иванов");
+        row1.createCell(4).setCellValue("0");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         wb.write(out);
         MockMultipartFile file = new MockMultipartFile("f", out.toByteArray());
@@ -33,5 +34,25 @@ class TrackExcelParserTest {
         assertEquals("1", rows.get(0).store());
         assertEquals("+375291234567", rows.get(0).phone());
         assertEquals("Иван Иванов", rows.get(0).fullName());
+        assertFalse(rows.get(0).preRegistered());
+    }
+
+    @Test
+    void parse_ReadsPreRegistrationFlag() throws Exception {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        var sheet = wb.createSheet();
+        sheet.createRow(0).createCell(0).setCellValue("num");
+        var row1 = sheet.createRow(1);
+        row1.createCell(0).setCellValue("");
+        row1.createCell(4).setCellValue("да");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        MockMultipartFile file = new MockMultipartFile("f", out.toByteArray());
+
+        TrackExcelParser parser = new TrackExcelParser();
+        List<TrackExcelRow> rows = parser.parse(file);
+
+        assertEquals(1, rows.size());
+        assertTrue(rows.get(0).preRegistered());
     }
 }


### PR DESCRIPTION
## Summary
- support pre-registrations from Excel via new boolean column
- validate and process pre-registered rows separately from tracked parcels
- forward pre-registered rows to dedicated service during upload

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af67343c8c832db84aa4aa07ff797f