### PR TITLE
Allow null tracking number during pre-registration

### DIFF
--- a/src/main/resources/db/migration/V11__allow_null_tracking_number.sql
+++ b/src/main/resources/db/migration/V11__allow_null_tracking_number.sql
@@ -1,0 +1,3 @@
+-- Разрешить хранение NULL в колонке tracking_number для предрегистрации
+ALTER TABLE tb_track_parcels
+    ALTER COLUMN tracking_number DROP NOT NULL;

--- a/src/test/java/com/project/tracking_system/service/registration/PreRegistrationServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/registration/PreRegistrationServiceTest.java
@@ -1,0 +1,66 @@
+package com.project.tracking_system.service.registration;
+
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.UserRepository;
+import com.project.tracking_system.service.store.StoreService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link PreRegistrationService}.
+ * Проверяется, что при пустом трек‑номере
+ * в базу сохраняется {@code null}.
+ */
+@ExtendWith(MockitoExtension.class)
+class PreRegistrationServiceTest {
+
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private StoreService storeService;
+
+    private PreRegistrationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PreRegistrationService(trackParcelRepository, userRepository, storeService);
+    }
+
+    /**
+     * Убеждаемся, что пустой номер не пытается сохраниться как строка
+     * и остаётся {@code null}.
+     */
+    @Test
+    void preRegister_BlankNumber_StoredAsNull() {
+        // Подготовка данных
+        long storeId = 1L;
+        long userId = 2L;
+        when(storeService.getStore(storeId, userId)).thenReturn(new Store());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
+        when(trackParcelRepository.save(any(TrackParcel.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // Выполнение
+        TrackParcel result = service.preRegister("   ", storeId, userId);
+
+        // Проверка
+        assertNull(result.getNumber(), "Трек-номер должен быть null при предрегистрации");
+        ArgumentCaptor<TrackParcel> captor = ArgumentCaptor.forClass(TrackParcel.class);
+        verify(trackParcelRepository).save(captor.capture());
+        assertNull(captor.getValue().getNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- Allow storing null tracking numbers for pre-registered parcels via migration
- Add unit test verifying blank numbers are persisted as null

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af98fbc2a0832d89a928722ea1c69a