### PR TITLE
Force reply keyboard resend on /start for bound buyers

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -355,7 +355,11 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         Customer customer = optional.get();
+        BuyerChatState previousState = getState(chatId);
         transitionToState(chatId, BuyerChatState.IDLE);
+        if (previousState != BuyerChatState.AWAITING_CONTACT) {
+            chatSessionRepository.markKeyboardHidden(chatId);
+        }
         sendMainMenu(chatId);
 
         if (!ensureValidStoredNameOrRequestUpdate(chatId, customer)) {

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -455,6 +455,37 @@ class BuyerTelegramBotStateIntegrationTest {
     }
 
     /**
+     * Проверяет, что команда /start заново отправляет клавиатуру меню, даже если флаг скрытия сброшен вручную.
+     */
+    @Test
+    void shouldResendReplyKeyboardOnStartWhenFlagReset() throws Exception {
+        Long chatId = 3031L;
+        Customer customer = new Customer();
+        customer.setTelegramConfirmed(true);
+        customer.setNameSource(NameSource.USER_CONFIRMED);
+        customer.setNotificationsEnabled(true);
+        customer.setFullName("Анна Смирнова");
+
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+
+        chatSessionRepository.markKeyboardVisible(chatId);
+
+        bot.consume(textUpdate(chatId, "/start"));
+
+        ArgumentCaptor<SendMessage> captor = ArgumentCaptor.forClass(SendMessage.class);
+        verify(telegramClient, atLeastOnce()).execute(captor.capture());
+
+        boolean hasMenuKeyboard = captor.getAllValues().stream()
+                .map(SendMessage::getReplyMarkup)
+                .filter(ReplyKeyboardMarkup.class::isInstance)
+                .map(ReplyKeyboardMarkup.class::cast)
+                .anyMatch(this::containsMenuButtons);
+
+        assertTrue(hasMenuKeyboard,
+                "После повторной команды /start бот обязан вернуть клавиатуру с кнопками «🏠 Меню» и «❓ Помощь»");
+    }
+
+    /**
      * Проверяет, что при потере якоря бот повторно отправляет постоянную клавиатуру.
      */
     @Test


### PR DESCRIPTION
## Summary
- mark the persistent keyboard as hidden before redrawing the main menu for an already linked buyer so the reply keyboard is re-sent
- add an integration test that covers `/start` after the keyboard visibility flag was reset

## Testing
- `mvn test` *(fails: parent POM download blocked because https://jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb106448c8832da45564a5296149d7