### PR TITLE
Allow deleting preregistered parcels without tracking numbers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -256,21 +256,47 @@ public class DeparturesController {
      * @param user            текущий пользователь
      * @return перенаправление на страницу истории.
      */
+    /**
+     * Удаляет выбранные пользователем посылки.
+     * <p>
+     * Удаление может происходить как по трек-номерам, так и по идентификаторам
+     * (для предрегистрационных посылок без номера).
+     * </p>
+     *
+     * @param selectedNumbers список трек-номеров
+     * @param selectedIds     список идентификаторов посылок
+     * @param user            текущий пользователь
+     * @return результат операции удаления
+     */
     @PostMapping("/delete-selected")
     public ResponseEntity<?> deleteSelected(
-            @RequestParam List<String> selectedNumbers,
+            @RequestParam(value = "selectedNumbers", required = false) List<String> selectedNumbers,
+            @RequestParam(value = "selectedIds", required = false) List<Long> selectedIds,
             @AuthenticationPrincipal User user) {
         Long userId = user.getId();
-        log.info("Запрос на удаление посылок {} для пользователя с ID: {}", selectedNumbers, userId);
+        log.info("Запрос на удаление посылок {} и ID {} для пользователя с ID: {}", selectedNumbers, selectedIds, userId);
 
-        if (selectedNumbers == null || selectedNumbers.isEmpty()) {
+        boolean hasNumbers = selectedNumbers != null && selectedNumbers.stream().anyMatch(num -> num != null && !num.isBlank());
+        boolean hasIds = selectedIds != null && !selectedIds.isEmpty();
+
+        if (!hasNumbers && !hasIds) {
             log.warn("Попытка удаления без выбранных посылок пользователем с ID: {}", userId);
             return ResponseBuilder.error(HttpStatus.BAD_REQUEST, "Ошибка: Не выбраны посылки для удаления.");
         }
 
         try {
-            trackFacade.deleteByNumbersAndUserId(selectedNumbers, userId);
-            log.info("Выбранные посылки {} удалены пользователем с ID: {}", selectedNumbers, userId);
+            if (hasNumbers) {
+                List<String> filteredNumbers = selectedNumbers.stream()
+                        .filter(num -> num != null && !num.isBlank())
+                        .toList();
+                if (!filteredNumbers.isEmpty()) {
+                    trackFacade.deleteByNumbersAndUserId(filteredNumbers, userId);
+                }
+            }
+            if (hasIds) {
+                trackFacade.deleteByIdsAndUserId(selectedIds, userId);
+            }
+            log.info("Выбранные посылки удалены пользователем с ID: {}", userId);
             webSocketController.sendUpdateStatus(userId, "Выбранные посылки успешно удалены.", true);
             return ResponseBuilder.ok("Выбранные посылки успешно удалены.");
         } catch (EntityNotFoundException ex) {
@@ -278,7 +304,7 @@ public class DeparturesController {
             webSocketController.sendUpdateStatus(userId, ex.getMessage(), false);
             return ResponseBuilder.error(HttpStatus.NOT_FOUND, ex.getMessage());
         } catch (Exception e) {
-            log.error("Ошибка при удалении посылок {} пользователем с ID: {}: {}", selectedNumbers, userId, e.getMessage(), e);
+            log.error("Ошибка при удалении посылок пользователем с ID: {}: {}", userId, e.getMessage(), e);
             webSocketController.sendUpdateStatus(userId, "Ошибка при удалении посылок.", false);
             return ResponseBuilder.error(HttpStatus.INTERNAL_SERVER_ERROR, "Ошибка при удалении посылок.");
         }

--- a/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackParcelRepository.java
@@ -29,6 +29,7 @@ public interface TrackParcelRepository extends JpaRepository<TrackParcel, Long> 
     TrackParcel findByNumberAndUserId(String number, Long userId);
 
     List<TrackParcel> findByNumberInAndUserId(List<String> numbers, Long userId);
+    List<TrackParcel> findByIdInAndUserId(List<Long> ids, Long userId);
 
     TrackParcel findByNumberAndStoreIdAndUserId(String number, Long storeId, Long userId);
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackFacade.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackFacade.java
@@ -107,4 +107,14 @@ public class TrackFacade {
         trackDeletionService.deleteByNumbersAndUserId(numbers, userId);
     }
 
+    /**
+     * Удаляет треки пользователя по их идентификаторам.
+     *
+     * @param ids    список идентификаторов посылок
+     * @param userId идентификатор пользователя
+     */
+    public void deleteByIdsAndUserId(List<Long> ids, Long userId) {
+        trackDeletionService.deleteByIdsAndUserId(ids, userId);
+    }
+
 }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1942,13 +1942,22 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // === Обработчик кнопки "Применить" ===
     document.getElementById("applyActionBtn")?.addEventListener("click", function () {
-        const selectedNumbers = Array.from(document.querySelectorAll(".selectCheckbox:checked"))
-            .map(checkbox => checkbox.value);
+        const selectedCheckboxes = Array.from(document.querySelectorAll(".selectCheckbox:checked"));
+        const selectedNumbers = [];
+        const selectedIds = [];
+
+        selectedCheckboxes.forEach(cb => {
+            if (cb.value) {
+                selectedNumbers.push(cb.value);
+            } else if (cb.dataset.id) {
+                selectedIds.push(cb.dataset.id);
+            }
+        });
 
         const selectedAction = document.getElementById("actionSelect").value;
         const applyBtn = document.getElementById("applyActionBtn");
 
-        if (selectedNumbers.length === 0) {
+        if (selectedNumbers.length === 0 && selectedIds.length === 0) {
             notifyUser("Выберите хотя бы одну посылку.", "warning");
             return;
         }
@@ -1962,7 +1971,7 @@ document.addEventListener("DOMContentLoaded", function () {
         applyBtn.innerHTML = '<i class="bi bi-arrow-repeat spin"></i> Выполняется...';
 
         if (selectedAction === "delete") {
-            sendDeleteRequest(selectedNumbers, applyBtn);
+            sendDeleteRequest(selectedNumbers, selectedIds, applyBtn);
         } else if (selectedAction === "update") {
             sendUpdateRequest(selectedNumbers, applyBtn);
         }
@@ -2083,12 +2092,13 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     // === Функция отправки запроса на удаление ===
-    function sendDeleteRequest(selectedNumbers, applyBtn) {
+    function sendDeleteRequest(selectedNumbers, selectedIds, applyBtn) {
         applyBtn.disabled = true;
         applyBtn.innerHTML = "Удаление...";
 
         const formData = new URLSearchParams();
         selectedNumbers.forEach(number => formData.append("selectedNumbers", number));
+        selectedIds.forEach(id => formData.append("selectedIds", id));
 
         fetch("/app/departures/delete-selected", {
             method: "POST",

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -130,8 +130,8 @@
                                     <tbody>
                                     <tr th:each="item : ${trackParcelDTO}" th:attr="data-track-number=${item.number},data-track-id=${item.id}">
                                         <td class="checkbox-column">
-                                            <input type="checkbox" class="selectCheckbox" th:value="${item.number}" name="selectedNumbers"
-                                                   th:disabled="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}">
+                                            <input type="checkbox" class="selectCheckbox" th:value="${item.number}"
+                                                   th:data-id="${item.id}" name="selectedNumbers">
                                             <span th:if="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}"
                                                   class="badge bg-warning ms-2">Пропущено: нет трека</span>
                                         </td>


### PR DESCRIPTION
## Summary
- Enable selection of preregistered parcels without track numbers and transmit their IDs
- Support parcel deletion by IDs on server side
- Add unit tests for deletion by IDs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0082c39f0832daa2d7638b639b7b9