### PR TITLE
feat: handle empty track number

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TypeDefinitionTrackPostService.java
@@ -43,6 +43,11 @@ public class TypeDefinitionTrackPostService {
      * <p>Возвращает {@link PostalServiceType#UNKNOWN}, если шаблон не подходит.</p>
      */
     public PostalServiceType detectPostalService(String number) {
+        // Если номер не указан или состоит из пробелов, считаем службу неизвестной
+        if (number == null || number.isBlank()) {
+            return PostalServiceType.UNKNOWN;
+        }
+
         if (number.matches("^(PC|BV|BP|PE)\\d{9}BY$")) {
             return PostalServiceType.BELPOST;
         }


### PR DESCRIPTION
## Summary
- return UNKNOWN when track number is null or blank in detectPostalService

## Testing
- `mvn -q -Dtest=com.project.tracking_system.service.track.*Test test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b022542da8832daab9d0827e90003e