### PR TITLE
Adjust return pickup pattern handling

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -48,7 +48,16 @@ public class StatusTrackService {
      * для выдачи отправителю, когда начинается ожидание на возврат.
      */
     private static final Pattern EUROPOST_RETURN_PICKUP_PATTERN = Pattern.compile(
-            "^Отправление [A-Z]{2}[A-Z0-9]+ прибыло для возврата в ОПС №\\d+.*$");
+            "^Отправление [A-Z]{2}[A-Z0-9]+ прибыло для возврата в ОПС №\\s*\\d+.*$",
+            Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Шаблон для статусов Белпочты, указывающих на прибытие отправления в конкретное
+     * отделение для возврата отправителю и ожидания выдачи.
+     */
+    private static final Pattern RETURN_BRANCH_PICKUP_PATTERN = Pattern.compile(
+            "^Почтовое отправление прибыло на отделение №\\s*\\d+.*$",
+            Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
 
     static {
         // Инициализация карты регулярных выражений и статусов
@@ -69,8 +78,7 @@ public class StatusTrackService {
                 GlobalStatus.IN_TRANSIT);
         statusPatterns.put(RETURN_START_PATTERN, GlobalStatus.RETURN_IN_PROGRESS);
         statusPatterns.put(EUROPOST_RETURN_PICKUP_PATTERN, GlobalStatus.RETURN_PENDING_PICKUP);
-        statusPatterns.put(Pattern.compile("^Почтовое отправление прибыло на Отделение №\\d+.*для возврата.*"),
-                GlobalStatus.RETURN_PENDING_PICKUP);
+        statusPatterns.put(RETURN_BRANCH_PICKUP_PATTERN, GlobalStatus.RETURN_PENDING_PICKUP);
         statusPatterns.put(Pattern.compile("^Почтовое отправление возвращено отправителю$"), GlobalStatus.RETURNED);
         statusPatterns.put(Pattern.compile("^Заявка на почтовое отправление зарегистрирована$"), GlobalStatus.REGISTERED);
         statusPatterns.put(Pattern.compile("^Добрый день\\. Отправление [A-Z0-9]+ не востребовано получателем.*|" +

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -101,7 +101,22 @@ class StatusTrackServiceTest {
     @Test
     void setStatus_MapsEuroPostReturnPendingPickup() {
         List<TrackInfoDTO> list = List.of(
-                new TrackInfoDTO(null, "Отправление BY123456789BY прибыло для возврата в ОПС №25")
+                new TrackInfoDTO(null, "Отправление BY123456789BY прибыло для возврата в ОПС № 152, г. Минск")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.RETURN_PENDING_PICKUP, status);
+    }
+
+    /**
+     * Проверяет, что сообщение о прибытии отправления на отделение для возврата
+     * корректно интерпретируется как ожидание получения отправителем.
+     */
+    @Test
+    void setStatus_MapsBranchReturnPendingPickup() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO(null, "Почтовое отправление прибыло на отделение № 152 (г. Минск)")
         );
 
         GlobalStatus status = service.setStatus(list);


### PR DESCRIPTION
## Summary
- update EuroPost return pickup pattern to support spaced office numbers, case-insensitive matching and address tails
- introduce a reusable branch return pickup pattern shared across the service map
- cover EuroPost and branch return statuses in unit tests with realistic samples

## Testing
- mvn test *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd707af404832d8493d79722e1f433