### PR TITLE
Handle EuroPost return pickup statuses

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -43,6 +43,13 @@ public class StatusTrackService {
     private static final Pattern RETURN_START_PATTERN = Pattern.compile(
             "^Почтовое отправление готово к возврату$|^Подготовлено для возврата$");
 
+    /**
+     * Специальный шаблон для статусов Европочты о прибытии отправления в ОПС
+     * для выдачи отправителю, когда начинается ожидание на возврат.
+     */
+    private static final Pattern EUROPOST_RETURN_PICKUP_PATTERN = Pattern.compile(
+            "^Отправление [A-Z]{2}[A-Z0-9]+ прибыло для возврата в ОПС №\\d+.*$");
+
     static {
         // Инициализация карты регулярных выражений и статусов
         // Специальное правило для отмены выдачи, чтобы оно имело приоритет над успешным вручением
@@ -61,6 +68,7 @@ public class StatusTrackService {
                         "^Почтовое отправление подготовлено в сортировочном пункте к доставке на ОПС назначения$"),
                 GlobalStatus.IN_TRANSIT);
         statusPatterns.put(RETURN_START_PATTERN, GlobalStatus.RETURN_IN_PROGRESS);
+        statusPatterns.put(EUROPOST_RETURN_PICKUP_PATTERN, GlobalStatus.RETURN_PENDING_PICKUP);
         statusPatterns.put(Pattern.compile("^Почтовое отправление прибыло на Отделение №\\d+.*для возврата.*"),
                 GlobalStatus.RETURN_PENDING_PICKUP);
         statusPatterns.put(Pattern.compile("^Почтовое отправление возвращено отправителю$"), GlobalStatus.RETURNED);

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -95,6 +95,21 @@ class StatusTrackServiceTest {
     }
 
     /**
+     * Проверяет, что статус от Европочты о прибытии в ОПС для возврата
+     * корректно классифицируется как ожидание выдачи отправителю.
+     */
+    @Test
+    void setStatus_MapsEuroPostReturnPendingPickup() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO(null, "Отправление BY123456789BY прибыло для возврата в ОПС №25")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.RETURN_PENDING_PICKUP, status);
+    }
+
+    /**
      * Проверяет, что формулировка о прибытии отправления для выдачи
      * относится к статусу {@link GlobalStatus#WAITING_FOR_CUSTOMER}.
      */


### PR DESCRIPTION
## Summary
- recognize EuroPost return pickup messages as RETURN_PENDING_PICKUP
- add a unit test covering the EuroPost return pickup scenario

## Testing
- mvn test *(fails: jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd55918d78832d8eefa1409745b626