### PR TITLE
fix: track store update

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackProcessingService.java
@@ -150,7 +150,7 @@ public class TrackProcessingService {
         boolean isNewParcel = (trackParcel == null);
         GlobalStatus oldStatus = (!isNewParcel) ? trackParcel.getStatus() : null;
         ZonedDateTime previousDate = null; // дата отправления старого трека
-        Long previousStoreId = null;       // магазин, в котором хранился трек ранее
+        Long previousStoreId = null;       // идентификатор предыдущего магазина, фиксируем для статистики
 
         // Если трек новый, проверяем лимиты
         if (isNewParcel) {
@@ -172,14 +172,14 @@ public class TrackProcessingService {
             log.debug("Создан новый трек");
 
         } else {
-            // Запоминаем предыдущие значения для корректировки статистики
-            previousStoreId = trackParcel.getStore().getId();
+            // Запоминаем предыдущую дату для корректировки статистики
             previousDate = trackParcel.getTimestamp();
         }
         // Если трек уже существует, проверяем, соответствует ли магазин выбранному пользователем
         if (!trackParcel.getStore().getId().equals(storeId)) {
+            // Фиксируем старый магазин для последующей корректировки статистики
+            previousStoreId = trackParcel.getStore().getId();
             // Загружаем новый магазин
-            Long oldStoreId = trackParcel.getStore().getId();
             Store newStore = storeRepository.getReferenceById(storeId);
 
             // Обновляем магазин у трека


### PR DESCRIPTION
## Summary
- remove redundant old store tracking variable when updating a track's store
- document why previous store id is captured for statistics

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c345b93034832da39a6fbe9cfdc5f0