### PR TITLE
Add order column to admin notification body lines

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/AdminNotification.java
+++ b/src/main/java/com/project/tracking_system/entity/AdminNotification.java
@@ -29,6 +29,7 @@ public class AdminNotification {
 
     @ElementCollection
     @CollectionTable(name = "tb_admin_notification_lines", joinColumns = @JoinColumn(name = "notification_id"))
+    @OrderColumn(name = "body_lines_order")
     @Column(name = "line", nullable = false, columnDefinition = "TEXT")
     private List<String> bodyLines = new ArrayList<>();
 


### PR DESCRIPTION
## Summary
- add an order column mapping for admin notification body lines so Hibernate stores row indexes

## Testing
- mvn test *(fails: cannot resolve parent POM because https://jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb310e14c832d909fd2dc3b4b776e