### PR TITLE
Подтверждение имени через Telegram

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -121,10 +121,16 @@ public class CustomerTelegramService {
     public boolean confirmName(Long chatId) {
         return customerRepository.findByTelegramChatId(chatId)
                 .map(c -> {
-                    if (c.getFullName() == null) {
+                    String fullName = c.getFullName();
+                    if (fullName == null || fullName.isBlank()) {
                         return false;
                     }
-                    return customerService.updateCustomerName(c, c.getFullName(), NameSource.USER_CONFIRMED);
+                    if (c.getNameSource() != NameSource.USER_CONFIRMED) {
+                        c.setNameSource(NameSource.USER_CONFIRMED);
+                        c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                        customerRepository.save(c);
+                    }
+                    return true;
                 })
                 .orElse(false);
     }

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -1,0 +1,73 @@
+package com.project.tracking_system.service.customer;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.repository.CustomerNotificationLogRepository;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.service.telegram.TelegramNotificationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты для {@link CustomerTelegramService}, проверяющие подтверждение имени.
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomerTelegramServiceTest {
+
+    @Mock
+    private CustomerRepository customerRepository;
+    @Mock
+    private CustomerService customerService;
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private CustomerNotificationLogRepository notificationLogRepository;
+    @Mock
+    private TelegramNotificationService telegramNotificationService;
+
+    @InjectMocks
+    private CustomerTelegramService customerTelegramService;
+
+    /**
+     * Убеждаемся, что при подтверждении существующего ФИО источник обновляется до USER_CONFIRMED.
+     */
+    @Test
+    void confirmName_whenFullNameExistsAndSourceNotConfirmed_updatesSourceAndTimestamp() {
+        Long chatId = 42L;
+        ZonedDateTime oldTimestamp = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1);
+
+        Customer customer = new Customer();
+        customer.setId(1L);
+        customer.setTelegramChatId(chatId);
+        customer.setFullName("Иван Иванов");
+        customer.setNameSource(NameSource.MERCHANT_PROVIDED);
+        customer.setNameUpdatedAt(oldTimestamp);
+
+        when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
+        when(customerRepository.save(any(Customer.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        boolean result = customerTelegramService.confirmName(chatId);
+
+        assertTrue(result, "Метод должен вернуть истину при успешном подтверждении");
+        assertEquals(NameSource.USER_CONFIRMED, customer.getNameSource(),
+                "Источник имени обязан переключиться на USER_CONFIRMED");
+        assertNotNull(customer.getNameUpdatedAt(), "Дата обновления имени должна быть установлена");
+        assertTrue(customer.getNameUpdatedAt().isAfter(oldTimestamp),
+                "Метка времени обязана быть новее предыдущей");
+
+        verify(customerRepository).save(customer);
+        verify(customerService, never()).updateCustomerName(any(), anyString(), any());
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -23,6 +23,7 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -100,6 +101,31 @@ class BuyerTelegramBotTest {
         assertTrue(message.getText().contains("8029"));
         assertPhoneKeyboard(message.getReplyMarkup());
         verifyNoInteractions(telegramService);
+    }
+
+    /**
+     * Проверяет, что команда подтверждения имени отправляет сообщение об успешной операции.
+     */
+    @Test
+    void shouldSendSuccessMessageWhenConfirmingNameFromMenu() throws Exception {
+        Long chatId = 789L;
+        when(telegramService.confirmName(chatId)).thenReturn(true);
+
+        Update update = mockTextUpdate(chatId, "✅ Подтвердить имя");
+
+        bot.consume(update);
+
+        verify(telegramService).confirmName(chatId);
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+
+        boolean hasSuccess = captor.getAllValues().stream()
+                .map(SendMessage::getText)
+                .filter(Objects::nonNull)
+                .anyMatch(text -> text.contains("данные подтверждены"));
+
+        assertTrue(hasSuccess, "Бот обязан уведомить пользователя об успешном подтверждении");
     }
 
     /**


### PR DESCRIPTION
## Summary
- обновил CustomerTelegramService.confirmName, чтобы подтверждать имя без повторного вызова обновления ФИО
- добавил модульный тест CustomerTelegramServiceTest, проверяющий фиксацию источника имени
- расширил BuyerTelegramBotTest сценарием отправки сообщения об успешном подтверждении

## Testing
- mvn -Dtest=CustomerTelegramServiceTest,BuyerTelegramBotTest test *(fails: отсутствует доступ к репозиторию зависимостей)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9becdca4832d8ba5886559f288d9