### PR TITLE
test: remove unused web driver stubs

### DIFF
--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceTest.java
@@ -6,12 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**
@@ -30,6 +25,14 @@ class WebBelPostBatchServiceTest {
 
     private WebBelPostBatchService service;
 
+    /**
+     * Подготавливает окружение перед каждым тестом.
+     *<p>
+     * Настраивает фабрику драйверов так, чтобы при последовательных
+     * вызовах {@code create()} возвращались разные объекты, имитируя
+     * создание нового {@link WebDriver} для каждого трека.
+     * </p>
+     */
     @BeforeEach
     void init() {
         // Возвращаем разные драйверы при последовательных вызовах
@@ -38,14 +41,14 @@ class WebBelPostBatchServiceTest {
         when(factory.create())
                 .thenReturn(driver1)
                 .thenReturn(driver2);
-        doNothing().when(driver1).get(anyString());
-        doNothing().when(driver2).get(anyString());
-        when(driver1.findElement(any(By.class))).thenThrow(new NoSuchElementException("mock"));
-        when(driver2.findElement(any(By.class))).thenThrow(new NoSuchElementException("mock"));
 
         service = new WebBelPostBatchService(factory);
     }
 
+    /**
+     * Проверяет, что при каждом обращении к {@link WebBelPostBatchService#parseTrack(String)}
+     * создаётся новый экземпляр драйвера и он корректно закрывается.
+     */
     @Test
     void parseTrack_CreatesNewDriverEachCall() {
         service.parseTrack("111");


### PR DESCRIPTION
## Summary
- clean WebBelPostBatchServiceTest from unused driver stubs
- document setup and test methods in Russian

## Testing
- `mvn test -Dtest=WebBelPostBatchServiceTest` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c48dbe7188832db65ae81265e08457