### PR TITLE
Remove redundant Selenium DevTools dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,22 +88,10 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.13</version>
         </dependency>
+        <!-- Используем только selenium-java, так как DevTools API в проекте не применяется -->
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-chrome-driver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v138</artifactId>
-            <version>4.34.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
## Summary
- remove selenium DevTools and extra driver artifacts
- document the sole selenium-java dependency choice

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because jitpack.io unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4147743b0832da5d679d8c309a556