### PR TITLE
Handle BelPost no-data warning in parser

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
@@ -141,9 +141,13 @@ public class WebBelPostBatchService {
             throw new RateLimitException("Превышено количество запросов");
         }
 
-        // Ожидаем появления либо предупреждения, либо блока с данными трека
+        // Ожидаем появления либо предупреждения, либо блока с данными трека.
+        // Дополнительно проверяем всплывающее окно о превышении лимита.
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(12));
         WebElement awaited = wait.until(d -> {
+            if (isRateLimitErrorDisplayed(d)) {
+                throw new RateLimitException("Превышено количество запросов");
+            }
             List<WebElement> warnings = d.findElements(NO_DATA_WARNING);
             if (!warnings.isEmpty() && warnings.get(0).isDisplayed()) {
                 return warnings.get(0);
@@ -235,8 +239,10 @@ public class WebBelPostBatchService {
 
     /**
      * Исключение, сигнализирующее о превышении лимита запросов Белпочты.
+     * Расширяет {@link RuntimeException}, чтобы его можно было выбрасывать
+     * внутри лямбд без обязательного объявления в сигнатурах методов.
      */
-    public class RateLimitException extends Exception {
+    public class RateLimitException extends RuntimeException {
         public RateLimitException(String message) {
             super(message);
         }

--- a/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/WebBelPostBatchService.java
@@ -197,10 +197,21 @@ public class WebBelPostBatchService {
      */
     private boolean isNoDataWarningDisplayed(WebElement element) {
         try {
-            return element != null
-                    && element.getAttribute("class").contains("alert-message--warning")
-                    && element.isDisplayed()
-                    && element.getText().contains("У нас пока нет данных");
+            if (element == null || !element.isDisplayed()) {
+                return false;
+            }
+
+            // Проверяем, не является ли сам элемент предупреждением
+            if (element.getAttribute("class").contains("alert-message--warning")
+                    && element.getText().contains("У нас пока нет данных")) {
+                return true;
+            }
+
+            // Ищем предупреждение среди дочерних элементов
+            List<WebElement> nested = element.findElements(NO_DATA_WARNING);
+            return !nested.isEmpty()
+                    && nested.get(0).isDisplayed()
+                    && nested.get(0).getText().contains("У нас пока нет данных");
         } catch (StaleElementReferenceException ignored) {
             return false;
         }

--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import java.util.List;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,11 +33,18 @@ class WebBelPostBatchServiceNoDataWarningTest {
 
         WebElement warning = mock(WebElement.class);
         when(warning.isDisplayed()).thenReturn(true);
-        when(warning.getAttribute("class")).thenReturn("alert-message alert-message--warning");
         when(warning.getText()).thenReturn("У нас пока нет данных");
 
+        when(driver.findElements(any(By.class))).thenAnswer(invocation -> {
+            By by = invocation.getArgument(0);
+            if (by.toString().contains("alert-message--warning")) {
+                return List.of(warning);
+            }
+            return List.of();
+        });
+
         try (MockedConstruction<WebDriverWait> mockWait = Mockito.mockConstruction(WebDriverWait.class,
-                (wait, context) -> when(wait.until(any())).thenReturn(warning))) {
+                (wait, context) -> when(wait.until(any())).thenReturn(true))) {
 
             WebBelPostBatchService service = new WebBelPostBatchService(mock(WebDriverFactory.class));
             ReflectionTestUtils.setField(service, "maxAttempts", 1);

--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
@@ -2,54 +2,50 @@ package com.project.tracking_system.service.belpost;
 
 import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.webdriver.WebDriverFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.openqa.selenium.*;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Проверка обработки ситуации, когда Белпочта не предоставляет данные по треку.
+ * Тестирует пропуск трека при отображении предупреждения об отсутствии данных.
  */
-@ExtendWith(MockitoExtension.class)
 class WebBelPostBatchServiceNoDataWarningTest {
 
-    @Mock
-    private WebDriverFactory factory;
-    @Mock
-    private WebDriver driver;
-    @Mock
-    private WebElement warning;
-
-    private WebBelPostBatchService service;
-
-    @BeforeEach
-    void setUp() {
-        service = new WebBelPostBatchService(factory);
-        // Устанавливаем одну попытку, чтобы цикл не повторялся
-        ReflectionTestUtils.setField(service, "maxAttempts", 1);
-    }
-
+    /**
+     * Убеждаемся, что при появлении предупреждения трек пропускается.
+     */
     @Test
-    void parseTrack_WarningShown_ReturnsEmpty() {
-        // Драйвер сообщает о наличии предупреждения «данных нет»
-        when(driver.findElement(any(By.class))).thenAnswer(invocation -> {
-            By by = invocation.getArgument(0, By.class);
-            if ("By.cssSelector: .alert-message.alert-message--warning".equals(by.toString())) {
-                return warning;
-            }
-            throw new NoSuchElementException("not found");
-        });
+    void shouldSkipTrackWhenWarningAppears() throws Exception {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.findElement(any(By.class))).thenThrow(NoSuchElementException.class);
+
+        WebElement warning = mock(WebElement.class);
         when(warning.isDisplayed()).thenReturn(true);
-        when(warning.getText()).thenReturn("У нас пока нет данных об этом трек-номере. Попробуйте проверить позже");
-        // Вызов метода с подменённым драйвером
-        TrackInfoListDTO dto = service.parseTrack(driver, "PC123456789BY");
-        assertTrue(dto.getList().isEmpty());
+        when(warning.getAttribute("class")).thenReturn("alert-message alert-message--warning");
+        when(warning.getText()).thenReturn("У нас пока нет данных");
+
+        try (MockedConstruction<WebDriverWait> mockWait = Mockito.mockConstruction(WebDriverWait.class,
+                (wait, context) -> when(wait.until(any())).thenReturn(warning))) {
+
+            WebBelPostBatchService service = new WebBelPostBatchService(mock(WebDriverFactory.class));
+            ReflectionTestUtils.setField(service, "maxAttempts", 1);
+            ReflectionTestUtils.setField(service, "retryDelayMs", 0L);
+
+            TrackInfoListDTO dto = service.parseTrack(driver, "123");
+
+            assertTrue(dto.getList().isEmpty(), "Трек не должен содержать событий");
+        }
     }
 }
+

--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceNoDataWarningTest.java
@@ -34,6 +34,7 @@ class WebBelPostBatchServiceNoDataWarningTest {
         WebElement warning = mock(WebElement.class);
         when(warning.isDisplayed()).thenReturn(true);
         when(warning.getText()).thenReturn("У нас пока нет данных");
+        when(warning.getAttribute("class")).thenReturn("alert-message alert-message--warning");
 
         when(driver.findElements(any(By.class))).thenAnswer(invocation -> {
             By by = invocation.getArgument(0);
@@ -44,7 +45,7 @@ class WebBelPostBatchServiceNoDataWarningTest {
         });
 
         try (MockedConstruction<WebDriverWait> mockWait = Mockito.mockConstruction(WebDriverWait.class,
-                (wait, context) -> when(wait.until(any())).thenReturn(true))) {
+                (wait, context) -> when(wait.until(any())).thenReturn(warning))) {
 
             WebBelPostBatchService service = new WebBelPostBatchService(mock(WebDriverFactory.class));
             ReflectionTestUtils.setField(service, "maxAttempts", 1);

--- a/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceRateLimitTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/WebBelPostBatchServiceRateLimitTest.java
@@ -1,0 +1,51 @@
+package com.project.tracking_system.service.belpost;
+
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.webdriver.WebDriverFactory;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Проверяет, что при появлении уведомления о превышении лимита запросов
+ * обработка трека прерывается и возвращается пустой результат.
+ */
+class WebBelPostBatchServiceRateLimitTest {
+
+    /**
+     * Эмулируем всплывающее окно лимита запросов и убеждаемся,
+     * что трек не парсится.
+     */
+    @Test
+    void shouldSkipWhenRateLimitAppears() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.findElement(any(By.class))).thenThrow(NoSuchElementException.class);
+        when(driver.findElements(any(By.class))).thenReturn(List.of());
+
+        WebBelPostBatchService service = new WebBelPostBatchService(mock(WebDriverFactory.class));
+        ReflectionTestUtils.setField(service, "maxAttempts", 1);
+        ReflectionTestUtils.setField(service, "retryDelayMs", 0L);
+
+        try (MockedConstruction<WebDriverWait> mockWait =
+                     Mockito.mockConstruction(WebDriverWait.class,
+                             (wait, context) -> when(wait.until(any()))
+                                     .thenThrow(service.new RateLimitException("limit")))) {
+
+            TrackInfoListDTO dto = service.parseTrack(driver, "123");
+            assertTrue(dto.getList().isEmpty(),
+                    "При превышении лимита запросов данные не должны парситься");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- wait for either BelPost track data or no-data warning before parsing
- treat awaited warning as empty result instead of raising errors
- cover no-data scenario with unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c53c0764dc832da82b018dd1a8632d