### PR TITLE
Enforce full name segments length in Telegram validator

### DIFF
--- a/src/test/java/com/project/tracking_system/service/telegram/FullNameValidatorTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/FullNameValidatorTest.java
@@ -59,6 +59,23 @@ class FullNameValidatorTest {
     }
 
     /**
+     * Проверяет, что инициалы и короткие части слова отклоняются.
+     */
+    @Test
+    void shouldRejectInitialsAndShortParts() {
+        FullNameValidator.FullNameValidationResult surnameWithInitial = validator.validate("Иванов И");
+
+        assertFalse(surnameWithInitial.valid());
+        assertEquals(FullNameValidator.FullNameValidationError.WORD_PART_TOO_SHORT, surnameWithInitial.error());
+        assertTrue(surnameWithInitial.message().contains("полностью"));
+
+        FullNameValidator.FullNameValidationResult hyphenWithShortSegment = validator.validate("Мария С-петрова");
+
+        assertFalse(hyphenWithShortSegment.valid());
+        assertEquals(FullNameValidator.FullNameValidationError.WORD_PART_TOO_SHORT, hyphenWithShortSegment.error());
+    }
+
+    /**
      * Проверяет, что при пустом вводе возвращается подсказка с примером полного ФИО.
      */
     @Test
@@ -116,5 +133,9 @@ class FullNameValidatorTest {
         FullNameValidator.FullNameValidationResult hyphenated = validator.validate("  олег   смирнов-петров  ");
         assertTrue(hyphenated.valid());
         assertEquals("Олег Смирнов-Петров", hyphenated.normalizedFullName());
+
+        FullNameValidator.FullNameValidationResult complex = validator.validate("  жан-поль   де'лор  ");
+        assertTrue(complex.valid());
+        assertEquals("Жан-Поль Де'Лор", complex.normalizedFullName());
     }
 }


### PR DESCRIPTION
## Summary
- reject full names that use initials or one-letter parts when splitting by spaces, hyphens or apostrophes
- surface a dedicated validation error with guidance to enter full first and last names
- cover initials, short segments and complex valid names in the validator unit tests

## Testing
- mvn test *(fails: cannot reach parent POM repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cc641943ac832dad39fb078e47c9d6