### PR TITLE
Handle reply markup removal flag via JSON

### DIFF
--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.service.telegram;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -47,7 +48,7 @@ class BuyerTelegramBotLoggingTest {
     void setUp() {
         chatSessionRepository = new InMemoryChatSessionRepository();
         buyerTelegramBot = new BuyerTelegramBot(telegramClient, "token", customerTelegramService,
-                new FullNameValidator(), chatSessionRepository);
+                new FullNameValidator(), chatSessionRepository, new ObjectMapper());
         when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
         logger = (Logger) LoggerFactory.getLogger(BuyerTelegramBot.class);
         appender = new ListAppender<>();

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.service.telegram;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.tracking_system.entity.BuyerChatState;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.NameSource;
@@ -50,7 +51,8 @@ class BuyerTelegramBotStateIntegrationTest {
     void setUp() throws Exception {
         fullNameValidator = new FullNameValidator();
         chatSessionRepository = new InMemoryChatSessionRepository();
-        bot = new BuyerTelegramBot(telegramClient, "token", telegramService, fullNameValidator, chatSessionRepository);
+        bot = new BuyerTelegramBot(telegramClient, "token", telegramService, fullNameValidator, chatSessionRepository,
+                new ObjectMapper());
         when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
     }
 

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStatePersistenceIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStatePersistenceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.service.telegram;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.tracking_system.entity.BuyerBotScreen;
 import com.project.tracking_system.entity.BuyerChatState;
 import com.project.tracking_system.entity.Customer;
@@ -62,7 +63,7 @@ class BuyerTelegramBotStatePersistenceIntegrationTest {
         doNothing().when(telegramService).notifyActualStatuses(customer);
 
         BuyerTelegramBot bot = new BuyerTelegramBot(telegramClient, "token", telegramService,
-                fullNameValidator, chatSessionRepository);
+                fullNameValidator, chatSessionRepository, new ObjectMapper());
 
         bot.consume(contactUpdate(chatId, "+375291112233"));
 
@@ -72,7 +73,7 @@ class BuyerTelegramBotStatePersistenceIntegrationTest {
         TelegramClient restartedClient = mock(TelegramClient.class);
         when(restartedClient.execute(any(SendMessage.class))).thenReturn(null);
         BuyerTelegramBot restartedBot = new BuyerTelegramBot(restartedClient, "token", telegramService,
-                fullNameValidator, chatSessionRepository);
+                fullNameValidator, chatSessionRepository, new ObjectMapper());
 
         clearInvocations(telegramService);
         when(telegramService.updateNameFromTelegram(chatId, "Иван Иванов")).thenAnswer(invocation -> {
@@ -110,7 +111,7 @@ class BuyerTelegramBotStatePersistenceIntegrationTest {
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
         BuyerTelegramBot bot = new BuyerTelegramBot(initialClient, "token", telegramService,
-                fullNameValidator, chatSessionRepository);
+                fullNameValidator, chatSessionRepository, new ObjectMapper());
         bot.consume(textUpdate(chatId, "/start"));
 
         ChatSession savedSession = chatSessionRepository.find(chatId).orElse(null);
@@ -125,7 +126,7 @@ class BuyerTelegramBotStatePersistenceIntegrationTest {
         when(restartedClient.execute(any(EditMessageText.class))).thenReturn(null);
 
         BuyerTelegramBot restartedBot = new BuyerTelegramBot(restartedClient, "token", telegramService,
-                fullNameValidator, chatSessionRepository);
+                fullNameValidator, chatSessionRepository, new ObjectMapper());
 
         CallbackQuery callbackQuery = mock(CallbackQuery.class);
         MaybeInaccessibleMessage callbackMessage = mock(MaybeInaccessibleMessage.class);


### PR DESCRIPTION
## Summary
- parse incoming Telegram messages with ObjectMapper to detect reply_markup.remove_keyboard and persist keyboard hidden state
- inject ObjectMapper into BuyerTelegramBot and update tests to use the new constructor
- add unit coverage ensuring remove_keyboard messages hide the keyboard and inline keyboards remain unaffected

## Testing
- `mvn test` *(fails: unable to resolve parent POM because network to https://jitpack.io is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68caeb1b36a8832db10341d00b22a923