### PR TITLE
Handle WebDriver retry limits in BelPost queue

### DIFF
--- a/src/main/java/com/project/tracking_system/service/belpost/QueuedTrack.java
+++ b/src/main/java/com/project/tracking_system/service/belpost/QueuedTrack.java
@@ -21,11 +21,68 @@ import com.project.tracking_system.service.track.TrackSource;
  * @param source      источник добавления трека {@link TrackSource}
  * @param batchId     идентификатор партии обработки
  * @param phone       номер телефона получателя (может быть {@code null})
+ * @param attempt     номер текущей попытки обработки (начинается с нуля)
  */
 public record QueuedTrack(String trackNumber,
                           Long userId,
                           Long storeId,
                           TrackSource source,
                           Long batchId,
-                          String phone) {
+                          String phone,
+                          int attempt) {
+
+    /**
+     * Создаёт элемент очереди с нулевой попыткой обработки.
+     *
+     * @param trackNumber номер отправления
+     * @param userId      идентификатор пользователя
+     * @param storeId     идентификатор магазина
+     * @param source      источник добавления трека
+     * @param batchId     идентификатор партии
+     * @param phone       номер телефона получателя
+     */
+    public QueuedTrack(String trackNumber,
+                       Long userId,
+                       Long storeId,
+                       TrackSource source,
+                       Long batchId,
+                       String phone) {
+        this(trackNumber, userId, storeId, source, batchId, phone, 0);
+    }
+
+    /**
+     * Основной конструктор записи с проверкой корректности номера попытки.
+     *
+     * @param trackNumber номер отправления
+     * @param userId      идентификатор пользователя
+     * @param storeId     идентификатор магазина
+     * @param source      источник добавления трека
+     * @param batchId     идентификатор партии
+     * @param phone       номер телефона получателя
+     * @param attempt     номер текущей попытки обработки (не может быть отрицательным)
+     */
+    public QueuedTrack {
+        if (attempt < 0) {
+            throw new IllegalArgumentException("Номер попытки не может быть отрицательным");
+        }
+    }
+
+    /**
+     * Возвращает новую запись с указанным номером попытки.
+     *
+     * @param nextAttempt номер следующей попытки
+     * @return копия текущего задания с обновлённым номером попытки
+     */
+    public QueuedTrack withAttempt(int nextAttempt) {
+        return new QueuedTrack(trackNumber, userId, storeId, source, batchId, phone, nextAttempt);
+    }
+
+    /**
+     * Создаёт копию задания, увеличивая номер попытки на единицу.
+     *
+     * @return новая запись с инкрементированным числом попыток
+     */
+    public QueuedTrack nextAttempt() {
+        return withAttempt(attempt + 1);
+    }
 }

--- a/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/belpost/BelPostTrackQueueServiceTest.java
@@ -1,9 +1,10 @@
 package com.project.tracking_system.service.belpost;
 
 import com.project.tracking_system.controller.WebSocketController;
-import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.TrackInfoDTO;
+import com.project.tracking_system.dto.TrackInfoListDTO;
 import com.project.tracking_system.dto.BelPostBatchFinishedDTO;
+import com.project.tracking_system.dto.TrackStatusUpdateDTO;
 import com.project.tracking_system.service.track.ProgressAggregatorService;
 import com.project.tracking_system.service.track.TrackProcessingService;
 import com.project.tracking_system.service.track.TrackSource;
