### PR TITLE
Добавлен условный рендеринг CSRF-полей в шаблонах

### DIFF
--- a/src/main/resources/templates/admin/customers.html
+++ b/src/main/resources/templates/admin/customers.html
@@ -55,7 +55,7 @@
             <td th:text="${c.returnedCount}"></td>
             <td>
                 <form th:action="@{/admin/customers/{id}/delete(id=${c.id})}" method="post" class="d-inline">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                     <button type="submit" class="btn btn-danger btn-sm">Удалить</button>
                 </form>
             </td>

--- a/src/main/resources/templates/admin/parcel-details.html
+++ b/src/main/resources/templates/admin/parcel-details.html
@@ -33,12 +33,12 @@
         </div>
 
         <form th:action="@{/admin/parcels/{id}/force-update(id=${parcel.id})}" method="post" class="mb-3">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
             <button type="submit" class="btn btn-success">Обновить статус</button>
         </form>
 
         <form th:action="@{/admin/parcels/{id}/delete(id=${parcel.id})}" method="post">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
             <button type="submit" class="btn btn-danger">Удалить посылку</button>
         </form>
     </div>

--- a/src/main/resources/templates/admin/plans.html
+++ b/src/main/resources/templates/admin/plans.html
@@ -35,7 +35,7 @@
         <tbody>
         <tr th:each="plan : ${plans}">
             <form th:action="@{/admin/plans/{id}(id=${plan.id})}" method="post">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
                 <td><input type="text" name="code" class="form-control" th:value="${plan.code}" /></td>
                 <td><input type="text" name="name" class="form-control" th:value="${plan.name}" /></td>
                 <td><input type="number" name="limits.maxTracksPerFile" class="form-control" th:value="${plan.limits.maxTracksPerFile}" /></td>
@@ -62,7 +62,7 @@
 
     <h4 class="mt-4">Новый план</h4>
     <form th:action="@{/admin/plans}" method="post" class="row row-cols-lg-auto g-2 align-items-end">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
         <div class="col-md-1">
             <label for="plan-code" class="form-label">Код</label>
             <input id="plan-code" type="text" name="code" class="form-control" />

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -63,7 +63,7 @@
 
     <h4 class="mt-4">Интервал автообновления треков</h4>
     <form th:action="@{/admin/settings/track-interval}" method="post" class="row g-2">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
         <div class="col-auto">
             <input type="number" min="1" class="form-control" name="interval" th:value="${interval}" required>
         </div>
@@ -74,7 +74,7 @@
 
     <h4 class="mt-4">TTL кэша результатов (мс)</h4>
     <form th:action="@{/admin/settings/cache-ttl}" method="post" class="row g-2">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
         <div class="col-auto">
             <input type="number" min="1" class="form-control" name="ttl" th:value="${cacheTtl}" required>
         </div>

--- a/src/main/resources/templates/admin/stores.html
+++ b/src/main/resources/templates/admin/stores.html
@@ -35,7 +35,7 @@
             <td th:text="${s.subscriptionPlan}"></td>
             <td>
                 <form th:action="@{/admin/stores/{id}/delete(id=${s.id})}" method="post" class="d-inline">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                     <button type="submit" class="btn btn-danger btn-sm">Удалить</button>
                 </form>
             </td>

--- a/src/main/resources/templates/admin/subscriptions.html
+++ b/src/main/resources/templates/admin/subscriptions.html
@@ -29,7 +29,7 @@
             <td th:text="${s.subscriptionEndDate}"></td>
             <td>
                 <form th:action="@{/admin/users/{id}/change-subscription(id=${s.user.id})}" method="post" class="d-flex">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                     <select name="subscriptionPlan" class="form-select form-select-sm me-2">
                         <option th:each="p : ${plans}"
                                 th:value="${p.code}"

--- a/src/main/resources/templates/admin/user-details.html
+++ b/src/main/resources/templates/admin/user-details.html
@@ -37,7 +37,7 @@
 
     <h4>Сменить роль</h4>
     <form th:action="@{/admin/users/{userId}/role-update(userId=${user.id})}" method="post" class="mb-4">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
         <div class="d-flex">
             <div class="mb-3 me-2">
                 <label for="role" class="form-label">Новая роль:</label>
