### PR TITLE
refactor: mask log events without mutating

### DIFF
--- a/src/main/java/com/project/tracking_system/logging/PiiMaskingFilter.java
+++ b/src/main/java/com/project/tracking_system/logging/PiiMaskingFilter.java
@@ -1,12 +1,18 @@
 package com.project.tracking_system.logging;
 
+import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import com.project.tracking_system.utils.EmailUtils;
 import com.project.tracking_system.utils.PhoneUtils;
+import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -23,18 +29,68 @@ public class PiiMaskingFilter extends Filter<ILoggingEvent> {
     /** Паттерн распознавания email-адреса. */
     private static final Pattern EMAIL_PATTERN = Pattern.compile("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}");
 
+    /**
+     * Оригинальные события, которые уже были обработаны.
+     * Используется {@link WeakHashMap}, чтобы избежать утечек памяти.
+     */
+    private final Set<ILoggingEvent> processedEvents =
+            Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+
+    /**
+     * События, созданные фильтром и содержащие уже маскированные сообщения.
+     */
+    private final Set<ILoggingEvent> maskedEvents = ConcurrentHashMap.newKeySet();
+
     @Override
     public FilterReply decide(ILoggingEvent event) {
-        if (!(event instanceof LoggingEvent loggingEvent)) {
+        if (maskedEvents.remove(event)) {
+            // Это уже маскированное событие, просто пропускаем его.
             return FilterReply.NEUTRAL;
         }
-        String formatted = loggingEvent.getFormattedMessage();
+
+        if (!processedEvents.add(event)) {
+            // Оригинальное событие уже обработано, запрещаем повторную запись.
+            return FilterReply.DENY;
+        }
+
+        String formatted = event.getFormattedMessage();
         String masked = mask(formatted);
         if (!formatted.equals(masked)) {
-            loggingEvent.setMessage(masked);
-            loggingEvent.setArgumentArray(null);
+            // Создаём новое событие с маскированным сообщением и отправляем его в те же аппендеры.
+            ILoggingEvent clone = cloneWithMessage(event, masked);
+
+            maskedEvents.add(clone);
+            Logger logger = (Logger) LoggerFactory.getLogger(event.getLoggerName());
+            logger.callAppenders(clone);
+            return FilterReply.DENY;
         }
+
+        // Маскировка не понадобилась, удаляем из обработанных.
+        processedEvents.remove(event);
         return FilterReply.NEUTRAL;
+    }
+
+    /**
+     * Создаёт клон события с заменённым сообщением.
+     *
+     * @param original      исходное событие логирования
+     * @param maskedMessage сообщение, в котором персональные данные скрыты
+     * @return новое событие для передачи в аппендеры
+     */
+    private ILoggingEvent cloneWithMessage(ILoggingEvent original, String maskedMessage) {
+        LoggingEvent clone = new LoggingEvent();
+        clone.setLoggerContextRemoteView(original.getLoggerContextVO());
+        clone.setLoggerName(original.getLoggerName());
+        clone.setLevel(original.getLevel());
+        clone.setTimeStamp(original.getTimeStamp());
+        clone.setThreadName(original.getThreadName());
+        clone.setMessage(maskedMessage);
+        clone.setArgumentArray(null); // строка уже отформатирована
+        clone.setThrowableProxy(original.getThrowableProxy());
+        clone.setCallerData(original.getCallerData());
+        clone.setMarker(original.getMarker());
+        clone.setMDCPropertyMap(original.getMDCPropertyMap());
+        return clone;
     }
 
     /**


### PR DESCRIPTION
## Summary
- clone logging events and mask message without mutating original event
- track processed events to mask only once per log event
- build clone using `LoggingEvent` and dispatch via `LoggerFactory`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_68b043acb824832d9ce736feb5979f07