### PR TITLE
test: mock rate limiter in HomeControllerTest

### DIFF
--- a/src/test/java/com/project/tracking_system/controller/HomeControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/HomeControllerTest.java
@@ -10,6 +10,8 @@ import com.project.tracking_system.service.track.BelPostManualService;
 import com.project.tracking_system.service.track.TrackFacade;
 import com.project.tracking_system.service.track.TrackServiceClassifier;
 import com.project.tracking_system.service.admin.AppInfoService;
+import com.project.tracking_system.service.ratelimit.Bucket4jRateLimiter;
+import io.github.bucket4j.Bucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -52,6 +54,8 @@ class HomeControllerTest {
     private CustomerService customerService;
     @MockBean
     private AppInfoService appInfoService;
+    @MockBean
+    private Bucket4jRateLimiter bucket4jRateLimiter; // Мокаем ограничитель для ApiRateLimitFilter
 
     /**
      * Проверяем, что при подтверждённом пользователем имени поле ФИО
@@ -74,6 +78,12 @@ class HomeControllerTest {
                 .thenReturn(Optional.of(dto));
         // Мокаем получение версии приложения, используемой глобальным советом контроллеров
         when(appInfoService.getApplicationVersion()).thenReturn("1.0");
+
+        // Мокаем бакеты, чтобы фильтр ограничения запросов не вызывал реальных зависимостей
+        when(bucket4jRateLimiter.resolveCustomerBucket(Mockito.anyString()))
+                .thenReturn(Mockito.mock(Bucket.class));
+        when(bucket4jRateLimiter.resolveTelegramBucket(Mockito.anyString()))
+                .thenReturn(Mockito.mock(Bucket.class));
 
         mockMvc.perform(get("/app").param("phone", "375291112233"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- mock Bucket4jRateLimiter in HomeController tests to avoid rate limiter errors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c497b87ed8832d921d05794f53eed9