### PR TITLE
Handle BelPost retries separately from failures

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/BelPostBatchFinishedDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/BelPostBatchFinishedDTO.java
@@ -7,11 +7,13 @@ package com.project.tracking_system.dto;
  * @param processed обработано треков
  * @param success   количество успешных
  * @param failed    количество неуспешных
+ * @param retries   количество повторных попыток после временных сбоев
  * @param elapsed   время обработки партии в формате mm:ss
  */
 public record BelPostBatchFinishedDTO(long batchId,
                                       int processed,
                                       int success,
                                       int failed,
+                                      int retries,
                                       String elapsed) {
 }

--- a/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/BelPostTrackQueueService.java
@@ -167,7 +167,7 @@ public class BelPostTrackQueueService {
         } catch (WebDriverException e) {
             // Обрабатываем сбой работы Selenium
             log.error("\uD83D\uDEA7 Ошибка Selenium при обработке {}: {}", task.trackNumber(), e.getMessage());
-            progress.failed.incrementAndGet();
+            progress.retries.incrementAndGet();
             progress.processed.decrementAndGet();
             queue.offer(task); // возвращаем задачу в очередь
             // При сбое закрываем текущий браузер, чтобы следующий запуск создал новый
@@ -202,6 +202,7 @@ public class BelPostTrackQueueService {
                             progress.getProcessed(),
                             progress.getSuccess(),
                             progress.getFailed(),
+                            progress.getRetries(),
                             progress.getElapsed()));
             progressMap.remove(task.batchId());
         }
@@ -238,6 +239,8 @@ public class BelPostTrackQueueService {
         private final AtomicInteger processed = new AtomicInteger();
         private final AtomicInteger success = new AtomicInteger();
         private final AtomicInteger failed = new AtomicInteger();
+        /** Количество повторных попыток после временных сбоев Selenium. */
+        private final AtomicInteger retries = new AtomicInteger();
         /** Время начала обработки партии. */
         private final long startTime = System.currentTimeMillis();
 
@@ -255,6 +258,13 @@ public class BelPostTrackQueueService {
 
         public int getFailed() {
             return failed.get();
+        }
+
+        /**
+         * Возвращает количество повторных попыток, выполненных из-за временных ошибок Selenium.
+         */
+        public int getRetries() {
+            return retries.get();
         }
 
         /**

--- a/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
@@ -1,0 +1,122 @@
+package com.project.tracking_system.service.belpost;
+
+import com.project.tracking_system.controller.WebSocketController;
+import com.project.tracking_system.dto.TrackInfoListDTO;
+import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.dto.BelPostBatchFinishedDTO;
+import com.project.tracking_system.service.track.ProgressAggregatorService;
+import com.project.tracking_system.service.track.TrackProcessingService;
+import com.project.tracking_system.service.track.TrackSource;
+import com.project.tracking_system.service.track.TrackingResultCacheService;
+import com.project.tracking_system.webdriver.WebDriverFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Набор тестов для {@link BelPostTrackQueueService}, проверяющий корректный учёт ошибок Selenium.
+ */
+@ExtendWith(MockitoExtension.class)
+class BelPostTrackQueueServiceTest {
+
+    @Mock
+    private WebBelPostBatchService webBelPostBatchService;
+    @Mock
+    private TrackProcessingService trackProcessingService;
+    @Mock
+    private WebSocketController webSocketController;
+    @Mock
+    private ProgressAggregatorService progressAggregatorService;
+    @Mock
+    private TrackingResultCacheService trackingResultCacheService;
+    @Mock
+    private WebDriverFactory webDriverFactory;
+    @Mock
+    private WebDriver firstDriver;
+    @Mock
+    private WebDriver secondDriver;
+
+    private BelPostTrackQueueService queueService;
+
+    /**
+     * Подготавливает экземпляр сервиса и общие моки перед каждым тестом.
+     */
+    @BeforeEach
+    void setUp() {
+        queueService = new BelPostTrackQueueService(
+                webBelPostBatchService,
+                trackProcessingService,
+                webSocketController,
+                progressAggregatorService,
+                trackingResultCacheService,
+                webDriverFactory
+        );
+    }
+
+    /**
+     * Проверяет, что временные ошибки Selenium учитываются как повторные попытки,
+     * не увеличивая счётчик окончательных неудач.
+     */
+    @Test
+    void processQueue_TemporaryWebDriverErrorDoesNotIncrementFailed() throws Exception {
+        String trackNumber = "BY123456789";
+        long batchId = 7L;
+        QueuedTrack track = new QueuedTrack(trackNumber, 11L, 5L, TrackSource.MANUAL, batchId, null);
+
+        TrackInfoListDTO successInfo = new TrackInfoListDTO();
+        successInfo.addTrackInfo(new TrackInfoDTO("2024-01-01", "Доставлено"));
+
+        when(webDriverFactory.create()).thenReturn(firstDriver, secondDriver);
+        when(webBelPostBatchService.parseTrack(any(WebDriver.class), eq(trackNumber)))
+                .thenThrow(new WebDriverException("Временный сбой"))
+                .thenReturn(successInfo);
+
+        queueService.enqueue(track);
+
+        queueService.processQueue();
+
+        BelPostTrackQueueService.BatchProgress progressAfterRetry = queueService.getProgress(batchId);
+        assertNotNull(progressAfterRetry, "Прогресс должен существовать после первого сбоя");
+        assertThat(progressAfterRetry.getFailed()).isZero();
+        assertThat(progressAfterRetry.getRetries()).isEqualTo(1);
+        assertThat(progressAfterRetry.getProcessed()).isZero();
+
+        setPauseUntil(0L);
+
+        queueService.processQueue();
+
+        ArgumentCaptor<BelPostBatchFinishedDTO> finishedCaptor = ArgumentCaptor.forClass(BelPostBatchFinishedDTO.class);
+        verify(webSocketController).sendBelPostBatchFinished(eq(track.userId()), finishedCaptor.capture());
+        BelPostBatchFinishedDTO summary = finishedCaptor.getValue();
+        assertThat(summary.failed()).isZero();
+        assertThat(summary.retries()).isEqualTo(1);
+
+        verify(webDriverFactory, times(2)).create();
+    }
+
+    /**
+     * Сбрасывает приватное поле pauseUntil, чтобы повторная попытка обработки была возможна в тестах.
+     *
+     * @param value новое значение таймера паузы в миллисекундах
+     */
+    private void setPauseUntil(long value) throws Exception {
+        Field pauseField = BelPostTrackQueueService.class.getDeclaredField("pauseUntil");
+        pauseField.setAccessible(true);
+        pauseField.set(queueService, value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated retry counter in `BelPostTrackQueueService` so Selenium glitches do not pollute the failure metric
- extend `BelPostBatchFinishedDTO` and related flow to keep retry statistics internal while the UI toast still highlights only real failures
- cover temporary Selenium errors with a new `BelPostTrackQueueService` unit test

## Testing
- `mvn test` *(fails: cannot download org.springframework.boot:spring-boot-starter-parent:3.4.3 because jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16631be48832d988e43c36606a30c