### PR TITLE
feat: restore buyer menu keyboard when hidden

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerBotScreenState.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerBotScreenState.java
@@ -52,5 +52,11 @@ public class BuyerBotScreenState {
     @Enumerated(EnumType.STRING)
     @Column(name = "chat_state")
     private BuyerChatState chatState;
+
+    /**
+     * Признак того, что клавиатура меню скрыта у пользователя.
+     */
+    @Column(name = "keyboard_hidden")
+    private Boolean keyboardHidden;
 }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
@@ -15,6 +15,7 @@ public class ChatSession {
     private BuyerChatState state;
     private Integer anchorMessageId;
     private BuyerBotScreen lastScreen;
+    private boolean persistentKeyboardHidden;
 
     /**
      * Создаёт представление состояния чата.
@@ -28,10 +29,28 @@ public class ChatSession {
                        BuyerChatState state,
                        Integer anchorMessageId,
                        BuyerBotScreen lastScreen) {
+        this(chatId, state, anchorMessageId, lastScreen, true);
+    }
+
+    /**
+     * Создаёт представление состояния чата с указанием статуса клавиатуры.
+     *
+     * @param chatId                  идентификатор чата Telegram
+     * @param state                   сценарное состояние диалога
+     * @param anchorMessageId         идентификатор якорного сообщения
+     * @param lastScreen              последний отображённый экран
+     * @param persistentKeyboardHidden признак того, что меню-клавиатура скрыта
+     */
+    public ChatSession(Long chatId,
+                       BuyerChatState state,
+                       Integer anchorMessageId,
+                       BuyerBotScreen lastScreen,
+                       boolean persistentKeyboardHidden) {
         this.chatId = chatId;
         this.state = state != null ? state : BuyerChatState.IDLE;
         this.anchorMessageId = anchorMessageId;
         this.lastScreen = lastScreen;
+        this.persistentKeyboardHidden = persistentKeyboardHidden;
     }
 
     /**
@@ -95,5 +114,23 @@ public class ChatSession {
      */
     public void setLastScreen(BuyerBotScreen lastScreen) {
         this.lastScreen = lastScreen;
+    }
+
+    /**
+     * Показывает, скрыта ли клавиатура постоянного меню у пользователя.
+     *
+     * @return {@code true}, если клавиатура отсутствует и требует переотправки
+     */
+    public boolean isPersistentKeyboardHidden() {
+        return persistentKeyboardHidden;
+    }
+
+    /**
+     * Фиксирует состояние постоянной клавиатуры меню.
+     *
+     * @param persistentKeyboardHidden {@code true}, если клавиатура скрыта
+     */
+    public void setPersistentKeyboardHidden(boolean persistentKeyboardHidden) {
+        this.persistentKeyboardHidden = persistentKeyboardHidden;
     }
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
@@ -68,4 +68,26 @@ public interface ChatSessionRepository {
      * @param chatId идентификатор чата Telegram
      */
     void clearAnchor(Long chatId);
+
+    /**
+     * Проверяет, скрыта ли постоянная клавиатура меню у пользователя.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @return {@code true}, если клавиатура отсутствует и требуется переотправка
+     */
+    boolean isKeyboardHidden(Long chatId);
+
+    /**
+     * Помечает клавиатуру меню как скрытую пользователем.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
+    void markKeyboardHidden(Long chatId);
+
+    /**
+     * Фиксирует, что клавиатура меню успешно показана пользователю.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
+    void markKeyboardVisible(Long chatId);
 }

--- a/src/main/resources/db/migration/V15__buyer_keyboard_visibility_flag.sql
+++ b/src/main/resources/db/migration/V15__buyer_keyboard_visibility_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN keyboard_hidden BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
@@ -85,6 +85,35 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
         }
     }
 
+    @Override
+    public boolean isKeyboardHidden(Long chatId) {
+        if (chatId == null) {
+            return false;
+        }
+        return sessions.getOrDefault(chatId, new ChatSession(chatId, BuyerChatState.IDLE, null, null))
+                .isPersistentKeyboardHidden();
+    }
+
+    @Override
+    public void markKeyboardHidden(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+        ChatSession session = sessions.computeIfAbsent(chatId,
+                id -> new ChatSession(id, BuyerChatState.IDLE, null, null));
+        session.setPersistentKeyboardHidden(true);
+    }
+
+    @Override
+    public void markKeyboardVisible(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+        ChatSession session = sessions.computeIfAbsent(chatId,
+                id -> new ChatSession(id, BuyerChatState.IDLE, null, null));
+        session.setPersistentKeyboardHidden(false);
+    }
+
     /**
      * Создаёт копию сессии, чтобы тесты не изменяли внутреннее состояние напрямую.
      *
@@ -95,8 +124,8 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
         if (session == null) {
             return null;
         }
-        ChatSession copy = new ChatSession(session.getChatId(), session.getState(),
-                session.getAnchorMessageId(), session.getLastScreen());
-        return copy;
+        return new ChatSession(session.getChatId(), session.getState(),
+                session.getAnchorMessageId(), session.getLastScreen(),
+                session.isPersistentKeyboardHidden());
     }
 }


### PR DESCRIPTION
## Summary
- track the persistent menu keyboard state in chat sessions and database storage
- resend the reply keyboard when Telegram reports it hidden and on menu refresh
- add database migration and tests ensuring menu buttons return after hiding the keyboard

## Testing
- `mvn -q -Dtest=BuyerTelegramBotStateIntegrationTest test` *(fails: jitpack.io unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caca599250832d8032ac2340842c3f