### PR TITLE
feat: search customer by phone to avoid empty records

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -272,22 +272,39 @@ public class CustomerService {
     }
 
     /**
-     * Получить данные покупателя по номеру телефона.
+     * Найти покупателя по номеру телефона.
      * <p>
-     * Предусловие: телефон передаётся в произвольном формате и не должен быть {@code null} или пустым.
-     * Метод нормализует номер и ищет покупателя в репозитории.
+     * Номер нормализуется до формата {@code 375XXXXXXXXX}. При пустом значении
+     * возвращается {@link Optional#empty()}. Возможны исключения
+     * {@link IllegalArgumentException}, если номер не удаётся нормализовать.
      * </p>
      *
-     * @param phone телефон покупателя в произвольном формате
-     * @return Optional с информацией о покупателе или {@link Optional#empty()}, если клиент не найден
+     * @param rawPhone телефон в произвольном формате
+     * @return Optional с покупателем или {@link Optional#empty()}, если клиент не найден
+     * @throws IllegalArgumentException при неверном формате номера
      */
     @Transactional(readOnly = true)
-    public Optional<CustomerInfoDTO> getCustomerInfoByPhone(String phone) {
-        if (phone == null || phone.isBlank()) {
+    public Optional<Customer> findByPhone(String rawPhone) {
+        if (rawPhone == null || rawPhone.isBlank()) {
             return Optional.empty();
         }
-        String normalized = PhoneUtils.normalizePhone(phone);
-        return customerRepository.findByPhone(normalized).map(this::toInfoDto);
+        String phone = PhoneUtils.normalizePhone(rawPhone);
+        return customerRepository.findByPhone(phone);
+    }
+
+    /**
+     * Получить данные покупателя по номеру телефона.
+     * <p>
+     * Делегирует поиск методу {@link #findByPhone(String)} и не создаёт новых записей.
+     * </p>
+     *
+     * @param rawPhone телефон покупателя в произвольном формате
+     * @return Optional с информацией о покупателе или {@link Optional#empty()}, если клиент не найден
+     * @throws IllegalArgumentException при некорректном формате номера
+     */
+    @Transactional(readOnly = true)
+    public Optional<CustomerInfoDTO> getCustomerInfoByPhone(String rawPhone) {
+        return findByPhone(rawPhone).map(this::toInfoDto);
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerServiceTest.java
@@ -107,4 +107,30 @@ class CustomerServiceTest {
         verify(transactionalService, times(4)).findByPhone("375291234567");
 
     }
+
+    /**
+     * Проверяем, что поиск по телефону нормализует номер и обращается к репозиторию.
+     */
+    @Test
+    void findByPhone_NormalizesAndDelegatesToRepository() {
+        when(customerRepository.findByPhone("375291234567"))
+                .thenReturn(Optional.of(savedCustomer));
+
+        Optional<Customer> result = service.findByPhone("+375 (29) 123-45-67");
+
+        assertTrue(result.isPresent());
+        assertSame(savedCustomer, result.get());
+        verify(customerRepository).findByPhone("375291234567");
+    }
+
+    /**
+     * Если номер пустой, репозиторий не вызывается и возвращается пустой результат.
+     */
+    @Test
+    void findByPhone_BlankPhone_ReturnsEmpty() {
+        Optional<Customer> result = service.findByPhone("   ");
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(customerRepository);
+    }
 }


### PR DESCRIPTION
## Summary
- add `findByPhone` with phone normalization in `CustomerService`
- reuse phone search in customer info API to prevent creating blank customers
- cover phone search with unit tests

## Testing
- `mvn -q test` *(fails: Network is unreachable for dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68af7cc94524832d8217ee3594ea8834