### PR TITLE
Mark active announcements seen after contact

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
@@ -153,4 +153,13 @@ public interface ChatSessionRepository {
                             Long notificationId,
                             Integer anchorMessageId,
                             ZonedDateTime notificationUpdatedAt);
+
+    /**
+     * Фиксирует, что активное объявление уже просмотрено пользователем без смены якорного сообщения.
+     *
+     * @param chatId         идентификатор чата Telegram
+     * @param notificationId идентификатор активного уведомления администратора
+     * @param updatedAt      момент последнего обновления уведомления
+     */
+    void setAnnouncementAsSeen(Long chatId, Long notificationId, ZonedDateTime updatedAt);
 }

--- a/src/main/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/DatabaseChatSessionRepository.java
@@ -303,6 +303,22 @@ public class DatabaseChatSessionRepository implements ChatSessionRepository {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public void setAnnouncementAsSeen(Long chatId, Long notificationId, ZonedDateTime updatedAt) {
+        if (chatId == null) {
+            return;
+        }
+        BuyerAnnouncementState state = getOrCreateAnnouncementEntity(chatId);
+        state.setCurrentNotificationId(notificationId);
+        state.setAnnouncementSeen(true);
+        state.setNotificationUpdatedAt(updatedAt);
+        announcementRepository.save(state);
+    }
+
+    /**
      * Возвращает сущность состояния, создавая новую запись с настройками по умолчанию.
      *
      * @param chatId идентификатор чата Telegram

--- a/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
@@ -5,6 +5,7 @@ import com.project.tracking_system.entity.BuyerChatState;
 import com.project.tracking_system.service.telegram.ChatSession;
 import com.project.tracking_system.service.telegram.ChatSessionRepository;
 
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -187,7 +188,7 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
     public void updateAnnouncement(Long chatId,
                                    Long notificationId,
                                    Integer anchorMessageId,
-                                   java.time.ZonedDateTime notificationUpdatedAt) {
+                                   ZonedDateTime notificationUpdatedAt) {
         if (chatId == null) {
             return;
         }
@@ -197,6 +198,21 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
         session.setAnnouncementAnchorMessageId(anchorMessageId);
         session.setAnnouncementSeen(false);
         session.setAnnouncementUpdatedAt(notificationUpdatedAt);
+    }
+
+    /**
+     * Помечает активное объявление как просмотренное без изменения якоря.
+     */
+    @Override
+    public void setAnnouncementAsSeen(Long chatId, Long notificationId, ZonedDateTime updatedAt) {
+        if (chatId == null) {
+            return;
+        }
+        ChatSession session = sessions.computeIfAbsent(chatId,
+                id -> new ChatSession(id, BuyerChatState.IDLE, null, null));
+        session.setCurrentNotificationId(notificationId);
+        session.setAnnouncementSeen(true);
+        session.setAnnouncementUpdatedAt(updatedAt);
     }
 
     /**


### PR DESCRIPTION
## Summary
- mark existing admin announcements as read when a buyer links their phone so onboarding users do not see outdated banners
- extend chat session repositories with an atomic setAnnouncementAsSeen operation and cover it with unit tests
- add bot unit/integration scenarios ensuring new users skip the current banner but receive the next activation

## Testing
- mvn test *(fails: parent POM org.springframework.boot:spring-boot-starter-parent:3.4.3 could not be resolved because https://jitpack.io was unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd36392398832da65df3a9348868a0