### PR TITLE
Align track numbers block to left

### DIFF
--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -221,6 +221,12 @@
     border-bottom: 1px solid ui.$light;
   }
 
+  // Колонка с номерами треков выравнивается по левому краю
+  th:nth-child(2),
+  td:nth-child(2) {
+    text-align: left;
+  }
+
   /* Добавляем анимацию появления строк истории */
   tbody tr {
     animation: fadeSlideIn 0.5s ease forwards;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -3,14 +3,6 @@
   font-size: 2rem;
 }
 
-/* Классы текста статуса и даты наследуют выравнивание,
-   чтобы не переопределять центрирование */
-.status-text,
-.date-text {
-  text-align: inherit;
-  vertical-align: inherit;
-}
-
 .delivered {
   color: #008000;
 }
@@ -1189,6 +1181,10 @@ button:hover {
   text-align: center;
   border-bottom: 1px solid #f8f9fa;
 }
+.history-table th:nth-child(2),
+.history-table td:nth-child(2) {
+  text-align: left;
+}
 .history-table tbody tr {
   animation: fadeSlideIn 0.5s ease forwards;
 }
@@ -1407,12 +1403,10 @@ button:hover {
   white-space: nowrap;
 }
 
-/* иконка статуса: фиксируем ширину и выравниваем номер без скачков */
+/* ячейка номера: иконка статуса + номер в ряд без скачков */
 .history-table .status-icon {
   display: inline-flex;
   align-items: center;
-  justify-content: center; /* центрируем иконку в пределах выделенного места */
-  width: 1.5rem; /* фиксированная ширина, чтобы иконки занимали одинаковое место слева */
   margin-right: 0.25rem;
 }
 
@@ -1828,5 +1822,3 @@ body.loading {
   border-style: solid;
   border-color: #ddd transparent transparent transparent;
 }
-
-/*# sourceMappingURL=style.css.map */

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -116,7 +116,7 @@
                                         <th class="checkbox-column">
                                             <input type="checkbox" id="selectAllCheckbox" aria-label="Выделить все посылки">
                                         </th>
-                                        <th scope="col" class="align-middle text-center">№ посылки</th><!-- Заголовок номера: выравнивание по центру -->
+                                        <th scope="col" class="align-middle text-start">№ посылки</th><!-- Заголовок номера: выравнивание по левому краю -->
                                         <th scope="col">Покупатель</th>
                                         <th scope="col" class="align-middle text-center">Статус</th><!-- Заголовок статуса: выравнивание по центру -->
                                         <th scope="col" class="align-middle text-center">
@@ -140,9 +140,9 @@
                                                title="Предрегистрация: добавьте трек-номер"
                                                data-bs-toggle="tooltip" aria-label="Нет трека"></i>
                                         </td>
-                                        <td class="align-middle text-center">
-                                            <!-- Ячейка выравнивает содержимое по центру -->
-                                            <!-- Контейнер выравнивает иконку и номер по одному левому краю, оставляя ячейку по центру (SRP) -->
+                                        <td class="align-middle text-start">
+                                            <!-- Ячейка выравнивает содержимое по левому краю -->
+                                            <!-- Контейнер выравнивает иконку и номер по одному левому краю, сохраняя общую семантику таблицы (SRP) -->
                                             <div class="d-inline-flex align-items-center justify-content-start">
                                                 <!-- Изменено: выводим готовое значение iconHtml из DTO -->
                                                 <span th:if="${item.iconHtml != null}" th:utext="${item.iconHtml}" class="status-icon"


### PR DESCRIPTION
## Summary
- left-align track number column on departures page
- add SCSS rule for left alignment and rebuild CSS

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b064d58a6c832d91b669b9070c87f7