### PR TITLE
Fix duplicate contact request on repeated start command

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerBotScreenState.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerBotScreenState.java
@@ -58,5 +58,11 @@ public class BuyerBotScreenState {
      */
     @Column(name = "keyboard_hidden")
     private Boolean keyboardHidden;
+
+    /**
+     * Признак того, что запрос контакта уже был отправлен покупателю.
+     */
+    @Column(name = "contact_request_sent")
+    private Boolean contactRequestSent;
 }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
@@ -16,6 +16,7 @@ public class ChatSession {
     private Integer anchorMessageId;
     private BuyerBotScreen lastScreen;
     private boolean persistentKeyboardHidden;
+    private boolean contactRequestSent;
 
     /**
      * Создаёт представление состояния чата.
@@ -29,7 +30,7 @@ public class ChatSession {
                        BuyerChatState state,
                        Integer anchorMessageId,
                        BuyerBotScreen lastScreen) {
-        this(chatId, state, anchorMessageId, lastScreen, true);
+        this(chatId, state, anchorMessageId, lastScreen, true, false);
     }
 
     /**
@@ -46,11 +47,31 @@ public class ChatSession {
                        Integer anchorMessageId,
                        BuyerBotScreen lastScreen,
                        boolean persistentKeyboardHidden) {
+        this(chatId, state, anchorMessageId, lastScreen, persistentKeyboardHidden, false);
+    }
+
+    /**
+     * Создаёт представление состояния чата с расширенной информацией о показанных сообщениях.
+     *
+     * @param chatId                  идентификатор чата Telegram
+     * @param state                   сценарное состояние диалога
+     * @param anchorMessageId         идентификатор якорного сообщения
+     * @param lastScreen              последний отображённый экран
+     * @param persistentKeyboardHidden признак того, что меню-клавиатура скрыта
+     * @param contactRequestSent      признак того, что запрос контакта уже отправлен
+     */
+    public ChatSession(Long chatId,
+                       BuyerChatState state,
+                       Integer anchorMessageId,
+                       BuyerBotScreen lastScreen,
+                       boolean persistentKeyboardHidden,
+                       boolean contactRequestSent) {
         this.chatId = chatId;
         this.state = state != null ? state : BuyerChatState.IDLE;
         this.anchorMessageId = anchorMessageId;
         this.lastScreen = lastScreen;
         this.persistentKeyboardHidden = persistentKeyboardHidden;
+        this.contactRequestSent = contactRequestSent;
     }
 
     /**
@@ -132,5 +153,23 @@ public class ChatSession {
      */
     public void setPersistentKeyboardHidden(boolean persistentKeyboardHidden) {
         this.persistentKeyboardHidden = persistentKeyboardHidden;
+    }
+
+    /**
+     * Показывает, отправлялся ли запрос контакта в текущей сессии.
+     *
+     * @return {@code true}, если запрос контакта уже был отправлен
+     */
+    public boolean isContactRequestSent() {
+        return contactRequestSent;
+    }
+
+    /**
+     * Фиксирует факт отправки запроса контакта.
+     *
+     * @param contactRequestSent {@code true}, если сообщение уже показано пользователю
+     */
+    public void setContactRequestSent(boolean contactRequestSent) {
+        this.contactRequestSent = contactRequestSent;
     }
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
@@ -90,4 +90,26 @@ public interface ChatSessionRepository {
      * @param chatId идентификатор чата Telegram
      */
     void markKeyboardVisible(Long chatId);
+
+    /**
+     * Проверяет, зафиксирован ли факт отправки запроса контакта в чате.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @return {@code true}, если запрос контакта уже был отправлен
+     */
+    boolean isContactRequestSent(Long chatId);
+
+    /**
+     * Помечает, что пользователю отправлено сообщение с запросом контакта.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
+    void markContactRequestSent(Long chatId);
+
+    /**
+     * Сбрасывает признак отправленного запроса контакта.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
+    void clearContactRequestSent(Long chatId);
 }

--- a/src/main/resources/db/migration/V16__buyer_contact_request_flag.sql
+++ b/src/main/resources/db/migration/V16__buyer_contact_request_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN contact_request_sent BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
@@ -115,6 +115,35 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
         session.setPersistentKeyboardHidden(false);
     }
 
+    @Override
+    public boolean isContactRequestSent(Long chatId) {
+        if (chatId == null) {
+            return false;
+        }
+        return sessions.getOrDefault(chatId, new ChatSession(chatId, BuyerChatState.IDLE, null, null))
+                .isContactRequestSent();
+    }
+
+    @Override
+    public void markContactRequestSent(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+        ChatSession session = sessions.computeIfAbsent(chatId,
+                id -> new ChatSession(id, BuyerChatState.IDLE, null, null));
+        session.setContactRequestSent(true);
+    }
+
+    @Override
+    public void clearContactRequestSent(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+        ChatSession session = sessions.computeIfAbsent(chatId,
+                id -> new ChatSession(id, BuyerChatState.IDLE, null, null));
+        session.setContactRequestSent(false);
+    }
+
     /**
      * Создаёт копию сессии, чтобы тесты не изменяли внутреннее состояние напрямую.
      *
@@ -127,6 +156,7 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
         }
         return new ChatSession(session.getChatId(), session.getState(),
                 session.getAnchorMessageId(), session.getLastScreen(),
-                session.isPersistentKeyboardHidden());
+                session.isPersistentKeyboardHidden(),
+                session.isContactRequestSent());
     }
 }

--- a/src/test/resources/db/migration/h2/V4__buyer_contact_request_flag.sql
+++ b/src/test/resources/db/migration/h2/V4__buyer_contact_request_flag.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN IF NOT EXISTS contact_request_sent BOOLEAN DEFAULT FALSE;
+
+UPDATE tb_buyer_bot_screen_states
+SET contact_request_sent = FALSE
+WHERE contact_request_sent IS NULL;


### PR DESCRIPTION
## Summary
- track contact request prompts in chat sessions and skip repeated reminders for /start while awaiting a phone number
- persist the new contact request flag across storage implementations and database schema
- extend onboarding integration coverage to assert a single contact request for the my_chat_member → /start scenario

## Testing
- `mvn test` *(fails: missing parent POM because jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb42dd3d04832daba9f65c1fe9628f