### PR TITLE
refactor: reuse updated customer entity in tracking services

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -17,8 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 
 import java.time.*;
 
@@ -45,9 +43,6 @@ public class TrackProcessingService {
     private final UserRepository userRepository;
     private final TrackParcelRepository trackParcelRepository;
     private final TrackStatisticsUpdater trackStatisticsUpdater;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
 
     /**
@@ -235,10 +230,10 @@ public class TrackProcessingService {
         }
 
         if (isNewParcel && customer != null) {
-            // Фиксируем отправку в статистике покупателя и используем обновлённый объект
+            // Обновляем статистику отправленных посылок и получаем свежий объект покупателя
             customer = customerStatsService.incrementSent(customer);
-            // Отсоединяем покупателя, чтобы предотвратить повторное обновление при коммите
-            entityManager.detach(customer);
+            // Переназначаем ссылку, чтобы трек указывал на актуальную сущность
+            trackParcel.setCustomer(customer);
         }
 
         trackStatisticsUpdater.updateStatistics(trackParcel, isNewParcel, previousStoreId, previousDate);


### PR DESCRIPTION
## Summary
- use refreshed Customer from CustomerStatsService instead of detaching
- keep TrackParcel reference in sync with updated customer

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68c3415b8f20832d9328da3f8b26bc61