### PR TITLE
Simplify Chrome WebDriver configuration

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -10,7 +10,6 @@ import com.project.tracking_system.webdriver.ChromeWebDriverFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.beans.factory.annotation.Value;
 import java.time.Clock;
 
 /**
@@ -26,15 +25,6 @@ import java.time.Clock;
 @ComponentScan(basePackages = "com.project.tracking_system")
 @Configuration
 public class AppConfiguration {
-
-    /**
-     * Путь к исполняемому файлу chromedriver.
-     * <p>
-     * Инжектируется из конфигурации приложения и передаётся в фабрику драйверов.
-     * </p>
-     */
-    @Value("${webdriver.chrome.driver}")
-    private String chromeDriverPath;
 
     /**
      * Создает бин {@link RestTemplate} для выполнения HTTP-запросов.
@@ -91,15 +81,17 @@ public class AppConfiguration {
     /**
      * Предоставляет фабрику {@link WebDriverFactory} для создания драйверов.
      * <p>
-     * Путь к исполняемому файлу драйвера передаётся в конструктор, что позволяет
-     * избежать проблем с правами доступа при запуске браузера.
+     * При необходимости путь к исполняемому файлу ChromeDriver может быть задан
+     * через системное свойство <code>webdriver.chrome.driver</code>. В большинстве
+     * случаев Selenium Manager самостоятельно найдет подходящий драйвер, поэтому
+     * указывать путь не требуется.
      * </p>
      *
      * @return реализация фабрики для браузера Chrome
      */
     @Bean
     public WebDriverFactory webDriverFactory() {
-        return new ChromeWebDriverFactory(chromeDriverPath);
+        return new ChromeWebDriverFactory();
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove hardcoded chromedriver path injection and use default Selenium Manager
- instantiate ChromeWebDriverFactory without arguments

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to jitpack.io (https://jitpack.io): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c40e37c0e0832d99fe2ecfe938e1d1