### PR TITLE
feat: improve full name toggle logic

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1858,7 +1858,6 @@ document.addEventListener("DOMContentLoaded", function () {
     initBulkButtonToggle();
     initializePhoneToggle();
     autoFillFullName();
-    initializeFullNameToggle();
     initializePreRegistrationRequired();
     initAssignCustomerFormHandler();
     initEditCustomerPhoneFormHandler();

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -466,21 +466,6 @@ function initializePhoneToggle() {
     }
 }
 
-// Инициализация переключателя ввода ФИО
-function initializeFullNameToggle() {
-    const toggle = document.getElementById("toggleFullName");
-    const field = document.getElementById("fullNameField");
-
-    if (toggle && field) {
-        // Первичное состояние
-        toggleFieldsVisibility(toggle, field);
-
-        // Обработчик переключения
-        const handler = () => toggleFieldsVisibility(toggle, field);
-        toggle.addEventListener('change', handler);
-    }
-}
-
 /**
  * Автоматически подставляет ФИО по введённому номеру телефона.
  * <p>
@@ -516,6 +501,32 @@ function autoFillFullName() {
 
     // Если нужные элементы отсутствуют, дальнейшая логика не требуется
     if (!phoneInput || !fullNameInput || !toggleFullName) return;
+
+    /**
+     * Обновляет доступность поля ФИО и его видимость.
+     * Поле становится доступным только при активном переключателе
+     * и корректно введённом номере телефона.
+     * Пока условия не выполнены, блокируем ввод, чтобы исключить
+     * несогласованность данных между телефоном и ФИО.
+     */
+    const updateFullNameState = () => {
+        const phoneValid = phoneInput.value.trim() && phoneInput.checkValidity();
+        const allowFullName = toggleFullName.checked && phoneValid;
+
+        fullNameInput.disabled = !allowFullName; // блокируем поле до выполнения условий
+
+        // Если номер некорректен, скрываем поле и сбрасываем переключатель
+        if (!allowFullName) {
+            toggleFullName.checked = false;
+        }
+
+        toggleFieldsVisibility(toggleFullName, fullNameField);
+    };
+
+    // Первоначальная установка состояния поля и обработчики изменений
+    updateFullNameState();
+    toggleFullName.addEventListener('change', updateFullNameState);
+    phoneInput.addEventListener('input', updateFullNameState);
 
     /**
      * Вычисляет позицию бейджа репутации над введённым текстом ФИО
@@ -648,7 +659,7 @@ function autoFillFullName() {
 
                 // Активируем поле ФИО и подставляем полученное значение
                 toggleFullName.checked = true;
-                toggleFieldsVisibility(toggleFullName, fullNameField);
+                updateFullNameState();
                 fullNameInput.value = data.fullName;
 
                 // Отображаем репутацию, если она есть


### PR DESCRIPTION
## Summary
- add `updateFullNameState` to manage full name field availability
- refresh field state whenever phone or toggle changes
- auto-fill handler calls `updateFullNameState`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `mvn test` *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a839e02c832dbdee82ba50a2655a