### PR TITLE
feat: ensure unique batch ids for track processing

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/BatchIdGenerator.java
+++ b/src/main/java/com/project/tracking_system/service/track/BatchIdGenerator.java
@@ -1,0 +1,42 @@
+package com.project.tracking_system.service.track;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Генерирует уникальные идентификаторы партий обработки треков.
+ * <p>
+ * Класс потокобезопасен и использует атомарный счётчик, чтобы
+ * исключить повторное использование идентификаторов в параллельных
+ * сценариях запуска партий.
+ * </p>
+ */
+@Component
+public class BatchIdGenerator {
+
+    /** Последовательно увеличивающийся счётчик идентификаторов. */
+    private final AtomicLong sequence = new AtomicLong(System.currentTimeMillis());
+
+    /**
+     * Возвращает следующий уникальный идентификатор партии.
+     * <p>
+     * Значение гарантированно растёт даже при одновременных обращениях
+     * из разных потоков: если системное время не увеличилось, используется
+     * следующий номер в последовательности.
+     * </p>
+     *
+     * @return уникальное значение batchId
+     */
+    public long nextId() {
+        return sequence.updateAndGet(current -> {
+            long now = System.currentTimeMillis();
+            long candidate = Math.max(now, current + 1);
+            if (candidate == Long.MIN_VALUE) {
+                return 0L;
+            }
+            return candidate;
+        });
+    }
+}
+

--- a/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.service.track;
 import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
 import com.project.tracking_system.service.belpost.QueuedTrack;
 import com.project.tracking_system.service.track.TrackSource;
+import com.project.tracking_system.service.track.BatchIdGenerator;
 import com.project.tracking_system.controller.WebSocketController;
 import com.project.tracking_system.utils.DurationUtils;
 import com.project.tracking_system.utils.TrackNumberUtils;
