### PR TITLE
feat: reuse WebDriver in BelPost queue

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
@@ -85,12 +85,15 @@ public class WebBelPostBatchService {
     /**
      * Пытается получить данные по треку с указанным номером, повторяя запрос
      * при возникновении временных ошибок.
+     * <p>Метод предполагает, что драйвер создаётся и закрывается вызывающей
+     * стороной. {@link WebDriver} не потокобезопасен, поэтому передавать
+     * один экземпляр между потоками нельзя.</p>
      *
      * @param driver активный экземпляр {@link WebDriver}
      * @param number трек-номер Белпочты
      * @return список событий трека или пустой объект при неудаче
      */
-    private TrackInfoListDTO parseTrack(WebDriver driver, String number) {
+    public TrackInfoListDTO parseTrack(WebDriver driver, String number) {
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
                 return tryParseTrack(driver, number);


### PR DESCRIPTION
## Summary
- reuse single WebDriver instance across BelPost queue tasks
- expose driver-aware parseTrack in WebBelPostBatchService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to jitpack.io (https://jitpack.io): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c456c213d8832d97449e0e0cfde20b