@@ -52,7 +52,7 @@
 
     <h4>Изменить план подписки</h4>
     <form th:action="@{/admin/users/{userId}/change-subscription(userId=${user.id})}" method="post" class="mb-4">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
         <div class="d-flex">
             <div class="mb-3 me-2">
                 <label for="subscriptionPlan" class="form-label">Новый план:</label>

--- a/src/main/resources/templates/admin/user-list.html
+++ b/src/main/resources/templates/admin/user-list.html
@@ -67,7 +67,7 @@
             <td>
                 <a th:href="@{/admin/users/{userId}(userId=${user.id})}" class="btn btn-info btn-sm me-1">Подробнее</a>
                 <form th:action="@{/admin/users/{id}/delete(id=${user.id})}" method="post" class="d-inline">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                     <button type="submit" class="btn btn-danger btn-sm">Удалить</button>
                 </form>
             </td>

--- a/src/main/resources/templates/admin/user-new.html
+++ b/src/main/resources/templates/admin/user-new.html
@@ -20,7 +20,7 @@
         <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
 
         <form th:action="@{/admin/users/new}" method="post">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
             <div class="mb-3">
                 <label for="email" class="form-label">Email</label>
                 <input type="email" class="form-control" id="email" name="email" required>

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -108,7 +108,7 @@
                     <!-- Таблица истории -->
                     <div th:if="${trackParcelDTO != null and !trackParcelDTO.isEmpty()}" class="mt-3">
                         <form action="/app/departures/delete-selected" method="post">
-                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                             <div class="table-responsive">
                                 <table class="table history-table">
                                     <thead>
@@ -295,7 +295,7 @@
                 <!-- Форма отправки трек-номера на сервер -->
                 <form id="set-track-number-form" th:action="@{/app/departures/set-number}" method="post">
                     <!-- CSRF-поля для защиты формы -->
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                     <div class="modal-header">
                         <h5 class="modal-title" id="trackNumberModalLabel">Укажите трек-номер</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -39,7 +39,7 @@
                 <!-- Форма поиска посылки и загрузка файла -->
                 <div class="card shadow-sm p-4 rounded-4">
                     <form th:action="@{/app}" method="post" class="w-100 mb-4">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
 
                         <!-- Блок выбора магазина, если их больше одного -->
                         <div th:if="${stores != null and #lists.size(stores) > 1}" class="mb-3">
@@ -106,7 +106,7 @@
                     <hr class="my-3">
 
                     <form th:action="@{/app/upload}" method="post" enctype="multipart/form-data" class="w-100">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
 
                         <!-- Оборачиваем метку и ссылку в flex-контейнер для равномерного распределения -->
                         <div class="d-flex justify-content-between align-items-center mb-2">

--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -150,7 +150,7 @@
                         </h5>
 
                         <form id="store-settings-form">
-                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
 
                             <table class="table">
                                 <thead>
@@ -191,7 +191,7 @@
     <div class="card p-3 shadow-sm rounded-4 mb-4">
         <h5 class="mb-3">Уведомления (Telegram)</h5>
         <form id="telegram-notifications-form" class="mt-2">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
             <div class="form-check form-switch">
                 <!-- При недоступной функции переключатель всегда выключен -->
                 <input class="form-check-input" type="checkbox" id="telegramNotificationsToggle"
@@ -237,7 +237,7 @@
     <div class="card p-3 shadow-sm rounded-4 mb-4">
         <h5 class="mb-3">Функции и автоматизация</h5>
         <form id="auto-update-form" class="mt-2">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
             <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" id="autoUpdateToggle"
                        th:checked="${planDetails.allowAutoUpdate ? userProfile.autoUpdateEnabled : false}"
@@ -250,7 +250,7 @@
             <p class="form-text ms-4">Автообновления расходуют дневной лимит обновлений.</p>
         </form>
         <form id="bulk-button-form" class="mt-3">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
             <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" id="showBulkUpdateButton"
                        th:checked="${planDetails.allowBulkUpdate ? userSettingsDTO.showBulkUpdateButton : false}"
@@ -314,7 +314,7 @@
     <div class="d-flex mt-4">
         <form th:if="${userProfile.subscriptionCode != 'FREE'}"
               th:action="@{/subscription/renew}" method="post">
