### PR TITLE
Mark menu keyboard hidden when awaiting contact

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -351,6 +351,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         Optional<Customer> optional = telegramService.findByChatId(chatId);
         if (optional.isEmpty()) {
             transitionToState(chatId, BuyerChatState.AWAITING_CONTACT);
+            chatSessionRepository.markKeyboardHidden(chatId);
             sendSharePhoneKeyboard(chatId);
             return;
         }
@@ -990,6 +991,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
      */
     private void remindContactRequired(Long chatId) {
         transitionToState(chatId, BuyerChatState.AWAITING_CONTACT);
+        chatSessionRepository.markKeyboardHidden(chatId);
         sendPhoneRequestMessage(chatId,
                 "📱 Пожалуйста, поделитесь контактом через кнопку ниже — только так мы сможем принять номер. После получения телефона мы продолжим настройку.");
     }
@@ -1558,11 +1560,19 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
     /**
      * Отправляет сообщение с клавиатурой запроса телефона.
+     * <p>
+     * Дополнительно фиксирует, что постоянная клавиатура скрыта, чтобы при возврате в меню её переотправить.
+     * </p>
      *
      * @param chatId идентификатор чата
      * @param text   текст, который увидит пользователь
      */
     private void sendPhoneRequestMessage(Long chatId, String text) {
+        if (chatId == null) {
+            return;
+        }
+
+        chatSessionRepository.markKeyboardHidden(chatId);
         SendMessage message = new SendMessage(chatId.toString(), text);
         message.setReplyMarkup(createPhoneRequestKeyboard());
 
@@ -1737,6 +1747,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             log.warn("⚠️ Не удалось подтвердить владение номером: chatId={}, contactUserId={}, senderId={}",
                     chatId, contactUserId, senderId);
             transitionToState(chatId, BuyerChatState.AWAITING_CONTACT);
+            chatSessionRepository.markKeyboardHidden(chatId);
             sendContactOwnershipRejectedMessage(chatId);
             return;
         }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -351,7 +351,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         Optional<Customer> optional = telegramService.findByChatId(chatId);
         if (optional.isEmpty()) {
             transitionToState(chatId, BuyerChatState.AWAITING_CONTACT);
-            chatSessionRepository.markKeyboardHidden(chatId);
             sendSharePhoneKeyboard(chatId);
             return;
         }
@@ -991,7 +990,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
      */
     private void remindContactRequired(Long chatId) {
         transitionToState(chatId, BuyerChatState.AWAITING_CONTACT);
-        chatSessionRepository.markKeyboardHidden(chatId);
         sendPhoneRequestMessage(chatId,
                 "📱 Пожалуйста, поделитесь контактом через кнопку ниже — только так мы сможем принять номер. После получения телефона мы продолжим настройку.");
     }
@@ -1021,6 +1019,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
     /**
      * Фиксирует новое состояние сценария для указанного чата.
+     * <p>
+     * При переводе в режим ожидания контакта дополнительно помечает, что
+     * постоянная клавиатура скрыта и должна быть заменена кнопкой запроса номера.
+     * </p>
      *
      * @param chatId идентификатор чата Telegram
      * @param state  состояние, в которое нужно перевести сценарий
@@ -1031,6 +1033,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         chatSessionRepository.updateState(chatId, state);
+
+        if (state == BuyerChatState.AWAITING_CONTACT) {
+            chatSessionRepository.markKeyboardHidden(chatId);
+        }
     }
 
     /**
@@ -1365,6 +1371,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
     /**
      * Возвращает меню-клавиатуру, если она была скрыта ранее.
+     * <p>
+     * В режиме ожидания контакта клавиатура не восстанавливается, чтобы
+     * пользователь видел только кнопку отправки номера телефона.
+     * </p>
      *
      * @param chatId            идентификатор чата Telegram
      * @param skipCurrentUpdate {@code true}, если клавиатура скрыта прямо сейчас и её не нужно восстанавливать немедленно
@@ -1378,16 +1388,28 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return;
         }
 
+        if (getState(chatId) == BuyerChatState.AWAITING_CONTACT) {
+            return;
+        }
+
         ensurePersistentKeyboard(chatId);
     }
 
     /**
      * Обеспечивает наличие новой reply-клавиатуры в чате.
+     * <p>
+     * Клавиатура меню не переотправляется, если бот всё ещё ждёт контакт
+     * пользователя, чтобы не сбивать сценарий запроса телефона.
+     * </p>
      *
      * @param chatId идентификатор чата Telegram
      */
     private void ensurePersistentKeyboard(Long chatId) {
         if (chatId == null) {
+            return;
+        }
+
+        if (getState(chatId) == BuyerChatState.AWAITING_CONTACT) {
             return;
         }
 
@@ -1747,7 +1769,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             log.warn("⚠️ Не удалось подтвердить владение номером: chatId={}, contactUserId={}, senderId={}",
                     chatId, contactUserId, senderId);
             transitionToState(chatId, BuyerChatState.AWAITING_CONTACT);
-            chatSessionRepository.markKeyboardHidden(chatId);
             sendContactOwnershipRejectedMessage(chatId);
             return;
         }
@@ -1764,6 +1785,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 telegramService.notifyActualStatuses(customer);
             }
 
+            transitionToState(chatId, BuyerChatState.IDLE);
             sendMainMenu(chatId);
 
             if (!ensureValidStoredNameOrRequestUpdate(chatId, customer)) {
@@ -1779,8 +1801,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 promptForName(chatId);
                 return;
             }
-
-            transitionToState(chatId, BuyerChatState.IDLE);
         } catch (Exception e) {
             log.error("❌ Ошибка регистрации телефона {} для чата {}",
                     PhoneUtils.maskPhone(phone), chatId, e);

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -101,6 +101,12 @@ class BuyerTelegramBotStateIntegrationTest {
 
         bot.consume(contactUpdate(chatId, "+375291234567"));
 
+        assertEquals(BuyerChatState.AWAITING_NAME_INPUT, bot.getState(chatId),
+                "После привязки номера бот должен ждать ввод ФИО и показывать меню-клавиатуру");
+
+        assertFalse(chatSessionRepository.isKeyboardHidden(chatId),
+                "После возврата в меню клавиатура с кнопками «🏠 Меню»/«❓ Помощь» должна считаться видимой");
+
         ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         List<SendMessage> messages = captor.getAllValues();


### PR DESCRIPTION
## Summary
- фиксирую скрытие постоянной клавиатуры при каждом переходе в ожидание контакта
- помечаю клавиатуру скрытой перед отправкой сообщения с кнопкой «📱 Поделиться номером»
- добавляю интеграционный тест, проверяющий возврат клавиатуры меню после отправки контакта новым пользователем

## Testing
- mvn test *(падает: недоступен родительский POM из-за отсутствия сети)*

------
https://chatgpt.com/codex/tasks/task_e_68caff8338bc832da1b5bb06c2699419