### PR TITLE
Remove buyer activity tracking from announcement flow

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerAnnouncementState.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerAnnouncementState.java
@@ -1,28 +1,21 @@
 package com.project.tracking_system.entity;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Состояние рассылки объявлений для покупателя в Telegram.
  * <p>
  * Позволяет хранить идентификатор текущего уведомления и признак того,
  * что пользователь уже ознакомился с его содержимым. Дополнительно
- * сохраняется история просмотренных уведомлений, чтобы не дублировать
- * показ при повторных рассылках.
+ * сохраняется идентификатор якорного сообщения, чтобы бот мог обновить
+ * показанный баннер без повторной отправки.
  * </p>
  */
 @Getter
@@ -58,12 +51,5 @@ public class BuyerAnnouncementState {
     @Column(name = "anchor_message_id")
     private Integer anchorMessageId;
 
-    /**
-     * Набор идентификаторов объявлений, уже показанных пользователю ранее.
-     */
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "tb_buyer_seen_announcements", joinColumns = @JoinColumn(name = "chat_id"))
-    @Column(name = "notification_id")
-    private Set<Long> seenNotificationIds = new HashSet<>();
 }
 

--- a/src/main/java/com/project/tracking_system/entity/Customer.java
+++ b/src/main/java/com/project/tracking_system/entity/Customer.java
@@ -59,12 +59,6 @@ public class Customer {
     private BuyerReputation reputation = BuyerReputation.NEW;
 
     /**
-     * Дата и время последней активности покупателя в Telegram.
-     */
-    @Column(name = "last_active_at")
-    private ZonedDateTime lastActiveAt;
-
-    /**
      * Версия записи для реализации оптимистичной блокировки.
      */
     @Version

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -74,7 +74,6 @@ public class CustomerTelegramService {
         }
 
         customer.setTelegramChatId(chatId);
-        customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
         Customer saved = customerRepository.save(customer);
         log.info("✅ Чат {} привязан к покупателю {}", chatId, saved.getId());
         return saved;
@@ -107,7 +106,6 @@ public class CustomerTelegramService {
         }
         if (!customer.isTelegramConfirmed()) {
             customer.setTelegramConfirmed(true);
-            customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
             customer = customerRepository.save(customer);
             log.info("✅ Покупатель {} подтвердил Telegram", customer.getId());
         }
@@ -134,7 +132,6 @@ public class CustomerTelegramService {
                         if (c.getNameSource() == NameSource.USER_CONFIRMED) {
                             c.setNameSource(NameSource.MERCHANT_PROVIDED);
                             c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                            c.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                             customerRepository.save(c);
                         }
                         return false;
@@ -142,7 +139,6 @@ public class CustomerTelegramService {
                     if (c.getNameSource() != NameSource.USER_CONFIRMED) {
                         c.setNameSource(NameSource.USER_CONFIRMED);
                         c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                        c.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                         customerRepository.save(c);
                     }
                     return true;
@@ -175,7 +171,6 @@ public class CustomerTelegramService {
                 .ifPresent(c -> {
                     c.setNameSource(NameSource.MERCHANT_PROVIDED);
                     c.setNameUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    c.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                     customerRepository.save(c);
                 });
     }
@@ -242,7 +237,6 @@ public class CustomerTelegramService {
                 .filter(Customer::isNotificationsEnabled)
                 .map(customer -> {
                     customer.setNotificationsEnabled(false);
-                    customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                     customerRepository.save(customer);
                     log.info("🔕 Уведомления отключены для покупателя {}", customer.getId());
                     return true;
@@ -266,30 +260,11 @@ public class CustomerTelegramService {
                 .filter(c -> !c.isNotificationsEnabled())
                 .map(customer -> {
                     customer.setNotificationsEnabled(true);
-                    customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
                     customerRepository.save(customer);
                     log.info("🔔 Уведомления включены для покупателя {}", customer.getId());
                     return true;
                 })
                 .orElse(false);
-    }
-
-    /**
-     * Обновить отметку о последней активности покупателя по идентификатору чата.
-     *
-     * @param chatId идентификатор чата Telegram
-     */
-    @Transactional
-    public void updateLastActive(Long chatId) {
-        if (chatId == null) {
-            return;
-        }
-        customerRepository.findByTelegramChatId(chatId)
-                .ifPresent(customer -> {
-                    customer.setLastActiveAt(ZonedDateTime.now(ZoneOffset.UTC));
-                    customerRepository.save(customer);
-                    log.debug("🕒 Обновлена активность покупателя {}", customer.getId());
-                });
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepository.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
 import java.util.Optional;
 
 /**
@@ -68,9 +67,6 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
         announcement.setCurrentNotificationId(session.getCurrentNotificationId());
         announcement.setAnchorMessageId(session.getAnnouncementAnchorMessageId());
         announcement.setAnnouncementSeen(session.isAnnouncementSeen());
-        if (session.isAnnouncementSeen() && session.getCurrentNotificationId() != null) {
-            announcement.getSeenNotificationIds().add(session.getCurrentNotificationId());
-        }
         BuyerAnnouncementState savedAnnouncement = announcementRepository.save(announcement);
 
         ChatSession result = toSession(saved);
@@ -279,13 +275,6 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
         announcementRepository.findById(chatId).ifPresent(state -> {
             if (!Boolean.TRUE.equals(state.getAnnouncementSeen())) {
                 state.setAnnouncementSeen(true);
-                Long notificationId = state.getCurrentNotificationId();
-                if (notificationId != null) {
-                    if (state.getSeenNotificationIds() == null) {
-                        state.setSeenNotificationIds(new HashSet<>());
-                    }
-                    state.getSeenNotificationIds().add(notificationId);
-                }
                 announcementRepository.save(state);
             }
         });

--- a/src/main/resources/db/migration/V17__buyer_announcement_state.sql
+++ b/src/main/resources/db/migration/V17__buyer_announcement_state.sql
@@ -1,7 +1,4 @@
--- Добавление отметки последней активности покупателя и таблиц состояния объявлений
-
-ALTER TABLE tb_customers
-    ADD COLUMN last_active_at TIMESTAMPTZ;
+-- Добавление таблиц состояния объявлений для покупателей в Telegram
 
 CREATE TABLE tb_buyer_announcement_states (
     chat_id BIGINT PRIMARY KEY,
@@ -9,10 +6,3 @@ CREATE TABLE tb_buyer_announcement_states (
     announcement_seen BOOLEAN NOT NULL DEFAULT FALSE,
     anchor_message_id INTEGER
 );
-
-CREATE TABLE tb_buyer_seen_announcements (
-    chat_id BIGINT NOT NULL REFERENCES tb_buyer_announcement_states(chat_id) ON DELETE CASCADE,
-    notification_id BIGINT NOT NULL,
-    PRIMARY KEY (chat_id, notification_id)
-);
-

--- a/src/test/java/com/project/tracking_system/repository/CustomerRepositoryTest.java
+++ b/src/test/java/com/project/tracking_system/repository/CustomerRepositoryTest.java
@@ -8,9 +8,6 @@ import org.springframework.dao.OptimisticLockingFailureException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-
 /**
  * Проверка оптимистичной блокировки для {@link CustomerRepository}.
  */
@@ -40,19 +37,4 @@ class CustomerRepositoryTest {
                 () -> customerRepository.saveAndFlush(second));
     }
 
-    /**
-     * Проверяет сохранение и загрузку отметки последней активности покупателя.
-     */
-    @Test
-    void shouldPersistLastActiveAt() {
-        Customer customer = new Customer();
-        customer.setPhone("375000000001");
-        ZonedDateTime expected = ZonedDateTime.of(2024, 1, 2, 3, 4, 5, 0, ZoneOffset.UTC);
-        customer.setLastActiveAt(expected);
-        customerRepository.saveAndFlush(customer);
-
-        Customer reloaded = customerRepository.findById(customer.getId()).orElseThrow();
-        assertEquals(expected, reloaded.getLastActiveAt(),
-                "Отметка активности должна считываться из базы данных");
-    }
 }

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -148,7 +148,7 @@ class BuyerTelegramBotStateIntegrationTest {
         customer.setNotificationsEnabled(true);
         customer.setFullName("Иван Иванов");
         customer.setNameSource(NameSource.USER_CONFIRMED);
-        customer.setLastActiveAt(ZonedDateTime.now().minusHours(6));
+        customer.setTelegramConfirmed(true);
 
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 


### PR DESCRIPTION
## Summary
- stop persisting buyer last-activity timestamps and gate announcements purely by confirmed Telegram links
- simplify announcement state storage to a single table and keep repository logic minimal
- refresh buyer bot tests to cover confirmed-user scenarios without activity updates

## Testing
- mvn test *(fails: parent POM cannot be resolved because jitpack.io is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9c594f18832dbb3dac1d6b5ca2ac