### PR TITLE
feat: overlay customer reputation label

### DIFF
--- a/src/main/resources/assets/scss/components/_forms.scss
+++ b/src/main/resources/assets/scss/components/_forms.scss
@@ -97,3 +97,8 @@
 #phone {
   border-radius: ui.$border-radius !important;
 }
+
+// Лейбл репутации, располагающийся над полем ФИО
+.reputation-badge {
+  z-index: 1;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -637,6 +637,10 @@ button:hover {
   border-radius: 8px !important;
 }
 
+.reputation-badge {
+  z-index: 1;
+}
+
 .card {
   background: #ffffff;
   border-radius: 10px;

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -510,21 +510,30 @@ function autoFillFullName() {
     if (!phoneInput || !fullNameInput || !toggleFullName) return;
 
     /**
-     * Отображает бейдж репутации рядом с полем ФИО.
-     * Создаёт элемент при необходимости и применяет цветовое оформление.
+     * Отображает бейдж репутации над полем ФИО с нахлёстом.
+     * При необходимости создаёт элемент и применяет цветовое оформление.
      * @param {{reputationDisplayName?: string, colorClass?: string}} repData - данные о репутации
      */
     const renderReputationBadge = (repData) => {
         // Базовые классы бейджа, сохраняющиеся при сбросе состояния
-        const baseClasses = ['ms-2', 'small'];
+        const baseClasses = [
+            'badge',
+            'small',
+            'position-absolute',
+            'top-0',
+            'start-50',
+            'translate-middle',
+            'reputation-badge',
+            'd-none'
+        ];
         let badge = document.getElementById('reputationBadge');
 
-        // Если бейджа ещё нет в DOM, создаём его рядом с полем ФИО
+        // Если бейджа ещё нет в DOM, создаём его внутри контейнера поля ФИО
         if (!badge) {
             badge = document.createElement('span');
             badge.id = 'reputationBadge';
             badge.classList.add(...baseClasses);
-            fullNameInput.insertAdjacentElement('afterend', badge);
+            fullNameInput.parentElement.appendChild(badge);
         } else {
             // Сбрасываем классы к базовым при повторных вызовах
             badge.className = baseClasses.join(' ');
@@ -534,9 +543,11 @@ function autoFillFullName() {
         if (repData.reputationDisplayName && repData.colorClass) {
             badge.textContent = repData.reputationDisplayName;
             badge.classList.add(repData.colorClass);
+            badge.classList.remove('d-none');
         } else {
-            // При отсутствии данных очищаем содержимое бейджа
+            // При отсутствии данных скрываем бейдж и очищаем его содержимое
             badge.textContent = '';
+            badge.classList.add('d-none');
         }
     };
 

--- a/src/main/resources/templates/partials/full-name-input.html
+++ b/src/main/resources/templates/partials/full-name-input.html
@@ -1,13 +1,14 @@
 <!-- Фрагмент поля ФИО с подсказкой и поддержкой режима только для чтения -->
 <div th:fragment="fullNameBlock(readonlyFlag)" id="fullNameField" class="mb-3 hidden">
     <label for="fullName" class="form-label fw-semibold">ФИО покупателя:</label>
-    <div class="input-group">
+    <div class="input-group position-relative">
         <input type="text" id="fullName" name="fullName" class="form-control"
                placeholder="Иванов Иван Иванович"
                th:value="${customerFullName}"
                th:attr="readonly=${readonlyFlag}? 'readonly' : null">
-        <!-- Бейдж репутации покупателя; текст и цвет задаются из JS -->
-        <span id="reputationBadge" class="ms-2 small"></span>
+        <!-- Бейдж репутации покупателя; отображается над полем ФИО -->
+        <span id="reputationBadge"
+              class="badge small position-absolute top-0 start-50 translate-middle reputation-badge d-none"></span>
     </div>
     <small id="fullNameHint" class="form-text text-muted d-none">
         ФИО подтверждено покупателем и не может быть изменено.


### PR DESCRIPTION
## Summary
- display customer reputation badge as an overlay above the full name input
- adjust JS to manage the overlay badge visibility and positioning
- add SCSS/CSS styles for the new reputation badge

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0673c5e0c832da49d7238aa14917c