### PR TITLE
Remove redundant auto-save hints from profile page

### DIFF
--- a/src/main/resources/templates/app/profile.html
+++ b/src/main/resources/templates/app/profile.html
@@ -199,10 +199,6 @@
                        th:disabled="${!planDetails.allowTelegramNotifications}">
                 <label class="form-check-label" for="telegramNotificationsToggle">Отправлять уведомления о статусах посылок</label>
             </div>
-            <p class="form-text text-muted ms-4 auto-save-hint"
-               th:if="${planDetails.allowTelegramNotifications}">
-                Переключатель сохраняется автоматически.
-            </p>
                 <p class="form-text text-muted ms-4">
                     Попросите покупателей запустить
                     <a th:href='@{${@environment.getProperty("telegram.bot.link")}}' target="_blank">бота Belivery</a>
@@ -248,10 +244,6 @@
                        th:disabled="${!planDetails.allowAutoUpdate}">
                 <label class="form-check-label" for="autoUpdateToggle">Автообновление треков</label>
             </div>
-            <p class="form-text text-muted ms-4 auto-save-hint"
-               th:if="${planDetails.allowAutoUpdate}">
-                Переключатель сохраняется автоматически.
-            </p>
             <p class="form-text text-danger ms-4" th:if="${!planDetails.allowAutoUpdate}">
                 Функция доступна в тарифе "Бизнес" и выше
             </p>
@@ -265,10 +257,6 @@
                        th:disabled="${!planDetails.allowBulkUpdate}">
                 <label class="form-check-label" for="showBulkUpdateButton">Показывать кнопку массового обновления</label>
             </div>
-            <p class="form-text text-muted ms-4 auto-save-hint"
-               th:if="${planDetails.allowBulkUpdate}">
-                Переключатель сохраняется автоматически.
-            </p>
             <p class="form-text text-danger ms-4" th:if="${!planDetails.allowBulkUpdate}">
                 Функция доступна в тарифе "Бизнес" и выше
             </p>
@@ -346,9 +334,6 @@
                     <input class="form-check-input" type="checkbox" id="useCustomCredentials" name="useCustomCredentials" th:field="*{useCustomCredentials}">
                     <label class="form-check-label" for="useCustomCredentials">Подключить API Европочты (договор – бесплатно)</label>
                 </div>
-                <p class="form-text text-muted ms-4 auto-save-hint">
-                    Переключатель сохраняется автоматически.
-                </p>
                 <div id="custom-credentials-fields" class="hidden">
                     <div class="form-floating mb-3">
                         <input type="text" class="form-control" id="evropostUsername" name="evropostUsername" th:field="*{evropostUsername}" placeholder="LoginName" autocomplete="off">
@@ -497,11 +482,6 @@
                         Отправлять напоминания, если посылка не забрана
                     </label>
                 </div>
-
-                <p class="form-text text-muted ms-4 auto-save-hint"
-                   th:if="${planDetails.allowTelegramNotifications}">
-                    Переключатели сохраняются автоматически.
-                </p>
 
                 <div th:id="'tg-reminder-fields-' + ${store.id}" class="mb-3 ms-4 hidden reminder-fields">
                     <div class="mb-2">


### PR DESCRIPTION
## Summary
- remove the auto-save hint paragraphs from the profile toggles to declutter the UI while preserving layout
- verify that auto-save feedback still relies on the existing toast/alert handlers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c975d0f3f8832db19f36fbfc6dfa81