### PR TITLE
Rename pagination ellipsis factory method

### DIFF
--- a/src/main/java/com/project/tracking_system/utils/PaginationItem.java
+++ b/src/main/java/com/project/tracking_system/utils/PaginationItem.java
@@ -28,10 +28,11 @@ public record PaginationItem(Integer pageIndex, boolean ellipsis) {
 
     /**
      * Создаёт элемент разделителя «…», используемый при скрытии диапазона страниц.
+     * Метод получает уникальное имя, чтобы явно указывать на создание разделителя и избежать неоднозначности.
      *
      * @return элемент, обозначающий разрыв между страницами
      */
-    public static PaginationItem ellipsis() {
+    public static PaginationItem ellipsisItem() {
         return new PaginationItem(null, true);
     }
 

--- a/src/main/java/com/project/tracking_system/utils/PaginationUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/PaginationUtils.java
@@ -82,7 +82,7 @@ public final class PaginationUtils {
         if (startPage > 0) {
             items.add(PaginationItem.page(0));
             if (startPage > 1) {
-                items.add(PaginationItem.ellipsis());
+                items.add(PaginationItem.ellipsisItem());
             }
         }
 
@@ -92,7 +92,7 @@ public final class PaginationUtils {
 
         if (endPage < lastIndex) {
             if (endPage < lastIndex - 1) {
-                items.add(PaginationItem.ellipsis());
+                items.add(PaginationItem.ellipsisItem());
             }
             items.add(PaginationItem.page(lastIndex));
         }

--- a/src/test/java/com/project/tracking_system/utils/PaginationUtilsTest.java
+++ b/src/test/java/com/project/tracking_system/utils/PaginationUtilsTest.java
@@ -21,13 +21,13 @@ class PaginationUtilsTest {
         assertEquals(7, window.endPage(), "Окно должно охватывать пять последовательных страниц");
         assertEquals(List.of(
                         PaginationItem.page(0),
-                        PaginationItem.ellipsis(),
+                        PaginationItem.ellipsisItem(),
                         PaginationItem.page(3),
                         PaginationItem.page(4),
                         PaginationItem.page(5),
                         PaginationItem.page(6),
                         PaginationItem.page(7),
-                        PaginationItem.ellipsis(),
+                        PaginationItem.ellipsisItem(),
                         PaginationItem.page(31)
                 ),
                 window.paginationItems(),
@@ -59,7 +59,7 @@ class PaginationUtilsTest {
         assertEquals(9, window.endPage(), "Последняя страница должна быть включена в окно");
         assertEquals(List.of(
                         PaginationItem.page(0),
-                        PaginationItem.ellipsis(),
+                        PaginationItem.ellipsisItem(),
                         PaginationItem.page(5),
                         PaginationItem.page(6),
                         PaginationItem.page(7),


### PR DESCRIPTION
## Summary
- rename the pagination ellipsis factory to `ellipsisItem` and clarify its purpose in the comment
- update pagination utility and tests to use the new method name

## Testing
- mvn test *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd47d2308832da29466cb2155add8