### PR TITLE
Use Instant for postal daily stats timestamp

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/PostalServiceDailyStatistics.java
+++ b/src/main/java/com/project/tracking_system/entity/PostalServiceDailyStatistics.java
@@ -8,11 +8,11 @@ import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 
 /**
- * Daily statistics for a postal service.
+ * Ежедневная статистика по почтовой службе.
  */
 @Getter
 @Setter
@@ -52,11 +52,14 @@ public class PostalServiceDailyStatistics {
     @Column(name = "sum_pickup_days", nullable = false)
     private BigDecimal sumPickupDays = BigDecimal.ZERO;
 
+    /**
+     * Момент последнего обновления статистики (UTC).
+     */
     @Column(name = "updated_at")
-    private ZonedDateTime updatedAt;
+    private Instant updatedAt;
 
     /**
-     * Average number of days from send to delivery.
+     * Среднее количество дней от отправки до доставки.
      */
     @Transient
     public BigDecimal getAverageDeliveryDays() {
@@ -66,7 +69,7 @@ public class PostalServiceDailyStatistics {
     }
 
     /**
-     * Average number of days until parcel pick up (delivery only).
+     * Среднее количество дней нахождения посылки на пункте выдачи (только доставленные).
      */
     @Transient
     public BigDecimal getAveragePickupDays() {

--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -26,11 +26,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.Duration;
 import com.project.tracking_system.utils.DateParserUtils;
 import java.util.List;
 import java.util.Objects;
@@ -539,7 +540,7 @@ public class DeliveryHistoryService {
                 if (pickupDays != null) {
                     psDaily.setSumPickupDays(psDaily.getSumPickupDays().add(pickupDays));
                 }
-                psDaily.setUpdatedAt(ZonedDateTime.now());
+                psDaily.setUpdatedAt(Instant.now());
                 postalServiceDailyStatisticsRepository.save(psDaily);
             }
 
@@ -588,7 +589,7 @@ public class DeliveryHistoryService {
                 if (deliveryDays != null) {
                     psDaily.setSumDeliveryDays(psDaily.getSumDeliveryDays().add(deliveryDays));
                 }
-                psDaily.setUpdatedAt(ZonedDateTime.now());
+                psDaily.setUpdatedAt(Instant.now());
                 postalServiceDailyStatisticsRepository.save(psDaily);
             }
         }
@@ -681,7 +682,7 @@ public class DeliveryHistoryService {
                         .orElse(null);
                 if (psDaily != null && psDaily.getSent() > 0) {
                     psDaily.setSent(psDaily.getSent() - 1);
-                    psDaily.setUpdatedAt(ZonedDateTime.now());
+                    psDaily.setUpdatedAt(Instant.now());
                     postalServiceDailyStatisticsRepository.save(psDaily);
                 }
             }

--- a/src/main/java/com/project/tracking_system/service/analytics/TrackStatisticsUpdater.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/TrackStatisticsUpdater.java
@@ -130,7 +130,7 @@ public class TrackStatisticsUpdater {
                         return d;
                     });
             psDaily.setSent(psDaily.getSent() + 1);
-            psDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+            psDaily.setUpdatedAt(Instant.now());
             postalServiceDailyStatisticsRepository.save(psDaily);
         }
     }
@@ -177,7 +177,7 @@ public class TrackStatisticsUpdater {
                         .orElse(null);
                 if (oldPsDaily != null && oldPsDaily.getSent() > 0) {
                     oldPsDaily.setSent(oldPsDaily.getSent() - 1);
-                    oldPsDaily.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    oldPsDaily.setUpdatedAt(Instant.now());
                     postalServiceDailyStatisticsRepository.save(oldPsDaily);
                 }
             }


### PR DESCRIPTION
## Summary
- replace `ZonedDateTime` with `Instant` for daily postal statistics timestamp and document field
- update services to populate `PostalServiceDailyStatistics.updatedAt` using `Instant.now()`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c48d062320832da273ae05f919da25