### PR TITLE
Disable Selenium Manager analytics

### DIFF
--- a/src/main/java/com/project/tracking_system/configuration/SeleniumManagerConfig.java
+++ b/src/main/java/com/project/tracking_system/configuration/SeleniumManagerConfig.java
@@ -1,0 +1,26 @@
+package com.project.tracking_system.configuration;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Конфигурация для управления поведением Selenium Manager.
+ * <p>
+ * Отвечает за настройку системных свойств, отключающих отправку статистики.
+ * </p>
+ */
+@Configuration
+public class SeleniumManagerConfig {
+
+    /**
+     * Отключает отправку статистики Selenium Manager для уменьшения шума в логах.
+     * <p>
+     * Устанавливает системные свойства, запрещающие сбор и передачу аналитики.
+     * </p>
+     */
+    @PostConstruct
+    public void disableAnalytics() {
+        System.setProperty("SE_MANAGER_ANALYTICS", "false");
+        System.setProperty("SELENIUM_MANAGER_ANALYTICS", "false");
+    }
+}


### PR DESCRIPTION
## Summary
- add SeleniumManagerConfig to disable Selenium Manager analytics

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c463804b0c832dac3d3a515763c555