### PR TITLE
feat: prevent fullname field reanimation

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -500,6 +500,9 @@ function autoFillFullName() {
     let isPhoneRequestActive = false;
     // Флаг валидности номера телефона, используется для блокировки чекбокса
     let phoneValid = false;
+    // Предыдущее состояние доступности поля ФИО
+    // Нужно, чтобы не запускать анимацию повторно при неизменных условиях (SOLID)
+    let allowFullNamePrev = false;
 
     // Если нужные элементы отсутствуют, дальнейшая логика не требуется
     if (!phoneInput || !fullNameInput || !toggleFullName) return;
@@ -531,7 +534,12 @@ function autoFillFullName() {
         // Визуально блокируем чекбокс до появления валидного номера
         wrapper?.classList.toggle('opacity-50', !phoneValid);
 
-        toggleFieldsVisibility(toggleFullName, fullNameField);
+        // Отображаем или скрываем поле ФИО только при изменении условия
+        // Это предотвращает повторное проигрывание анимации (SRP)
+        if (allowFullName !== allowFullNamePrev) {
+            toggleFieldsVisibility(toggleFullName, fullNameField);
+            allowFullNamePrev = allowFullName;
+        }
     };
 
     /**
@@ -758,7 +766,7 @@ function autoFillFullName() {
 
                 // Активируем поле ФИО и подставляем полученное значение
                 toggleFullName.checked = true;
-                updateFullNameState();
+                updateFullNameState(); // Управляем показом через единый метод
                 fullNameInput.value = data.fullName;
 
                 // Отображаем репутацию, если она есть


### PR DESCRIPTION
## Summary
- track previous full name availability and toggle field visibility only when it changes
- document request handler to rely on updateFullNameState for UI updates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0d7fd9604832d9343ecff5098b177