### PR TITLE
Bind pre-registered parcels to customers without tracking numbers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/HomeController.java
+++ b/src/main/java/com/project/tracking_system/controller/HomeController.java
@@ -121,7 +121,7 @@ public class HomeController {
 
         // Предрегистрация обходится без обращений к почтовым сервисам
         if (Boolean.TRUE.equals(preRegistered)) {
-            handlePreRegistration(true, normalizedNumber, storeId, userId);
+            handlePreRegistration(true, normalizedNumber, storeId, userId, phone);
             if (normalizedNumber == null || normalizedNumber.isBlank()) {
                 model.addAttribute("successMessage", "Предрегистрация выполнена без номера.");
             } else {
@@ -207,11 +207,12 @@ public class HomeController {
     private void handlePreRegistration(Boolean preRegistered,
                                        String number,
                                        Long storeId,
-                                       Long userId) {
+                                       Long userId,
+                                       String phone) {
         if (preRegistered == null || !preRegistered) {
             return;
         }
-        preRegistrationService.preRegister(number, storeId, userId);
+        preRegistrationService.preRegister(number, storeId, userId, phone);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/track/PreRegistrationMeta.java
+++ b/src/main/java/com/project/tracking_system/service/track/PreRegistrationMeta.java
@@ -10,6 +10,7 @@ package com.project.tracking_system.service.track;
  *
  * @param number  нормализованный номер трека, может быть {@code null}
  * @param storeId идентификатор магазина
+ * @param phone   нормализованный номер телефона покупателя, может быть {@code null}
  */
-public record PreRegistrationMeta(String number, Long storeId) {
+public record PreRegistrationMeta(String number, Long storeId, String phone) {
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackMetaValidator.java
@@ -87,7 +87,13 @@ public class TrackMetaValidator {
             if (row.preRegistered()) {
                 String normalized = row.number() == null ? null : TrackNumberUtils.normalize(row.number());
                 Long storeId = parseStoreId(row.store(), defaultStoreId, userId);
-                preRegistered.add(new PreRegistrationMeta(normalized, storeId));
+                String phone = normalizePhone(row.phone());
+                String fullName = row.fullName();
+                if (phone != null && fullName != null && !fullName.isBlank()) {
+                    // Обновляем имя покупателя, если оно передано вместе с телефоном
+                    customerNameService.upsertFromStore(phone, fullName);
+                }
+                preRegistered.add(new PreRegistrationMeta(normalized, storeId, phone));
                 continue;
             }
             String raw = row.number();

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -103,7 +103,7 @@ public class TrackUploadProcessorService {
 
             for (PreRegistrationMeta pr : preRegistered) {
                 // Передаём строки предрегистрации отдельному сервису
-                preRegistrationService.preRegister(pr.number(), pr.storeId(), userId);
+                preRegistrationService.preRegister(pr.number(), pr.storeId(), userId, pr.phone());
             }
 
             metas = validationResult.validTracks().stream()

--- a/src/test/java/com/project/tracking_system/service/registration/PreRegistrationServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/registration/PreRegistrationServiceTest.java
@@ -3,9 +3,11 @@ package com.project.tracking_system.service.registration;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserRepository;
 import com.project.tracking_system.service.store.StoreService;
+import com.project.tracking_system.service.customer.CustomerService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -33,12 +36,14 @@ class PreRegistrationServiceTest {
     private UserRepository userRepository;
     @Mock
     private StoreService storeService;
+    @Mock
+    private CustomerService customerService;
 
     private PreRegistrationService service;
 
     @BeforeEach
     void setUp() {
-        service = new PreRegistrationService(trackParcelRepository, userRepository, storeService);
+        service = new PreRegistrationService(trackParcelRepository, userRepository, storeService, customerService);
     }
 
     /**
@@ -53,6 +58,7 @@ class PreRegistrationServiceTest {
         when(storeService.getStore(storeId, userId)).thenReturn(new Store());
         when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
         when(trackParcelRepository.save(any(TrackParcel.class))).thenAnswer(inv -> inv.getArgument(0));
+        doNothing().when(customerService).updateStatsOnTrackAdd(any());
 
         // Выполнение
         TrackParcel result = service.preRegister("   ", storeId, userId);
@@ -62,5 +68,31 @@ class PreRegistrationServiceTest {
         ArgumentCaptor<TrackParcel> captor = ArgumentCaptor.forClass(TrackParcel.class);
         verify(trackParcelRepository).save(captor.capture());
         assertNull(captor.getValue().getNumber());
+    }
+
+    /**
+     * При наличии телефона посылка связывается с покупателем.
+     */
+    @Test
+    void preRegister_WithPhone_AssignsCustomer() {
+        long storeId = 1L;
+        long userId = 2L;
+        String phone = "+375291234567";
+        Store store = new Store();
+        User user = new User();
+        Customer customer = new Customer();
+
+        when(storeService.getStore(storeId, userId)).thenReturn(store);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(customerService.registerOrGetByPhone(phone)).thenReturn(customer);
+        when(trackParcelRepository.save(any(TrackParcel.class))).thenAnswer(inv -> inv.getArgument(0));
+        doNothing().when(customerService).updateStatsOnTrackAdd(any());
+
+        TrackParcel result = service.preRegister(null, storeId, userId, phone);
+
+        verify(customerService).registerOrGetByPhone(phone);
+        verify(customerService).updateStatsOnTrackAdd(result);
+        assertNull(result.getNumber());
+        assertEquals(customer, result.getCustomer());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackMetaValidatorTest.java
@@ -191,5 +191,6 @@ class TrackMetaValidatorTest {
         assertTrue(result.invalidTracks().isEmpty());
         assertEquals(1, result.preRegistered().size());
         assertEquals(1L, result.preRegistered().get(0).storeId());
+        assertNull(result.preRegistered().get(0).phone());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -174,14 +174,14 @@ class TrackUploadProcessorServiceTest {
     @Test
     void process_HandlesPreRegisteredRows() throws Exception {
         MockMultipartFile file = new MockMultipartFile("f", new byte[0]);
-        PreRegistrationMeta pre = new PreRegistrationMeta(null, 1L);
+        PreRegistrationMeta pre = new PreRegistrationMeta(null, 1L, null);
         when(parser.parse(file)).thenReturn(List.of(new TrackExcelRow(null, "1", null, null, true)));
         when(trackMetaValidator.validate(anyList(), eq(1L)))
                 .thenReturn(new TrackMetaValidationResult(List.of(), List.of(), null, List.of(pre)));
 
         TrackMetaValidationResult result = processor.process(file, 1L);
 
-        verify(preRegistrationService).preRegister(null, 1L, 1L);
+        verify(preRegistrationService).preRegister(null, 1L, 1L, null);
         assertEquals(1, result.preRegistered().size());
     }
 }


### PR DESCRIPTION
## Summary
- link pre-registered parcels to existing or new customers by phone
- propagate phone through upload validation and processing
- expand tests for pre-registration with customer binding

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afffad741c832d92e55fabd5a58d93