### PR TITLE
Route track number button clicks through main body handler

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -61,14 +61,6 @@ function promptTrackNumber(id) {
 // Экспортируем функцию, чтобы она была доступна из HTML-разметки
 window.promptTrackNumber = promptTrackNumber;
 
-// Делегируем клики по кнопкам добавления трек‑номера, исключая уже открывающие модали
-document.body.addEventListener('click', e => {
-    const btn = e.target.closest('button.parcel-number:not(.open-modal)');
-    if (btn) {
-        promptTrackNumber(btn.dataset.id);
-    }
-});
-
 /**
  * Отправляет трек-номер на сервер и обновляет интерфейс.
  * @param {SubmitEvent} event событие отправки формы
@@ -1209,7 +1201,19 @@ function enableTooltips(root = document) {
 
         // === Клик/Тап для мобильных устройств ===
         tooltipTriggerEl.addEventListener("click", function (e) {
-            // Останавливаем всплытие, чтобы глобальный обработчик клика не сработал сразу
+            // Для кнопок ввода трек-номера разрешаем всплытие,
+            // чтобы внешний обработчик тела открыл модальное окно
+            if (tooltipTriggerEl.classList.contains('parcel-number')) {
+                if (activeTooltip === newTooltip) {
+                    newTooltip.hide();
+                    activeTooltip = null;
+                }
+                // Не останавливаем событие и не показываем подсказку вручную
+                return;
+            }
+
+            // Для остальных элементов блокируем всплытие,
+            // чтобы глобальный обработчик не закрыл tooltip мгновенно
             e.stopPropagation();
             if (activeTooltip === newTooltip) {
                 newTooltip.hide();
@@ -1851,6 +1855,15 @@ document.addEventListener("DOMContentLoaded", function () {
      */
     document.body.addEventListener("click", function (event) {
         const target = event.target;
+
+        // Перехватываем клики по кнопкам добавления трек-номера,
+        // которые ещё не открывали модальное окно
+        const trackBtn = event.target.closest('button.parcel-number:not(.open-modal)');
+        if (trackBtn) {
+            // Показываем модаль с вводом трек-номера
+            promptTrackNumber(trackBtn.dataset.id);
+            return;
+        }
 
         // Открытие модального окна с деталями отправления
         // Ищем только элементы с классом .open-modal, чтобы не перехватывать клики по другим кнопкам


### PR DESCRIPTION
## Summary
- Remove separate click delegate for track number buttons
- Handle parcel-number clicks in main body listener to open track number modal
- Let parcel-number tooltips bubble clicks so modal opens correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b03a387d10832da12b2fe8d33ce0c3