### PR TITLE
Align auto update batches with progress aggregator

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateService.java
@@ -328,7 +328,7 @@ public class TrackUpdateService {
     }
 
     /**
-     * Обрабатывает набор треков для указанного пользователя.
+     * Обрабатывает набор треков для указанного пользователя, создавая новую партию обновления.
      *
      * @param tracks список метаданных треков
      * @param userId идентификатор пользователя
@@ -337,6 +337,21 @@ public class TrackUpdateService {
     public List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId) {
         long batchId = batchIdGenerator.nextId();
         progressAggregatorService.registerBatch(batchId, tracks.size(), userId);
+        return process(tracks, userId, batchId);
+    }
+
+    /**
+     * Обрабатывает треки, используя заранее созданный идентификатор партии.
+     * <p>Метод не регистрирует партию в агрегаторе, предполагая, что это уже
+     * сделано вызывающей стороной, и просто синхронизирует очередь Белпочты
+     * и параллельный диспетчер с общим batchId.</p>
+     *
+     * @param tracks набор треков для обработки
+     * @param userId идентификатор владельца треков
+     * @param batchId внешний идентификатор партии
+     * @return объединённый список результатов трекинга
+     */
+    public List<TrackingResultAdd> process(List<TrackMeta> tracks, Long userId, long batchId) {
         Map<PostalServiceType, List<TrackMeta>> grouped = groupingService.group(tracks);
 
         // Отдельно обрабатываем номера Белпочты через централизованную очередь


### PR DESCRIPTION
## Summary
- register auto-update batches in the progress aggregator before any queue or dispatcher work begins
- reuse generated batch identifiers when delegating to TrackUpdateService so Belpost queue and other services share the same progress counters

## Testing
- mvn test *(fails: Non-resolvable parent POM for com.project:tracking_system:0.5.0 – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d140b23cb4832da529bd59d05defe9