### PR TITLE
Wrap CSRF meta tags with conditional rendering

### DIFF
--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -7,8 +7,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta name="_csrf" th:content="${_csrf.token}"/>
-    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+    <!-- Мета-теги для передачи CSRF-токена; выводятся только при наличии токена -->
+    <meta name="_csrf" th:if="${_csrf != null}" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:if="${_csrf != null}" th:content="${_csrf.headerName}"/>
 
     <!-- Здесь вы подключаете все общие стили/скрипты для всего сайта -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap">


### PR DESCRIPTION
## Summary
- render CSRF meta tags only when CSRF token is available

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c49a127b80832d9640701e106fe0f9