### PR TITLE
Implement customer name shortening in departures

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.dto;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.NameSource;
 import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.utils.NameUtils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,6 +24,10 @@ public class TrackParcelDTO {
     private transient String iconHtml;
     private Long storeId;
     private String customerName;
+    /**
+     * Сокращённое представление ФИО покупателя для компактного вывода.
+     */
+    private String shortCustomerName;
     private String customerPhone;
     private NameSource nameSource;
 
@@ -48,6 +53,8 @@ public class TrackParcelDTO {
         Customer customer = trackParcel.getCustomer();
         if (customer != null) {
             this.customerName = customer.getFullName();
+            // Формируем сокращённое имя на основе полного ФИО
+            this.shortCustomerName = NameUtils.shortenName(this.customerName);
             this.customerPhone = customer.getPhone();
             this.nameSource = customer.getNameSource();
         }

--- a/src/main/java/com/project/tracking_system/utils/NameUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/NameUtils.java
@@ -36,4 +36,29 @@ public final class NameUtils {
         }
         return sb.toString();
     }
+
+    /**
+     * Сокращает ФИО, оставляя фамилию полностью и инициалы имени и отчества.
+     * <p>
+     * Если строка содержит менее двух частей, она возвращается без изменений.
+     * </p>
+     *
+     * @param fullName исходное полное имя
+     * @return сокращённая запись либо исходная строка при недостатке данных
+     */
+    public static String shortenName(String fullName) {
+        if (fullName == null || fullName.isBlank()) {
+            return fullName;
+        }
+        String[] parts = fullName.trim().split("\\s+");
+        if (parts.length < 2) {
+            return fullName;
+        }
+        StringBuilder result = new StringBuilder(parts[0]);
+        for (int i = 1; i < parts.length; i++) {
+            String part = parts[i];
+            result.append(' ').append(part.charAt(0)).append('.');
+        }
+        return result.toString();
+    }
 }

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -165,7 +165,7 @@
                                                 <!-- Проверяем, что имя покупателя не пустое -->
                                                 <div class="d-flex align-items-center" th:if="${!#strings.isEmpty(item.customerName)}">
                                                     <button type="button" class="btn btn-link p-0 customer-icon ms-0"
-                                                            th:text="${item.customerName}"
+                                                            th:text="${item.shortCustomerName}"
                                                             th:data-trackid="${item.id}"
                                                             aria-label="Информация о покупателе"></button>
 

--- a/src/test/java/com/project/tracking_system/utils/NameUtilsTest.java
+++ b/src/test/java/com/project/tracking_system/utils/NameUtilsTest.java
@@ -1,0 +1,38 @@
+package com.project.tracking_system.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты для {@link NameUtils#shortenName(String)}.
+ */
+class NameUtilsTest {
+
+    /**
+     * Проверяет сокращение полного ФИО из трёх частей.
+     */
+    @Test
+    void shouldShortenThreePartRussianName() {
+        String result = NameUtils.shortenName("Иванов Иван Иванович");
+        assertEquals("Иванов И. И.", result);
+    }
+
+    /**
+     * Проверяет сокращение ФИО из двух частей.
+     */
+    @Test
+    void shouldShortenTwoPartRussianName() {
+        String result = NameUtils.shortenName("Петров Пётр");
+        assertEquals("Петров П.", result);
+    }
+
+    /**
+     * Проверяет, что при одной части строка возвращается без изменений.
+     */
+    @Test
+    void shouldReturnOriginalWhenSinglePartProvided() {
+        String result = NameUtils.shortenName("Сидоров");
+        assertEquals("Сидоров", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add utility to shorten full names to surname with initials
- Display shortened customer names in departure list
- Compute and expose short customer name in track parcel DTO
- Cover name shortening with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b0545ddf70832dbfb304e7c42b8b0f