### PR TITLE
feat: sanitize and validate phone before name autofill

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -612,13 +612,39 @@ function autoFillFullName() {
     };
 
     /**
-     * Обрабатывает ввод телефона и запрашивает ФИО.
+     * Очищает номер телефона от лишних символов.
+     * Удаляет пробелы, плюсы, дефисы и скобки, возвращая только цифры.
+     * @param {string} phoneRaw - исходное значение из поля ввода
+     * @returns {string} очищенный номер телефона
+     */
+    const sanitizePhone = (phoneRaw) => phoneRaw.trim().replace(/[+\-\s()]/g, '');
+
+    /**
+     * Проверяет номер телефона на соответствие допустимым форматам.
+     * Допускаются номера, начинающиеся на 80 или 375 и содержащие 9 последующих цифр.
+     * @param {string} phone - очищенный номер телефона
+     * @returns {boolean} true, если номер валиден
+     */
+    const isValidPhone = (phone) => /^(80|375)\d{9}$/.test(phone);
+
+    /**
+     * Обрабатывает ввод телефона: очищает, проверяет и при валидности запрашивает ФИО.
      * Повторный запрос для того же номера не выполняется.
      */
     const requestHandler = () => {
-        const phone = phoneInput.value.trim();
-        // Пустой/повторный номер или активный запрос — обрабатываем только один раз
-        if (!phone || phone === lastRequestedPhone || isPhoneRequestActive) return;
+        const phone = sanitizePhone(phoneInput.value);
+
+        // Игнорируем пустой ввод
+        if (!phone) return;
+
+        // Невалидный номер: уведомляем пользователя и прекращаем обработку
+        if (!isValidPhone(phone)) {
+            notifyUser('Неверный номер телефона', 'danger');
+            return;
+        }
+
+        // Повторный номер или активный запрос — обрабатываем только один раз
+        if (phone === lastRequestedPhone || isPhoneRequestActive) return;
 
         const headers = {};
         if (window.csrfHeader && window.csrfToken) {


### PR DESCRIPTION
## Summary
- sanitize phone numbers by stripping non-digit symbols
- validate phone formats (80 or 375 + 9 digits) before autofilling name
- inform users about invalid phone numbers and skip autofill requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ab9f7ba4832da45768cdcdd2f63e