### PR TITLE
Adjust history pagination active styles

### DIFF
--- a/src/main/resources/assets/scss/pages/_history.scss
+++ b/src/main/resources/assets/scss/pages/_history.scss
@@ -286,45 +286,47 @@
   .page-item {
     margin: 0; // Управление отступами полностью возложено на gap
 
-    .page-link {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 40px;
-      height: 40px;
-      font-size: 1rem;
-      font-weight: bold;
-      color: ui.$primary;
-      background: ui.$white;
-      border: 1px solid ui.$primary;
-      border-radius: 50%;
-      box-shadow: ui.$box-shadow;
-      transition: all 0.3s ease-in-out;
+      .page-link {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        font-size: 1rem;
+        font-weight: bold;
+        color: ui.$primary;
+        background: ui.$white;
+        border: 1px solid ui.$primary;
+        border-radius: 50%;
+        box-shadow: ui.$box-shadow;
+        transition: all 0.3s ease-in-out;
 
-      &:hover {
-        background: ui.$primary;
-        color: ui.$white;
-        border-color: ui.$primary;
-        transform: scale(1.1);
+        &:hover {
+          background: color.scale(ui.$primary, $lightness: 20%);
+          color: ui.$white;
+          border-color: color.scale(ui.$primary, $lightness: 5%);
+          box-shadow: 0 0 0 3px color.change(ui.$primary, $alpha: 0.2);
+          transform: scale(1.08);
+        }
       }
-    }
 
-    &.active .page-link {
-      background: ui.$primary;
-      color: ui.$white;
-      border-color: ui.$primary;
-      cursor: default;
-      transform: scale(1);
-    }
+      &.active .page-link {
+        background: color.scale(ui.$primary, $lightness: -10%);
+        color: ui.$white;
+        border-color: color.scale(ui.$primary, $lightness: -15%);
+        box-shadow: 0 0 0 3px color.change(ui.$primary, $alpha: 0.35);
+        cursor: default;
+        transform: none;
+      }
 
-    &.disabled .page-link {
-      color: ui.$secondary;
-      background: ui.$light;
-      border-color: ui.$light;
-      cursor: not-allowed;
-      opacity: 0.6;
-      transform: none;
-    }
+      &.disabled .page-link {
+        color: ui.$secondary;
+        background: ui.$light;
+        border-color: ui.$light;
+        cursor: not-allowed;
+        opacity: 0.6;
+        transform: none;
+      }
   }
 
   @include ui.respond-to(md) {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1286,17 +1286,19 @@ button:hover {
   transition: all 0.3s ease-in-out;
 }
 .pagination .page-item .page-link:hover {
-  background: #007bff;
+  background: rgb(51, 149.4, 255);
   color: #ffffff;
-  border-color: #007bff;
-  transform: scale(1.1);
+  border-color: rgb(12.75, 129.6, 255);
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.2);
+  transform: scale(1.08);
 }
 .pagination .page-item.active .page-link {
-  background: #007bff;
+  background: rgb(0, 110.7, 229.5);
   color: #ffffff;
-  border-color: #007bff;
+  border-color: rgb(0, 104.55, 216.75);
+  box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.35);
   cursor: default;
-  transform: scale(1);
+  transform: none;
 }
 .pagination .page-item.disabled .page-link {
   color: #6c757d;


### PR DESCRIPTION
## Summary
- refresh the history page pagination styles so hover and active states are visually distinct
- rebuild the compiled stylesheet to publish the updated pagination rules

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68d2882cb19c832d9a0341cd27536fab