### PR TITLE
Handle Belpost no-data warning for pre-registered tracks

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
@@ -135,6 +135,12 @@ public class WebBelPostBatchService {
             throw new RateLimitException("Превышено количество запросов");
         }
 
+        // Если Белпочта ещё не внесла данные по этому треку, возвращаем пустой результат
+        if (isNoDataWarningDisplayed(driver)) {
+            log.debug("Предупреждение об отсутствии данных для номера {}", number);
+            return dto;
+        }
+
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(12));
         WebElement trackItem = wait.until(ExpectedConditions.visibilityOfElementLocated(
                 By.cssSelector("article.track-item")));
@@ -161,6 +167,22 @@ public class WebBelPostBatchService {
         }
 
         return dto;
+    }
+
+    /**
+     * Проверяет, появилось ли сообщение об отсутствии данных по трек-номеру.
+     *
+     * @param driver активный {@link WebDriver}
+     * @return {@code true}, если отображается предупреждение
+     */
+    private boolean isNoDataWarningDisplayed(WebDriver driver) {
+        try {
+            WebElement warning = driver.findElement(By.cssSelector(".alert-message.alert-message--warning"));
+            return warning.isDisplayed()
+                    && warning.getText().contains("У нас пока нет данных");
+        } catch (NoSuchElementException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
@@ -1,0 +1,55 @@
+package com.project.tracking_system.service.belpost;
+
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.webdriver.WebDriverFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openqa.selenium.*;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Проверка обработки ситуации, когда Белпочта не предоставляет данные по треку.
+ */
+@ExtendWith(MockitoExtension.class)
+class WebBelPostBatchServiceNoDataWarningTest {
+
+    @Mock
+    private WebDriverFactory factory;
+    @Mock
+    private WebDriver driver;
+    @Mock
+    private WebElement warning;
+
+    private WebBelPostBatchService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WebBelPostBatchService(factory);
+        // Устанавливаем одну попытку, чтобы цикл не повторялся
+        ReflectionTestUtils.setField(service, "maxAttempts", 1);
+    }
+
+    @Test
+    void parseTrack_WarningShown_ReturnsEmpty() {
+        // Драйвер сообщает о наличии предупреждения «данных нет»
+        when(driver.findElement(any(By.class))).thenAnswer(invocation -> {
+            By by = invocation.getArgument(0, By.class);
+            if ("By.cssSelector: .alert-message.alert-message--warning".equals(by.toString())) {
+                return warning;
+            }
+            throw new NoSuchElementException("not found");
+        });
+        when(warning.isDisplayed()).thenReturn(true);
+        when(warning.getText()).thenReturn("У нас пока нет данных об этом трек-номере. Попробуйте проверить позже");
+        // Вызов метода с подменённым драйвером
+        TrackInfoListDTO dto = service.parseTrack(driver, "PC123456789BY");
+        assertTrue(dto.getList().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- skip status updates when Belpost page warns that tracking data is unavailable
- add unit test covering warning detection logic

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c0e19514832da0ecd23479432b4e