-            <input type="hidden" name="_csrf" th:value="${_csrf.token}"/>
+            <input type="hidden" name="_csrf" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
             <button class="btn btn-outline-success">Продлить</button>
         </form>
         <a th:if="${userProfile.subscriptionCode != 'ENTERPRISE'}"
@@ -329,7 +329,7 @@
         <div id="evropost-content" th:fragment="evropostFragment">
             <h5 class="mb-3">Настройки Европочты</h5>
             <form id="evropost-settings-form" th:action="@{/app/profile/settings/evropost}" th:object="${evropostCredentialsDTO}" method="post">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
                 <div class="form-check form-switch">
                     <input class="form-check-input" type="checkbox" id="useCustomCredentials" name="useCustomCredentials" th:field="*{useCustomCredentials}">
                     <label class="form-check-label" for="useCustomCredentials">Подключить API Европочты (договор – бесплатно)</label>
@@ -374,7 +374,7 @@
         <div id="password-content" th:fragment="passwordFragment">
             <h5 class="mb-3">Изменение пароля</h5>
             <form id="password-settings-form" th:action="@{/app/profile/settings/password}" th:object="${passwordChangeDTO}" method="post">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
                 <div class="form-floating mb-3 position-relative">
                     <input type="password" class="form-control password-input" id="currentPassword" name="currentPassword" th:field="*{currentPassword}" placeholder="Текущий пароль" autocomplete="off">
                     <label for="currentPassword">Текущий пароль</label>
@@ -458,7 +458,7 @@
              th:classappend="${first} ? ' expanded' : ' collapsed'">
             <form class="telegram-settings-form" th:action="@{/app/stores/{id}/telegram-settings(id=${store.id})}"
                   method="post">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
                 <div class="form-check form-switch mb-2">
                     <input class="form-check-input" type="checkbox" th:id="'tg-enable-' + ${store.id}" name="enabled"
                            th:checked="${store.telegramSettings != null and store.telegramSettings.enabled}"
@@ -588,7 +588,7 @@
                 <div class="modal-footer d-flex justify-content-between">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
                     <form th:action="@{/app/profile/settings/delete}" method="post">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
                         <button class="btn btn-danger">
                             <i class="bi bi-trash-fill"></i> Да, удалить
                         </button>

--- a/src/main/resources/templates/auth/forgot-password.html
+++ b/src/main/resources/templates/auth/forgot-password.html
@@ -25,7 +25,7 @@
     </div>
 
     <form th:action="@{/auth/forgot-password}" method="post">
-      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
 
       <div class="form-floating mb-3 position-relative">
         <input type="email" class="form-control" id="email" name="email" placeholder="Адрес электронной почты" required>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -28,7 +28,7 @@
     </div>
 
     <form th:action="@{/auth/login}" method="post">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
         <!-- Поле Email -->
         <div class="form-floating mb-3">
             <input type="email" class="form-control" id="email" name="email" placeholder="Email" required>

--- a/src/main/resources/templates/auth/registration.html
+++ b/src/main/resources/templates/auth/registration.html
@@ -25,7 +25,7 @@
     </div>
 
     <form th:action="@{/auth/registration}" th:object="${userDTO}" method="post">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
         <!-- Первый этап: Ввод email и паролей -->
         <div th:unless="${confirmCodRegistration}">
             <div class="form-floating mb-3">

--- a/src/main/resources/templates/auth/reset-password.html
+++ b/src/main/resources/templates/auth/reset-password.html
@@ -25,7 +25,7 @@
         </div>
 
         <form th:action="@{/auth/reset-password}" th:object="${passwordResetDTO}" method="post">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
             <input type="hidden" name="token" th:value="${token}"/>
 
             <div class="form-floating mb-3 position-relative">

--- a/src/main/resources/templates/marketing/contacts.html
+++ b/src/main/resources/templates/marketing/contacts.html
@@ -37,7 +37,7 @@
             </div>
 
             <form th:action="@{/contacts/submit}" th:object="${contactForm}" method="post" class="row g-3">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
                 <div class="col-12">
                     <label for="name" class="form-label">Ваше имя</label>
                     <input type="text" th:field="*{name}" class="form-control" id="name"

