### PR TITLE
Handle MaybeInaccessibleMessage in Telegram callbacks

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -16,7 +16,8 @@ import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageRe
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Contact;
-import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.message.MaybeInaccessibleMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;
@@ -91,13 +92,20 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         return botToken;
     }
 
+    /**
+     * Возвращает обработчик обновлений, регистрируя самого бота как потребителя.
+     *
+     * @return обработчик обновлений Telegram
+     */
     @Override
     public LongPollingUpdateConsumer getUpdatesConsumer() {
         return this;
     }
 
     /**
-     * Новый метод, который вызывает TelegramBots v9
+     * Обрабатывает входящее обновление Telegram, реагируя на сообщения и callback-запросы.
+     *
+     * @param update объект обновления Telegram
      */
     @Override
     public void consume(Update update) {
@@ -184,9 +192,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         String data = callbackQuery.getData();
-        Message message = callbackQuery.getMessage();
-        Long chatId = message != null ? message.getChatId() : null;
-        Integer messageId = message != null ? message.getMessageId() : null;
+        MaybeInaccessibleMessage callbackMessage = callbackQuery.getMessage();
+        Long chatId = callbackMessage != null ? callbackMessage.getChatId() : null;
+        Integer messageId = callbackMessage != null ? callbackMessage.getMessageId() : null;
 
         if (data == null || chatId == null) {
             answerCallbackQuery(callbackQuery, "Команда недоступна");

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Contact;
-import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -12,7 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.Contact;
-import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -12,7 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboard;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup;


### PR DESCRIPTION
## Summary
- update BuyerTelegramBot to use the TelegramBots v9 message package
- align unit and integration tests with the new Message class package
- handle callback queries via MaybeInaccessibleMessage now returned by TelegramBots v9 and document the update consumer

## Testing
- mvn -q test *(fails: network is unreachable while resolving spring-boot-starter-parent from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7eaf83d8832d96ec47b45b90f013