### PR TITLE
Fix input-group single input border radius

### DIFF
--- a/src/main/resources/assets/scss/components/_forms.scss
+++ b/src/main/resources/assets/scss/components/_forms.scss
@@ -70,6 +70,11 @@
 
   input {
     border-radius: ui.$border-radius 0 0 ui.$border-radius;
+
+    // Если внутри группы только одно поле ввода, сохраняем скругление всех углов
+    &:only-child {
+      border-radius: ui.$border-radius;
+    }
   }
 
   .btn {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -616,6 +616,9 @@ button:hover {
 .input-group input {
   border-radius: 8px 0 0 8px;
 }
+.input-group input:only-child {
+  border-radius: 8px;
+}
 .input-group .btn {
   border-radius: 0 8px 8px 0;
 }


### PR DESCRIPTION
## Summary
- keep rounded corners when `.input-group` has only one input
- rebuild compiled CSS

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b06bc32c10832da9593f0645ee734b