### PR TITLE
Add announcement state persistence and track customer activity

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerAnnouncementState.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerAnnouncementState.java
@@ -1,0 +1,69 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Состояние рассылки объявлений для покупателя в Telegram.
+ * <p>
+ * Позволяет хранить идентификатор текущего уведомления и признак того,
+ * что пользователь уже ознакомился с его содержимым. Дополнительно
+ * сохраняется история просмотренных уведомлений, чтобы не дублировать
+ * показ при повторных рассылках.
+ * </p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tb_buyer_announcement_states")
+public class BuyerAnnouncementState {
+
+    /**
+     * Уникальный идентификатор чата покупателя в Telegram.
+     */
+    @Id
+    @Column(name = "chat_id")
+    private Long chatId;
+
+    /**
+     * Идентификатор актуального уведомления, которое должно быть показано пользователю.
+     */
+    @Column(name = "current_notification_id")
+    private Long currentNotificationId;
+
+    /**
+     * Признак того, что пользователь уже просмотрел текущее уведомление.
+     */
+    @Column(name = "announcement_seen", nullable = false)
+    private Boolean announcementSeen = Boolean.FALSE;
+
+    /**
+     * Сообщение, содержащее текст объявления и управляющие элементы.
+     */
+    @Column(name = "anchor_message_id")
+    private Integer anchorMessageId;
+
+    /**
+     * Набор идентификаторов объявлений, уже показанных пользователю ранее.
+     */
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "tb_buyer_seen_announcements", joinColumns = @JoinColumn(name = "chat_id"))
+    @Column(name = "notification_id")
+    private Set<Long> seenNotificationIds = new HashSet<>();
+}
+

