### PR TITLE
Handle Telegram notification failures

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -174,9 +174,13 @@ public class DeliveryHistoryService {
         }
 
         if (!initialFinalStatus && newStatus != GlobalStatus.PRE_REGISTERED && shouldNotifyCustomer(trackParcel, newStatus)) {
-            telegramNotificationService.sendStatusUpdate(trackParcel, newStatus);
-            log.info("✅ Уведомление о статусе {} отправлено для трека {}", newStatus, trackParcel.getNumber());
-            saveNotificationLog(trackParcel, newStatus);
+            boolean notificationSent = telegramNotificationService.sendStatusUpdate(trackParcel, newStatus);
+            if (notificationSent) {
+                log.info("✅ Уведомление о статусе {} отправлено для трека {}", newStatus, trackParcel.getNumber());
+                saveNotificationLog(trackParcel, newStatus);
+            } else {
+                log.debug("Уведомление о статусе {} не было отправлено для трека {}", newStatus, trackParcel.getNumber());
+            }
         }
     }
 

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -209,7 +209,12 @@ public class CustomerTelegramService {
                 continue; // статус не подлежит уведомлению
             }
 
-            telegramNotificationService.sendStatusUpdate(parcel, status);
+            boolean sent = telegramNotificationService.sendStatusUpdate(parcel, status);
+            if (!sent) {
+                log.debug("Уведомление для посылки {} со статусом {} не отправлено, запись в журнал пропущена",
+                        parcel.getNumber(), status);
+                continue;
+            }
 
             CustomerNotificationLog logEntry = new CustomerNotificationLog();
             logEntry.setCustomer(customer);

--- a/src/test/java/com/project/tracking_system/service/telegram/TelegramNotificationServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/TelegramNotificationServiceTest.java
@@ -1,0 +1,96 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.StoreTelegramSettings;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.service.customer.CustomerService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Тесты для {@link TelegramNotificationService}, контролирующие ранние выходы.
+ */
+@ExtendWith(MockitoExtension.class)
+class TelegramNotificationServiceTest {
+
+    @Mock
+    private TelegramClient telegramClient;
+
+    @Mock
+    private CustomerService customerService;
+
+    @InjectMocks
+    private TelegramNotificationService telegramNotificationService;
+
+    /**
+     * Проверяет, что при запрете на уведомления метод возвращает {@code false} и не отправляет сообщение.
+     */
+    @Test
+    void sendStatusUpdate_whenCustomerNotNotifiable_returnsFalse() throws TelegramApiException {
+        TrackParcel parcel = buildParcel();
+
+        when(customerService.isNotifiable(parcel.getCustomer(), parcel.getStore())).thenReturn(false);
+
+        boolean result = telegramNotificationService.sendStatusUpdate(parcel, GlobalStatus.DELIVERED);
+
+        assertFalse(result, "Метод обязан вернуть false при раннем выходе");
+        verify(telegramClient, never()).execute(any(SendMessage.class));
+    }
+
+    /**
+     * Проверяет, что при выполнении условий сообщение отправляется и метод возвращает {@code true}.
+     */
+    @Test
+    void sendStatusUpdate_whenConditionsMet_returnsTrue() throws TelegramApiException {
+        TrackParcel parcel = buildParcel();
+        Store store = parcel.getStore();
+        StoreTelegramSettings settings = new StoreTelegramSettings();
+        settings.setEnabled(true);
+        store.setTelegramSettings(settings);
+
+        when(customerService.isNotifiable(parcel.getCustomer(), store)).thenReturn(true);
+        when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
+
+        boolean result = telegramNotificationService.sendStatusUpdate(parcel, GlobalStatus.DELIVERED);
+
+        assertTrue(result, "Метод обязан сообщать об успешной отправке");
+        verify(telegramClient).execute(any(SendMessage.class));
+    }
+
+    /**
+     * Создаёт заготовку посылки с покупателем и магазином для тестов.
+     */
+    private TrackParcel buildParcel() {
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber("RB000000001BY");
+
+        Customer customer = new Customer();
+        customer.setId(1L);
+        customer.setTelegramChatId(123456L);
+        customer.setNotificationsEnabled(true);
+        parcel.setCustomer(customer);
+
+        Store store = new Store();
+        store.setId(5L);
+        store.setName("Store");
+        parcel.setStore(store);
+
+        return parcel;
+    }
+}
+


### PR DESCRIPTION
## Summary
- make TelegramNotificationService#sendStatusUpdate return a boolean and guard early exit scenarios
- persist customer notification logs only when Telegram sending succeeds in delivery history and customer workflows
- cover early-exit behaviour with unit tests for DeliveryHistoryService and TelegramNotificationService

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 could not be downloaded; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6977aea4832d8294a5b7dfde169b