### PR TITLE
Validate stored names before confirmation

### DIFF
--- a/src/main/resources/db/migration/V12__invalidate_incorrect_confirmed_names.sql
+++ b/src/main/resources/db/migration/V12__invalidate_incorrect_confirmed_names.sql
@@ -1,0 +1,47 @@
+-- Приведение подтверждённых ФИО к актуальным требованиям валидации.
+-- Все записи, нарушающие правила валидатора, переводятся в статус неподтверждённых,
+-- чтобы бот повторно запросил корректное значение у покупателя.
+WITH normalized AS (
+    SELECT c.id,
+           c.full_name,
+           CASE
+               WHEN c.full_name IS NULL THEN NULL
+               ELSE btrim(
+                       regexp_replace(
+                           regexp_replace(
+                               regexp_replace(c.full_name, '\\s+', ' ', 'g'),
+                               '\\s*-\\s*', '-', 'g'
+                           ),
+                           '\\s*''\\s*', '''', 'g'
+                       )
+                   )
+           END AS normalized_full_name
+    FROM tb_customers AS c
+    WHERE c.name_source = 'USER_CONFIRMED'
+), analyzed AS (
+    SELECT n.id,
+           n.normalized_full_name,
+           CASE
+               WHEN n.normalized_full_name IS NULL THEN 0
+               ELSE (
+                   SELECT COUNT(word)
+                   FROM unnest(regexp_split_to_array(n.normalized_full_name, '[-\\s]+')) AS word
+                   WHERE word <> ''
+               )
+           END AS word_count
+    FROM normalized AS n
+)
+UPDATE tb_customers AS c
+SET name_source    = 'MERCHANT_PROVIDED',
+    name_updated_at = NOW()
+FROM analyzed AS a
+WHERE c.id = a.id
+  AND (
+        a.normalized_full_name IS NULL
+        OR a.normalized_full_name = ''
+        OR length(a.normalized_full_name) < 2
+        OR length(a.normalized_full_name) > 100
+        OR lower(a.normalized_full_name) IN ('да', 'верно', 'ок', 'окей', 'ага', 'yes', 'y')
+        OR a.normalized_full_name !~ '^[\\p{L}\\s''-]+$'
+        OR a.word_count < 2
+      );

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceLoggingTest.java
@@ -8,6 +8,7 @@ import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.repository.CustomerNotificationLogRepository;
 import com.project.tracking_system.repository.CustomerRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.service.telegram.FullNameValidator;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -40,6 +42,9 @@ class CustomerTelegramServiceLoggingTest {
     private CustomerNotificationLogRepository notificationLogRepository;
     @Mock
     private TelegramNotificationService telegramNotificationService;
+
+    @Spy
+    private FullNameValidator fullNameValidator = new FullNameValidator();
 
     @InjectMocks
     private CustomerTelegramService customerTelegramService;


### PR DESCRIPTION
## Summary
- validate сохранённое ФИО перед показом подтверждения и настроек в BuyerTelegramBot, запрашивая повторный ввод при некорректных данных
- обновить CustomerTelegramService, чтобы отклонять подтверждение некорректных имён и сбрасывать источник, дополнив тесты
- добавить миграцию, которая сбрасывает подтверждение для некорректных ФИО в базе, чтобы они прошли повторную проверку

## Testing
- mvn -q test *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68caa37b1240832daf15763d4cac9baf