### PR TITLE
Add Telegram full name validation and confirmation handling

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/FullNameValidator.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/FullNameValidator.java
@@ -1,0 +1,209 @@
+package com.project.tracking_system.service.telegram;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Проверяет корректность ввода ФИО покупателя и нормализует его представление.
+ * <p>Валидатор обеспечивает единые правила обработки строк, поступающих из Telegram,</p>
+ * <p>чтобы последующие сервисы получали уже очищенное и нормализованное значение.</p>
+ */
+@Component
+public class FullNameValidator {
+
+    /** Минимально допустимая длина ФИО после нормализации. */
+    static final int MIN_LENGTH = 2;
+    /** Максимально допустимая длина ФИО после нормализации. */
+    static final int MAX_LENGTH = 100;
+
+    /** Разрешённый набор символов: буквы, пробелы, дефисы и апострофы. */
+    private static final Pattern ALLOWED_SYMBOLS = Pattern.compile("^[\\p{L}\\s'\\-]+$");
+    /** Паттерн для схлопывания последовательных пробелов. */
+    private static final Pattern COLLAPSE_SPACES = Pattern.compile("\\s+");
+    /** Паттерн для удаления пробелов вокруг дефисов. */
+    private static final Pattern TRIM_HYPHEN_SPACES = Pattern.compile("\\s*-\\s*");
+    /** Паттерн для удаления пробелов вокруг апострофов. */
+    private static final Pattern TRIM_APOSTROPHE_SPACES = Pattern.compile("\\s*'\\s*");
+
+    /** Слова, которые используются для подтверждения и не должны сохраняться как ФИО. */
+    private static final Set<String> CONFIRMATION_WORDS = Set.of(
+            "да",
+            "верно",
+            "ок",
+            "окей",
+            "ага",
+            "yes",
+            "y"
+    );
+
+    /**
+     * Проверяет введённое ФИО и возвращает результат с признаком валидности и нормализованным значением.
+     *
+     * @param rawFullName исходная строка из Telegram
+     * @return результат проверки с ошибкой или нормализованным значением
+     */
+    public FullNameValidationResult validate(String rawFullName) {
+        if (rawFullName == null) {
+            return FullNameValidationResult.invalid(
+                    FullNameValidationError.EMPTY,
+                    "⚠️ Пожалуйста, укажите ФИО полностью, например: Иван Иванов."
+            );
+        }
+
+        String trimmed = rawFullName.strip();
+        if (trimmed.isEmpty()) {
+            return FullNameValidationResult.invalid(
+                    FullNameValidationError.EMPTY,
+                    "⚠️ Пожалуйста, укажите ФИО полностью, например: Иван Иванов."
+            );
+        }
+
+        String normalizedWhitespace = normalizeWhitespace(trimmed);
+
+        if (normalizedWhitespace.length() < MIN_LENGTH) {
+            return FullNameValidationResult.invalid(
+                    FullNameValidationError.TOO_SHORT,
+                    "⚠️ ФИО должно содержать не менее 2 символов."
+            );
+        }
+
+        if (normalizedWhitespace.length() > MAX_LENGTH) {
+            return FullNameValidationResult.invalid(
+                    FullNameValidationError.TOO_LONG,
+                    "⚠️ ФИО должно содержать не более 100 символов."
+            );
+        }
+
+        if (isConfirmationPhrase(normalizedWhitespace)) {
+            return FullNameValidationResult.invalid(
+                    FullNameValidationError.CONFIRMATION_PHRASE,
+                    "ℹ️ Для подтверждения текущего ФИО воспользуйтесь кнопкой или укажите его полностью."
+            );
+        }
+
+        if (!ALLOWED_SYMBOLS.matcher(normalizedWhitespace).matches()) {
+            return FullNameValidationResult.invalid(
+                    FullNameValidationError.INVALID_SYMBOLS,
+                    "⚠️ ФИО может содержать только буквы, пробелы, дефисы и апострофы."
+            );
+        }
+
+        String normalizedCase = normalizeCase(normalizedWhitespace);
+        return FullNameValidationResult.valid(normalizedCase);
+    }
+
+    /**
+     * Проверяет, относится ли введённая строка к подтверждающим словам.
+     *
+     * @param candidate строка из Telegram
+     * @return {@code true}, если строка соответствует слову подтверждения
+     */
+    public boolean isConfirmationPhrase(String candidate) {
+        if (candidate == null) {
+            return false;
+        }
+        String normalized = candidate.strip().toLowerCase(Locale.ROOT);
+        return CONFIRMATION_WORDS.contains(normalized);
+    }
+
+    /**
+     * Нормализует пробелы вокруг символов и схлопывает последовательности пробелов.
+     *
+     * @param value исходное значение ФИО
+     * @return строка с одним пробелом между словами и без пробелов вокруг дефисов/апострофов
+     */
+    private String normalizeWhitespace(String value) {
+        String collapsed = COLLAPSE_SPACES.matcher(value).replaceAll(" ");
+        String trimmedHyphen = TRIM_HYPHEN_SPACES.matcher(collapsed).replaceAll("-");
+        return TRIM_APOSTROPHE_SPACES.matcher(trimmedHyphen).replaceAll("'").strip();
+    }
+
+    /**
+     * Приводит каждое слово к «титульному» регистру, учитывая разделители.
+     * <p>После обработки первая буква каждого сегмента становится заглавной, остальные — строчными.</p>
+     *
+     * @param value строка с нормализованными пробелами
+     * @return строка с единым стилем написания ФИО
+     */
+    private String normalizeCase(String value) {
+        StringBuilder builder = new StringBuilder();
+        boolean capitalizeNext = true;
+        for (int i = 0; i < value.length(); ) {
+            int codePoint = value.codePointAt(i);
+            int charCount = Character.charCount(codePoint);
+
+            if (Character.isLetter(codePoint)) {
+                if (capitalizeNext) {
+                    builder.appendCodePoint(Character.toTitleCase(codePoint));
+                } else {
+                    builder.appendCodePoint(Character.toLowerCase(codePoint));
+                }
+                capitalizeNext = false;
+            } else {
+                builder.appendCodePoint(codePoint);
+                capitalizeNext = codePoint == ' ' || codePoint == '-' || codePoint == '\'';
+            }
+
+            i += charCount;
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Результат проверки ФИО с нормализованным значением или описанием ошибки.
+     *
+     * @param valid                признак успешной валидации
+     * @param normalizedFullName   нормализованное ФИО
+     * @param error                тип обнаруженной ошибки
+     * @param message              текст подсказки для пользователя
+     */
+    public record FullNameValidationResult(
+            boolean valid,
+            String normalizedFullName,
+            FullNameValidationError error,
+            String message
+    ) {
+
+        /**
+         * Создаёт успешный результат с нормализованным ФИО.
+         *
+         * @param normalizedFullName нормализованное ФИО
+         * @return успешный результат проверки
+         */
+        public static FullNameValidationResult valid(String normalizedFullName) {
+            return new FullNameValidationResult(true, normalizedFullName, FullNameValidationError.NONE, null);
+        }
+
+        /**
+         * Создаёт результат с ошибкой и подсказкой для пользователя.
+         *
+         * @param error   тип ошибки валидации
+         * @param message текст подсказки
+         * @return неуспешный результат проверки
+         */
+        public static FullNameValidationResult invalid(FullNameValidationError error, String message) {
+            return new FullNameValidationResult(false, null, error, message);
+        }
+    }
+
+    /**
+     * Перечень возможных ошибок валидации ФИО.
+     */
+    public enum FullNameValidationError {
+        /** Ошибок нет, ФИО корректно. */
+        NONE,
+        /** ФИО не указано или состоит только из пробелов. */
+        EMPTY,
+        /** ФИО короче минимально допустимой длины. */
+        TOO_SHORT,
+        /** ФИО превышает максимально допустимую длину. */
+        TOO_LONG,
+        /** ФИО содержит недопустимые символы. */
+        INVALID_SYMBOLS,
+        /** ФИО совпало с подтверждающей фразой. */
+        CONFIRMATION_PHRASE
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Contact;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -34,7 +34,6 @@ class BuyerTelegramBotLoggingTest {
     @Mock
     private CustomerTelegramService customerTelegramService;
 
-    @InjectMocks
     private BuyerTelegramBot buyerTelegramBot;
 
     private Logger logger;
@@ -42,6 +41,8 @@ class BuyerTelegramBotLoggingTest {
 
     @BeforeEach
     void setUp() {
+        buyerTelegramBot = new BuyerTelegramBot(telegramClient, "token", customerTelegramService, new FullNameValidator());
+        when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
         logger = (Logger) LoggerFactory.getLogger(BuyerTelegramBot.class);
         appender = new ListAppender<>();
         appender.start();

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -34,13 +34,15 @@ class BuyerTelegramBotStateIntegrationTest {
     private CustomerTelegramService telegramService;
 
     private BuyerTelegramBot bot;
+    private FullNameValidator fullNameValidator;
 
     /**
      * Создаёт экземпляр бота перед каждым сценарием и стабилизирует клиент Telegram.
      */
     @BeforeEach
     void setUp() throws Exception {
-        bot = new BuyerTelegramBot(telegramClient, "token", telegramService);
+        fullNameValidator = new FullNameValidator();
+        bot = new BuyerTelegramBot(telegramClient, "token", telegramService, fullNameValidator);
         when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
     }
 
@@ -220,6 +222,142 @@ class BuyerTelegramBotStateIntegrationTest {
                 .filter(text -> text != null)
                 .anyMatch(text -> text.contains("Главное меню"));
         assertTrue(hasMenuMessage, "Бот должен показать главное меню");
+    }
+
+    /**
+     * Проверяет, что при вводе недопустимых символов бот остаётся в ожидании ФИО и показывает подсказку.
+     */
+    @Test
+    void shouldStayAwaitingNameOnInvalidCharacters() throws Exception {
+        Long chatId = 1007L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName(null);
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+
+        bot.consume(contactUpdate(chatId, "+375294444444"));
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId));
+        clearInvocations(telegramClient);
+
+        bot.consume(textUpdate(chatId, "Иван123"));
+
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId),
+                "Состояние не должно меняться при некорректном вводе");
+        verify(telegramService, never()).updateNameFromTelegram(anyLong(), anyString());
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasValidationMessage = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(text -> text != null)
+                .anyMatch(text -> text.contains("буквы"));
+        assertTrue(hasValidationMessage, "Пользователь должен получить подсказку о допустимых символах");
+    }
+
+    /**
+     * Убеждается, что подтверждающая фраза «да» во время ожидания ФИО фиксирует существующее имя.
+     */
+    @Test
+    void shouldConfirmExistingNameOnConfirmationPhraseWhileAwaiting() throws Exception {
+        Long chatId = 1008L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName("Иван Иванов");
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+        when(telegramService.confirmName(chatId)).thenReturn(true);
+
+        bot.consume(contactUpdate(chatId, "+375293333333"));
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId));
+        clearInvocations(telegramClient);
+
+        bot.consume(textUpdate(chatId, "да"));
+
+        assertEquals(BuyerTelegramBot.ChatState.IDLE, bot.getState(chatId),
+                "После подтверждения бот должен вернуться в режим команд");
+        verify(telegramService).confirmName(chatId);
+        verify(telegramService, never()).updateNameFromTelegram(anyLong(), anyString());
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasSuccessMessage = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(text -> text != null)
+                .anyMatch(text -> text.contains("данные подтверждены"));
+        assertTrue(hasSuccessMessage, "Пользователь должен получить подтверждение успешного ответа");
+    }
+
+    /**
+     * Проверяет, что при подтверждающей фразе без сохранённого имени бот просит указать ФИО.
+     */
+    @Test
+    void shouldWarnWhenConfirmationPhraseWithoutStoredName() throws Exception {
+        Long chatId = 1009L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(false);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName(null);
+
+        when(telegramService.linkTelegramToCustomer(anyString(), eq(chatId))).thenReturn(customer);
+        when(telegramService.confirmTelegram(customer)).thenReturn(customer);
+        when(telegramService.confirmName(chatId)).thenReturn(false);
+
+        bot.consume(contactUpdate(chatId, "+375292222222"));
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId));
+        clearInvocations(telegramClient);
+
+        bot.consume(textUpdate(chatId, "ок"));
+
+        assertEquals(BuyerTelegramBot.ChatState.AWAITING_NAME_INPUT, bot.getState(chatId),
+                "Имя остаётся неподтверждённым, бот продолжает ожидать ввод");
+        verify(telegramService).confirmName(chatId);
+        verify(telegramService, never()).updateNameFromTelegram(anyLong(), anyString());
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasReminder = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(text -> text != null)
+                .anyMatch(text -> text.contains("Пожалуйста, укажите его полностью"));
+        assertTrue(hasReminder, "Бот должен подсказать о необходимости ввести ФИО");
+    }
+
+    /**
+     * Убеждается, что в режиме меню ответ «верно» также подтверждает имя без повторного ввода.
+     */
+    @Test
+    void shouldConfirmNameInIdleOnConfirmationPhrase() throws Exception {
+        Long chatId = 1010L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(true);
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setFullName("Мария Петрова");
+
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+        when(telegramService.confirmName(chatId)).thenReturn(true);
+
+        bot.consume(textUpdate(chatId, "/start"));
+        clearInvocations(telegramClient);
+
+        bot.consume(textUpdate(chatId, "Верно"));
+
+        assertEquals(BuyerTelegramBot.ChatState.IDLE, bot.getState(chatId),
+                "Подтверждение не должно менять состояние меню");
+        verify(telegramService).confirmName(chatId);
+        verify(telegramService, never()).updateNameFromTelegram(anyLong(), anyString());
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+        boolean hasSuccess = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(text -> text != null)
+                .anyMatch(text -> text.contains("данные подтверждены"));
+        assertTrue(hasSuccess, "Пользователь должен получить сообщение об успешном подтверждении");
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -41,13 +41,15 @@ class BuyerTelegramBotTest {
     private CustomerTelegramService telegramService;
 
     private BuyerTelegramBot bot;
+    private FullNameValidator fullNameValidator;
 
     /**
      * Подготавливает экземпляр бота и стаб под клиента Telegram перед каждым тестом.
      */
     @BeforeEach
     void setUp() {
-        bot = new BuyerTelegramBot(telegramClient, "token", telegramService);
+        fullNameValidator = new FullNameValidator();
+        bot = new BuyerTelegramBot(telegramClient, "token", telegramService, fullNameValidator);
         doReturn(null).when(telegramClient).execute(any(SendMessage.class));
     }
 

--- a/src/test/java/com/project/tracking_system/service/telegram/FullNameValidatorTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/FullNameValidatorTest.java
@@ -1,0 +1,82 @@
+package com.project.tracking_system.service.telegram;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты проверяют правила валидации и нормализации ФИО для Telegram-бота.
+ */
+class FullNameValidatorTest {
+
+    private final FullNameValidator validator = new FullNameValidator();
+
+    /**
+     * Убеждается, что валидатор нормализует регистр и лишние пробелы.
+     */
+    @Test
+    void shouldNormalizeWhitespaceAndCase() {
+        FullNameValidator.FullNameValidationResult result = validator.validate("  иВАН   иваНов-сидОРов  ");
+
+        assertTrue(result.valid(), "Ожидалась успешная валидация ФИО");
+        assertEquals("Иван Иванов-Сидоров", result.normalizedFullName());
+    }
+
+    /**
+     * Проверяет, что слишком короткое ФИО отклоняется.
+     */
+    @Test
+    void shouldRejectTooShortName() {
+        FullNameValidator.FullNameValidationResult result = validator.validate("И");
+
+        assertFalse(result.valid());
+        assertEquals(FullNameValidator.FullNameValidationError.TOO_SHORT, result.error());
+        assertTrue(result.message().contains("не менее"));
+    }
+
+    /**
+     * Убеждается, что в имени не допускаются цифры и спецсимволы.
+     */
+    @Test
+    void shouldRejectInvalidCharacters() {
+        FullNameValidator.FullNameValidationResult result = validator.validate("Иван123");
+
+        assertFalse(result.valid());
+        assertEquals(FullNameValidator.FullNameValidationError.INVALID_SYMBOLS, result.error());
+        assertTrue(result.message().contains("буквы"));
+    }
+
+    /**
+     * Проверяет, что подтверждающие слова попадают в чёрный список.
+     */
+    @Test
+    void shouldRejectConfirmationPhrase() {
+        FullNameValidator.FullNameValidationResult result = validator.validate("ДА");
+
+        assertFalse(result.valid());
+        assertEquals(FullNameValidator.FullNameValidationError.CONFIRMATION_PHRASE, result.error());
+        assertTrue(result.message().contains("подтверждения"));
+    }
+
+    /**
+     * Убеждается, что метод распознаёт подтверждающие слова вне зависимости от регистра и пробелов.
+     */
+    @Test
+    void shouldRecognizeConfirmationPhraseIgnoringCase() {
+        assertTrue(validator.isConfirmationPhrase("  оК  "));
+        assertFalse(validator.isConfirmationPhrase("Мария"));
+    }
+
+    /**
+     * Проверяет ограничение на максимальную длину ФИО.
+     */
+    @Test
+    void shouldRejectTooLongName() {
+        String veryLong = "А".repeat(FullNameValidator.MAX_LENGTH + 1);
+        FullNameValidator.FullNameValidationResult result = validator.validate(veryLong);
+
+        assertFalse(result.valid());
+        assertEquals(FullNameValidator.FullNameValidationError.TOO_LONG, result.error());
+        assertTrue(result.message().contains("не более"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable FullNameValidator that normalizes full names, enforces length and allowed symbols, and blocks confirmation keywords
- update BuyerTelegramBot to use the validator, treat confirmation replies as name confirmation, and send detailed hints when validation fails
- expand unit and integration tests for the validator and confirmation/name change scenarios

## Testing
- `mvn test` *(fails: cannot download org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 because jitpack.io is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f6cd9350832db6f35932b6b9bbae