### PR TITLE
refactor: add event delegation for track number

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -61,6 +61,14 @@ function promptTrackNumber(id) {
 // Экспортируем функцию, чтобы она была доступна из HTML-разметки
 window.promptTrackNumber = promptTrackNumber;
 
+// Делегируем клики по кнопкам добавления трек‑номера, исключая уже открывающие модали
+document.body.addEventListener('click', e => {
+    const btn = e.target.closest('button.parcel-number:not(.open-modal)');
+    if (btn) {
+        promptTrackNumber(btn.dataset.id);
+    }
+});
+
 /**
  * Копирует текст в буфер обмена и показывает уведомление о результате.
  * @param {string} text - копируемый текст

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -150,7 +150,7 @@
                                                         th:data-id="${item.id}"
                                                         title="Добавьте трек-номер, чтобы начать обновлять"
                                                         data-bs-toggle="tooltip"
-                                                        onclick="promptTrackNumber(this.dataset.id)">Указать трек</button>
+                                                        >Указать трек</button>
                                                 <button th:unless="${item.status == 'Предрегистрация' and #strings.isEmpty(item.number)}" type="button" class="btn btn-link parcel-number open-modal"
                                                         th:text="${item.number}"
                                                         th:data-itemnumber="${item.number}"


### PR DESCRIPTION
## Summary
- remove inline handler from departures track button
- delegate parcel number button clicks to prompt track number
- expose promptTrackNumber on window

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b02fbe43c0832db34e5a1bb1b9e61b