### PR TITLE
Improve pagination responsiveness and limit page links

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -55,6 +55,11 @@ public class AdminController {
     private final ApplicationSettingsService applicationSettingsService;
 
     /**
+     * Ограничение количества отображаемых ссылок пагинации для компактности.
+     */
+    private static final int PAGE_WINDOW = 6;
+
+    /**
      * Отображает дашборд администратора.
      * <p>
      * Метод подготавливает общую статистику по пользователям и отслеживаниям
@@ -448,9 +453,18 @@ public class AdminController {
         // Загружаем посылки постранично
         org.springframework.data.domain.Page<TrackParcelAdminInfoDTO> parcelPage = adminService.getAllParcels(page, size);
 
+        int currentPageIndex = parcelPage.getNumber();
+        int totalPages = parcelPage.getTotalPages();
+
+        // Рассчитываем диапазон отображаемых страниц
+        int startPage = (currentPageIndex / PAGE_WINDOW) * PAGE_WINDOW;
+        int endPage = Math.min(startPage + PAGE_WINDOW - 1, totalPages - 1);
+
         model.addAttribute("parcels", parcelPage.getContent());
-        model.addAttribute("currentPage", parcelPage.getNumber());
-        model.addAttribute("totalPages", parcelPage.getTotalPages());
+        model.addAttribute("currentPage", currentPageIndex);
+        model.addAttribute("totalPages", totalPages);
+        model.addAttribute("startPage", startPage);
+        model.addAttribute("endPage", endPage);
         model.addAttribute("size", size);
 
         // Хлебные крошки

--- a/src/main/java/com/project/tracking_system/controller/AdminController.java
+++ b/src/main/java/com/project/tracking_system/controller/AdminController.java
@@ -467,11 +467,14 @@ public class AdminController {
             paginationWindow = PaginationUtils.calculateWindow(paginationWindow.currentPage(), totalPages, PAGE_WINDOW);
         }
 
+        List<Integer> pageIndexes = paginationWindow.pageIndexes();
+
         model.addAttribute("parcels", parcelPage.getContent());
         model.addAttribute("currentPage", paginationWindow.currentPage());
         model.addAttribute("totalPages", totalPages);
         model.addAttribute("startPage", paginationWindow.startPage());
         model.addAttribute("endPage", paginationWindow.endPage());
+        model.addAttribute("pageIndexes", pageIndexes);
         model.addAttribute("size", size);
 
         // Хлебные крошки

--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -143,6 +143,8 @@ public class DeparturesController {
         log.debug("Передача атрибутов в модель: stores={}, storeId={}, trackParcelDTO={}, currentPage={}, totalPages={}, size={}",
                 stores, storeId, trackParcelPage.getContent(), paginationWindow.currentPage(), totalPages, size);
 
+        List<Integer> pageIndexes = paginationWindow.pageIndexes();
+
         // Добавляем атрибуты в модель
         model.addAttribute("stores", stores);
         model.addAttribute("storeId", storeId != null ? storeId : ""); // Если null, передаем пустую строку
@@ -154,6 +156,7 @@ public class DeparturesController {
         model.addAttribute("totalPages", totalPages);
         model.addAttribute("startPage", paginationWindow.startPage());
         model.addAttribute("endPage", paginationWindow.endPage());
+        model.addAttribute("pageIndexes", pageIndexes);
         model.addAttribute("trackParcelNotification", trackParcelPage.isEmpty() ? "Отслеживаемых посылок нет" : null);
         model.addAttribute("bulkUpdateButtonDTO",
                 new BulkUpdateButtonDTO(userService.isShowBulkUpdateButton(user.getId())));

--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -56,6 +56,12 @@ public class DeparturesController {
     private final TrackViewService trackViewService;
 
     /**
+     * Максимальное количество ссылок пагинации, отображаемых одновременно.
+     * Помогает избежать длинных списков страниц на экране.
+     */
+    private static final int PAGE_WINDOW = 6;
+
+    /**
      * Метод для отображения списка отслеживаемых посылок пользователя с
      * возможностью фильтрации по магазину, статусу и сортировки по дате.
      *
@@ -154,6 +160,13 @@ public class DeparturesController {
 
         log.debug("Передача атрибутов в модель: stores={}, storeId={}, trackParcelDTO={}, currentPage={}, totalPages={}, size={}", stores, storeId, trackParcelPage.getContent(), trackParcelPage.getNumber(), trackParcelPage.getTotalPages(), size);
 
+        int currentPageIndex = trackParcelPage.getNumber();
+        int totalPages = trackParcelPage.getTotalPages();
+
+        // Определяем диапазон страниц для вывода, избегая длинных списков
+        int startPage = (currentPageIndex / PAGE_WINDOW) * PAGE_WINDOW;
+        int endPage = Math.min(startPage + PAGE_WINDOW - 1, totalPages - 1);
+
         // Добавляем атрибуты в модель
         model.addAttribute("stores", stores);
         model.addAttribute("storeId", storeId != null ? storeId : ""); // Если null, передаем пустую строку
@@ -161,8 +174,10 @@ public class DeparturesController {
         model.addAttribute("trackParcelDTO", trackParcelPage.getContent());
         model.addAttribute("statusString", statusString);
         model.addAttribute("query", query);
-        model.addAttribute("currentPage", trackParcelPage.getNumber());
-        model.addAttribute("totalPages", trackParcelPage.getTotalPages());
+        model.addAttribute("currentPage", currentPageIndex);
+        model.addAttribute("totalPages", totalPages);
+        model.addAttribute("startPage", startPage);
+        model.addAttribute("endPage", endPage);
         model.addAttribute("trackParcelNotification", trackParcelPage.isEmpty() ? "Отслеживаемых посылок нет" : null);
         model.addAttribute("bulkUpdateButtonDTO",
                 new BulkUpdateButtonDTO(userService.isShowBulkUpdateButton(user.getId())));

--- a/src/main/java/com/project/tracking_system/utils/PaginationUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/PaginationUtils.java
@@ -27,13 +27,23 @@ public final class PaginationUtils {
         }
 
         int normalizedTotalPages = Math.max(totalPages, 0);
-        int safeRequestedPage = Math.max(requestedPage, 0);
 
-        int maxPageIndex = normalizedTotalPages > 0 ? normalizedTotalPages - 1 : 0;
+        if (normalizedTotalPages == 0) {
+            // Нет данных — возвращаем пустое окно и фиксируем страницу на нуле
+            return new PaginationWindow(0, 0, -1);
+        }
+
+        int safeRequestedPage = Math.max(requestedPage, 0);
+        int maxPageIndex = normalizedTotalPages - 1;
         int currentPage = Math.min(safeRequestedPage, maxPageIndex);
 
-        int startPage = normalizedTotalPages > 0 ? (currentPage / windowSize) * windowSize : 0;
-        int endPage = normalizedTotalPages > 0 ? Math.min(startPage + windowSize - 1, maxPageIndex) : 0;
+        int startPage = (currentPage / windowSize) * windowSize;
+        int endPage = Math.min(startPage + windowSize - 1, maxPageIndex);
+
+        if (startPage > endPage) {
+            // Возможна ситуация при подмене номера страницы: гарантируем корректные границы окна
+            startPage = endPage;
+        }
 
         return new PaginationWindow(currentPage, startPage, endPage);
     }

--- a/src/main/java/com/project/tracking_system/utils/PaginationUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/PaginationUtils.java
@@ -1,0 +1,40 @@
+package com.project.tracking_system.utils;
+
+/**
+ * Утилитный класс для расчёта безопасного окна пагинации.
+ */
+public final class PaginationUtils {
+
+    private PaginationUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Рассчитывает параметры окна пагинации, гарантируя что индексы страниц останутся в допустимых пределах.
+     * <p>
+     * Метод фиксирует некорректные значения текущей страницы (например, отрицательные или выходящие за количество страниц),
+     * чтобы исключить исключения при генерации диапазона ссылок.
+     * </p>
+     *
+     * @param requestedPage исходно запрошенный индекс страницы
+     * @param totalPages    количество доступных страниц
+     * @param windowSize    размер окна пагинации
+     * @return объект {@link PaginationWindow} с безопасными индексами
+     */
+    public static PaginationWindow calculateWindow(int requestedPage, int totalPages, int windowSize) {
+        if (windowSize <= 0) {
+            throw new IllegalArgumentException("Размер окна пагинации должен быть положительным");
+        }
+
+        int normalizedTotalPages = Math.max(totalPages, 0);
+        int safeRequestedPage = Math.max(requestedPage, 0);
+
+        int maxPageIndex = normalizedTotalPages > 0 ? normalizedTotalPages - 1 : 0;
+        int currentPage = Math.min(safeRequestedPage, maxPageIndex);
+
+        int startPage = normalizedTotalPages > 0 ? (currentPage / windowSize) * windowSize : 0;
+        int endPage = normalizedTotalPages > 0 ? Math.min(startPage + windowSize - 1, maxPageIndex) : 0;
+
+        return new PaginationWindow(currentPage, startPage, endPage);
+    }
+}

--- a/src/main/java/com/project/tracking_system/utils/PaginationWindow.java
+++ b/src/main/java/com/project/tracking_system/utils/PaginationWindow.java
@@ -1,0 +1,11 @@
+package com.project.tracking_system.utils;
+
+/**
+ * Представляет параметры окна пагинации для вывода ссылок на страницы.
+ *
+ * @param currentPage фактически используемый индекс текущей страницы (с учётом ограничений)
+ * @param startPage   начальный индекс окна пагинации
+ * @param endPage     конечный индекс окна пагинации
+ */
+public record PaginationWindow(int currentPage, int startPage, int endPage) {
+}

--- a/src/main/java/com/project/tracking_system/utils/PaginationWindow.java
+++ b/src/main/java/com/project/tracking_system/utils/PaginationWindow.java
@@ -1,5 +1,8 @@
 package com.project.tracking_system.utils;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
 /**
  * Представляет параметры окна пагинации для вывода ссылок на страницы.
  *
@@ -8,4 +11,22 @@ package com.project.tracking_system.utils;
  * @param endPage     конечный индекс окна пагинации
  */
 public record PaginationWindow(int currentPage, int startPage, int endPage) {
+
+    /**
+     * Формирует неизменяемый список индексов страниц внутри текущего окна.
+     * <p>
+     * Если окно некорректно (например, при отсутствии страниц), возвращается пустой список,
+     * чтобы слой представления не пытался отрисовать несуществующие номера.
+     * </p>
+     *
+     * @return список индексов страниц в порядке возрастания
+     */
+    public List<Integer> pageIndexes() {
+        if (endPage < startPage) {
+            return List.of();
+        }
+        return IntStream.rangeClosed(startPage, endPage)
+                .boxed()
+                .toList();
+    }
 }

--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -279,9 +279,12 @@
   margin-top: 2rem;
   list-style: none;
   padding: 0;
+  flex-wrap: wrap; // Позволяет переносить элементы пагинации на небольших экранах
+  gap: 0.5rem; // Формирует равномерные отступы между кнопками
+  max-width: 100%; // Исключает выход списка за границы контейнера
 
   .page-item {
-    margin: 0 5px;
+    margin: 0; // Управление отступами полностью возложено на gap
 
     .page-link {
       display: flex;
@@ -321,6 +324,31 @@
       cursor: not-allowed;
       opacity: 0.6;
       transform: none;
+    }
+  }
+
+  @include ui.respond-to(md) {
+    gap: 0.4rem; // Уменьшаем расстояние между элементами на планшетах
+
+    .page-item {
+      .page-link {
+        width: 36px;
+        height: 36px;
+        font-size: 0.9rem;
+      }
+    }
+  }
+
+  @include ui.respond-to(sm) {
+    gap: 0.35rem; // Дополнительно сжимаем пагинацию на телефонах
+    padding: 0 0.5rem; // Добавляем минимальные отступы от краёв экрана
+
+    .page-item {
+      .page-link {
+        width: 32px;
+        height: 32px;
+        font-size: 0.85rem;
+      }
     }
   }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1263,9 +1263,12 @@ button:hover {
   margin-top: 2rem;
   list-style: none;
   padding: 0;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  max-width: 100%;
 }
 .pagination .page-item {
-  margin: 0 5px;
+  margin: 0;
 }
 .pagination .page-item .page-link {
   display: flex;
@@ -1302,6 +1305,27 @@ button:hover {
   cursor: not-allowed;
   opacity: 0.6;
   transform: none;
+}
+@media (max-width: 768px) {
+  .pagination {
+    gap: 0.4rem;
+  }
+  .pagination .page-item .page-link {
+    width: 36px;
+    height: 36px;
+    font-size: 0.9rem;
+  }
+}
+@media (max-width: 576px) {
+  .pagination {
+    gap: 0.35rem;
+    padding: 0 0.5rem;
+  }
+  .pagination .page-item .page-link {
+    width: 32px;
+    height: 32px;
+    font-size: 0.85rem;
+  }
 }
 
 .modal-dialog-centered {

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -58,10 +58,10 @@
                 </a>
             </li>
 
-            <!-- Номера страниц -->
-            <li class="page-item" th:each="i : ${#numbers.sequence(0, totalPages - 1)}" th:classappend="${i == currentPage} ? 'active'">
-                <a class="page-link" th:href="@{/admin/parcels(page=${i}, size=${size})}" th:text="${i + 1}" aria-label="Страница ${i + 1}"></a>
-            </li>
+              <!-- Номера страниц (ограниченный диапазон) -->
+              <li class="page-item" th:each="i : ${#numbers.sequence(startPage, endPage)}" th:classappend="${i == currentPage} ? 'active'">
+                  <a class="page-link" th:href="@{/admin/parcels(page=${i}, size=${size})}" th:text="${i + 1}" aria-label="Страница ${i + 1}"></a>
+              </li>
 
             <!-- Кнопка "Вперёд" -->
             <li class="page-item" th:classappend="${currentPage == totalPages - 1} ? 'disabled'">

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -59,7 +59,7 @@
             </li>
 
               <!-- Номера страниц (ограниченный диапазон) -->
-              <li class="page-item" th:each="i : ${#numbers.sequence(startPage, endPage)}" th:classappend="${i == currentPage} ? 'active'">
+              <li class="page-item" th:each="i : ${pageIndexes}" th:classappend="${i == currentPage} ? 'active'">
                   <a class="page-link" th:href="@{/admin/parcels(page=${i}, size=${size})}" th:text="${i + 1}" aria-label="Страница ${i + 1}"></a>
               </li>
 

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -230,7 +230,7 @@
                             </li>
 
                             <!-- Номера страниц (ограниченный диапазон) -->
-                            <li class="page-item" th:each="i : ${#numbers.sequence(startPage, endPage)}"
+                            <li class="page-item" th:each="i : ${pageIndexes}"
                                 th:classappend="${i == currentPage} ? 'active'">
                                 <!-- Ссылка на определённую страницу, учитывающая поисковый запрос, если поле поиска не пустое -->
                                 <a class="page-link"

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -229,8 +229,8 @@
                                 </a>
                             </li>
 
-                            <!-- Номера страниц -->
-                            <li class="page-item" th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
+                            <!-- Номера страниц (ограниченный диапазон) -->
+                            <li class="page-item" th:each="i : ${#numbers.sequence(startPage, endPage)}"
                                 th:classappend="${i == currentPage} ? 'active'">
                                 <!-- Ссылка на определённую страницу, учитывающая поисковый запрос, если поле поиска не пустое -->
                                 <a class="page-link"

--- a/src/test/java/com/project/tracking_system/utils/PaginationUtilsTest.java
+++ b/src/test/java/com/project/tracking_system/utils/PaginationUtilsTest.java
@@ -1,0 +1,54 @@
+package com.project.tracking_system.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Набор модульных тестов для {@link PaginationUtils}, проверяющих корректность нормализации индекса страницы
+ * и формирования окна пагинации при различных входных данных.
+ */
+class PaginationUtilsTest {
+
+    @Test
+    void shouldClampRequestedPageAboveRange() {
+        PaginationWindow window = PaginationUtils.calculateWindow(10, 6, 6);
+
+        assertEquals(5, window.currentPage(), "Индекс страницы должен быть ограничен последней доступной страницей");
+        assertEquals(0, window.startPage(), "Окно должно начинаться с первой страницы блока");
+        assertEquals(5, window.endPage(), "Окно должно заканчиваться последней страницей блока");
+        assertEquals(List.of(0, 1, 2, 3, 4, 5), window.pageIndexes(), "Список индексов должен содержать последовательность страниц окна");
+    }
+
+    @Test
+    void shouldNormalizeNegativeRequestedPage() {
+        PaginationWindow window = PaginationUtils.calculateWindow(-3, 5, 6);
+
+        assertEquals(0, window.currentPage(), "Отрицательные индексы переводятся на первую страницу");
+        assertEquals(0, window.startPage(), "Окно должно начинаться с нулевой страницы");
+        assertEquals(4, window.endPage(), "Окно должно охватывать все доступные страницы");
+        assertEquals(List.of(0, 1, 2, 3, 4), window.pageIndexes(), "Должны выводиться все доступные страницы");
+    }
+
+    @Test
+    void shouldReturnEmptyWindowWhenNoPagesAvailable() {
+        PaginationWindow window = PaginationUtils.calculateWindow(3, 0, 6);
+
+        assertEquals(0, window.currentPage(), "Текущая страница фиксируется на нуле при отсутствии данных");
+        assertEquals(0, window.startPage(), "Начало окна должно быть нулевым");
+        assertEquals(-1, window.endPage(), "Конец окна равен -1, что сигнализирует об отсутствии страниц");
+        assertTrue(window.pageIndexes().isEmpty(), "При отсутствии данных список индексов должен быть пустым");
+    }
+
+    @Test
+    void shouldProduceWindowForLastBlock() {
+        PaginationWindow window = PaginationUtils.calculateWindow(11, 12, 6);
+
+        assertEquals(11, window.currentPage(), "Должен использоваться последний индекс страницы");
+        assertEquals(6, window.startPage(), "Окно должно начинаться с начала последнего блока");
+        assertEquals(11, window.endPage(), "Окно должно заканчиваться последней доступной страницей");
+        assertEquals(List.of(6, 7, 8, 9, 10, 11), window.pageIndexes(), "Список индексов должен соответствовать последнему окну");
+    }
+}


### PR DESCRIPTION
## Summary
- limit number of pagination links shown at once with a fixed window
- compute page window range in controllers and expose to templates
- update templates to iterate over the current pagination window

## Testing
- `npm run build:css`
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c95f3ede78832da2375849b085e19d