### PR TITLE
Verify and disable full name editing for confirmed customers

### DIFF
--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -78,7 +78,8 @@
                                 <label class="form-check-label" for="togglePreRegistration">Предрегистрация</label>
                             </div>
                             <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" id="toggleFullName">
+                                <input class="form-check-input" type="checkbox" id="toggleFullName"
+                                       th:attr="disabled=${fullNameReadOnly}? 'disabled' : null">
                                 <label class="form-check-label" for="toggleFullName">Указать ФИО</label>
                             </div>
                         </div>
@@ -92,7 +93,7 @@
                         </div>
 
                         <!-- Блок поля ввода ФИО подключается через фрагмент -->
-                        <div th:replace="~{partials/full-name-input :: fullNameBlock(false)}"></div>
+                        <div th:replace="~{partials/full-name-input :: fullNameBlock(${fullNameReadOnly})}"></div>
                     </form>
 
                     <hr class="my-3">

--- a/src/main/resources/templates/partials/full-name-input.html
+++ b/src/main/resources/templates/partials/full-name-input.html
@@ -4,6 +4,7 @@
     <div class="input-group">
         <input type="text" id="fullName" name="fullName" class="form-control"
                placeholder="Иванов Иван Иванович"
+               th:value="${customerFullName}"
                th:attr="readonly=${readonlyFlag}? 'readonly' : null">
     </div>
     <small id="fullNameHint" class="form-text text-muted d-none">

--- a/src/test/java/com/project/tracking_system/controller/HomeControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/HomeControllerTest.java
@@ -1,0 +1,78 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.CustomerInfoDTO;
+import com.project.tracking_system.entity.BuyerReputation;
+import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.service.customer.CustomerService;
+import com.project.tracking_system.service.registration.PreRegistrationService;
+import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.track.BelPostManualService;
+import com.project.tracking_system.service.track.TrackFacade;
+import com.project.tracking_system.service.track.TrackServiceClassifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+/**
+ * Тесты для {@link HomeController}.
+ */
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(HomeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class HomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TrackFacade trackFacade;
+    @MockBean
+    private StoreService storeService;
+    @MockBean
+    private TrackServiceClassifier trackServiceClassifier;
+    @MockBean
+    private BelPostManualService belPostManualService;
+    @MockBean
+    private PreRegistrationService preRegistrationService;
+    @MockBean
+    private CustomerService customerService;
+
+    /**
+     * Проверяем, что при подтверждённом пользователем имени поле ФИО
+     * отображается только для чтения, а переключатель отключён.
+     *
+     * Предусловие: покупатель с указанным телефоном найден и подтвердил своё имя.
+     * Ожидаемое поведение: HTML содержит атрибуты readonly и disabled.
+     */
+    @Test
+    void home_WithConfirmedName_DisablesEditing() throws Exception {
+        CustomerInfoDTO dto = new CustomerInfoDTO(
+                "375291112233",
+                "Иван Иванов",
+                NameSource.USER_CONFIRMED,
+                0, 0, 0,
+                0.0,
+                BuyerReputation.RELIABLE
+        );
+        when(customerService.getCustomerInfoByPhone("375291112233"))
+                .thenReturn(Optional.of(dto));
+
+        mockMvc.perform(get("/app").param("phone", "375291112233"))
+                .andExpect(status().isOk())
+                .andExpect(xpath("//input[@id='fullName'][@readonly]").exists())
+                .andExpect(xpath("//input[@id='toggleFullName'][@disabled]").exists());
+    }
+}


### PR DESCRIPTION
## Summary
- prefill customer data on home page and block name editing when user-confirmed
- render full-name fragment in read-only mode and disable toggle
- test that confirmed name makes full name field read-only

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e1b9afc832d86f15473b26e91dc