### PR TITLE
Add notifications link to admin header

### DIFF
--- a/src/main/resources/templates/partials/header-admin.html
+++ b/src/main/resources/templates/partials/header-admin.html
@@ -21,6 +21,7 @@
                     <li><a href="/admin" class="nav-link px-2" data-path="/admin">Панель</a></li>
                     <li><a href="/admin/users" class="nav-link px-2" data-path="/admin/users">Пользователи</a></li>
                     <li><a href="/admin/parcels" class="nav-link px-2" data-path="/admin/parcels">Посылки</a></li>
+                    <li><a href="/admin/notifications" class="nav-link px-2" data-path="/admin/notifications">Уведомления</a></li>
                     <li><a href="/admin/settings" class="nav-link px-2" data-path="/admin/settings">Настройки</a></li>
                 </ul>
             </div>
@@ -44,6 +45,7 @@
                 <li><a href="/admin" data-path="/admin">Панель</a></li>
                 <li><a href="/admin/users" data-path="/admin/users">Пользователи</a></li>
                 <li><a href="/admin/parcels" data-path="/admin/parcels">Посылки</a></li>
+                <li><a href="/admin/notifications" data-path="/admin/notifications">Уведомления</a></li>
                 <li><a href="/admin/settings" data-path="/admin/settings">Настройки</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
## Summary
- add a notifications menu link to the main admin navigation
- mirror the notifications link in the mobile navigation with matching data-path attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccb306b3d8832dbe61c6a02f781974