### PR TITLE
feat: add track number validation on client and server

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -23,6 +23,7 @@ import com.project.tracking_system.utils.ResponseBuilder;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
+import org.springframework.http.HttpStatus;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -249,6 +250,9 @@ public class DeparturesController {
         } catch (TrackNumberAlreadyExistsException e) {
             log.warn("Попытка добавить уже существующий трек-номер: {} для пользователя {}", number, user.getId());
             return ResponseBuilder.error(HttpStatus.CONFLICT, e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.warn("Некорректный трек-номер: {} для пользователя {}", number, user.getId());
+            return ResponseBuilder.error(HttpStatus.BAD_REQUEST, e.getMessage());
         }
     }
 

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -118,6 +118,45 @@ function handleTrackNumberFormSubmit(event) {
 }
 
 /**
+ * Инициализирует проверку трек-номера на стороне клиента.
+ * Навешивает обработчик на поле ввода и управляет сообщением об ошибке.
+ */
+function initTrackNumberValidation() {
+    const input = document.getElementById('number');
+    const error = document.getElementById('numberError');
+    const submitBtn = input?.closest('form')?.querySelector('button[type="submit"]');
+    const preRegToggle = document.getElementById('togglePreRegistration');
+    if (!input || !error || !submitBtn) {
+        return;
+    }
+
+    // Функция обновляет состояние поля и кнопки
+    const updateState = () => {
+        const value = input.value;
+        // Пустой номер допустим при предрегистрации
+        if (preRegToggle?.checked && value.trim() === '') {
+            input.classList.remove('is-invalid');
+            error.textContent = '';
+            submitBtn.disabled = false;
+            return;
+        }
+        const result = trackValidator.validate(value);
+        if (result.valid) {
+            input.classList.remove('is-invalid');
+            error.textContent = '';
+            submitBtn.disabled = false;
+        } else {
+            input.classList.add('is-invalid');
+            error.textContent = result.message;
+            submitBtn.disabled = true;
+        }
+    };
+
+    input.addEventListener('input', updateState);
+    preRegToggle?.addEventListener('change', updateState);
+}
+
+/**
  * Копирует текст в буфер обмена и показывает уведомление о результате.
  * @param {string} text - копируемый текст
  */
@@ -1992,6 +2031,7 @@ document.addEventListener("DOMContentLoaded", function () {
     initializePhoneToggle();
     autoFillFullName();
     initializePreRegistrationRequired();
+    initTrackNumberValidation();
     initAssignCustomerFormHandler();
     initEditCustomerPhoneFormHandler();
     initPhoneEditToggle();

--- a/src/main/resources/static/js/track-validator.js
+++ b/src/main/resources/static/js/track-validator.js
@@ -1,0 +1,39 @@
+(function (global) {
+    'use strict';
+
+    /**
+     * Определяет почтовую службу по формату трек-номера.
+     * @param {string} number исходный трек-номер
+     * @returns {string|null} BELPOST, EVROPOST или null, если формат не распознан
+     */
+    function detectService(number) {
+        const value = (number || '').toUpperCase().trim();
+        if (/^(PC|BV|BP|PE)\d{9}BY$/.test(value)) {
+            return 'BELPOST';
+        }
+        if (/^BY\d{12}$/.test(value)) {
+            return 'EVROPOST';
+        }
+        return null;
+    }
+
+    /**
+     * Проверяет корректность трек-номера и возвращает результат валидации.
+     * @param {string} number трек-номер для проверки
+     * @returns {{valid: boolean, service: string|null, message: string}} результат проверки
+     */
+    function validate(number) {
+        const value = (number || '').toUpperCase().trim();
+        if (!value) {
+            return { valid: false, service: null, message: 'Номер обязателен' };
+        }
+        const service = detectService(value);
+        if (!service) {
+            return { valid: false, service: null, message: 'Неверный формат номера' };
+        }
+        return { valid: true, service, message: '' };
+    }
+
+    // Экспортируем функции в глобальную область видимости
+    global.trackValidator = { detectService, validate };
+})(window);

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -64,6 +64,7 @@
                         <div class="input-group mb-3">
                             <!-- Атрибут required устанавливается динамически через JS -->
                             <input type="text" id="number" name="number" class="form-control" placeholder="Номер посылки">
+                            <div id="numberError" class="invalid-feedback"></div>
                             <button type="submit" class="btn btn-outline-primary btn-equal">Проверить</button>
                         </div>
 

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -78,6 +78,7 @@
 <!-- Общие скрипты -->
 <script src="/bootstrap/bootstrap.bundle.min.js"></script>
 <script src="/js/libs/stomp.min.js"></script>
+<script src="/js/track-validator.js"></script>
 <script src="/js/app.js"></script>
 <script src="/js/progress-tracking.js"></script>
 

--- a/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceSortingTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceSortingTest.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
 import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.service.track.TrackServiceClassifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,11 +35,22 @@ class TrackParcelServiceSortingTest {
     @Mock
     private UserSubscriptionRepository userSubscriptionRepository;
 
+    @Mock
+    private TrackServiceClassifier trackServiceClassifier;
+
     private TrackParcelService service;
 
+    /**
+     * Подготавливает сервис с заглушками зависимостей перед каждым тестом.
+     */
     @BeforeEach
     void setUp() {
-        service = new TrackParcelService(userService, trackParcelRepository, userSubscriptionRepository);
+        service = new TrackParcelService(
+                userService,
+                trackParcelRepository,
+                userSubscriptionRepository,
+                trackServiceClassifier
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- add reusable track number validator module
- enforce client-side validation for track input with error feedback
- validate track numbers on server when assigning numbers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5db2a9e0c832d93dc3f7ff57bf563