### PR TITLE
Keep full name checkbox visible until phone validation

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -514,7 +514,7 @@ function autoFillFullName() {
         phoneValid = !getPhoneError(sanitizePhone(phoneInput.value));
 
         if (!phoneValid) {
-            // Номер невалиден — скрываем чекбокс и очищаем поле ФИО
+            // Номер невалиден — сбрасываем состояние чекбокса и очищаем поле ФИО
             toggleFullName.checked = false;
             fullNameInput.value = '';
         }
@@ -523,13 +523,13 @@ function autoFillFullName() {
 
         fullNameInput.disabled = !allowFullName; // блокируем поле до выполнения условий
 
-        // Чекбокс недоступен до успешной валидации телефона
+        // Чекбокс остаётся в DOM для ясности интерфейса,
+        // но активируется лишь после прохождения валидации телефона
         toggleFullName.disabled = !phoneValid;
         const wrapper = toggleFullName.closest('.form-check') || toggleFullName.labels?.[0];
 
-        // Скрываем и приглушаем чекбокс до появления валидного номера
-        wrapper?.classList.toggle('d-none', !phoneValid); // появится после успешной валидации
-        wrapper?.classList.toggle('opacity-50', !phoneValid); // визуально блокируем
+        // Визуально блокируем чекбокс до появления валидного номера
+        wrapper?.classList.toggle('opacity-50', !phoneValid);
 
         toggleFieldsVisibility(toggleFullName, fullNameField);
     };


### PR DESCRIPTION
## Summary
- Keep full-name checkbox visible and only disable it until phone is valid
- Clarify with comment that checkbox stays in DOM for interface clarity

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d4c1c368832daad00b076d4ce767