### PR TITLE
feat: расширить tmpfs для приложения

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,7 @@ services:
     volumes:
       - ./logs:/app/logs
     tmpfs:
-      - /tmp
+      - /tmp:rw,exec,nosuid,size=64m # хранение временных файлов в памяти с ограничением 64MB
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- mount `/tmp` with RW, exec, nosuid and 64MB limit for app container

## Testing
- `npm test` (fails: Missing script "test")
- `mvn -q test` (fails: Network is unreachable)
- `docker compose build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c4ae142c80832d9324f545712c7d5d