### PR TITLE
feat: recognize arrival-for-issuance status

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -46,8 +46,11 @@ public class StatusTrackService {
     static {
         // Инициализация карты регулярных выражений и статусов
         statusPatterns.put(Pattern.compile("^Почтовое отправление выдано|^Вручено"), GlobalStatus.DELIVERED);
-        statusPatterns.put(Pattern.compile("^Почтовое отправление прибыло на ОПС выдачи|^Добрый день\\. Срок бесплатного хранения|" +
-                "^Поступило в учреждение доставки.*"), GlobalStatus.WAITING_FOR_CUSTOMER);
+        statusPatterns.put(Pattern.compile("^Почтовое отправление прибыло на ОПС выдачи|" +
+                "^Почтовое отправление прибыло для выдачи|" +
+                "^Добрый день\\. Срок бесплатного хранения|" +
+                "^Поступило в учреждение доставки.*"),
+                GlobalStatus.WAITING_FOR_CUSTOMER);
         statusPatterns.put(Pattern.compile("^Почтовое отправление принято на ОПС|" +
                         "^Оплачено на ОПС|^Отправлено|^Принято от отправителя|" +
                         "^Поступило в обработку|" +

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -77,4 +77,19 @@ class StatusTrackServiceTest {
 
         assertEquals(GlobalStatus.RETURN_IN_PROGRESS, status);
     }
+
+    /**
+     * Проверяет, что формулировка о прибытии отправления для выдачи
+     * относится к статусу {@link GlobalStatus#WAITING_FOR_CUSTOMER}.
+     */
+    @Test
+    void setStatus_MapsArrivalForIssuance() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO("20.07.2025, 12:00", "Почтовое отправление прибыло для выдачи")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.WAITING_FOR_CUSTOMER, status);
+    }
 }


### PR DESCRIPTION
## Summary
- handle "Прибыло для выдачи" as WAITING_FOR_CUSTOMER
- test waiting status for arrival-for-issuance wording

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b09854adf0832d98aadaddfed0d0ed