### PR TITLE
Refresh customer entity after stats updates

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -12,6 +12,8 @@ import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.utils.DateParserUtils;
 import com.project.tracking_system.utils.PhoneUtils;
 import com.project.tracking_system.utils.TrackNumberUtils;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,10 @@ public class TrackProcessingService {
     private final UserRepository userRepository;
     private final TrackParcelRepository trackParcelRepository;
     private final TrackStatisticsUpdater trackStatisticsUpdater;
+
+    /** Менеджер сущностей для синхронизации состояния покупателя с базой данных. */
+    @PersistenceContext
+    private EntityManager entityManager;
 
     /**
      * Обрабатывает номер посылки: получает информацию и при необходимости сохраняет её.
@@ -230,6 +236,8 @@ public class TrackProcessingService {
 
         if (isNewParcel && customer != null) {
             customerStatsService.incrementSent(customer);
+            // Обновляем данные покупателя, чтобы получить актуальные счётчики
+            entityManager.refresh(customer);
         }
 
         trackStatisticsUpdater.updateStatistics(trackParcel, isNewParcel, previousStoreId, previousDate);


### PR DESCRIPTION
## Summary
- refresh customer state after updating sent parcel count
- refresh customer after incrementing picked up or returned stats in delivery history

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b17afe9600832dab330f22b724e966