### PR TITLE
test: allow deletion by ids with null numbers

### DIFF
--- a/src/test/java/com/project/tracking_system/service/track/TrackDeletionServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackDeletionServiceTest.java
@@ -101,6 +101,30 @@ class TrackDeletionServiceTest {
     }
 
     /**
+     * Проверяет, что удаление допускает посылки без номера и статусом {@code PRE_REGISTERED}.
+     */
+    @Test
+    void deleteByIdsAndUserId_AllowsNullNumbers() {
+        List<Long> ids = List.of(3L);
+
+        // Подготавливаем посылку без номера и с предварительной регистрацией
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber(null);
+        parcel.setStatus(GlobalStatus.PRE_REGISTERED);
+
+        List<TrackParcel> parcels = List.of(parcel);
+        when(trackParcelRepository.findByIdInAndUserId(ids, 1L)).thenReturn(parcels);
+
+        // Убедимся, что выполнение не приводит к исключениям
+        assertDoesNotThrow(() -> service.deleteByIdsAndUserId(ids, 1L));
+
+        // Проверяем, что были вызваны необходимые зависимости
+        verify(trackParcelRepository).findByIdInAndUserId(ids, 1L);
+        verify(deliveryHistoryService).handleTrackParcelBeforeDelete(parcel);
+        verify(trackParcelRepository).deleteAll(parcels);
+    }
+
+    /**
      * Создаёт тестовую посылку с историей доставки.
      */
     private static TrackParcel buildParcel(String number) {


### PR DESCRIPTION
## Summary
- add test ensuring deletion by IDs handles parcels without numbers

## Testing
- `mvn -q -Dtest=TrackDeletionServiceTest test` *(fails: Non-resolvable parent POM due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b025ba0a10832d993aba4238f9b8f6