### PR TITLE
feat: make BelPost batch retry configurable

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,6 +50,11 @@ contact.recipient=support@belivery.by
 
 belpost.queue.delay-ms=100
 
+# Задержка между повторными попытками получения данных Белпочты (мс)
+belpost.retry.delay-ms=60000
+# Максимальное количество попыток запросов к Белпочте
+belpost.retry.max-attempts=2
+
 # Minimal interval between progress updates in milliseconds
 progress.update-interval-ms=250
 


### PR DESCRIPTION
## Summary
- make BelPost batch retry delay and attempt count configurable
- document retry parameters and helper methods in Russian

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c42f5cb728832d8313a3ea44f24dd1