### PR TITLE
Handle EuroPost return awaiting pickup statuses

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -44,11 +44,11 @@ public class StatusTrackService {
             "^Почтовое отправление готово к возврату$|^Подготовлено для возврата$");
 
     /**
-     * Специальный шаблон для статусов Европочты о прибытии отправления в ОПС
-     * для выдачи отправителю, когда начинается ожидание на возврат.
+     * Специальный шаблон для статусов Европочты, которые сигнализируют о прибытии
+     * или ожидании выдачи отправления в ОПС при оформленном возврате отправителю.
      */
     private static final Pattern EUROPOST_RETURN_PICKUP_PATTERN = Pattern.compile(
-            "^Отправление [A-Z]{2}[A-Z0-9]+ прибыло для возврата в ОПС №\\s*\\d+.*$",
+            "^Отправление [A-Z]{2}[A-Z0-9]+ (?:(?:прибыло.*для возврата.*)|(?:ожидает вручения .*для возврата.*))$",
             Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
 
     /**
@@ -134,9 +134,7 @@ public class StatusTrackService {
                         hasReturnStart = hasReturnStartStatus(trackInfoDTOList);
                         returnStartChecked = true;
                     }
-                    if (!hasReturnStart) {
-                        return GlobalStatus.WAITING_FOR_CUSTOMER;
-                    }
+                    return hasReturnStart ? GlobalStatus.RETURN_PENDING_PICKUP : GlobalStatus.WAITING_FOR_CUSTOMER;
                 }
                 return matchedStatus;
             }

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -111,6 +111,24 @@ class StatusTrackServiceTest {
     }
 
     /**
+     * Симулирует последовательность от Европочты с переходом от прибытия к ожиданию
+     * вручения и убеждается, что при наличии стартового события возврата итоговый
+     * статус остаётся {@link GlobalStatus#RETURN_PENDING_PICKUP}.
+     */
+    @Test
+    void setStatus_MapsEuroPostAwaitingReturnAfterArrival() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO(null, "Отправление BY123456789BY ожидает вручения в ОПС № 152 для возврата"),
+                new TrackInfoDTO(null, "Отправление BY123456789BY прибыло для возврата в ОПС № 152, г. Минск"),
+                new TrackInfoDTO(null, "Подготовлено для возврата")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.RETURN_PENDING_PICKUP, status);
+    }
+
+    /**
      * Проверяет, что сообщение о прибытии отправления на отделение без указания на возврат
      * трактуется как ожидание клиента.
      */


### PR DESCRIPTION
## Summary
- расширил шаблон Европочты, чтобы статус с текстом «ожидает вручения … для возврата» также распознавался как ожидание выдачи отправителю
- скорректировал блок обработки RETURN_PENDING_PICKUP, чтобы при найденном старте возврата возвращать нужный статус
- добавил модульный тест, проверяющий последовательность «прибыло для возврата» → «ожидает вручения … для возврата»

## Testing
- mvn test *(неудачно из-за недоступного сетевого репозитория spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d28843c6ac832daf34c9acb1918f5c