### PR TITLE
refactor: move number error below input

### DIFF
--- a/src/main/resources/assets/scss/components/_forms.scss
+++ b/src/main/resources/assets/scss/components/_forms.scss
@@ -98,6 +98,15 @@
   }
 }
 
+// Сообщение об ошибке для поля номера трека
+#numberError {
+  display: block; // показываем блок под полем ввода
+
+  &:empty {
+    display: none; // скрываем, если текст отсутствует
+  }
+}
+
 // Округление поля ввода телефона
 #phone {
   border-radius: ui.$border-radius !important;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -636,6 +636,13 @@ button:hover {
   }
 }
 
+#numberError {
+  display: block;
+}
+#numberError:empty {
+  display: none;
+}
+
 #phone {
   border-radius: 8px !important;
 }
@@ -1851,18 +1858,3 @@ body.loading {
   border-style: solid;
   border-color: #ddd transparent transparent transparent;
 }
-
-/* Отключаем встроенную иконку ошибки Bootstrap,
-   чтобы поле не меняло ширину и не смещало кнопку */
-.form-control.is-invalid {
-  background-image: none;
-  padding-right: 0.75rem;
-}
-
-/*# sourceMappingURL=style.css.map */
-
-/*# sourceMappingURL=style.css.map */
-
-/*# sourceMappingURL=style.css.map */
-
-/*# sourceMappingURL=style.css.map */

--- a/src/main/resources/templates/app/home.html
+++ b/src/main/resources/templates/app/home.html
@@ -61,11 +61,14 @@
                             <i class="bi bi-info-circle text-primary" data-bs-toggle="tooltip"
                                data-bs-placement="right" title="Белпочта, Европочта"></i>
                         </label>
-                        <div class="input-group mb-3">
-                            <!-- Атрибут required устанавливается динамически через JS -->
-                            <input type="text" id="number" name="number" class="form-control" placeholder="Номер посылки">
+                        <div class="mb-3">
+                            <div class="input-group">
+                                <!-- Атрибут required устанавливается динамически через JS -->
+                                <input type="text" id="number" name="number" class="form-control" placeholder="Номер посылки">
+                                <button type="submit" class="btn btn-outline-primary btn-equal">Проверить</button>
+                            </div>
+                            <!-- Блок отображения ошибок ввода номера -->
                             <div id="numberError" class="invalid-feedback"></div>
-                            <button type="submit" class="btn btn-outline-primary btn-equal">Проверить</button>
                         </div>
 
                         <!-- Переключатели дополнительных полей -->


### PR DESCRIPTION
## Summary
- place tracking number error message below input and action button
- add CSS rules to display error without affecting layout
- ensure JS validation still finds the error block

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e8d71d44832d95aaab7b9215feab