### PR TITLE
Добавлен блок мгновенного отображения ошибок телефона

### DIFF
--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -88,7 +88,10 @@
                         <div id="phoneField" class="mb-3 hidden">
                             <label for="phone" class="form-label fw-semibold">Номер телефона покупателя:</label>
                             <div class="input-group">
+                                <!-- Класс form-control необходим для корректной работы Bootstrap и подсветки ошибок -->
                                 <input type="text" id="phone" name="phone" class="form-control" placeholder="375XXXXXXXXX">
+                                <!-- Блок для мгновенного отображения ошибок ввода -->
+                                <div id="phoneError" class="invalid-feedback"></div>
                                 <!-- Мини-индикатор загрузки, отображается при автоподстановке ФИО -->
                                 <div id="phoneLoading" class="spinner-border spinner-border-sm text-secondary ms-2 d-none" role="status">
                                     <span class="visually-hidden">Загрузка...</span>


### PR DESCRIPTION
## Summary
- Добавлен блок `<div id="phoneError" class="invalid-feedback">` для мгновенного отображения ошибок ввода телефона
- Добавлен комментарий о использовании `form-control` для корректной подсветки Bootstrap

## Testing
- `mvn test` *(ошибка: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b2792ebc832dbc3073f69d24c35b