--- a/src/main/resources/templates/marketing/pricing.html
+++ b/src/main/resources/templates/marketing/pricing.html
@@ -116,7 +116,7 @@
                         <!-- ✅ Покупка или улучшение -->
                             <form th:if="${plan.code != 'FREE' && (userProfile == null || userPlanPosition == null || plan.position > userPlanPosition)}"
                                   th:action="@{/pricing/buy}" method="post" class="mt-auto">
-                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}"/>
                             <input type="hidden" id="monthsInput" name="months" value="1"/>
                             <input type="hidden" name="plan" th:value="${plan.code}"/>
                             <button type="submit" class="btn btn-primary w-100"

--- a/src/main/resources/templates/partials/customer-info.html
+++ b/src/main/resources/templates/partials/customer-info.html
@@ -3,7 +3,7 @@
         <p>Покупатель не найден</p>
         <form id="assign-customer-form" th:action="@{/app/customers/assign}" method="post" class="mt-3">
             <input type="hidden" name="trackId" th:value="${trackId}">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
             <div class="input-group mb-2">
                 <input type="text" name="phone" class="form-control" placeholder="375XXXXXXXXX" required>
                 <button type="submit" class="btn btn-primary">Сохранить</button>
@@ -25,7 +25,7 @@
                 <form id="edit-phone-form" th:action="@{/app/customers/change}" method="post"
                       class="mt-2 hidden">
                     <input type="hidden" name="trackId" th:value="${trackId}">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                     <div class="input-group mb-2">
                         <input type="text" name="phone" class="form-control" placeholder="375XXXXXXXXX" required>
                         <button type="submit" class="btn btn-primary">Сохранить</button>
@@ -37,7 +37,7 @@
                     <strong>ФИО:</strong>
                     <form id="edit-name-form" th:action="@{/app/customers/update-name}" method="post" class="mt-2">
                         <input type="hidden" name="trackId" th:value="${trackId}">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                         <div class="input-group mb-2">
                             <input type="text" name="fullName" class="form-control" placeholder="Иванов Иван Иванович" required>
                             <button type="submit" class="btn btn-primary">Сохранить</button>
@@ -68,7 +68,7 @@
                     <form th:if="${customerInfo.nameSource != T(com.project.tracking_system.entity.NameSource).USER_CONFIRMED}"
                           id="edit-name-form" th:action="@{/app/customers/update-name}" method="post" class="mt-2 hidden">
                         <input type="hidden" name="trackId" th:value="${trackId}">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                         <div class="input-group mb-2">
                             <input type="text" name="fullName" class="form-control" placeholder="Иванов Иван Иванович" required>
                             <button type="submit" class="btn btn-primary">Сохранить</button>

--- a/src/main/resources/templates/partials/header-admin.html
+++ b/src/main/resources/templates/partials/header-admin.html
@@ -28,7 +28,7 @@
             <!-- Блок авторизации -->
             <div class="auth-buttons">
                 <form th:action="@{/logout}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
                     <button type="submit" class="btn btn-danger btn-text">
                         <i class="bi bi-box-arrow-right"></i> Выйти
                     </button>

--- a/src/main/resources/templates/partials/header-app.html
+++ b/src/main/resources/templates/partials/header-app.html
@@ -46,7 +46,7 @@
 
                 <!-- Кнопка выхода -->
                 <form th:if="${authenticatedUser != null}" th:action="@{/logout}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
                     <button type="submit" class="btn btn-danger btn-text">
                         <i class="bi bi-box-arrow-right"></i> Выйти
                     </button>

--- a/src/main/resources/templates/partials/header-marketing.html
+++ b/src/main/resources/templates/partials/header-marketing.html
@@ -51,7 +51,7 @@
                     <i class="bi bi-box-arrow-in-up-right"></i>
                 </a>
                 <form th:if="${authenticatedUser != null}" th:action="@{/logout}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}" />
                     <button type="submit" class="btn btn-danger btn-text">
                         <i class="bi bi-box-arrow-right"></i> Выйти
                     </button>


### PR DESCRIPTION
## Summary
- Добавлены проверки `th:if"${_csrf != null}"` для скрытых CSRF-полей во всех шаблонах
- Исключено рендеринг полей при отсутствии CSRF-токена, предотвращая ошибки Thymeleaf

## Testing
- `mvn -q test` *(провалено: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(провалено: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c4ab2b82b0832dbd2817dfa0d551af