### PR TITLE
Show admin announcements in buyer bot menu

### DIFF
--- a/src/main/java/com/project/tracking_system/service/admin/AdminNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminNotificationService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Сервис управления административными уведомлениями.
@@ -47,6 +48,16 @@ public class AdminNotificationService {
         notification.setStatus(AdminNotificationStatus.INACTIVE);
         notification.setResetRequested(true);
         return notificationRepository.save(notification);
+    }
+
+    /**
+     * Ищет активное уведомление, которое должно отображаться пользователям.
+     *
+     * @return опциональное уведомление в статусе {@link AdminNotificationStatus#ACTIVE}
+     */
+    @Transactional(readOnly = true)
+    public Optional<AdminNotification> findActiveNotification() {
+        return notificationRepository.findFirstByStatus(AdminNotificationStatus.ACTIVE);
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.NameSource;
+import com.project.tracking_system.service.admin.AdminNotificationService;
 import com.project.tracking_system.service.customer.CustomerTelegramService;
 import com.project.tracking_system.service.telegram.support.InMemoryChatSessionRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +38,8 @@ class BuyerTelegramBotLoggingTest {
     private TelegramClient telegramClient;
     @Mock
     private CustomerTelegramService customerTelegramService;
+    @Mock
+    private AdminNotificationService adminNotificationService;
 
     private BuyerTelegramBot buyerTelegramBot;
     private InMemoryChatSessionRepository chatSessionRepository;
@@ -47,9 +50,10 @@ class BuyerTelegramBotLoggingTest {
     @BeforeEach
     void setUp() {
         chatSessionRepository = new InMemoryChatSessionRepository();
-        buyerTelegramBot = new BuyerTelegramBot(telegramClient, "token", customerTelegramService,
+        buyerTelegramBot = new BuyerTelegramBot(telegramClient, "token", customerTelegramService, adminNotificationService,
                 new FullNameValidator(), chatSessionRepository, new ObjectMapper());
         when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
+        when(adminNotificationService.findActiveNotification()).thenReturn(Optional.empty());
         logger = (Logger) LoggerFactory.getLogger(BuyerTelegramBot.class);
         appender = new ListAppender<>();
         appender.start();


### PR DESCRIPTION
## Summary
- wire `AdminNotificationService` into `BuyerTelegramBot` to detect active admin announcements and render a banner with an “Ок” confirmation button in the main menu flow
- handle the new announcement callback to mark notifications as seen, refresh the menu anchor, and guard against repeated clicks
- update and extend bot tests to cover announcement display, repeated acknowledgements, and the absence of banners for new users while adapting existing helpers to the new dependency

## Testing
- `mvn test` *(fails: network is unreachable when resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cc86db4098832dbb1a1bc3aad68e29