### PR TITLE
Implement buyer bot state machine and add integration tests

### DIFF
--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -1,0 +1,276 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.service.customer.CustomerTelegramService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.Contact;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Интеграционные сценарии для {@link BuyerTelegramBot}, проверяющие переходы между состояниями.
+ */
+@ExtendWith(MockitoExtension.class)
+class BuyerTelegramBotStateIntegrationTest {
+
+    @Mock
+    private TelegramClient telegramClient;
+
+    @Mock
+    private CustomerTelegramService telegramService;
+
+    private BuyerTelegramBot bot;
+
+    /**
+     * Создаёт экземпляр бота перед каждым сценарием и стабилизирует клиент Telegram.
+     */
+    @BeforeEach
+    void setUp() throws Exception {
+        bot = new BuyerTelegramBot(telegramClient, "token", telegramService);
+        when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
+    }
+
+    /**
+     * Проверяет, что после команды /start бот переходит в ожидание контакта.
+     */
+    @Test
+    void shouldTransitionToAwaitingContactAfterStart() throws Exception {
+        Long chatId = 1001L;
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.empty());
+
+        bot.consume(textUpdate(chatId, "/start"));
+
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_CONTACT, bot.getState(chatId),
+                "Состояние должно перейти в ожидание контакта");
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(captor.capture());
+        SendMessage message = captor.getValue();
+
+        assertTrue(message.getText().contains("номер"),
+                "Пользователь должен получить приглашение поделиться номером");
+        assertNotNull(message.getReplyMarkup(),
+                "Должна отправляться клавиатура запроса контакта");
+    }
+
+    /**
+     * Убеждается, что после получения контакта без ФИО бот ждёт ввод имени.
+     */
+    @Test
+    void shouldAwaitNameAfterContactWhenMissing() throws Exception {
+        Long chatId = 1002L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setNotificationsEnabled(true);
+        customer.setFullName(null);
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+
+        bot.consume(contactUpdate(chatId, "+375291112233"));
+
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId),
+                "После контакта без имени бот должен ожидать ввод ФИО");
+        verify(telegramService).confirmTelegram(customer);
+        verify(telegramService).notifyActualStatuses(customer);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasNamePrompt = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(text -> text != null)
+                .anyMatch(text -> text.contains("укажите своё ФИО"));
+        assertTrue(hasNamePrompt, "Пользователь должен получить просьбу указать ФИО");
+    }
+
+    /**
+     * Проверяет, что ввод ФИО переводит сценарий в состояние ожидания команд.
+     */
+    @Test
+    void shouldSwitchToIdleAfterNameInput() throws Exception {
+        Long chatId = 1003L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName(null);
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+
+        bot.consume(contactUpdate(chatId, "+375297777777"));
+        clearInvocations(telegramClient);
+
+        when(telegramService.updateNameFromTelegram(chatId, "Иван Иванов")).thenAnswer(invocation -> {
+            customer.setFullName("Иван Иванов");
+            customer.setNameSource(NameSource.USER_CONFIRMED);
+            return true;
+        });
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+
+        bot.consume(textUpdate(chatId, "  Иван Иванов  "));
+
+        assertEquals(BuyerTelegramBot.ChatState.IDLE, bot.getState(chatId),
+                "После ввода имени бот должен перейти в состояние IDLE");
+        verify(telegramService).updateNameFromTelegram(chatId, "Иван Иванов");
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasSuccessMessage = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .anyMatch("✅ ФИО сохранено и подтверждено"::equals);
+        assertTrue(hasSuccessMessage, "Пользователь должен получить подтверждение сохранения ФИО");
+    }
+
+    /**
+     * Убеждается, что неподходящая команда не выводит бота из ожидания контакта.
+     */
+    @Test
+    void shouldStayAwaitingContactOnForeignCommand() throws Exception {
+        Long chatId = 1004L;
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.empty());
+
+        bot.consume(textUpdate(chatId, "/start"));
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_CONTACT, bot.getState(chatId));
+        clearInvocations(telegramClient);
+
+        bot.consume(textUpdate(chatId, "/stats"));
+
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_CONTACT, bot.getState(chatId),
+                "Бот должен продолжать ожидать контакт");
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(captor.capture());
+        assertTrue(captor.getValue().getText().contains("поделитесь контактом"),
+                "Пользователь должен получить напоминание об отправке контакта");
+        verify(telegramService, never()).getStatistics(chatId);
+    }
+
+    /**
+     * Проверяет, что бот напоминает о необходимости ввести ФИО при неуместной команде.
+     */
+    @Test
+    void shouldWarnAboutNameDuringUnexpectedCommand() throws Exception {
+        Long chatId = 1005L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName(null);
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+
+        bot.consume(contactUpdate(chatId, "+375296666666"));
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId));
+        clearInvocations(telegramClient);
+
+        bot.consume(textUpdate(chatId, "Верно"));
+
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId),
+                "Бот не должен завершать ожидание ФИО после неподходящей команды");
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient).execute(captor.capture());
+        assertTrue(captor.getValue().getText().contains("ожидается ввод ФИО"),
+                "Пользователь должен получить напоминание о вводе ФИО");
+        verify(telegramService, never()).confirmName(chatId);
+        verify(telegramService, never()).updateNameFromTelegram(anyLong(), anyString());
+    }
+
+    /**
+     * Проверяет, что команда /menu возвращает диалог в состояние IDLE.
+     */
+    @Test
+    void shouldResetStateToIdleOnMenuFromAnyState() throws Exception {
+        Long chatId = 1006L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName(null);
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+
+        bot.consume(contactUpdate(chatId, "+375295555555"));
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId));
+        clearInvocations(telegramClient);
+
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+
+        bot.consume(textUpdate(chatId, "/menu"));
+
+        assertEquals(BuyerTelegramBot.ChatState.IDLE, bot.getState(chatId),
+                "Команда /menu должна переводить бот в состояние IDLE");
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasMenuMessage = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(text -> text != null)
+                .anyMatch(text -> text.contains("Главное меню"));
+        assertTrue(hasMenuMessage, "Бот должен показать главное меню");
+    }
+
+    /**
+     * Создаёт обновление Telegram с текстовым сообщением пользователя.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @param text   текст, который отправил пользователь
+     * @return объект {@link Update} для передачи в бота
+     */
+    private Update textUpdate(Long chatId, String text) {
+        Message message = new Message();
+        message.setMessageId(1);
+        message.setText(text);
+        message.setChat(createChat(chatId));
+
+        Update update = new Update();
+        update.setMessage(message);
+        return update;
+    }
+
+    /**
+     * Создаёт обновление с контактом пользователя.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @param phone  номер телефона, переданный пользователем
+     * @return объект {@link Update} с заполненным контактом
+     */
+    private Update contactUpdate(Long chatId, String phone) {
+        Message message = new Message();
+        message.setMessageId(1);
+        message.setChat(createChat(chatId));
+        Contact contact = new Contact();
+        contact.setPhoneNumber(phone);
+        contact.setUserId(chatId);
+        message.setContact(contact);
+
+        Update update = new Update();
+        update.setMessage(message);
+        return update;
+    }
+
+    /**
+     * Создаёт объект чата Telegram для обновления.
+     *
+     * @param chatId идентификатор чата
+     * @return объект {@link Chat} с заданным идентификатором
+     */
+    private Chat createChat(Long chatId) {
+        Chat chat = new Chat();
+        chat.setId(chatId);
+        chat.setType("private");
+        return chat;
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -61,7 +61,7 @@ class BuyerTelegramBotTest {
     @MethodSource("recognizedPhones")
     void shouldRecognizePhoneFormatsWhenAwaiting(String input, String expectedMask) throws Exception {
         Long chatId = 123L;
-        markAwaitingPhone(chatId);
+        markAwaitingContact(chatId);
 
         Update update = mockTextUpdate(chatId, input);
 
@@ -83,7 +83,7 @@ class BuyerTelegramBotTest {
     @Test
     void shouldShowFormatHintForUnrecognizedPhone() throws Exception {
         Long chatId = 456L;
-        markAwaitingPhone(chatId);
+        markAwaitingContact(chatId);
 
         Update update = mockTextUpdate(chatId, "random text");
 
@@ -136,16 +136,16 @@ class BuyerTelegramBotTest {
     }
 
     /**
-     * Помечает чат как ожидающий ввода телефона через отражение приватного состояния бота.
+     * Помечает чат как ожидающий контакта через отражение приватного состояния бота.
      *
      * @param chatId идентификатор чата Telegram
      */
-    private void markAwaitingPhone(Long chatId) throws Exception {
-        Field field = BuyerTelegramBot.class.getDeclaredField("awaitingPhone");
+    private void markAwaitingContact(Long chatId) throws Exception {
+        Field field = BuyerTelegramBot.class.getDeclaredField("chatStates");
         field.setAccessible(true);
         @SuppressWarnings("unchecked")
-        Map<Long, Boolean> awaiting = (Map<Long, Boolean>) field.get(bot);
-        awaiting.put(chatId, Boolean.TRUE);
+        Map<Long, BuyerTelegramBot.ChatState> states = (Map<Long, BuyerTelegramBot.ChatState>) field.get(bot);
+        states.put(chatId, BuyerTelegramBot.ChatState.AWAITING_CONTACT);
     }
 
     /**


### PR DESCRIPTION
## Summary
- introduce a chat state machine for the buyer bot with explicit transitions and state-aware handlers
- adjust contact and name flows to follow the specification and provide contextual feedback
- update existing tests and add integration scenarios that verify state transitions and invalid actions

## Testing
- `mvn test` *(fails: parent POM cannot be resolved because the Maven repositories are unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cefa8c18832dbc935837475d92c0