### PR TITLE
Ensure admin notifications load body lines eagerly

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/AdminNotificationRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/AdminNotificationRepository.java
@@ -2,6 +2,7 @@ package com.project.tracking_system.repository;
 
 import com.project.tracking_system.entity.AdminNotification;
 import com.project.tracking_system.entity.AdminNotificationStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,6 +16,7 @@ public interface AdminNotificationRepository extends JpaRepository<AdminNotifica
     /**
      * Находит активное уведомление, если оно существует.
      */
+    @EntityGraph(attributePaths = "bodyLines")
     Optional<AdminNotification> findFirstByStatus(AdminNotificationStatus status);
 
     /**

--- a/src/main/java/com/project/tracking_system/service/admin/AdminNotificationService.java
+++ b/src/main/java/com/project/tracking_system/service/admin/AdminNotificationService.java
@@ -61,7 +61,11 @@ public class AdminNotificationService {
      */
     @Transactional(readOnly = true)
     public Optional<AdminNotification> findActiveNotification() {
-        return notificationRepository.findFirstByStatus(AdminNotificationStatus.ACTIVE);
+        Optional<AdminNotification> activeNotification =
+                notificationRepository.findFirstByStatus(AdminNotificationStatus.ACTIVE);
+        // Принудительно загружаем строки тела уведомления в пределах транзакции.
+        activeNotification.ifPresent(notification -> notification.getBodyLines().size());
+        return activeNotification;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure admin notifications fetch their body lines eagerly when requesting active entries
- force initialization of body lines in the admin notification service to avoid LazyInitializationException outside transactions

## Testing
- mvn test *(fails: could not download org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd45ca2a78832da21eedc6b1f9402b