### PR TITLE
test: add concurrency IT for customer stats

### DIFF
--- a/src/test/java/com/project/tracking_system/service/customer/CustomerStatsConcurrencyIT.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerStatsConcurrencyIT.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -24,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @DataJpaTest
 @Import(CustomerStatsService.class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 class CustomerStatsConcurrencyIT {
 
     @Autowired
@@ -43,6 +46,7 @@ class CustomerStatsConcurrencyIT {
     void concurrentIncrementDoesNotThrowOptimisticLock() throws Exception {
         Customer customer = new Customer();
         customer.setPhone("375000000000");
+        // Сохраняем клиента в отдельной транзакции, чтобы он был виден параллельным потокам
         customerRepository.saveAndFlush(customer);
 
         int iterations = 5;


### PR DESCRIPTION
## Summary
- add CustomerStatsConcurrencyIT to ensure concurrent updates handle optimistic locking

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c330138164832d8b778976ff3942a0