### PR TITLE
Normalize track statuses before pattern matching

### DIFF
--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -123,4 +123,35 @@ class StatusTrackServiceTest {
 
         assertEquals(GlobalStatus.WAITING_FOR_CUSTOMER, status);
     }
+
+    /**
+     * Проверяет, что наличие неразрывного пробела в статусе не мешает корректному
+     * сопоставлению и строка распознаётся как ожидание клиента.
+     */
+    @Test
+    void setStatus_HandlesNonBreakingSpace() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO("21.07.2025, 09:00", "Почтовое\u00A0отправление прибыло на ОПС выдачи")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.WAITING_FOR_CUSTOMER, status);
+    }
+
+    /**
+     * Убеждается, что дополнительная информация в скобках в конце статуса не препятствует
+     * распознаванию возврата после появления соответствующего стартового события.
+     */
+    @Test
+    void setStatus_ReturnInProgressWithLocationTail() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO(null, "Почтовое отправление прибыло на сортировочный пункт (Минск)"),
+                new TrackInfoDTO(null, "Подготовлено для возврата")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.RETURN_IN_PROGRESS, status);
+    }
 }


### PR DESCRIPTION
## Summary
- normalize raw status texts by replacing non-breaking spaces, collapsing duplicates, and removing trailing decorations before matching patterns
- reuse the normalization while scanning history to correctly detect return flows
- extend StatusTrackServiceTest with cases covering non-breaking spaces and trailing location hints

## Testing
- mvn -Dtest=StatusTrackServiceTest test *(fails: parent POM cannot be resolved because jitpack.io is unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6dda19fc832dbe94ed4865428922