### PR TITLE
Add admin notification management

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/AdminNotificationForm.java
+++ b/src/main/java/com/project/tracking_system/dto/AdminNotificationForm.java
@@ -1,0 +1,46 @@
+package com.project.tracking_system.dto;
+
+import com.project.tracking_system.entity.AdminNotification;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Форма создания или редактирования административного уведомления.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminNotificationForm {
+
+    private Long id;
+    private String title;
+    private String body;
+
+    /**
+     * Преобразует тело уведомления в список строк для хранения в БД.
+     */
+    public List<String> toBodyLines() {
+        if (body == null || body.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(body.split("\r?\n"))
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Создаёт форму на основе сохранённого уведомления.
+     */
+    public static AdminNotificationForm fromEntity(AdminNotification notification) {
+        AdminNotificationForm form = new AdminNotificationForm();
+        form.setId(notification.getId());
+        form.setTitle(notification.getTitle());
+        form.setBody(String.join("\n", notification.getBodyLines()));
+        return form;
+    }
+}

--- a/src/main/java/com/project/tracking_system/entity/AdminNotification.java
+++ b/src/main/java/com/project/tracking_system/entity/AdminNotification.java
@@ -1,0 +1,65 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Административное уведомление, отображаемое пользователям панели.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "tb_admin_notifications")
+public class AdminNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @ElementCollection
+    @CollectionTable(name = "tb_admin_notification_lines", joinColumns = @JoinColumn(name = "notification_id"))
+    @Column(name = "line", nullable = false, columnDefinition = "TEXT")
+    private List<String> bodyLines = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private AdminNotificationStatus status = AdminNotificationStatus.INACTIVE;
+
+    @Column(name = "reset_requested", nullable = false)
+    private boolean resetRequested = true;
+
+    @Column(name = "created_at", nullable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private ZonedDateTime updatedAt;
+
+    /**
+     * Устанавливает временные метки перед сохранением новой записи.
+     */
+    @PrePersist
+    public void onCreate() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    /**
+     * Обновляет временную метку перед изменением записи.
+     */
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = ZonedDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/project/tracking_system/entity/AdminNotificationStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/AdminNotificationStatus.java
@@ -1,0 +1,15 @@
+package com.project.tracking_system.entity;
+
+/**
+ * Статус административного уведомления.
+ */
+public enum AdminNotificationStatus {
+    /**
+     * Уведомление активно и должно отображаться пользователям.
+     */
+    ACTIVE,
+    /**
+     * Уведомление не активно и хранится в истории.
+     */
+    INACTIVE
+}

--- a/src/main/java/com/project/tracking_system/repository/AdminNotificationRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/AdminNotificationRepository.java
@@ -1,0 +1,24 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.AdminNotification;
+import com.project.tracking_system.entity.AdminNotificationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Репозиторий управления административными уведомлениями.
+ */
+public interface AdminNotificationRepository extends JpaRepository<AdminNotification, Long> {
+
+    /**
+     * Находит активное уведомление, если оно существует.
+     */
+    Optional<AdminNotification> findFirstByStatus(AdminNotificationStatus status);
+
+    /**
+     * Возвращает историю уведомлений в порядке от новых к старым.
+     */
+    List<AdminNotification> findAllByOrderByCreatedAtDesc();
+}

--- a/src/main/java/com/project/tracking_system/service/admin/AdminNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminNotificationService.java
@@ -1,0 +1,101 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.entity.AdminNotification;
+import com.project.tracking_system.entity.AdminNotificationStatus;
+import com.project.tracking_system.repository.AdminNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Сервис управления административными уведомлениями.
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminNotificationService {
+
+    private final AdminNotificationRepository notificationRepository;
+
+    /**
+     * Возвращает историю уведомлений в порядке создания.
+     */
+    @Transactional(readOnly = true)
+    public List<AdminNotification> getHistory() {
+        return notificationRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    /**
+     * Получает уведомление по идентификатору.
+     */
+    @Transactional(readOnly = true)
+    public AdminNotification getNotification(Long id) {
+        return notificationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Уведомление не найдено"));
+    }
+
+    /**
+     * Создаёт новое уведомление и запрашивает его показ пользователям.
+     */
+    @Transactional
+    public AdminNotification createNotification(String title, List<String> bodyLines) {
+        AdminNotification notification = new AdminNotification();
+        notification.setTitle(title);
+        notification.setBodyLines(new ArrayList<>(bodyLines));
+        notification.setStatus(AdminNotificationStatus.INACTIVE);
+        notification.setResetRequested(true);
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * Обновляет текстовое содержимое уведомления.
+     */
+    @Transactional
+    public AdminNotification updateNotification(Long id, String title, List<String> bodyLines) {
+        AdminNotification notification = getNotification(id);
+        notification.setTitle(title);
+        notification.setBodyLines(new ArrayList<>(bodyLines));
+        return notification;
+    }
+
+    /**
+     * Активирует выбранное уведомление и отключает предыдущее активное.
+     */
+    @Transactional
+    public void activateNotification(Long id) {
+        AdminNotification toActivate = getNotification(id);
+        notificationRepository.findFirstByStatus(AdminNotificationStatus.ACTIVE)
+                .filter(active -> !active.getId().equals(id))
+                .ifPresent(active -> active.setStatus(AdminNotificationStatus.INACTIVE));
+        toActivate.setStatus(AdminNotificationStatus.ACTIVE);
+        toActivate.setResetRequested(true);
+    }
+
+    /**
+     * Переводит уведомление в неактивное состояние.
+     */
+    @Transactional
+    public void deactivateNotification(Long id) {
+        AdminNotification notification = getNotification(id);
+        notification.setStatus(AdminNotificationStatus.INACTIVE);
+    }
+
+    /**
+     * Удаляет уведомление из истории.
+     */
+    @Transactional
+    public void deleteNotification(Long id) {
+        notificationRepository.deleteById(id);
+    }
+
+    /**
+     * Запрашивает повторный показ уведомления пользователям.
+     */
+    @Transactional
+    public void requestReset(Long id) {
+        AdminNotification notification = getNotification(id);
+        notification.setResetRequested(true);
+    }
+}

--- a/src/main/resources/templates/admin/notifications/form.html
+++ b/src/main/resources/templates/admin/notifications/form.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<head>
+    <title layout:fragment="title"
+           th:text="${isEdit} ? 'Редактирование уведомления' : 'Новое уведомление'"></title>
+</head>
+
+<div layout:fragment="header"
+     th:replace="~{partials/header-admin :: header}">
+</div>
+
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
+</div>
+
+<main layout:fragment="content">
+    <div class="container mt-4">
+        <h1 th:text="${isEdit} ? 'Редактирование уведомления' : 'Создание уведомления'"></h1>
+
+        <form th:action="${isEdit} ? @{/admin/notifications/{id}/update(id=${notificationForm.id})} : @{/admin/notifications}"
+              method="post"
+              th:object="${notificationForm}">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
+
+            <div class="mb-3">
+                <label for="title" class="form-label">Заголовок</label>
+                <input type="text" id="title" class="form-control" th:field="*{title}" required>
+            </div>
+
+            <div class="mb-3">
+                <label for="body" class="form-label">Текст уведомления</label>
+                <textarea id="body" class="form-control" rows="8" th:field="*{body}" placeholder="Каждая строка будет отдельным абзацем"></textarea>
+            </div>
+
+            <div class="mb-3" th:if="${notification}">
+                <div class="form-text">Последнее обновление: <span th:text="${#temporals.format(notification.updatedAt, 'dd.MM.yyyy HH:mm')}"></span></div>
+                <div class="form-text">Статус: <span th:text="${notification.status.name()}"></span></div>
+                <div class="form-text">Флаг показа: <span th:text="${notification.resetRequested ? 'запрошено' : 'отключено'}"></span></div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary" th:text="${isEdit} ? 'Сохранить' : 'Создать'"></button>
+                <a th:href="@{/admin/notifications}" class="btn btn-secondary">Отмена</a>
+            </div>
+        </form>
+    </div>
+</main>
+
+</html>

--- a/src/main/resources/templates/admin/notifications/list.html
+++ b/src/main/resources/templates/admin/notifications/list.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}">
+
+<head>
+    <title layout:fragment="title">Уведомления администратора</title>
+</head>
+
+<div layout:fragment="header"
+     th:replace="~{partials/header-admin :: header}">
+</div>
+
+<div layout:fragment="afterHeader">
+    <div th:replace="~{partials/breadcrumbs :: breadcrumbs(items=${breadcrumbs})}"></div>
+</div>
+
+<main layout:fragment="content">
+    <div class="container mt-4">
+        <h1 class="mb-3">Уведомления администратора</h1>
+
+        <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+        <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+        <a th:href="@{/admin/notifications/new}" class="btn btn-primary mb-3">Создать уведомление</a>
+
+        <div th:if="${notifications.isEmpty()}">
+            <div class="alert alert-info">Пока нет созданных уведомлений.</div>
+        </div>
+
+        <div th:if="${!notifications.isEmpty()}">
+            <table class="table table-striped table-bordered">
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Заголовок</th>
+                    <th>Статус</th>
+                    <th>Обновлено</th>
+                    <th>Показ снова</th>
+                    <th>Действия</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="notification : ${notifications}"
+                    th:classappend="${notification.status} == ${activeStatus} ? 'table-success' : ''">
+                    <td th:text="${notification.id}"></td>
+                    <td>
+                        <span th:text="${notification.title}"></span>
+                        <div class="small text-muted" th:if="${notification.status} == ${activeStatus}">Активное</div>
+                    </td>
+                    <td th:text="${notification.status == activeStatus ? 'Активно' : 'Не активно'}"></td>
+                    <td th:text="${#temporals.format(notification.updatedAt, 'dd.MM.yyyy HH:mm')}"></td>
+                    <td th:text="${notification.resetRequested ? 'Запрошено' : 'Отключено'}"></td>
+                    <td>
+                        <a th:href="@{/admin/notifications/{id}/edit(id=${notification.id})}"
+                           class="btn btn-sm btn-secondary mb-1">Изменить</a>
+                        <form th:action="@{/admin/notifications/{id}/activate(id=${notification.id})}"
+                              method="post" class="d-inline"
+                              th:if="${notification.status} != ${activeStatus}">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
+                            <button type="submit" class="btn btn-sm btn-success mb-1">Активировать</button>
+                        </form>
+                        <form th:action="@{/admin/notifications/{id}/deactivate(id=${notification.id})}"
+                              method="post" class="d-inline"
+                              th:if="${notification.status} == ${activeStatus}">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
+                            <button type="submit" class="btn btn-sm btn-warning mb-1">Деактивировать</button>
+                        </form>
+                        <form th:action="@{/admin/notifications/{id}/reset(id=${notification.id})}"
+                              method="post" class="d-inline"
+                              th:if="${!notification.resetRequested}">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
+                            <button type="submit" class="btn btn-sm btn-info mb-1">Показать снова</button>
+                        </form>
+                        <form th:action="@{/admin/notifications/{id}/delete(id=${notification.id})}"
+                              method="post" class="d-inline"
+                              onsubmit="return confirm('Удалить уведомление?');">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
+                            <button type="submit" class="btn btn-sm btn-danger mb-1">Удалить</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</main>
+
+</html>

--- a/src/test/java/com/project/tracking_system/controller/AdminControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/AdminControllerTest.java
@@ -1,7 +1,19 @@
 package com.project.tracking_system.controller;
 
+import com.project.tracking_system.dto.AdminNotificationForm;
 import com.project.tracking_system.dto.TrackingResultAdd;
+import com.project.tracking_system.repository.StoreRepository;
+import com.project.tracking_system.service.DynamicSchedulerService;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.analytics.StatsAggregationService;
+import com.project.tracking_system.service.admin.AdminNotificationService;
 import com.project.tracking_system.service.admin.AdminService;
+import com.project.tracking_system.service.admin.AppInfoService;
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import com.project.tracking_system.service.admin.SubscriptionPlanService;
+import com.project.tracking_system.service.tariff.TariffService;
+import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -9,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -20,7 +34,40 @@ import static org.mockito.Mockito.*;
 class AdminControllerTest {
 
     @Mock
+    private UserService userService;
+
+    @Mock
+    private TrackParcelService trackParcelService;
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @Mock
+    private SubscriptionPlanService subscriptionPlanService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private StatsAggregationService statsAggregationService;
+
+    @Mock
     private AdminService adminService;
+
+    @Mock
+    private AdminNotificationService adminNotificationService;
+
+    @Mock
+    private AppInfoService appInfoService;
+
+    @Mock
+    private DynamicSchedulerService dynamicSchedulerService;
+
+    @Mock
+    private TariffService tariffService;
+
+    @Mock
+    private ApplicationSettingsService applicationSettingsService;
 
     @InjectMocks
     private AdminController controller;
@@ -36,5 +83,41 @@ class AdminControllerTest {
         assertEquals("redirect:/admin/parcels/1", view);
         assertEquals("ok", attrs.getFlashAttributes().get("updateStatus"));
         verify(adminService).forceUpdateParcel(1L);
+    }
+
+    @Test
+    void createNotification_DelegatesToServiceAndRedirects() {
+        AdminNotificationForm form = new AdminNotificationForm();
+        form.setTitle("Обновление");
+        form.setBody("Первая строка\nВторая строка");
+
+        RedirectAttributes attrs = new RedirectAttributesModelMap();
+        String view = controller.createNotification(form, attrs);
+
+        assertEquals("redirect:/admin/notifications", view);
+        assertEquals("Уведомление создано", attrs.getFlashAttributes().get("successMessage"));
+        verify(adminNotificationService).createNotification(eq("Обновление"), eq(List.of("Первая строка", "Вторая строка")));
+    }
+
+    @Test
+    void activateNotification_SetsFlashMessage() {
+        RedirectAttributes attrs = new RedirectAttributesModelMap();
+
+        String view = controller.activateNotification(5L, attrs);
+
+        assertEquals("redirect:/admin/notifications", view);
+        assertEquals("Уведомление активировано", attrs.getFlashAttributes().get("successMessage"));
+        verify(adminNotificationService).activateNotification(5L);
+    }
+
+    @Test
+    void resetNotification_DelegatesToService() {
+        RedirectAttributes attrs = new RedirectAttributesModelMap();
+
+        String view = controller.resetNotification(7L, attrs);
+
+        assertEquals("redirect:/admin/notifications", view);
+        assertEquals("Показ уведомления будет повторён", attrs.getFlashAttributes().get("successMessage"));
+        verify(adminNotificationService).requestReset(7L);
     }
 }


### PR DESCRIPTION
## Summary
- add a persistent AdminNotification entity with repository support for history queries
- implement AdminNotificationService to manage activation, reset requests and updates
- extend AdminController with notification CRUD endpoints and add Thymeleaf views
- expand controller unit tests to cover creation, activation and reset flows

## Testing
- mvn -q -Dtest=AdminControllerTest test *(fails: unable to resolve parent POM because external repository is unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7d92992c832dacc7b13b6f007299