### PR TITLE
feat: allow specifying ChromeDriver path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ Belpost and Evropost
 ## Конфигурация ChromeDriver
 
 Selenium Manager автоматически определяет и скачивает совместимый
-ChromeDriver, поэтому указывать `System.setProperty("webdriver.chrome.driver", …)`
-больше не требуется.
+ChromeDriver, поэтому указывать путь к драйверу обычно не требуется.
+При необходимости использования локального бинарника задайте свойство
+`webdriver.chrome.driver` в `application.properties` или переменную окружения
+`WEBDRIVER_CHROME_DRIVER`.
+Если файл существует и доступен для выполнения, Selenium Manager
+будет отключён, а указанный драйвер использован.
 
 ```java
 import org.openqa.selenium.WebDriver;
@@ -23,8 +27,8 @@ import org.openqa.selenium.chrome.ChromeDriver;
 WebDriver driver = new ChromeDriver();
 ```
 
-В Docker при необходимости путь к бинарнику можно задать через переменные
-окружения, например `CHROMEDRIVER_PATH`.
+В Docker путь к бинарнику также можно передать через переменную окружения
+`WEBDRIVER_CHROME_DRIVER` или `CHROMEDRIVER_PATH`.
 
 ### Отключение аналитики Selenium Manager
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,3 +68,6 @@ contact.rate-limit.max=5
 contact.rate-limit.window-ms=60000
 
 debug.log-masked-fio=false
+
+# Путь к ChromeDriver; оставьте пустым, чтобы Selenium Manager скачал драйвер автоматически
+webdriver.chrome.driver=

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,1 +1,4 @@
 spring.flyway.locations=classpath:db/migration/h2
+
+# Путь к ChromeDriver для тестов (по умолчанию пуст)
+webdriver.chrome.driver=


### PR DESCRIPTION
## Summary
- allow `ChromeWebDriverFactory` to use local driver when `webdriver.chrome.driver` points to executable
- expose empty `webdriver.chrome.driver` property for optional driver path configuration
- document driver path configuration in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ac52d298832d984b7d9f24bc0bae