@@ -24,8 +25,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import java.util.List;
+
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -50,6 +54,8 @@ class BelPostTrackQueueServiceTest {
     private WebDriver firstDriver;
     @Mock
     private WebDriver secondDriver;
+    @Mock
+    private WebDriver thirdDriver;
 
     private BelPostTrackQueueService queueService;
 
@@ -81,9 +87,11 @@ class BelPostTrackQueueServiceTest {
         TrackInfoListDTO successInfo = new TrackInfoListDTO();
         successInfo.addTrackInfo(new TrackInfoDTO("2024-01-01", "Доставлено"));
 
-        when(webDriverFactory.create()).thenReturn(firstDriver, secondDriver);
+        setWebDriverMaxAttempts(3);
+        when(webDriverFactory.create()).thenReturn(firstDriver, secondDriver, thirdDriver);
         when(webBelPostBatchService.parseTrack(any(WebDriver.class), eq(trackNumber)))
                 .thenThrow(new WebDriverException("Временный сбой"))
+                .thenThrow(new WebDriverException("Повторный сбой"))
                 .thenReturn(successInfo);
 
         queueService.enqueue(track);
@@ -100,13 +108,92 @@ class BelPostTrackQueueServiceTest {
 
         queueService.processQueue();
 
+        BelPostTrackQueueService.BatchProgress progressAfterSecondRetry = queueService.getProgress(batchId);
+        assertNotNull(progressAfterSecondRetry, "Прогресс должен существовать после второго сбоя");
+        assertThat(progressAfterSecondRetry.getFailed()).isZero();
+        assertThat(progressAfterSecondRetry.getRetries()).isEqualTo(2);
+        assertThat(progressAfterSecondRetry.getProcessed()).isZero();
+
+        setPauseUntil(0L);
+
+        queueService.processQueue();
+
         ArgumentCaptor<BelPostBatchFinishedDTO> finishedCaptor = ArgumentCaptor.forClass(BelPostBatchFinishedDTO.class);
         verify(webSocketController).sendBelPostBatchFinished(eq(track.userId()), finishedCaptor.capture());
         BelPostBatchFinishedDTO summary = finishedCaptor.getValue();
         assertThat(summary.failed()).isZero();
+        assertThat(summary.retries()).isEqualTo(2);
+
+        verify(webDriverFactory, times(3)).create();
+    }
+
+    /**
+     * Проверяет, что при превышении лимита повторов трек помечается как окончательно проваленный.
+     */
+    @Test
+    void processQueue_WebDriverExceptionExceedsLimitMarksAsFailed() throws Exception {
+        String trackNumber = "BY987654321";
+        long batchId = 13L;
+        QueuedTrack track = new QueuedTrack(trackNumber, 21L, 8L, TrackSource.MANUAL, batchId, null);
+
+        setWebDriverMaxAttempts(2);
+        when(webDriverFactory.create()).thenReturn(firstDriver, secondDriver);
+        when(webBelPostBatchService.parseTrack(any(WebDriver.class), eq(trackNumber)))
+                .thenThrow(new WebDriverException("Сбой драйвера"))
+                .thenThrow(new WebDriverException("Повторный сбой драйвера"));
+
+        queueService.enqueue(track);
+
+        queueService.processQueue();
+
+        BelPostTrackQueueService.BatchProgress progressAfterFirstRetry = queueService.getProgress(batchId);
+        assertNotNull(progressAfterFirstRetry, "Прогресс должен фиксироваться после первой ошибки");
+        assertThat(progressAfterFirstRetry.getRetries()).isEqualTo(1);
+        assertThat(progressAfterFirstRetry.getFailed()).isZero();
+        assertThat(progressAfterFirstRetry.getProcessed()).isZero();
+
+        setPauseUntil(0L);
+
+        queueService.processQueue();
+
+        ArgumentCaptor<TrackStatusUpdateDTO> statusCaptor = ArgumentCaptor.forClass(TrackStatusUpdateDTO.class);
+        verify(webSocketController).sendBelPostTrackProcessed(eq(track.userId()), statusCaptor.capture());
+        TrackStatusUpdateDTO failedStatus = statusCaptor.getValue();
+        assertThat(failedStatus.status()).contains("превышен лимит попыток");
+        assertThat(failedStatus.completed()).isEqualTo(1);
+        assertThat(failedStatus.total()).isEqualTo(1);
+
+        verify(trackingResultCacheService).addResult(eq(track.userId()), eq(failedStatus));
+        verify(progressAggregatorService).trackProcessed(batchId);
+        verifyNoInteractions(trackProcessingService);
+
+        ArgumentCaptor<BelPostBatchFinishedDTO> finishedCaptor = ArgumentCaptor.forClass(BelPostBatchFinishedDTO.class);
+        verify(webSocketController).sendBelPostBatchFinished(eq(track.userId()), finishedCaptor.capture());
+        BelPostBatchFinishedDTO summary = finishedCaptor.getValue();
+        assertThat(summary.failed()).isEqualTo(1);
+        assertThat(summary.success()).isZero();
         assertThat(summary.retries()).isEqualTo(1);
 
+        ArgumentCaptor<String> statusMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(webSocketController, times(2)).sendUpdateStatus(eq(track.userId()), statusMessageCaptor.capture(), eq(false));
+        List<String> statusMessages = statusMessageCaptor.getAllValues();
+        assertThat(statusMessages).hasSize(2);
+        assertThat(statusMessages.get(1)).contains("превышен лимит попыток");
+
+        verify(webBelPostBatchService, times(2)).parseTrack(any(WebDriver.class), eq(trackNumber));
         verify(webDriverFactory, times(2)).create();
+        assertThat(queueService.getProgress(batchId)).isNull();
+    }
+
+    /**
+     * Устанавливает максимальное число попыток обработки для проверки граничных сценариев.
+     *
+     * @param attempts желаемое значение лимита повторов
+     */
+    private void setWebDriverMaxAttempts(int attempts) throws Exception {
+        Field attemptsField = BelPostTrackQueueService.class.getDeclaredField("webDriverMaxAttempts");
+        attemptsField.setAccessible(true);
+        attemptsField.set(queueService, attempts);
     }
 
     /**


### PR DESCRIPTION
## Summary
- track retry attempts per BelPost queue task and stop requeueing after the configured Selenium failure limit
- send final failure notifications, cache updates, and batch summaries when the retry limit is exceeded
- expand queue service tests to cover multi-retry success paths and permanent failure paths

## Testing
- `mvn -q test` *(fails: parent POM org.springframework.boot:spring-boot-starter-parent:3.4.3 cannot be resolved because https://jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17d2ed5c4832da7d0e93742c589a5