### PR TITLE
style: align status icons and parcel number

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1407,10 +1407,12 @@ button:hover {
   white-space: nowrap;
 }
 
-/* ячейка номера: иконка статуса + номер в ряд без скачков */
+/* иконка статуса: фиксируем ширину и выравниваем номер без скачков */
 .history-table .status-icon {
   display: inline-flex;
   align-items: center;
+  justify-content: center; /* центрируем иконку в пределах выделенного места */
+  width: 1.5rem; /* фиксированная ширина, чтобы иконки занимали одинаковое место слева */
   margin-right: 0.25rem;
 }
 

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -142,8 +142,8 @@
                                         </td>
                                         <td class="align-middle text-center">
                                             <!-- Ячейка выравнивает содержимое по центру -->
-                                            <!-- Контейнер выравнивает иконку и номер, соблюдая SRP -->
-                                            <div class="d-flex justify-content-center align-items-center">
+                                            <!-- Контейнер выравнивает иконку и номер по одному левому краю, оставляя ячейку по центру (SRP) -->
+                                            <div class="d-inline-flex align-items-center justify-content-start">
                                                 <!-- Изменено: выводим готовое значение iconHtml из DTO -->
                                                 <span th:if="${item.iconHtml != null}" th:utext="${item.iconHtml}" class="status-icon"
                                                       th:attr="title=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'Добавьте трек-номер, чтобы начать обновлять' : null}, data-bs-toggle=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'tooltip' : null}"></span>


### PR DESCRIPTION
## Summary
- left-align parcel number icon and text within departures table cell
- ensure status icons occupy consistent width and centered in their block

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b05f57d7cc832d9060f30fc4335749