### PR TITLE
Обработать ошибки создания WebDriver

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
@@ -56,12 +56,22 @@ public class WebBelPostBatchService {
             return result;
         }
 
-        WebDriver driver = webDriverFactory.create();
+        // Пытаемся создать WebDriver и корректно обработать возможные ошибки инициализации
+        WebDriver driver;
+        try {
+            driver = webDriverFactory.create();
+        } catch (WebDriverException e) {
+            log.error("❌ Не удалось создать WebDriver: {}", e.getMessage(), e);
+            // Возвращаем пустой результат, чтобы вызывающий код мог продолжить работу
+            return result;
+        }
+
         try {
             for (String number : trackNumbers) {
                 result.put(number, parseTrack(driver, number));
             }
         } finally {
+            // Закрываем драйвер в блоке finally, чтобы гарантировать освобождение ресурсов
             driver.quit();
         }
         return result;


### PR DESCRIPTION
## Summary
- Обернул создание WebDriver в try/catch и добавил логирование при ошибке
- Гарантировал закрытие WebDriver через блок finally

## Testing
- ⚠️ `mvn -q test` *(проект не собран: отсутствует родительский POM из-за недоступной сети)*

------
https://chatgpt.com/codex/tasks/task_e_68c473ed31bc832d94872291cb92f6a2