### PR TITLE
Fix Telegram user creation in buyer bot tests

### DIFF
--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -454,9 +454,7 @@ class BuyerTelegramBotStateIntegrationTest {
                 .when(telegramClient).execute(any(EditMessageText.class));
 
         Update update = contactUpdate(chatId, "+375298888888");
-        User user = new User();
-        user.setId(chatId);
-        update.getMessage().setFrom(user);
+        update.getMessage().setFrom(createUser(chatId));
 
         bot.consume(update);
 
@@ -476,6 +474,16 @@ class BuyerTelegramBotStateIntegrationTest {
 
         verify(telegramClient).execute(any(EditMessageText.class));
         verify(telegramClient, never()).execute(any(EditMessageReplyMarkup.class));
+    }
+
+    /**
+     * Создаёт пользователя Telegram с минимально необходимыми данными для тестов.
+     *
+     * @param chatId идентификатор пользователя Telegram
+     * @return объект {@link User} с заполненным идентификатором
+     */
+    private User createUser(Long chatId) {
+        return new User(chatId, "TestUser", false);
     }
 
     /**


### PR DESCRIPTION
## Summary
- replace the buyer bot integration test setup to create Telegram users via a supported constructor
- add a reusable helper that returns a minimal Telegram User instance for the scenarios

## Testing
- mvn -q -DskipITs test *(fails: Non-resolvable parent POM because org.springframework.boot:spring-boot-starter-parent:3.4.3 could not be downloaded from jitpack.io; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cddf5a9900832d9713194bb4b21f1e