### PR TITLE
feat: normalize track number before submission

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -81,6 +81,8 @@ function handleTrackNumberFormSubmit(event) {
     const form = event.target;
     const id = form.querySelector('input[name="id"]').value;
     const number = form.querySelector('input[name="number"]').value;
+    // Нормализуем номер: удаляем пробелы и приводим к верхнему регистру
+    const normalized = number.toUpperCase().trim();
 
     fetch('/app/departures/set-number', {
         method: 'POST',
@@ -88,7 +90,7 @@ function handleTrackNumberFormSubmit(event) {
             ...getCsrfHeaders(),
             'Content-Type': 'application/x-www-form-urlencoded'
         },
-        body: new URLSearchParams({ id, number })
+        body: new URLSearchParams({ id, number: normalized })
     })
         .then(response => {
             if (!response.ok) {
@@ -99,11 +101,11 @@ function handleTrackNumberFormSubmit(event) {
             if (row) {
                 const btn = row.querySelector('button.parcel-number');
                 if (btn) {
-                    btn.textContent = number;
+                    btn.textContent = normalized;
                     btn.classList.add('open-modal');
-                    btn.dataset.itemnumber = number;
+                    btn.dataset.itemnumber = normalized;
                 }
-                row.dataset.trackNumber = number;
+                row.dataset.trackNumber = normalized;
                 notifyUser('Трек-номер добавлен', 'success');
             } else {
                 window.location.reload();

--- a/src/main/resources/static/js/track-validator.js
+++ b/src/main/resources/static/js/track-validator.js
@@ -2,12 +2,21 @@
     'use strict';
 
     /**
+     * Нормализует трек-номер: приводит к верхнему регистру и удаляет пробелы.
+     * @param {string} number исходный трек-номер
+     * @returns {string} нормализованный трек-номер
+     */
+    function normalize(number) {
+        return (number || '').toUpperCase().trim();
+    }
+
+    /**
      * Определяет почтовую службу по формату трек-номера.
      * @param {string} number исходный трек-номер
      * @returns {string|null} BELPOST, EVROPOST или null, если формат не распознан
      */
     function detectService(number) {
-        const value = (number || '').toUpperCase().trim();
+        const value = normalize(number);
         if (/^(PC|BV|BP|PE)\d{9}BY$/.test(value)) {
             return 'BELPOST';
         }
@@ -23,7 +32,7 @@
      * @returns {{valid: boolean, service: string|null, message: string}} результат проверки
      */
     function validate(number) {
-        const value = (number || '').toUpperCase().trim();
+        const value = normalize(number);
         if (!value) {
             return { valid: false, service: null, message: 'Номер обязателен' };
         }
@@ -35,5 +44,5 @@
     }
 
     // Экспортируем функции в глобальную область видимости
-    global.trackValidator = { detectService, validate };
+    global.trackValidator = { normalize, detectService, validate };
 })(window);


### PR DESCRIPTION
## Summary
- normalize track numbers before sending to server and storing in DOM
- centralize track number normalization logic

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebcc5a38832d807a96fd923b2b7d