### PR TITLE
feat: hide user password from serialization

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/User.java
+++ b/src/main/java/com/project/tracking_system/entity/User.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -31,6 +32,11 @@ public class User implements UserDetails {
     @Email(message = "Email должен быть корректным")
     private String email;
 
+    /**
+     * Пароль пользователя, скрываемый при сериализации и в строковом представлении.
+     */
+    @JsonIgnore // исключает пароль из JSON-ответов
+    @ToString.Exclude // предотвращает вывод пароля в методе toString
     @NotBlank(message = "Введите пароль")
     private String password;
 


### PR DESCRIPTION
## Summary
- ensure user password isn't exposed in JSON or logs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b09361e204832d8af914ec78de37f2