### PR TITLE
chore: disable selenium manager analytics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN apt-get update && \
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+# Отключаем отправку анонимной статистики Selenium Manager и лишние предупреждения
+ENV SELENIUM_MANAGER_ANALYTICS=false
+
 # Копируем собранное приложение из предыдущего шага
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar


### PR DESCRIPTION
## Summary
- disable Selenium Manager analytics to prevent anonymous statistics and warnings

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c42ea40da0832da2a1d20ecadd2330