--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -59,6 +59,12 @@ public class Customer {
     private BuyerReputation reputation = BuyerReputation.NEW;
 
     /**
+     * Дата и время последней активности покупателя в Telegram.
+     */
+    @Column(name = "last_active_at")
+    private ZonedDateTime lastActiveAt;
+
+    /**
      * Версия записи для реализации оптимистичной блокировки.
      */
     @Version

--- a/src/main/java/com/project/tracking_system/repository/BuyerAnnouncementStateRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/BuyerAnnouncementStateRepository.java
@@ -1,0 +1,11 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.BuyerAnnouncementState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Репозиторий состояния объявлений для покупателей в Telegram.
+ */
+public interface BuyerAnnouncementStateRepository extends JpaRepository<BuyerAnnouncementState, Long> {
+}
+

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -74,6 +74,7 @@ public class CustomerTelegramService {
         }
 
         customer.setTelegramChatId(chatId);
+        customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
         Customer saved = customerRepository.save(customer);
         log.info("✅ Чат {} привязан к покупателю {}", chatId, saved.getId());
         return saved;
@@ -106,6 +107,7 @@ public class CustomerTelegramService {
         }
         if (!customer.isTelegramConfirmed()) {
             customer.setTelegramConfirmed(true);
+            customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
             customer = customerRepository.save(customer);
             log.info("✅ Покупатель {} подтвердил Telegram", customer.getId());
         }
@@ -132,6 +134,7 @@ public class CustomerTelegramService {
                         if (c.getNameSource() == NameSource.USER_CONFIRMED) {
                             c.setNameSource(NameSource.MERCHANT_PROVIDED);
                             c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                            c.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                             customerRepository.save(c);
                         }
                         return false;
@@ -139,6 +142,7 @@ public class CustomerTelegramService {
                     if (c.getNameSource() != NameSource.USER_CONFIRMED) {
                         c.setNameSource(NameSource.USER_CONFIRMED);
                         c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                        c.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                         customerRepository.save(c);
                     }
                     return true;
@@ -171,6 +175,7 @@ public class CustomerTelegramService {
                 .ifPresent(c -> {
                     c.setNameSource(NameSource.MERCHANT_PROVIDED);
                     c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    c.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                     customerRepository.save(c);
                 });
     }
@@ -237,6 +242,7 @@ public class CustomerTelegramService {
                 .filter(Customer::isNotificationsEnabled)
                 .map(customer -> {
                     customer.setNotificationsEnabled(false);
+                    customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                     customerRepository.save(customer);
                     log.info("🔕 Уведомления отключены для покупателя {}", customer.getId());
                     return true;
@@ -260,11 +266,30 @@ public class CustomerTelegramService {
                 .filter(c -> !c.isNotificationsEnabled())
                 .map(customer -> {
                     customer.setNotificationsEnabled(true);
+                    customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                     customerRepository.save(customer);
                     log.info("🔔 Уведомления включены для покупателя {}", customer.getId());
                     return true;
                 })
                 .orElse(false);
+    }
+
+    /**
+     * Обновить отметку о последней активности покупателя по идентификатору чата.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
+    @Transactional
+    public void updateLastActive(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+        customerRepository.findByTelegramChatId(chatId)
+                .ifPresent(customer -> {
+                    customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
+                    customerRepository.save(customer);
+                    log.debug("🕒 Обновлена активность покупателя {}", customer.getId());
+                });
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -126,6 +126,11 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     public void consume(Update update) {
         log.info("📩 Получено обновление: {}", formatUpdateMetadata(update));
 
+        Long chatIdForActivity = extractChatId(update);
+        if (chatIdForActivity != null) {
+            telegramService.updateLastActive(chatIdForActivity);
+        }
+
         if (update.hasCallbackQuery()) {
             handleCallbackQuery(update.getCallbackQuery());
             return;
@@ -153,6 +158,43 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         if (message.hasContact()) {
             handleContact(chatId, message, message.getContact());
         }
+    }
+
+    /**
+     * Определяет идентификатор чата, связанный с обновлением Telegram.
+     *
+     * @param update входящее обновление Telegram
+     * @return идентификатор чата или {@code null}, если его нельзя определить
+     */
+    private Long extractChatId(Update update) {
+        if (update == null) {
+            return null;
+        }
+
+        if (update.hasCallbackQuery()) {
+            CallbackQuery callbackQuery = update.getCallbackQuery();
+            if (callbackQuery != null) {
+                MaybeInaccessibleMessage callbackMessage = callbackQuery.getMessage();
+                if (callbackMessage != null) {
+                    return callbackMessage.getChatId();
+                }
+            }
+        }
+
+        if (update.hasMessage()) {
+            Message message = update.getMessage();
+            if (message != null && message.getChat() != null) {
+                return message.getChatId();
+            }
+        }
+
+        if (update.hasMyChatMember()
+                && update.getMyChatMember() != null
+                && update.getMyChatMember().getChat() != null) {
+            return update.getMyChatMember().getChat().getId();
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
@@ -17,6 +17,9 @@ public class ChatSession {
     private BuyerBotScreen lastScreen;
     private boolean persistentKeyboardHidden;
     private boolean contactRequestSent;
+    private Long currentNotificationId;
+    private Integer announcementAnchorMessageId;
+    private boolean announcementSeen;
 
     /**
      * Создаёт представление состояния чата.
@@ -72,6 +75,9 @@ public class ChatSession {
         this.lastScreen = lastScreen;
         this.persistentKeyboardHidden = persistentKeyboardHidden;
         this.contactRequestSent = contactRequestSent;
+        this.currentNotificationId = null;
+        this.announcementAnchorMessageId = null;
+        this.announcementSeen = false;
     }
 
     /**
@@ -171,5 +177,59 @@ public class ChatSession {
      */
     public void setContactRequestSent(boolean contactRequestSent) {
         this.contactRequestSent = contactRequestSent;
+    }
+
+    /**
+     * Возвращает идентификатор текущего объявления для покупателя.
+     *
+     * @return идентификатор объявления или {@code null}
+     */
+    public Long getCurrentNotificationId() {
+        return currentNotificationId;
+    }
+
+    /**
+     * Сохраняет идентификатор актуального объявления для последующего показа.
+     *
+     * @param currentNotificationId идентификатор объявления или {@code null}
+     */
+    public void setCurrentNotificationId(Long currentNotificationId) {
+        this.currentNotificationId = currentNotificationId;
+    }
+
+    /**
+     * Возвращает идентификатор сообщения с объявлением, отправленного пользователю.
+     *
+     * @return идентификатор сообщения или {@code null}
+     */
+    public Integer getAnnouncementAnchorMessageId() {
+        return announcementAnchorMessageId;
+    }
+
+    /**
+     * Сохраняет сообщение, содержащее объявление и его элементы управления.
+     *
+     * @param announcementAnchorMessageId идентификатор сообщения или {@code null}
+     */
+    public void setAnnouncementAnchorMessageId(Integer announcementAnchorMessageId) {
+        this.announcementAnchorMessageId = announcementAnchorMessageId;
+    }
+
+    /**
+     * Проверяет, видел ли пользователь актуальное объявление.
+     *
+     * @return {@code true}, если объявление уже просмотрено
+     */
+    public boolean isAnnouncementSeen() {
+        return announcementSeen;
+    }
+
+    /**
+     * Фиксирует факт просмотра текущего объявления пользователем.
+     *
+     * @param announcementSeen {@code true}, если объявление просмотрено
+     */
+    public void setAnnouncementSeen(boolean announcementSeen) {
+        this.announcementSeen = announcementSeen;
     }
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
@@ -124,4 +124,28 @@ public interface ChatSessionRepository {
      * @param chatId идентификатор чата Telegram
      */
     void clearContactRequestSent(Long chatId);
+
+    /**
+     * Проверяет, просмотрено ли последнее объявление пользователем.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @return {@code true}, если объявление уже просмотрено
+     */
+    boolean isAnnouncementSeen(Long chatId);
+
+    /**
+     * Помечает текущее объявление как просмотренное.
+     *
+     * @param chatId идентификатор чата Telegram
+     */
+    void markAnnouncementSeen(Long chatId);
+
+    /**
+     * Устанавливает новое объявление и сбрасывает признак просмотра.
+     *
+     * @param chatId              идентификатор чата Telegram
+     * @param notificationId      идентификатор уведомления для показа
+     * @param anchorMessageId     идентификатор сообщения Telegram, в котором отображено объявление
+     */
+    void updateAnnouncement(Long chatId, Long notificationId, Integer anchorMessageId);
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepository.java
@@ -1,13 +1,16 @@
 package com.project.tracking_system.service.telegram;
 
+import com.project.tracking_system.entity.BuyerAnnouncementState;
 import com.project.tracking_system.entity.BuyerBotScreen;
 import com.project.tracking_system.entity.BuyerBotScreenState;
 import com.project.tracking_system.entity.BuyerChatState;
+import com.project.tracking_system.repository.BuyerAnnouncementStateRepository;
 import com.project.tracking_system.repository.BuyerBotScreenStateRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.Optional;
 
 /**
@@ -18,6 +21,7 @@ import java.util.Optional;
 public class DatabaseChatSessionRepository implements ChatSessionRepository {
 
     private final BuyerBotScreenStateRepository repository;
+    private final BuyerAnnouncementStateRepository announcementRepository;
 
     /**
      * {@inheritDoc}
@@ -28,7 +32,18 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
         if (chatId == null) {
             return Optional.empty();
         }
-        return repository.findById(chatId).map(this::toSession);
+        Optional<BuyerBotScreenState> screenState = repository.findById(chatId);
+        Optional<BuyerAnnouncementState> announcementState = announcementRepository.findById(chatId);
+
+        if (screenState.isEmpty() && announcementState.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ChatSession session = screenState
+                .map(this::toSession)
+                .orElseGet(() -> new ChatSession(chatId, BuyerChatState.IDLE, null, null));
+        announcementState.ifPresent(state -> populateAnnouncement(session, state));
+        return Optional.of(session);
     }
 
     /**
@@ -40,14 +55,27 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
         if (session == null || session.getChatId() == null) {
             return session;
         }
-        BuyerBotScreenState entity = getOrCreateEntity(session.getChatId());
+        Long chatId = session.getChatId();
+        BuyerBotScreenState entity = getOrCreateEntity(chatId);
         entity.setChatState(session.getState());
         entity.setAnchorMessageId(session.getAnchorMessageId());
         entity.setLastScreen(session.getLastScreen());
         entity.setKeyboardHidden(session.isPersistentKeyboardHidden());
         entity.setContactRequestSent(session.isContactRequestSent());
         BuyerBotScreenState saved = repository.save(entity);
-        return toSession(saved);
+
+        BuyerAnnouncementState announcement = getOrCreateAnnouncementEntity(chatId);
+        announcement.setCurrentNotificationId(session.getCurrentNotificationId());
+        announcement.setAnchorMessageId(session.getAnnouncementAnchorMessageId());
+        announcement.setAnnouncementSeen(session.isAnnouncementSeen());
+        if (session.isAnnouncementSeen() && session.getCurrentNotificationId() != null) {
+            announcement.getSeenNotificationIds().add(session.getCurrentNotificationId());
+        }
+        BuyerAnnouncementState savedAnnouncement = announcementRepository.save(announcement);
+
+        ChatSession result = toSession(saved);
+        populateAnnouncement(result, savedAnnouncement);
+        return result;
     }
 
     /**
@@ -225,6 +253,61 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isAnnouncementSeen(Long chatId) {
+        if (chatId == null) {
+            return false;
+        }
+        return announcementRepository.findById(chatId)
+                .map(BuyerAnnouncementState::getAnnouncementSeen)
+                .map(Boolean::booleanValue)
+                .orElse(false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void markAnnouncementSeen(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+        announcementRepository.findById(chatId).ifPresent(state -> {
+            if (!Boolean.TRUE.equals(state.getAnnouncementSeen())) {
+                state.setAnnouncementSeen(true);
+                Long notificationId = state.getCurrentNotificationId();
+                if (notificationId != null) {
+                    if (state.getSeenNotificationIds() == null) {
+                        state.setSeenNotificationIds(new HashSet<>());
+                    }
+                    state.getSeenNotificationIds().add(notificationId);
+                }
+                announcementRepository.save(state);
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void updateAnnouncement(Long chatId, Long notificationId, Integer anchorMessageId) {
+        if (chatId == null) {
+            return;
+        }
+        BuyerAnnouncementState state = getOrCreateAnnouncementEntity(chatId);
+        state.setCurrentNotificationId(notificationId);
+        state.setAnchorMessageId(anchorMessageId);
+        state.setAnnouncementSeen(false);
+        announcementRepository.save(state);
+    }
+
+    /**
      * Возвращает сущность состояния, создавая новую запись с настройками по умолчанию.
      *
      * @param chatId идентификатор чата Telegram
@@ -233,6 +316,22 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
     private BuyerBotScreenState getOrCreateEntity(Long chatId) {
         return repository.findById(chatId)
                 .orElseGet(() -> new BuyerBotScreenState(chatId, null, null, BuyerChatState.IDLE, Boolean.TRUE, Boolean.FALSE));
+    }
+
+    /**
+     * Возвращает состояние объявлений, создавая запись с настройками по умолчанию.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @return сущность состояния объявлений
+     */
+    private BuyerAnnouncementState getOrCreateAnnouncementEntity(Long chatId) {
+        return announcementRepository.findById(chatId)
+                .orElseGet(() -> {
+                    BuyerAnnouncementState state = new BuyerAnnouncementState();
+                    state.setChatId(chatId);
+                    state.setAnnouncementSeen(false);
+                    return state;
+                });
     }
 
     /**
@@ -253,5 +352,20 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
                 Boolean.TRUE.equals(entity.getKeyboardHidden()),
                 Boolean.TRUE.equals(entity.getContactRequestSent())
         );
+    }
+
+    /**
+     * Переносит данные об объявлении в объект сессии.
+     *
+     * @param session     доменная модель сессии
+     * @param announcement состояние объявлений, загруженное из базы
+     */
+    private void populateAnnouncement(ChatSession session, BuyerAnnouncementState announcement) {
+        if (session == null || announcement == null) {
+            return;
+        }
+        session.setCurrentNotificationId(announcement.getCurrentNotificationId());
+        session.setAnnouncementAnchorMessageId(announcement.getAnchorMessageId());
+        session.setAnnouncementSeen(Boolean.TRUE.equals(announcement.getAnnouncementSeen()));
     }
 }

--- a/src/main/resources/db/migration/V17__buyer_announcement_state.sql
+++ b/src/main/resources/db/migration/V17__buyer_announcement_state.sql
@@ -1,0 +1,18 @@
+-- Добавление отметки последней активности покупателя и таблиц состояния объявлений
+
+ALTER TABLE tb_customers
+    ADD COLUMN last_active_at TIMESTAMPTZ;
+
+CREATE TABLE tb_buyer_announcement_states (
+    chat_id BIGINT PRIMARY KEY,
+    current_notification_id BIGINT,
+    announcement_seen BOOLEAN NOT NULL DEFAULT FALSE,
+    anchor_message_id INTEGER
+);
+
+CREATE TABLE tb_buyer_seen_announcements (
+    chat_id BIGINT NOT NULL REFERENCES tb_buyer_announcement_states(chat_id) ON DELETE CASCADE,
+    notification_id BIGINT NOT NULL,
+    PRIMARY KEY (chat_id, notification_id)
+);
+

--- a/src/test/java/com/project/tracking_system/repository/CustomerRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/CustomerRepositoryTest.java
@@ -8,6 +8,9 @@ import org.springframework.dao.OptimisticLockingFailureException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
 /**
  * Проверка оптимистичной блокировки для {@link CustomerRepository}.
  */
@@ -35,5 +38,21 @@ class CustomerRepositoryTest {
         second.setFullName("Второй");
         assertThrows(OptimisticLockingFailureException.class,
                 () -> customerRepository.saveAndFlush(second));
+    }
+
+    /**
+     * Проверяет сохранение и загрузку отметки последней активности покупателя.
+     */
+    @Test
+    void shouldPersistLastActiveAt() {
+        Customer customer = new Customer();
+        customer.setPhone("375000000001");
+        ZonedDateTime expected = ZonedDateTime.of(2024, 1, 2, 3, 4, 5, 0, ZoneOffset.UTC);
+        customer.setLastActiveAt(expected);
+        customerRepository.saveAndFlush(customer);
+
+        Customer reloaded = customerRepository.findById(customer.getId()).orElseThrow();
+        assertEquals(expected, reloaded.getLastActiveAt(),
+                "Отметка активности должна считываться из базы данных");
     }
 }

--- a/src/test/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.BuyerBotScreen;
+import com.project.tracking_system.entity.BuyerChatState;
+import com.project.tracking_system.repository.BuyerAnnouncementStateRepository;
+import com.project.tracking_system.repository.BuyerBotScreenStateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Тесты репозитория сохранения сессий, проверяющие работу с объявлениями.
+ */
+@DataJpaTest
+class DatabaseChatSessionRepositoryTest {
+
+    @Autowired
+    private BuyerBotScreenStateRepository screenStateRepository;
+
+    @Autowired
+    private BuyerAnnouncementStateRepository announcementStateRepository;
+
+    private DatabaseChatSessionRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new DatabaseChatSessionRepository(screenStateRepository, announcementStateRepository);
+    }
+
+    /**
+     * Проверяет, что новые поля объявления сохраняются и считываются вместе с сессией.
+     */
+    @Test
+    void shouldPersistAnnouncementFields() {
+        Long chatId = 101L;
+        ChatSession session = new ChatSession(chatId, BuyerChatState.AWAITING_CONTACT, 123,
+                BuyerBotScreen.MENU, false, false);
+        session.setCurrentNotificationId(77L);
+        session.setAnnouncementAnchorMessageId(555);
+        session.setAnnouncementSeen(false);
+
+        repository.save(session);
+
+        ChatSession loaded = repository.find(chatId).orElseThrow();
+        assertEquals(77L, loaded.getCurrentNotificationId(), "Идентификатор объявления должен сохраняться");
+        assertEquals(555, loaded.getAnnouncementAnchorMessageId(),
+                "Якорное сообщение объявления должно считываться из БД");
+        assertFalse(loaded.isAnnouncementSeen(), "Признак просмотра не должен устанавливаться автоматически");
+    }
+
+    /**
+     * Проверяет изменение признака просмотра объявления через специализированные методы репозитория.
+     */
+    @Test
+    void shouldMarkAnnouncementSeen() {
+        Long chatId = 202L;
+        repository.updateAnnouncement(chatId, 88L, 501);
+        assertFalse(repository.isAnnouncementSeen(chatId),
+                "После установки объявления оно не должно считаться просмотренным");
+
+        repository.markAnnouncementSeen(chatId);
+
+        assertTrue(repository.isAnnouncementSeen(chatId),
+                "После подтверждения флаг просмотра должен быть установлен");
+
+        ChatSession loaded = repository.find(chatId).orElseThrow();
+        assertTrue(loaded.isAnnouncementSeen(), "Сохранённая сессия должна отражать признак просмотра");
+        assertEquals(88L, loaded.getCurrentNotificationId(),
+                "У сессии должен сохраняться идентификатор текущего объявления");
+        assertEquals(501, loaded.getAnnouncementAnchorMessageId(),
+                "Должен сохраняться идентификатор сообщения с объявлением");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add the lastActiveAt timestamp to Customer and refresh it on every Telegram update
- introduce BuyerAnnouncementState persistence with extended chat session repository API for announcements
- provide Flyway migration and repository-level tests covering the new fields

## Testing
- mvn -q test *(fails: cannot resolve Spring Boot parent because the network to jitpack.io is unreachable in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68cc81f73f04832dbc211d71503c669d