### PR TITLE
Ensure contact reminder shows keyboard and add tests

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -161,6 +161,18 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         String trimmed = text.trim();
+        ChatState state = getState(chatId);
+
+        if (state == ChatState.AWAITING_CONTACT) {
+            if (trimmed.isEmpty() || trimmed.startsWith("/")) {
+                remindContactRequired(chatId);
+                return;
+            }
+
+            handleAwaitedPhoneText(chatId, trimmed);
+            return;
+        }
+
         if (trimmed.isEmpty()) {
             return;
         }
@@ -172,17 +184,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
         if ("/start".equals(trimmed)) {
             handleStartCommand(chatId);
-            return;
-        }
-
-        ChatState state = getState(chatId);
-
-        if (state == ChatState.AWAITING_CONTACT) {
-            if (trimmed.startsWith("/")) {
-                remindContactRequired(chatId);
-            } else {
-                handleAwaitedPhoneText(chatId, trimmed);
-            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure the awaiting-contact flow routes slash commands and empty replies through the contact reminder that uses the phone request keyboard
- keep the contact reminder using the dedicated phone request keyboard to re-show the button consistently
- add unit and integration tests that verify the keyboard is attached after /start, arbitrary text, slash commands, and empty replies before phone confirmation

## Testing
- mvn test *(fails: Non-resolvable parent POM because org.springframework.boot:spring-boot-starter-parent:3.4.3 cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabe82c6a8832db2e07b5cd9f7af55