### PR TITLE
Refine admin notification reset flow

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/AdminNotification.java
+++ b/src/main/java/com/project/tracking_system/entity/AdminNotification.java
@@ -38,7 +38,7 @@ public class AdminNotification {
     private AdminNotificationStatus status = AdminNotificationStatus.INACTIVE;
 
     @Column(name = "reset_requested", nullable = false)
-    private boolean resetRequested = true;
+    private boolean resetRequested = false;
 
     @Column(name = "created_at", nullable = false)
     private ZonedDateTime createdAt;

--- a/src/main/java/com/project/tracking_system/repository/BuyerAnnouncementStateRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/BuyerAnnouncementStateRepository.java
@@ -3,9 +3,19 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.BuyerAnnouncementState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Репозиторий состояния объявлений для покупателей в Telegram.
  */
 public interface BuyerAnnouncementStateRepository extends JpaRepository<BuyerAnnouncementState, Long> {
+
+    /**
+     * Возвращает состояния объявлений, связанные с указанным уведомлением администратора.
+     *
+     * @param notificationId идентификатор административного уведомления
+     * @return список состояний пользователей, подписанных на указанное уведомление
+     */
+    List<BuyerAnnouncementState> findAllByCurrentNotificationId(Long notificationId);
 }
 

--- a/src/main/resources/db/migration/V19__admin_notification_reset_flag.sql
+++ b/src/main/resources/db/migration/V19__admin_notification_reset_flag.sql
@@ -5,4 +5,4 @@ ALTER TABLE tb_admin_notifications
 
 UPDATE tb_admin_notifications
 SET reset_requested = FALSE
-WHERE reset_requested IS NULL;
+WHERE reset_requested = TRUE;

--- a/src/main/resources/db/migration/V19__admin_notification_reset_flag.sql
+++ b/src/main/resources/db/migration/V19__admin_notification_reset_flag.sql
@@ -1,0 +1,8 @@
+-- Изменение значения по умолчанию для флага повторного показа административных уведомлений
+
+ALTER TABLE tb_admin_notifications
+    ALTER COLUMN reset_requested SET DEFAULT FALSE;
+
+UPDATE tb_admin_notifications
+SET reset_requested = FALSE
+WHERE reset_requested IS NULL;

--- a/src/main/resources/templates/admin/notifications/list.html
+++ b/src/main/resources/templates/admin/notifications/list.html
@@ -67,6 +67,11 @@
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" th:if="${_csrf != null}">
                             <button type="submit" class="btn btn-sm btn-warning mb-1">Деактивировать</button>
                         </form>
+                        <div class="d-inline" th:if="${notification.resetRequested}">
+                            <button type="button" class="btn btn-sm btn-outline-secondary mb-1" disabled>
+                                Показ запрошен
+                            </button>
+                        </div>
                         <form th:action="@{/admin/notifications/{id}/reset(id=${notification.id})}"
                               method="post" class="d-inline"
                               th:if="${!notification.resetRequested}">

--- a/src/test/java/com/project/tracking_system/service/admin/AdminNotificationServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/admin/AdminNotificationServiceTest.java
@@ -1,0 +1,82 @@
+package com.project.tracking_system.service.admin;
+
+import com.project.tracking_system.entity.AdminNotification;
+import com.project.tracking_system.entity.AdminNotificationStatus;
+import com.project.tracking_system.entity.BuyerAnnouncementState;
+import com.project.tracking_system.repository.AdminNotificationRepository;
+import com.project.tracking_system.repository.BuyerAnnouncementStateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Интеграционные тесты сервиса административных уведомлений, проверяющие сброс просмотров баннеров.
+ */
+@DataJpaTest
+class AdminNotificationServiceTest {
+
+    @Autowired
+    private AdminNotificationRepository notificationRepository;
+
+    @Autowired
+    private BuyerAnnouncementStateRepository announcementStateRepository;
+
+    private AdminNotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new AdminNotificationService(notificationRepository, announcementStateRepository);
+    }
+
+    /**
+     * Убеждается, что запрос сброса очищает просмотры и снимает флаг повторного показа.
+     */
+    @Test
+    void shouldResetAnnouncementViewsAndClearRequestFlag() {
+        AdminNotification notification = new AdminNotification();
+        notification.setTitle("Обновление условий");
+        notification.setStatus(AdminNotificationStatus.ACTIVE);
+        notification.setResetRequested(true);
+        notification = notificationRepository.save(notification);
+        ZonedDateTime initialUpdatedAt = notification.getUpdatedAt();
+
+        BuyerAnnouncementState firstState = new BuyerAnnouncementState();
+        firstState.setChatId(101L);
+        firstState.setCurrentNotificationId(notification.getId());
+        firstState.setAnnouncementSeen(true);
+        firstState.setNotificationUpdatedAt(initialUpdatedAt.minusHours(2));
+        announcementStateRepository.save(firstState);
+
+        BuyerAnnouncementState secondState = new BuyerAnnouncementState();
+        secondState.setChatId(202L);
+        secondState.setCurrentNotificationId(notification.getId());
+        secondState.setAnnouncementSeen(true);
+        secondState.setNotificationUpdatedAt(initialUpdatedAt.minusHours(3));
+        announcementStateRepository.save(secondState);
+
+        notificationService.requestReset(notification.getId());
+
+        List<BuyerAnnouncementState> states = announcementStateRepository.findAllByCurrentNotificationId(notification.getId());
+        assertEquals(2, states.size(), "Должны обновиться состояния всех покупателей, получивших объявление");
+
+        states.forEach(state -> {
+            assertFalse(Boolean.TRUE.equals(state.getAnnouncementSeen()),
+                    "После сброса объявление не должно считаться просмотренным");
+            assertNotNull(state.getNotificationUpdatedAt(),
+                    "Дата обновления баннера должна быть установлена после сброса");
+            assertFalse(state.getNotificationUpdatedAt().isBefore(initialUpdatedAt),
+                    "Время последнего обновления должно быть не раньше исходного значения");
+        });
+
+        AdminNotification reloaded = notificationRepository.findById(notification.getId()).orElseThrow();
+        assertFalse(reloaded.isResetRequested(), "Флаг запроса повтора должен быть снят после обработки");
+        assertTrue(reloaded.getUpdatedAt().isAfter(initialUpdatedAt),
+                "Обновление уведомления должно изменить отметку времени модификации");
+    }
+}


### PR DESCRIPTION
## Summary
- default admin notification reset flag to false via entity and migration and only raise it when activation really changes
- reset buyer announcement views through the service using the announcement state repository and expose the reset button state in the template
- cover the new reset workflow with data JPA and bot tests to ensure the banner shows again after a reset

## Testing
- mvn -q test *(fails: parent POM could not be resolved because jitpack.io is unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3096b5d4832d87441b8977c72b10