### PR TITLE
Fix profile settings block overflow handling

### DIFF
--- a/src/main/resources/assets/scss/pages/_profile.scss
+++ b/src/main/resources/assets/scss/pages/_profile.scss
@@ -4,17 +4,17 @@
 
 .tg-settings-content {
   transition: max-height 0.3s ease, opacity 0.3s ease;
-  overflow: hidden;
 
   &.collapsed {
     max-height: 0;
     opacity: 0;
     padding: 0 !important;
     margin: 0 !important;
+    overflow: hidden;
   }
 
   &.expanded {
-    max-height: 1000px; // Достаточно большое значение
+    max-height: none; // Снимаем ограничение высоты при раскрытии
     opacity: 1;
   }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1470,16 +1470,16 @@ button:hover {
 
 .tg-settings-content {
   transition: max-height 0.3s ease, opacity 0.3s ease;
-  overflow: hidden;
 }
 .tg-settings-content.collapsed {
   max-height: 0;
   opacity: 0;
   padding: 0 !important;
   margin: 0 !important;
+  overflow: hidden;
 }
 .tg-settings-content.expanded {
-  max-height: 1000px;
+  max-height: none;
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- move overflow clipping from the base profile settings container to the collapsed modifier
- allow the expanded container to grow without height limits and rebuild the compiled stylesheet

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68c96a85a580832d9fc471f6714960d8