### PR TITLE
Prevent duplicate track numbers for pre-registered parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -22,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import com.project.tracking_system.utils.ResponseBuilder;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -242,8 +243,13 @@ public class DeparturesController {
             @RequestParam Long id,
             @RequestParam String number,
             @AuthenticationPrincipal User user) {
-        trackParcelService.assignTrackNumber(id, number, user.getId());
-        return ResponseBuilder.ok("Трек-номер добавлен");
+        try {
+            trackParcelService.assignTrackNumber(id, number, user.getId());
+            return ResponseBuilder.ok("Трек-номер добавлен");
+        } catch (TrackNumberAlreadyExistsException e) {
+            log.warn("Попытка добавить уже существующий трек-номер: {} для пользователя {}", number, user.getId());
+            return ResponseBuilder.error(HttpStatus.CONFLICT, e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/exception/TrackNumberAlreadyExistsException.java
+++ b/src/main/java/com/project/tracking_system/exception/TrackNumberAlreadyExistsException.java
@@ -1,0 +1,17 @@
+package com.project.tracking_system.exception;
+
+/**
+ * Исключение, указывающее на попытку присвоить трек-номер,
+ * который уже существует у пользователя.
+ */
+public class TrackNumberAlreadyExistsException extends RuntimeException {
+
+    /**
+     * Создаёт исключение с указанным сообщением.
+     *
+     * @param message описание ошибки
+     */
+    public TrackNumberAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackParcelService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.utils.PhoneUtils;
+import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -368,8 +369,11 @@ public class TrackParcelService {
      * Присваивает трек-номер предварительно зарегистрированной посылке пользователя.
      * <p>
      * Метод проверяет принадлежность посылки пользователю и наличие статуса
-     * предварительной регистрации. В случае отсутствия посылки или
-     * несоответствия владельца выбрасывается {@link EntityNotFoundException}.
+     * предварительной регистрации. Дополнительно выполняется проверка
+     * уникальности трек-номера для данного пользователя. В случае отсутствия
+     * посылки или несоответствия владельца выбрасывается
+     * {@link EntityNotFoundException}, а при обнаружении дубликата номера —
+     * {@link TrackNumberAlreadyExistsException}.
      * </p>
      *
      * @param parcelId идентификатор посылки
@@ -381,6 +385,9 @@ public class TrackParcelService {
         TrackParcel parcel = trackParcelRepository.findByIdAndPreRegisteredTrue(parcelId);
         if (parcel == null || !parcel.getUser().getId().equals(userId)) {
             throw new EntityNotFoundException("Посылка не найдена");
+        }
+        if (trackParcelRepository.existsByNumberAndUserId(number, userId)) {
+            throw new TrackNumberAlreadyExistsException("Трек-номер уже привязан к другой посылке");
         }
         trackParcelRepository.updatePreRegisteredNumber(parcelId, number);
     }

--- a/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceAssignNumberTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceAssignNumberTest.java
@@ -1,0 +1,84 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.UserSubscriptionRepository;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для метода {@link TrackParcelService#assignTrackNumber(Long, String, Long)}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackParcelServiceAssignNumberTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private UserSubscriptionRepository userSubscriptionRepository;
+
+    private TrackParcelService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TrackParcelService(userService, trackParcelRepository, userSubscriptionRepository);
+    }
+
+    /**
+     * Проверяем, что при попытке присвоить уже существующий трек-номер
+     * выбрасывается {@link TrackNumberAlreadyExistsException}.
+     */
+    @Test
+    void assignTrackNumber_Duplicate_ThrowsException() {
+        Long userId = 1L;
+        Long parcelId = 2L;
+        String number = "ABC";
+
+        TrackParcel parcel = new TrackParcel();
+        User user = new User();
+        user.setId(userId);
+        parcel.setUser(user);
+        parcel.setPreRegistered(true);
+
+        when(trackParcelRepository.findByIdAndPreRegisteredTrue(parcelId)).thenReturn(parcel);
+        when(trackParcelRepository.existsByNumberAndUserId(number, userId)).thenReturn(true);
+
+        assertThrows(TrackNumberAlreadyExistsException.class,
+                () -> service.assignTrackNumber(parcelId, number, userId));
+        verify(trackParcelRepository, never()).updatePreRegisteredNumber(anyLong(), anyString());
+    }
+
+    /**
+     * Убеждаемся, что при отсутствии дубликата номер сохраняется.
+     */
+    @Test
+    void assignTrackNumber_Success_UpdatesNumber() {
+        Long userId = 1L;
+        Long parcelId = 2L;
+        String number = "ABC";
+
+        TrackParcel parcel = new TrackParcel();
+        User user = new User();
+        user.setId(userId);
+        parcel.setUser(user);
+        parcel.setPreRegistered(true);
+
+        when(trackParcelRepository.findByIdAndPreRegisteredTrue(parcelId)).thenReturn(parcel);
+        when(trackParcelRepository.existsByNumberAndUserId(number, userId)).thenReturn(false);
+
+        service.assignTrackNumber(parcelId, number, userId);
+
+        verify(trackParcelRepository).updatePreRegisteredNumber(parcelId, number);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent assigning an already used track number by checking repository before update
- introduce `TrackNumberAlreadyExistsException` with user-friendly message
- catch duplicate number error in departures controller and return HTTP 409
- cover `assignTrackNumber` scenarios with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f9a667c832d94aa1cb303a69398