### PR TITLE
Handle annulled delivery status from Belpochta

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -45,6 +45,8 @@ public class StatusTrackService {
 
     static {
         // Инициализация карты регулярных выражений и статусов
+        // Специальное правило для отмены выдачи, чтобы оно имело приоритет над успешным вручением
+        statusPatterns.put(Pattern.compile("^Аннулирование операции вручения$"), GlobalStatus.WAITING_FOR_CUSTOMER);
         statusPatterns.put(Pattern.compile("^Почтовое отправление выдано|^Вручено"), GlobalStatus.DELIVERED);
         statusPatterns.put(Pattern.compile("^Почтовое отправление прибыло на ОПС выдачи|" +
                 "^Почтовое отправление прибыло для выдачи|" +

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -48,6 +48,22 @@ class StatusTrackServiceTest {
     }
 
     /**
+     * Если вручение отменено, то итоговый статус должен вернуться к ожиданию клиента,
+     * даже если ранее отправление отмечалось как вручённое.
+     */
+    @Test
+    void setStatus_AnnulmentOverridesDelivered() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO("20.07.2025, 15:30", "Аннулирование операции вручения"),
+                new TrackInfoDTO("20.07.2025, 14:00", "Вручено")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.WAITING_FOR_CUSTOMER, status);
+    }
+
+    /**
      * Проверяет, что статус «Подготовлено для возврата» приводит к
      * {@link GlobalStatus#RETURN_IN_PROGRESS}.
      */


### PR DESCRIPTION
## Summary
- prioritize the Belpochta "Аннулирование операции вручения" status over the delivered pattern so it maps to WAITING_FOR_CUSTOMER
- add a regression test covering a delivered event followed by an annulment to keep the waiting status

## Testing
- `mvn test` *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3fa05c44832da57d3774e4f1b8b5