### PR TITLE
Disable pagination links for current page

### DIFF
--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -62,7 +62,11 @@
               <li class="page-item" th:each="item : ${paginationItems}"
                   th:classappend="${item.ellipsis} ? ' disabled' : (item.pageIndex == currentPage ? ' active' : '')">
                   <span class="page-link" th:if="${item.ellipsis}" aria-hidden="true">&hellip;</span>
-                  <a class="page-link" th:if="${!item.ellipsis}"
+                  <span class="page-link"
+                        th:if="${!item.ellipsis and item.pageIndex == currentPage}"
+                        th:text="${item.pageIndex + 1}"
+                        th:attr="aria-current='page'"></span>
+                  <a class="page-link" th:if="${!item.ellipsis and item.pageIndex != currentPage}"
                      th:href="@{/admin/parcels(page=${item.pageIndex}, size=${size})}"
                      th:text="${item.pageIndex + 1}"
                      th:attr="aria-label=${'Страница ' + (item.pageIndex + 1)}"></a>

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -233,7 +233,11 @@
                             <li class="page-item" th:each="item : ${paginationItems}"
                                 th:classappend="${item.ellipsis} ? ' disabled' : (item.pageIndex == currentPage ? ' active' : '')">
                                 <span class="page-link" th:if="${item.ellipsis}" aria-hidden="true">&hellip;</span>
-                                <a class="page-link" th:if="${!item.ellipsis}"
+                                <span class="page-link"
+                                      th:if="${!item.ellipsis and item.pageIndex == currentPage}"
+                                      th:text="${item.pageIndex + 1}"
+                                      th:attr="aria-current='page'"></span>
+                                <a class="page-link" th:if="${!item.ellipsis and item.pageIndex != currentPage}"
                                    th:href="${!#strings.isEmpty(query)} ? @{/app/departures(storeId=${storeId}, status=${statusString}, page=${item.pageIndex}, size=${size}, query=${query}, sortOrder=${sortOrder})} : @{/app/departures(storeId=${storeId}, status=${statusString}, page=${item.pageIndex}, size=${size}, sortOrder=${sortOrder})}"
                                    th:text="${item.pageIndex + 1}"
                                    th:attr="aria-label=${'Страница ' + (item.pageIndex + 1)}">


### PR DESCRIPTION
## Summary
- render the active pagination item as a span with `aria-current="page"` so it is highlighted without being clickable
- apply the same behavior for the admin parcels and departures paginations

## Testing
- `./mvnw test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*
- `mvn test` *(fails: unable to resolve parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d326932568832d8f34d6294ab8a1ab