### PR TITLE
chore: silence CDP version warnings

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -49,4 +49,8 @@
     </logger>
 
     <logger name="org.springframework" level="WARN"/>
+
+    <!-- Скрываем предупреждения о версии CDP до появления поддержки Chrome 140 -->
+    <logger name="org.openqa.selenium.devtools" level="ERROR"/>
+    <logger name="org.openqa.selenium.chromium" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
## Summary
- suppress Selenium CDP version warnings until Chrome 140 support

## Testing
- `mvn -q test` *(fails: could not resolve org.springframework.boot:spring-boot-starter-parent due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4656023bc832db35c920fc9dfb190