### PR TITLE
docs: сделать путь к ChromeDriver необязательным

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,7 +45,8 @@ tracking.result-cache.expiration-ms=3600000
 app.default-timezone=Europe/Minsk
 
 server.forward-headers-strategy=framework
-webdriver.chrome.driver=${CHROMEDRIVER_PATH:/usr/local/bin/chromedriver}
+# Путь к ChromeDriver. Если значение не указано, драйвер подбирается Selenium Manager.
+#webdriver.chrome.driver=${CHROMEDRIVER_PATH:/usr/local/bin/chromedriver}
 
 contact.recipient=support@belivery.by
 


### PR DESCRIPTION
## Summary
- пояснить использование Selenium Manager без указания пути к ChromeDriver

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c410cbe144832db237fba9caaf0e8e