@@ -20,6 +21,8 @@ public class BelPostManualService {
     private final BelPostTrackQueueService belPostTrackQueueService;
     private final TrackUpdateEligibilityService trackUpdateEligibilityService;
     private final WebSocketController webSocketController;
+    /** Генератор уникальных идентификаторов партий очереди. */
+    private final BatchIdGenerator batchIdGenerator;
 
     /**
      * Добавляет трек в очередь, если разрешено его обновлять.
@@ -33,12 +36,13 @@ public class BelPostManualService {
     public boolean enqueueIfAllowed(String number, Long storeId, Long userId, String phone) {
         String normalized = TrackNumberUtils.normalize(number);
         if (trackUpdateEligibilityService.canUpdate(normalized, userId)) {
+            long batchId = batchIdGenerator.nextId();
             belPostTrackQueueService.enqueue(new QueuedTrack(
                     normalized,
                     userId,
                     storeId,
                     TrackSource.MANUAL,
-                    System.currentTimeMillis(),
+                    batchId,
                     phone
             ));
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateProcessor.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackAutoUpdateProcessor.java
@@ -11,6 +11,7 @@ import com.project.tracking_system.service.track.TrackSource;
 import com.project.tracking_system.service.track.TrackMeta;
 import com.project.tracking_system.service.track.TrackUpdateService;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
+import com.project.tracking_system.service.track.BatchIdGenerator;
 import com.project.tracking_system.service.admin.ApplicationSettingsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,8 @@ public class TrackAutoUpdateProcessor {
     private final BelPostTrackQueueService belPostTrackQueueService;
     private final TypeDefinitionTrackPostService typeDefinitionTrackPostService;
     private final ApplicationSettingsService applicationSettingsService;
+    /** Генератор уникальных идентификаторов для партий автообновления. */
+    private final BatchIdGenerator batchIdGenerator;
 
     /**
      * Обновляет треки для указанного пользователя.
@@ -71,7 +74,7 @@ public class TrackAutoUpdateProcessor {
 
         List<TrackMeta> others = new ArrayList<>();
         List<QueuedTrack> belpostTracks = new ArrayList<>();
-        long batchId = System.currentTimeMillis();
+        long batchId = batchIdGenerator.nextId();
 
         for (TrackParcel parcel : limited) {
             PostalServiceType type = parcel.getDeliveryHistory() != null

--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.service.belpost.QueuedTrack;
 import com.project.tracking_system.service.track.ProgressAggregatorService;
 import com.project.tracking_system.service.track.TrackingResultCacheService;
 import com.project.tracking_system.service.track.TrackSource;
+import com.project.tracking_system.service.track.BatchIdGenerator;
 import com.project.tracking_system.service.admin.ApplicationSettingsService;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.dto.TrackProcessingProgressDTO;
@@ -58,6 +59,8 @@ public class TrackUpdateService {
     private final ApplicationSettingsService applicationSettingsService;
     /** Сервис управления пользователями для получения часового пояса. */
     private final UserService userService;
+    /** Генератор уникальных идентификаторов партий обработки. */
+    private final BatchIdGenerator batchIdGenerator;
 
     /**
      * Обновляет историю всех посылок пользователя.
@@ -332,7 +335,7 @@ public class TrackUpdateService {
      * @return список объединенных результатов
      */
     public List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId) {
-        long batchId = System.currentTimeMillis();
+        long batchId = batchIdGenerator.nextId();
         progressAggregatorService.registerBatch(batchId, tracks.size(), userId);
         Map<PostalServiceType, List<TrackMeta>> grouped = groupingService.group(tracks);
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUploadProcessorService.java
@@ -14,6 +14,7 @@ import com.project.tracking_system.service.track.TrackUploadGroupingService;
 import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
 import com.project.tracking_system.service.track.TrackingResultCacheService;
 import com.project.tracking_system.service.track.InvalidTrackCacheService;
+import com.project.tracking_system.service.track.BatchIdGenerator;
 import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.dto.TrackStatusUpdateDTO;
 import com.project.tracking_system.dto.TrackProcessingProgressDTO;
@@ -62,6 +63,8 @@ public class TrackUploadProcessorService {
     private final InvalidTrackCacheService invalidTrackCacheService;
     /** Сервис предрегистрации отправлений. */
     private final PreRegistrationService preRegistrationService;
+    /** Генератор уникальных идентификаторов партий обработки. */
+    private final BatchIdGenerator batchIdGenerator;
 
     /**
      * Принимает Excel-файл, валидирует строки и конвертирует их
@@ -85,7 +88,7 @@ public class TrackUploadProcessorService {
      */
     public TrackMetaValidationResult process(MultipartFile file, Long userId) throws IOException {
         List<TrackExcelRow> rows = parser.parse(file);
-        long batchId = System.currentTimeMillis();
+        long batchId = batchIdGenerator.nextId();
 
         List<TrackMeta> metas;
         List<InvalidTrack> invalid = List.of();

--- a/src/test/java/com/project/tracking_system/service/track/BatchIdGeneratorConcurrencyTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/BatchIdGeneratorConcurrencyTest.java
@@ -1,0 +1,99 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.TrackProcessingProgressDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Проверяет, что при одновременном запуске нескольких партий
+ * генератор выдаёт уникальные идентификаторы, а прогресс
+ * по каждой партии завершается корректно.
+ */
+@ExtendWith(MockitoExtension.class)
+class BatchIdGeneratorConcurrencyTest {
+
+    @Mock
+    private WebSocketController webSocketController;
+
+    @Test
+    void concurrentBatchesReceiveUniqueIdsAndFinishProgress() throws Exception {
+        BatchIdGenerator generator = new BatchIdGenerator();
+        ProgressAggregatorService aggregator = new ProgressAggregatorService(webSocketController, Clock.systemUTC(), 0L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            CountDownLatch ready = new CountDownLatch(2);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Long> batchIds = Collections.synchronizedList(new ArrayList<>());
+            List<Long> users = List.of(101L, 202L);
+
+            for (Long userId : users) {
+                executor.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("Ожидание запуска партий было прервано", e);
+                    }
+                    long batchId = generator.nextId();
+                    batchIds.add(batchId);
+                    aggregator.registerBatch(batchId, 1, userId);
+                    aggregator.trackProcessed(batchId);
+                    return null;
+                });
+            }
+
+            ready.await();
+            start.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Параллельные задачи должны завершиться вовремя");
+
+            Set<Long> unique = new HashSet<>(batchIds);
+            assertEquals(users.size(), unique.size(), "Каждая партия должна получить уникальный batchId");
+
+            ArgumentCaptor<Long> userCaptor = ArgumentCaptor.forClass(Long.class);
+            ArgumentCaptor<TrackProcessingProgressDTO> progressCaptor = ArgumentCaptor.forClass(TrackProcessingProgressDTO.class);
+            verify(webSocketController, atLeast(users.size() * 2)).sendProgress(userCaptor.capture(), progressCaptor.capture());
+
+            for (Long userId : users) {
+                boolean hasFinal = false;
+                List<Long> capturedUsers = userCaptor.getAllValues();
+                List<TrackProcessingProgressDTO> progresses = progressCaptor.getAllValues();
+                for (int i = 0; i < capturedUsers.size(); i++) {
+                    if (userId.equals(capturedUsers.get(i))) {
+                        TrackProcessingProgressDTO dto = progresses.get(i);
+                        if (dto.total() == 1 && dto.processed() == 1) {
+                            hasFinal = true;
+                            break;
+                        }
+                    }
+                }
+                assertTrue(hasFinal, "Пользователь " + userId + " должен получить финальный прогресс 1/1");
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}
+

--- a/src/test/java/com/project/tracking_system/service/track/TrackUpdateServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUpdateServiceTest.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.dto.TrackingResultAdd;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.service.belpost.QueuedTrack;
 import com.project.tracking_system.service.track.TrackSource;
+import com.project.tracking_system.service.track.BatchIdGenerator;
 import com.project.tracking_system.repository.StoreRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.service.SubscriptionService;
@@ -64,6 +65,8 @@ class TrackUpdateServiceTest {
     private ApplicationSettingsService applicationSettingsService;
     @Mock
     private UserService userService;
+    @Mock
+    private BatchIdGenerator batchIdGenerator;
     // endregion
 
     /**
@@ -87,8 +90,10 @@ class TrackUpdateServiceTest {
                 progressAggregatorService,
                 trackingResultCacheService,
                 applicationSettingsService,
-                userService
+                userService,
+                batchIdGenerator
         );
+        when(batchIdGenerator.nextId()).thenReturn(1L);
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackUploadProcessorServiceTest.java
@@ -15,6 +15,7 @@ import com.project.tracking_system.service.track.TrackUploadGroupingService;
 import com.project.tracking_system.service.track.TrackUpdateDispatcherService;
 import com.project.tracking_system.service.track.TrackingResultCacheService;
 import com.project.tracking_system.service.track.InvalidTrackCacheService;
+import com.project.tracking_system.service.track.BatchIdGenerator;
 import com.project.tracking_system.service.registration.PreRegistrationService;
 import com.project.tracking_system.service.track.PreRegistrationMeta;
 import com.project.tracking_system.entity.PostalServiceType;
@@ -61,6 +62,8 @@ class TrackUploadProcessorServiceTest {
     private InvalidTrackCacheService invalidTrackCacheService;
     @Mock
     private PreRegistrationService preRegistrationService;
+    @Mock
+    private BatchIdGenerator batchIdGenerator;
 
     private TrackUploadProcessorService processor;
 
@@ -77,8 +80,10 @@ class TrackUploadProcessorServiceTest {
                 dispatcherService,
                 trackingResultCacheService,
                 invalidTrackCacheService,
-                preRegistrationService
+                preRegistrationService,
+                batchIdGenerator
         );
+        when(batchIdGenerator.nextId()).thenReturn(1L);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add a shared BatchIdGenerator component to supply thread-safe batch identifiers
- inject the generator into track update, upload, auto update, and manual Belpost services so queued tasks reuse consistent ids
- add a concurrency-focused unit test validating unique batch ids and completed progress for simultaneous users

## Testing
- mvn test *(fails: unable to resolve org.springframework.boot:spring-boot-starter-parent because https://jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d128a93b4c832dbc2c17457b8a1017