### PR TITLE
Восстановление reply-клавиатуры в главном меню бота покупателя

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1332,8 +1332,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         String text = buildMainMenuText(customer);
         InlineKeyboardMarkup markup = buildMainMenuKeyboard(customer);
         sendInlineMessage(chatId, text, markup, BuyerBotScreen.MENU, forceResendOnNotModified);
-
-        ensurePersistentKeyboard(chatId);
     }
 
     /**
@@ -1508,16 +1506,17 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return;
         }
 
-        ensurePersistentKeyboard(chatId);
+        BuyerBotScreen screen = chatSessionRepository.find(chatId)
+                .map(ChatSession::getLastScreen)
+                .orElse(null);
+        renderScreen(chatId, screen);
     }
 
     /**
-     * Обеспечивает наличие постоянной reply-клавиатуры внизу диалога.
+     * Фиксирует в сессии факт отображения постоянной reply-клавиатуры.
      * <p>
-     * Сообщение, которое содержит клавиатуру, остаётся последним, чтобы кнопки
-     * «🏠 Меню» и «❓ Помощь» были доступны даже после перезапуска бота и ручного
-     * скрытия клавиатуры пользователем. Во время ожидания контакта клавиатура не
-     * восстанавливается, чтобы не мешать сценарию отправки номера телефона.
+     * Метод не обращается к Telegram напрямую, а лишь обновляет состояние хранилища,
+     * позволяя сценариям понимать, что клавиатура уже активна и не требует повторной отправки.
      * </p>
      *
      * @param chatId идентификатор чата Telegram
@@ -1527,29 +1526,25 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return;
         }
 
-        if (getState(chatId) == BuyerChatState.AWAITING_CONTACT) {
-            return;
+        chatSessionRepository.markKeyboardVisible(chatId);
+    }
+
+    /**
+     * Определяет, требуется ли повторно показать постоянную клавиатуру меню.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @return {@code true}, если клавиатура скрыта и её нужно вернуть
+     */
+    private boolean shouldRestorePersistentKeyboard(Long chatId) {
+        if (chatId == null) {
+            return false;
         }
 
         if (!chatSessionRepository.isKeyboardHidden(chatId)) {
-            return;
+            return false;
         }
 
-        SendMessage message = new SendMessage(chatId.toString(),
-                "Клавиши быстрого доступа доступны на панели ниже: «🏠 Меню» и «❓ Помощь».");
-        message.setReplyMarkup(createPersistentMenuKeyboard());
-        message.setDisableNotification(true);
-
-        try {
-            Message sent = telegramClient.execute(message);
-            chatSessionRepository.markKeyboardVisible(chatId);
-            if (sent == null) {
-                log.debug("ℹ️ Telegram не вернул данные отправленного сообщения для чата {}", chatId);
-            }
-        } catch (TelegramApiException e) {
-            chatSessionRepository.markKeyboardHidden(chatId);
-            log.error("❌ Ошибка применения reply-клавиатуры", e);
-        }
+        return getState(chatId) != BuyerChatState.AWAITING_CONTACT;
     }
 
     /**
@@ -1591,9 +1586,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 && session.getAnchorMessageId() == null;
         Integer messageId = session != null ? session.getAnchorMessageId() : null;
 
-        boolean shouldSendNewMessage = manualAnchorReset || messageId == null;
+        boolean shouldRestoreKeyboard = shouldRestorePersistentKeyboard(chatId);
+        boolean shouldSendNewMessage = manualAnchorReset || messageId == null || shouldRestoreKeyboard;
 
-        if (messageId != null && !manualAnchorReset) {
+        if (messageId != null && !manualAnchorReset && !shouldRestoreKeyboard) {
             EditMessageText edit = EditMessageText.builder()
                     .chatId(chatId.toString())
                     .messageId(messageId)
@@ -1603,6 +1599,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             try {
                 telegramClient.execute(edit);
                 chatSessionRepository.updateAnchorAndScreen(chatId, messageId, screen);
+                ensurePersistentKeyboard(chatId);
                 return;
             } catch (TelegramApiException e) {
                 String errorMessage = e.getMessage();
@@ -1621,6 +1618,8 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                     shouldSendNewMessage = true;
                 }
             }
+        } else if (messageId != null && shouldRestoreKeyboard) {
+            deactivateAnchorAndRemoveKeyboard(chatId, messageId, true);
         }
 
         if (!shouldSendNewMessage) {
@@ -1628,13 +1627,37 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         SendMessage message = new SendMessage(chatId.toString(), text);
-        message.setReplyMarkup(markup);
+        if (shouldRestoreKeyboard) {
+            message.setReplyMarkup(createPersistentMenuKeyboard());
+        } else {
+            message.setReplyMarkup(markup);
+        }
         message.setDisableNotification(true);
         try {
             Message sent = telegramClient.execute(message);
             Integer newAnchorId = sent != null ? sent.getMessageId() : null;
             chatSessionRepository.updateAnchorAndScreen(chatId, newAnchorId, screen);
+            if (shouldRestoreKeyboard) {
+                chatSessionRepository.markKeyboardVisible(chatId);
+                if (newAnchorId != null && markup != null) {
+                    EditMessageReplyMarkup editMarkup = EditMessageReplyMarkup.builder()
+                            .chatId(chatId.toString())
+                            .messageId(newAnchorId)
+                            .replyMarkup(markup)
+                            .build();
+                    try {
+                        telegramClient.execute(editMarkup);
+                    } catch (TelegramApiException e) {
+                        log.warn("⚠️ Не удалось восстановить инлайн-клавиатуру для чата {}", chatId, e);
+                    }
+                }
+            } else {
+                ensurePersistentKeyboard(chatId);
+            }
         } catch (TelegramApiException e) {
+            if (shouldRestoreKeyboard) {
+                chatSessionRepository.markKeyboardHidden(chatId);
+            }
             log.error("❌ Ошибка отправки якорного сообщения", e);
         }
     }
@@ -1658,7 +1681,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         boolean keyboardHiddenBeforeUpdate = chatSessionRepository.isKeyboardHidden(chatId);
         chatSessionRepository.updateAnchorAndScreen(chatId, messageId, screen);
         if (keyboardHiddenBeforeUpdate) {
-            ensurePersistentKeyboard(chatId);
+            chatSessionRepository.markKeyboardHidden(chatId);
         } else {
             chatSessionRepository.markKeyboardVisible(chatId);
         }


### PR DESCRIPTION
## Summary
- перевёл восстановление постоянной клавиатуры на переиспользование якорного сообщения и убрал дополнительный текст
- доработал обработку скрытия клавиатуры и повторного рендеринга экранов
- добавил интеграционный тест, проверяющий единственное сообщение главного меню и активную reply-клавиатуру после /start и my_chat_member

## Testing
- mvn test *(не удалось скачать родительский POM из-за недоступности сети)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2fb26558832dade7047f74571ef1