### PR TITLE
docs: обновить секцию про ChromeDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ Belpost and Evropost
 
 ## Конфигурация ChromeDriver
 
-Для запуска веб-драйвера в файле `application.properties` используется свойство
-`webdriver.chrome.driver`, которое определяет путь к исполняемому файлу
-ChromeDriver. В контейнере по умолчанию применяется путь
-`/usr/local/bin/chromedriver`, задаваемый в `Dockerfile`. При локальном запуске
-приложения значение можно изменить, передав параметр JVM:
+Selenium Manager автоматически определяет и скачивает совместимый
+ChromeDriver, поэтому указывать `System.setProperty("webdriver.chrome.driver", …)`
+больше не требуется.
 
-```bash
-java -jar app.jar --webdriver.chrome.driver=/path/to/chromedriver
+```java
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+WebDriver driver = new ChromeDriver();
 ```
+
+В Docker при необходимости путь к бинарнику можно задать через переменные
+окружения, например `CHROMEDRIVER_PATH`.
 
 ## Автообновление треков
 


### PR DESCRIPTION
## Summary
- описана автоматическая подстановка ChromeDriver с помощью Selenium Manager
- добавлен пример создания ChromeDriver без `System.setProperty`
- упомянут способ указать путь к драйверу в Docker через переменные окружения

## Testing
- ⚠️ `mvn -q test` *(Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4139958c4832db0f9946519be66a9