### PR TITLE
Ensure status set before body in rate limit filter

### DIFF
--- a/src/main/java/com/project/tracking_system/utils/ApiRateLimitFilter.java
+++ b/src/main/java/com/project/tracking_system/utils/ApiRateLimitFilter.java
@@ -81,10 +81,10 @@ public class ApiRateLimitFilter extends OncePerRequestFilter {
         }
 
 
-        //response.setStatus(HttpServletResponse.SC_TOO_MANY_REQUESTS);
         response.setContentType("text/plain;charset=UTF-8");
-        response.getWriter().write("Превышен лимит запросов.");
+        // Сначала устанавливаем статус, затем пишем тело ответа
         setTooManyRequests(response);
+        response.getWriter().write("Превышен лимит запросов.");
     }
 
     /**


### PR DESCRIPTION
## Summary
- set HTTP status before writing rate limit response body
- remove dead code for status handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68b093669958832d862c7e42380ab10b