### PR TITLE
Fix date formatting in customer info modal

### DIFF
--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -98,7 +98,8 @@
                     <div class="modal-body">
                         <ul class="list-group" th:if="${!events.isEmpty()}">
                             <li class="list-group-item" th:each="ev : ${events}">
-                                <span th:text="${#dates.format(ev.createdAt, 'dd.MM.yyyy HH:mm')}"></span>
+                                <!-- Форматируем дату события с учётом поддержки java.time -->
+                                <span th:text="${#temporals.format(ev.createdAt, 'dd.MM.yyyy HH:mm')}"></span>
                                 <span class="ms-2" th:text="${ev.status}"></span>
                             </li>
                         </ul>


### PR DESCRIPTION
## Summary
- Use `#temporals.format` to format event dates in customer modal
- Add comment explaining Java time formatting

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68affe0ff8e4832db63b89e4c6a253aa