### PR TITLE
Implement inline settings UI for buyer bot

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1153,8 +1153,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 telegramService.notifyActualStatuses(customer);
             }
 
-            sendMainMenu(chatId, customer.isNotificationsEnabled(),
-                    customer.getNameSource() == NameSource.USER_CONFIRMED);
+            sendMainMenu(chatId);
 
             if (customer.getFullName() != null) {
                 if (customer.getNameSource() != NameSource.USER_CONFIRMED) {


### PR DESCRIPTION
## Summary
- add callback handling and inline settings screen with notification toggle, name confirmation, and back navigation
- reorganize the buyer bot main menu to show statistics, settings, and help entries with a universal /menu command
- provide inline statistics and help views plus shared helpers for inline message updates

## Testing
- `mvn test` *(fails: Maven cannot resolve the Spring Boot parent due to unreachable jitpack.io repository in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d48fb138832d83000cf16c1c50ef