### PR TITLE
Refactor credential selection in Evropost tracking service

### DIFF
--- a/src/main/java/com/project/tracking_system/service/jsonEvropostService/JsonEvroTrackingService.java
+++ b/src/main/java/com/project/tracking_system/service/jsonEvropostService/JsonEvroTrackingService.java
@@ -41,6 +41,8 @@ public class JsonEvroTrackingService {
      * <p>
      * Метод выполняет запрос к внешнему API для получения данных о трекинге посылки по номеру,
      * а затем десериализует ответ в объект {@link JsonEvroTrackingResponse}.
+     * В зависимости от настроек пользователя и флага использования личных данных
+     * выбирает между персональными и системными учётными данными.
      * </p>
      *
      * @param number Номер посылки, для которой требуется получить информацию о трекинге.
@@ -48,20 +50,31 @@ public class JsonEvroTrackingService {
      * @throws IllegalStateException если произошла ошибка десериализации JSON или запроса
      */
     public JsonEvroTrackingResponse getJson(Long userId, String number) {
+        // Определяем, нужно ли применять личные учётные данные пользователя
+        boolean useCustomCredentials = userService.isUsingCustomCredentials(userId);
         ResolvedCredentialsDTO credentials;
-        boolean useCustomCredentials = false;
 
-        if (userId == null) {
-            log.warn("Анонимный пользователь делает запрос. Используем системные учетные данные.");
-            credentials = userCredentialsResolver.getSystemCredentials(); // Новый метод
+        if (useCustomCredentials) {
+            // Флаг включён: ожидаем наличие идентификатора пользователя
+            if (userId != null) {
+                // Получаем личные креды пользователя
+                credentials = userService.resolveCredentials(userId);
+                if (credentials == null) {
+                    // Креды не найдены – логируем и прерываем выполнение
+                    log.warn("Личные учётные данные отсутствуют для пользователя ID={}", userId);
+                    throw new IllegalStateException("Личные учётные данные не найдены");
+                }
+                log.info("Используем личные учётные данные пользователя ID={}", userId);
+            } else {
+                // Включённый флаг без userId – критичная ситуация
+                log.warn("Флаг использования личных учётных данных включён, но userId не указан");
+                throw new IllegalStateException("Не указан идентификатор пользователя при включённых личных учётных данных");
+            }
         } else {
-            useCustomCredentials = userService.isUsingCustomCredentials(userId);
-            log.info("Запрос на получение данных для пользователя ID: {}, почтовый номер: {}", userId, number);
-            credentials = userService.resolveCredentials(userId);
+            // Флаг выключен: всегда берём системные креды
+            credentials = userCredentialsResolver.getSystemCredentials();
+            log.info("User ID={} → интеграция с личными кредами отключена, используем системные", userId);
         }
-
-        log.info("Данные для запроса определены. Используются {} данные.",
-                useCustomCredentials ? "пользовательские" : "системные");
 
         // Выполняем запрос
         JsonRequest jsonRequest = requestFactory.createTrackingRequest(


### PR DESCRIPTION
## Summary
- handle custom vs system credential selection with detailed logging
- document credential selection logic in JsonEvroTrackingService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c539c3aeac832d9738b981170bcc64