### PR TITLE
feat: propagate user context through track processors

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessor.java
@@ -78,19 +78,20 @@ public class BelpostTrackUpdateProcessor implements TrackUpdateProcessor {
     /**
      * Загружает и сохраняет информацию по одному треку.
      *
-     * @param meta метаданные трек-номера
+     * @param meta   метаданные трек-номера
+     * @param userId идентификатор пользователя, может быть {@code null}
      * @return результат обработки
      */
     @Override
-    public TrackingResultAdd process(TrackMeta meta) {
+    public TrackingResultAdd process(TrackMeta meta, Long userId) {
         if (meta == null) {
             return new TrackingResultAdd(null, TrackConstants.NO_DATA_STATUS, new TrackInfoListDTO());
         }
         Map<String, TrackInfoListDTO> infoMap = webBelPostBatchService.processBatch(List.of(meta.number()));
         TrackInfoListDTO info = infoMap.getOrDefault(meta.number(), new TrackInfoListDTO());
         boolean hasStatus = !info.getList().isEmpty();
-        if (meta.canSave()) {
-            trackProcessingService.save(meta.number(), info, meta.storeId(), null, meta.phone());
+        if (userId != null && meta.canSave()) {
+            trackProcessingService.save(meta.number(), info, meta.storeId(), userId, meta.phone());
         }
         // Информируем о результате обработки без персональных данных
         log.debug(hasStatus ? "Статусы получены" : "Статусы отсутствуют");

--- a/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessor.java
@@ -73,16 +73,17 @@ public class EvropostTrackUpdateProcessor implements TrackUpdateProcessor {
     /**
      * Обрабатывает один трек синхронно.
      *
-     * @param meta метаданные трек-номера
+     * @param meta   метаданные трек-номера
+     * @param userId идентификатор пользователя, может быть {@code null}
      * @return результат обработки
      */
     @Override
-    public TrackingResultAdd process(TrackMeta meta) {
+    public TrackingResultAdd process(TrackMeta meta, Long userId) {
         if (meta == null) {
             return new TrackingResultAdd(null, TrackConstants.NO_DATA_STATUS, new TrackInfoListDTO());
         }
         TrackInfoListDTO info = trackProcessingService.processTrack(
-                meta.number(), meta.storeId(), null, meta.canSave(), meta.phone());
+                meta.number(), meta.storeId(), userId, meta.canSave(), meta.phone());
         boolean hasStatus = !info.getList().isEmpty();
         // Информируем о результате обработки без персональных данных
         log.debug(hasStatus ? "Статусы получены" : "Статусы отсутствуют");

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateDispatcherService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateDispatcherService.java
@@ -70,6 +70,18 @@ public class TrackUpdateDispatcherService {
      * @return результат обработки
      */
     public TrackingResultAdd dispatch(TrackMeta meta) {
+        return dispatch(meta, null);
+    }
+
+    /**
+     * Обрабатывает одиночный трек-номер с возможной привязкой к пользователю.
+     * Если тип почтовой службы не указан, определяется автоматически.
+     *
+     * @param meta   метаданные трека
+     * @param userId идентификатор пользователя, может быть {@code null}
+     * @return результат обработки
+     */
+    public TrackingResultAdd dispatch(TrackMeta meta, Long userId) {
         if (meta == null) {
             return new TrackingResultAdd(null, TrackConstants.NO_DATA_STATUS, new TrackInfoListDTO());
         }
@@ -81,7 +93,7 @@ public class TrackUpdateDispatcherService {
         if (processor == null) {
             return new TrackingResultAdd(meta.number(), TrackConstants.NO_DATA_STATUS, new TrackInfoListDTO(), "Unsupported service");
         }
-        return processor.process(meta);
+        return processor.process(meta, userId);
     }
 
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateProcessor.java
@@ -25,10 +25,11 @@ public interface TrackUpdateProcessor {
     List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId);
 
     /**
-     * Обрабатывает один трек без привязки к пользователю.
+     * Обрабатывает один трек.
      *
-     * @param meta метаданные трека
+     * @param meta   метаданные трека
+     * @param userId идентификатор пользователя, может быть {@code null}
      * @return результат обработки
      */
-    TrackingResultAdd process(TrackMeta meta);
+    TrackingResultAdd process(TrackMeta meta, Long userId);
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -77,7 +77,7 @@ public class TrackViewService {
         if (canUpdate) {
             TrackMeta meta = new TrackMeta(itemNumber, null, null, false,
                     trackParcelService.getPostalServiceType(itemNumber));
-            trackInfo = trackUpdateDispatcherService.dispatch(meta).getTrackInfo();
+            trackInfo = trackUpdateDispatcherService.dispatch(meta, userId).getTrackInfo();
             trackProcessingService.save(itemNumber, trackInfo, parcel.getStore().getId(), userId);
             log.info("🎯 Передано {} записей для трека {}", trackInfo.getList().size(), itemNumber);
         } else {

--- a/src/test/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/BelpostTrackUpdateProcessorTest.java
@@ -41,9 +41,9 @@ class BelpostTrackUpdateProcessorTest {
         TrackInfoListDTO info = new TrackInfoListDTO();
         when(webService.processBatch(List.of("B1"))).thenReturn(Map.of("B1", info));
 
-        TrackingResultAdd result = processor.process(meta);
+        TrackingResultAdd result = processor.process(meta, 1L);
 
-        verify(trackProcessingService).save("B1", info, 1L, null, null);
+        verify(trackProcessingService).save("B1", info, 1L, 1L, null);
         assertEquals(info, result.getTrackInfo());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessorTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/EvropostTrackUpdateProcessorTest.java
@@ -34,11 +34,11 @@ class EvropostTrackUpdateProcessorTest {
     void processSingle_ReturnsInfo() {
         TrackMeta meta = new TrackMeta("E1", 1L, null, false);
         TrackInfoListDTO info = new TrackInfoListDTO();
-        when(trackProcessingService.processTrack("E1", 1L, null, false, null)).thenReturn(info);
+        when(trackProcessingService.processTrack("E1", 1L, 2L, false, null)).thenReturn(info);
 
-        TrackingResultAdd result = processor.process(meta);
+        TrackingResultAdd result = processor.process(meta, 2L);
 
-        verify(trackProcessingService).processTrack("E1", 1L, null, false, null);
+        verify(trackProcessingService).processTrack("E1", 1L, 2L, false, null);
         assertEquals(info, result.getTrackInfo());
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackUpdateDispatcherServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUpdateDispatcherServiceTest.java
@@ -58,9 +58,9 @@ class TrackUpdateDispatcherServiceTest {
     void dispatchSingle_ResolvesServiceAndCallsProcessor() {
         TrackMeta meta = new TrackMeta("B1", null, null, false);
         when(classifier.detect("B1")).thenReturn(PostalServiceType.BELPOST);
-        when(belpostProcessor.process(meta)).thenReturn(new TrackingResultAdd("B1", "ok", new TrackInfoListDTO()));
+        when(belpostProcessor.process(meta, 5L)).thenReturn(new TrackingResultAdd("B1", "ok", new TrackInfoListDTO()));
 
-        TrackingResultAdd result = dispatcher.dispatch(meta);
+        TrackingResultAdd result = dispatcher.dispatch(meta, 5L);
 
         assertEquals("B1", result.getTrackingNumber());
     }

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -21,6 +21,8 @@ import java.time.ZonedDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -62,7 +64,7 @@ class TrackViewServiceTest {
 
         service.getTrackDetails("A1", 1L);
 
-        verify(trackUpdateDispatcherService, never()).dispatch(any(TrackMeta.class));
+        verify(trackUpdateDispatcherService, never()).dispatch(any(TrackMeta.class), anyLong());
         verify(trackProcessingService, never()).save(anyString(), any(), anyLong(), anyLong());
     }
 
@@ -78,12 +80,12 @@ class TrackViewServiceTest {
         when(applicationSettingsService.getTrackUpdateIntervalHours()).thenReturn(3);
         when(trackParcelService.getPostalServiceType("A1")).thenReturn(PostalServiceType.BELPOST);
         TrackInfoListDTO info = new TrackInfoListDTO();
-        when(trackUpdateDispatcherService.dispatch(any(TrackMeta.class)))
+        when(trackUpdateDispatcherService.dispatch(any(TrackMeta.class), anyLong()))
                 .thenReturn(new TrackingResultAdd("A1", "ok", info));
 
         service.getTrackDetails("A1", 1L);
 
-        verify(trackUpdateDispatcherService).dispatch(any(TrackMeta.class));
+        verify(trackUpdateDispatcherService).dispatch(any(TrackMeta.class), eq(1L));
         verify(trackProcessingService).save("A1", info, 1L, 1L);
     }
 
@@ -101,7 +103,7 @@ class TrackViewServiceTest {
 
         service.getTrackDetails("A1", 1L);
 
-        verify(trackUpdateDispatcherService, never()).dispatch(any(TrackMeta.class));
+        verify(trackUpdateDispatcherService, never()).dispatch(any(TrackMeta.class), anyLong());
         verify(trackProcessingService, never()).save(anyString(), any(), anyLong(), anyLong());
     }
 


### PR DESCRIPTION
## Summary
- pass userId through TrackUpdateProcessor for single track processing
- allow dispatcher and view services to forward user context
- update Evrpoost/Belpost processors and tests to use new parameter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b8183dbc832db7168872675783b7