### PR TITLE
Reload customer stats from DB after atomic update

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -96,6 +96,27 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     int incrementReturnedCount(@Param("id") Long id, @Param("version") long version);
 
     /**
+     * Обновить репутацию покупателя без изменения версии записи.
+     *
+     * @param id         идентификатор покупателя
+     * @param version    ожидаемая версия записи
+     * @param reputation новое значение репутации
+     * @return количество обновлённых записей
+     */
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE Customer c
+        SET c.reputation = :reputation
+        WHERE c.id = :id AND c.version = :version
+        """)
+    int updateReputation(
+            @Param("id") Long id,
+            @Param("version") long version,
+            @Param("reputation") BuyerReputation reputation
+    );
+
+    /**
      * Подсчитать количество покупателей с указанной репутацией.
      *
      * @param reputation репутация покупателя

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerService.java
@@ -372,16 +372,20 @@ public class CustomerService {
         parcel.setCustomer(newCustomer);
         trackParcelRepository.save(parcel);
 
+        // Отсоединяем исходный экземпляр, чтобы его старые данные не сохранялись
+        entityManager.detach(newCustomer);
+
         log.debug("📦 Посылка ID={} привязана к покупателю ID={}", parcelId, newCustomer.getId());
 
-        // Обновляем статистику покупателя и получаем актуализированную сущность
+        // Обновляем статистику покупателя и получаем перечитанную сущность
         newCustomer = customerStatsService.incrementSent(newCustomer);
         if (parcel.getStatus() == GlobalStatus.DELIVERED) {
             newCustomer = customerStatsService.incrementPickedUp(newCustomer);
         } else if (parcel.getStatus() == GlobalStatus.RETURNED) {
             newCustomer = customerStatsService.incrementReturned(newCustomer);
         }
-        // Отсоединяем сущность, чтобы предотвратить повторное обновление при commit
+        // Подменяем ссылку у посылки на актуальную сущность и отсоединяем её
+        parcel.setCustomer(newCustomer);
         entityManager.detach(newCustomer);
 
         log.debug("📈 Статистика покупателя ID={} обновлена после привязки посылки ID={}",

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerAssignServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerAssignServiceTest.java
@@ -19,7 +19,7 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -87,6 +87,7 @@ class CustomerAssignServiceTest {
         Customer fresh1 = buildCustomer(2L, 4, 2, 0); fresh1.setVersion(1);
         Customer fresh2 = buildCustomer(2L, 4, 3, 0); fresh2.setVersion(2);
         when(customerRepository.findById(2L)).thenReturn(Optional.of(fresh1), Optional.of(fresh2));
+        when(customerRepository.updateReputation(anyLong(), anyLong(), any())).thenReturn(1);
 
         service.assignCustomerToParcel(10L, "375111111111");
 
@@ -95,12 +96,12 @@ class CustomerAssignServiceTest {
         assertEquals(2, oldCustomer.getPickedUpCount());
         assertEquals(BuyerReputation.NEW, oldCustomer.getReputation());
 
-        // new customer increased
-        assertEquals(4, newCustomer.getSentCount());
-        assertEquals(3, newCustomer.getPickedUpCount());
-        assertEquals(BuyerReputation.RELIABLE, newCustomer.getReputation());
-
-        assertSame(newCustomer, parcel.getCustomer());
+        // new customer stats taken from обновлённой сущности у посылки
+        Customer refreshed = parcel.getCustomer();
+        assertEquals(4, refreshed.getSentCount());
+        assertEquals(3, refreshed.getPickedUpCount());
+        assertEquals(BuyerReputation.RELIABLE, refreshed.getReputation());
+        assertEquals(newCustomer.getId(), refreshed.getId());
     }
 
     /**
@@ -123,6 +124,7 @@ class CustomerAssignServiceTest {
         Customer fresh1 = buildCustomer(2L, 3, 1, 1); fresh1.setVersion(1);
         Customer fresh2 = buildCustomer(2L, 3, 1, 2); fresh2.setVersion(2);
         when(customerRepository.findById(2L)).thenReturn(Optional.of(fresh1), Optional.of(fresh2));
+        when(customerRepository.updateReputation(anyLong(), anyLong(), any())).thenReturn(1);
 
         service.assignCustomerToParcel(11L, "375222222222");
 
@@ -131,12 +133,12 @@ class CustomerAssignServiceTest {
         assertEquals(1, oldCustomer.getReturnedCount());
         assertEquals(BuyerReputation.NEW, oldCustomer.getReputation());
 
-        // new customer increased
-        assertEquals(3, newCustomer.getSentCount());
-        assertEquals(2, newCustomer.getReturnedCount());
-        assertEquals(BuyerReputation.UNRELIABLE, newCustomer.getReputation());
-
-        assertSame(newCustomer, parcel.getCustomer());
+        // new customer stats from refreshed entity on parcel
+        Customer refreshed = parcel.getCustomer();
+        assertEquals(3, refreshed.getSentCount());
+        assertEquals(2, refreshed.getReturnedCount());
+        assertEquals(BuyerReputation.UNRELIABLE, refreshed.getReputation());
+        assertEquals(newCustomer.getId(), refreshed.getId());
     }
 
     private static Customer buildCustomer(Long id, int sent, int picked, int returned) {

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerStatsServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerStatsServiceTest.java
@@ -12,7 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -47,13 +47,15 @@ class CustomerStatsServiceTest {
         fresh.setVersion(1);
         fresh.setSentCount(1);
         when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
+        when(customerRepository.updateReputation(anyLong(), anyLong(), any())).thenReturn(1);
 
         Customer result = service.incrementSent(customer);
 
-        assertEquals(1, customer.getSentCount());
+        assertEquals(0, customer.getSentCount());
         assertSame(fresh, result);
         verify(customerRepository).incrementSentCount(1L, 0L);
         verify(customerRepository).findById(1L);
+        verify(customerRepository).updateReputation(1L, 1L, fresh.getReputation());
         verify(customerRepository, never()).save(any());
     }
 
@@ -71,10 +73,11 @@ class CustomerStatsServiceTest {
 
         Customer result = service.incrementSent(customer);
 
-        assertEquals(1, customer.getSentCount());
+        assertEquals(0, customer.getSentCount());
         assertSame(fresh, result);
         verify(customerRepository).findById(1L);
         verify(customerRepository).save(fresh);
+        verify(customerRepository, never()).updateReputation(anyLong(), anyLong(), any());
     }
 
     /**
@@ -88,13 +91,15 @@ class CustomerStatsServiceTest {
         fresh.setVersion(1);
         fresh.setPickedUpCount(1);
         when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
+        when(customerRepository.updateReputation(anyLong(), anyLong(), any())).thenReturn(1);
 
         Customer result = service.incrementPickedUp(customer);
 
-        assertEquals(1, customer.getPickedUpCount());
+        assertEquals(0, customer.getPickedUpCount());
         assertSame(fresh, result);
         verify(customerRepository).incrementPickedUpCount(1L, 0L);
         verify(customerRepository).findById(1L);
+        verify(customerRepository).updateReputation(1L, 1L, fresh.getReputation());
         verify(customerRepository, never()).save(any());
     }
 
@@ -112,10 +117,11 @@ class CustomerStatsServiceTest {
 
         Customer result = service.incrementPickedUp(customer);
 
-        assertEquals(1, customer.getPickedUpCount());
+        assertEquals(0, customer.getPickedUpCount());
         assertSame(fresh, result);
         verify(customerRepository).findById(1L);
         verify(customerRepository).save(fresh);
+        verify(customerRepository, never()).updateReputation(anyLong(), anyLong(), any());
     }
 
     /**
@@ -129,13 +135,15 @@ class CustomerStatsServiceTest {
         fresh.setVersion(1);
         fresh.setReturnedCount(1);
         when(customerRepository.findById(1L)).thenReturn(Optional.of(fresh));
+        when(customerRepository.updateReputation(anyLong(), anyLong(), any())).thenReturn(1);
 
         Customer result = service.incrementReturned(customer);
 
-        assertEquals(1, customer.getReturnedCount());
+        assertEquals(0, customer.getReturnedCount());
         assertSame(fresh, result);
         verify(customerRepository).incrementReturnedCount(1L, 0L);
         verify(customerRepository).findById(1L);
+        verify(customerRepository).updateReputation(1L, 1L, fresh.getReputation());
         verify(customerRepository, never()).save(any());
     }
 
@@ -153,9 +161,10 @@ class CustomerStatsServiceTest {
 
         Customer result = service.incrementReturned(customer);
 
-        assertEquals(1, customer.getReturnedCount());
+        assertEquals(0, customer.getReturnedCount());
         assertSame(fresh, result);
         verify(customerRepository).findById(1L);
         verify(customerRepository).save(fresh);
+        verify(customerRepository, never()).updateReputation(anyLong(), anyLong(), any());
     }
 }


### PR DESCRIPTION
## Summary
- refactor customer statistic update to re-read entity from DB after atomic update
- return refreshed Customer from increment methods and document behavior
- adjust tests for new flow

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c33a6b4124832d9f20640af125d130