### PR TITLE
Добавить прогресс для ручной постановки трека Белпочты

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
+++ b/src/main/java/com/project/tracking_system/service/track/BelPostManualService.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
 import com.project.tracking_system.service.belpost.QueuedTrack;
 import com.project.tracking_system.service.track.TrackSource;
 import com.project.tracking_system.service.track.BatchIdGenerator;
+import com.project.tracking_system.service.track.ProgressAggregatorService;
 import com.project.tracking_system.controller.WebSocketController;
 import com.project.tracking_system.utils.DurationUtils;
 import com.project.tracking_system.utils.TrackNumberUtils;
@@ -23,6 +24,8 @@ public class BelPostManualService {
     private final WebSocketController webSocketController;
     /** Генератор уникальных идентификаторов партий очереди. */
     private final BatchIdGenerator batchIdGenerator;
+    /** Сервис агрегации прогресса обработки, информирующий клиента. */
+    private final ProgressAggregatorService progressAggregatorService;
 
     /**
      * Добавляет трек в очередь, если разрешено его обновлять.
@@ -37,6 +40,8 @@ public class BelPostManualService {
         String normalized = TrackNumberUtils.normalize(number);
         if (trackUpdateEligibilityService.canUpdate(normalized, userId)) {
             long batchId = batchIdGenerator.nextId();
+            // Регистрируем партию из одного трека и отправляем стартовый прогресс
+            progressAggregatorService.registerBatch(batchId, 1, userId);
             belPostTrackQueueService.enqueue(new QueuedTrack(
                     normalized,
                     userId,

--- a/src/test/java/com/project/tracking_system/service/track/BelPostManualServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/BelPostManualServiceTest.java
@@ -1,0 +1,96 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.TrackProcessingProgressDTO;
+import com.project.tracking_system.service.belpost.BelPostTrackQueueService;
+import com.project.tracking_system.service.belpost.QueuedTrack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Набор тестов для {@link BelPostManualService},
+ * проверяющий регистрацию партий и начальное уведомление о прогрессе.
+ */
+@ExtendWith(MockitoExtension.class)
+class BelPostManualServiceTest {
+
+    @Mock
+    private BelPostTrackQueueService belPostTrackQueueService;
+    @Mock
+    private TrackUpdateEligibilityService trackUpdateEligibilityService;
+    @Mock
+    private WebSocketController webSocketController;
+    @Mock
+    private BatchIdGenerator batchIdGenerator;
+
+    private ProgressAggregatorService progressAggregatorService;
+    private BelPostManualService service;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+        progressAggregatorService = spy(new ProgressAggregatorService(webSocketController, clock, 0L));
+        service = new BelPostManualService(
+                belPostTrackQueueService,
+                trackUpdateEligibilityService,
+                webSocketController,
+                batchIdGenerator,
+                progressAggregatorService
+        );
+    }
+
+    /**
+     * Убеждаемся, что ручное добавление трека создаёт новую партию,
+     * отправляет стартовый прогресс и ставит задачу в очередь.
+     */
+    @Test
+    void enqueueIfAllowed_RegistersBatchAndSendsProgress() {
+        long batchId = 42L;
+        Long storeId = 11L;
+        Long userId = 7L;
+        String number = "RA123456789BY";
+
+        when(trackUpdateEligibilityService.canUpdate(number, userId)).thenReturn(true);
+        when(batchIdGenerator.nextId()).thenReturn(batchId);
+
+        boolean result = service.enqueueIfAllowed(number, storeId, userId, null);
+
+        assertTrue(result, "Трек должен быть поставлен в очередь");
+
+        InOrder inOrder = inOrder(progressAggregatorService, belPostTrackQueueService);
+        inOrder.verify(progressAggregatorService).registerBatch(batchId, 1, userId);
+        ArgumentCaptor<QueuedTrack> queuedTrackCaptor = ArgumentCaptor.forClass(QueuedTrack.class);
+        inOrder.verify(belPostTrackQueueService).enqueue(queuedTrackCaptor.capture());
+
+        QueuedTrack queuedTrack = queuedTrackCaptor.getValue();
+        assertEquals(number, queuedTrack.trackNumber(), "Номер трека должен нормализоваться без изменений");
+        assertEquals(userId, queuedTrack.userId(), "В очередь должен передаваться корректный пользователь");
+        assertEquals(storeId, queuedTrack.storeId(), "В очередь должен попадать магазин, из которого запрошен трек");
+        assertEquals(batchId, queuedTrack.batchId(), "Очередь должна знать идентификатор новой партии");
+        assertEquals(TrackSource.MANUAL, queuedTrack.source(), "Источник трека должен отражать ручное добавление");
+
+        ArgumentCaptor<TrackProcessingProgressDTO> progressCaptor = ArgumentCaptor.forClass(TrackProcessingProgressDTO.class);
+        verify(webSocketController).sendProgress(eq(userId), progressCaptor.capture());
+        TrackProcessingProgressDTO progressDto = progressCaptor.getValue();
+        assertEquals(batchId, progressDto.batchId(), "Прогресс отправляется по верному batchId");
+        assertEquals(0, progressDto.processed(), "На старте обработанных треков быть не должно");
+        assertEquals(1, progressDto.total(), "Сервис сообщает, что в партии один трек");
+
+        TrackProcessingProgressDTO storedProgress = progressAggregatorService.getProgress(batchId);
+        assertEquals(1, storedProgress.total(), "Партия зарегистрирована с ожидаемым объёмом");
+        assertEquals(0, storedProgress.processed(), "Новые партии начинают с нулевого прогресса");
+    }
+}


### PR DESCRIPTION
## Summary
- подключил `ProgressAggregatorService` к ручному сервису Белпочты и регистрирую партию перед постановкой трека в очередь
- добавил модульный тест, проверяющий регистрацию партии, первичную отправку прогресса и передачу корректного batchId в очередь

## Testing
- mvn test *(падает: среда не позволяет скачать spring-boot-starter-parent из сети)*

------
https://chatgpt.com/codex/tasks/task_e_68d14543647c832db5effb4db518fce7