### PR TITLE
Preserve keyboard visibility when resetting menu anchor

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -361,7 +361,8 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
      * <p>
      * Метод используется при повторном выборе пункта «🏠 Меню», чтобы бот заново отправил
      * сообщение с главной навигацией. При наличии предыдущего сообщения его инлайн-клавиатура
-     * удаляется, чтобы пользователь не взаимодействовал с устаревшим экземпляром.
+     * удаляется, чтобы пользователь не взаимодействовал с устаревшим экземпляром. При этом
+     * сохраняется признак видимости постоянной клавиатуры, чтобы не отправлять лишние подсказки.
      * </p>
      *
      * @param chatId идентификатор чата Telegram
@@ -375,7 +376,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 .filter(session -> session.getLastScreen() == BuyerBotScreen.MENU)
                 .ifPresent(session -> {
                     Integer anchorMessageId = session.getAnchorMessageId();
-                    chatSessionRepository.clearAnchor(chatId);
+                    chatSessionRepository.deactivateAnchor(chatId);
                     if (anchorMessageId != null) {
                         removeInlineKeyboard(chatId, anchorMessageId);
                     }


### PR DESCRIPTION
## Summary
- replace menu anchor reset logic to keep the persistent keyboard visibility flag intact
- add a regression test ensuring the bot does not send the keyboard hint when the menu button is pressed twice in idle state

## Testing
- mvn -q test *(fails: unable to download parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc47f029bc832dbc39b5fb321f8f0a