### PR TITLE
Handle registration cancellation status

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
@@ -24,6 +24,7 @@ public enum GlobalStatus {
     RETURNED("Возврат забран", "<i class='bi bi-check2-circle status-icon returned'></i>"),
     PRE_REGISTERED("Предрегистрация", "<i class='bi bi-hourglass status-icon preregistered'></i>"),
     REGISTERED("Заявка зарегистрирована", "<i class='bi bi-file-earmark-text status-icon registered'></i>"),
+    REGISTRATION_CANCELLED("Регистрация отменена", "<i class='bi bi-x-octagon status-icon registration-cancelled'></i>"),
     UNKNOWN_STATUS("Неизвестный статус", "<i class='bi bi-question-circle status-icon unknown'></i>");
 
     private final String description;

--- a/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
+++ b/src/main/java/com/project/tracking_system/service/track/StatusTrackService.java
@@ -113,6 +113,7 @@ public class StatusTrackService {
             if (DELIVERED.matcher(last).matches())               return GlobalStatus.DELIVERED;
             if (RETURNED.matcher(last).matches())                return GlobalStatus.RETURNED;
             if (REGISTERED.matcher(last).matches())              return GlobalStatus.REGISTERED;
+            if (REGISTRATION_CANCELLED.matcher(last).matches())  return GlobalStatus.REGISTRATION_CANCELLED;
             if (CUSTOMER_NOT_PICKING_UP.matcher(last).matches()) return GlobalStatus.CUSTOMER_NOT_PICKING_UP;
 
             // === 2) Явные возвратные шаги (без истории) ===

--- a/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/StatusTrackServiceTest.java
@@ -48,6 +48,22 @@ class StatusTrackServiceTest {
     }
 
     /**
+     * Убеждается, что отмена заявки преобразуется в статус
+     * {@link GlobalStatus#REGISTRATION_CANCELLED}, перекрывая ранее зарегистрированную заявку.
+     */
+    @Test
+    void setStatus_MapsRegistrationCancelled() {
+        List<TrackInfoDTO> list = List.of(
+                new TrackInfoDTO("22.07.2025, 08:15", "Заявка отменена, срок предоставления почтового отправления истек"),
+                new TrackInfoDTO("21.07.2025, 19:00", "Заявка на почтовое отправление зарегистрирована")
+        );
+
+        GlobalStatus status = service.setStatus(list);
+
+        assertEquals(GlobalStatus.REGISTRATION_CANCELLED, status);
+    }
+
+    /**
      * Если вручение отменено, то итоговый статус должен вернуться к ожиданию клиента,
      * даже если ранее отправление отмечалось как вручённое.
      */


### PR DESCRIPTION
## Summary
- add a dedicated `REGISTRATION_CANCELLED` global status with description and icon
- map the "Заявка отменена" pattern in `StatusTrackService` to the new status
- cover the behaviour with a unit test for the resolver

## Testing
- `mvn test` *(fails: cannot download parent POM because jitpack.io is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d324302908832daaf9d05c9138e679