### PR TITLE
Handle deletion for parcels without numbers

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1946,11 +1946,12 @@ document.addEventListener("DOMContentLoaded", function () {
         const selectedNumbers = [];
         const selectedIds = [];
 
+        // Раскладываем выбранные значения по массивам согласно имени чекбокса
         selectedCheckboxes.forEach(cb => {
-            if (cb.value) {
+            if (cb.name === "selectedNumbers") {
                 selectedNumbers.push(cb.value);
-            } else if (cb.dataset.id) {
-                selectedIds.push(cb.dataset.id);
+            } else if (cb.name === "selectedIds") {
+                selectedIds.push(cb.value);
             }
         });
 
@@ -2091,7 +2092,12 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
-    // === Функция отправки запроса на удаление ===
+    /**
+     * Отправляет запрос на массовое удаление выбранных отправлений.
+     * @param {string[]} selectedNumbers - номера треков для удаления
+     * @param {string[]} selectedIds - идентификаторы предрегистрационных отправлений
+     * @param {HTMLElement} applyBtn - кнопка запуска действия
+     */
     function sendDeleteRequest(selectedNumbers, selectedIds, applyBtn) {
         applyBtn.disabled = true;
         applyBtn.innerHTML = "Удаление...";

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -130,8 +130,11 @@
                                     <tbody>
                                     <tr th:each="item : ${trackParcelDTO}" th:attr="data-track-number=${item.number},data-track-id=${item.id}">
                                         <td class="checkbox-column">
-                                            <input type="checkbox" class="selectCheckbox" th:value="${item.number}"
-                                                   th:data-id="${item.id}" name="selectedNumbers">
+                                            <!-- Чекбокс выбора: при отсутствии номера используем ID -->
+                                            <input type="checkbox" class="selectCheckbox"
+                                                   th:name="${#strings.isEmpty(item.number) ? 'selectedIds' : 'selectedNumbers'}"
+                                                   th:value="${#strings.isEmpty(item.number) ? item.id : item.number}"
+                                                   th:data-id="${item.id}">
                                             <span th:if="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}"
                                                   class="badge bg-warning ms-2">Пропущено: нет трека</span>
                                         </td>


### PR DESCRIPTION
## Summary
- Support selecting parcels without track numbers by sending their IDs
- Use checkbox name to group selected numbers and IDs
- Document delete-request helper

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b011d4ecb4832d8077384ff546edac