### PR TITLE
Remove chromedriver installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,7 @@ RUN apt-get update && \
     curl -sSL https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROME_VERSION}/linux64/chrome-linux64.zip -o /tmp/chrome.zip && \
     unzip /tmp/chrome.zip -d /opt/chrome && \
     ln -s /opt/chrome/chrome-linux64/chrome /usr/bin/google-chrome && \
-    curl -sSL https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROME_VERSION}/linux64/chromedriver-linux64.zip -o /tmp/chromedriver.zip && \
-    unzip /tmp/chromedriver.zip -d /tmp && \
-    mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/ && \
-    chmod +x /usr/local/bin/chromedriver && \
-    rm -rf /tmp/*.zip /tmp/chromedriver-linux64 && \
+    rm -rf /tmp/*.zip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,8 +45,6 @@ tracking.result-cache.expiration-ms=3600000
 app.default-timezone=Europe/Minsk
 
 server.forward-headers-strategy=framework
-# Путь к ChromeDriver. Если значение не указано, драйвер подбирается Selenium Manager.
-#webdriver.chrome.driver=${CHROMEDRIVER_PATH:/usr/local/bin/chromedriver}
 
 contact.recipient=support@belivery.by
 


### PR DESCRIPTION
## Summary
- remove chromedriver download and install steps from Dockerfile
- drop obsolete chromedriver configuration from application properties

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68c42a4cdf08832d8b4b0b8abf990733