### PR TITLE
Style current pagination items

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1300,6 +1300,20 @@ button:hover {
   cursor: default;
   transform: none;
 }
+.page-link-current {
+  background-color: #0d6efd;
+  color: #ffffff;
+  border-color: #0d6efd;
+  box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.35);
+  cursor: default;
+  pointer-events: none;
+  transition: none;
+}
+.page-link-current:hover {
+  background-color: #0d6efd;
+  color: #ffffff;
+  border-color: #0d6efd;
+}
 .pagination .page-item.disabled .page-link {
   color: #6c757d;
   background: #f8f9fa;

--- a/src/main/resources/templates/admin/parcels.html
+++ b/src/main/resources/templates/admin/parcels.html
@@ -62,7 +62,7 @@
               <li class="page-item" th:each="item : ${paginationItems}"
                   th:classappend="${item.ellipsis} ? ' disabled' : (item.pageIndex == currentPage ? ' active' : '')">
                   <span class="page-link" th:if="${item.ellipsis}" aria-hidden="true">&hellip;</span>
-                  <span class="page-link"
+                  <span class="page-link page-link-current"
                         th:if="${!item.ellipsis and item.pageIndex == currentPage}"
                         th:text="${item.pageIndex + 1}"
                         th:attr="aria-current='page'"></span>

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -233,7 +233,7 @@
                             <li class="page-item" th:each="item : ${paginationItems}"
                                 th:classappend="${item.ellipsis} ? ' disabled' : (item.pageIndex == currentPage ? ' active' : '')">
                                 <span class="page-link" th:if="${item.ellipsis}" aria-hidden="true">&hellip;</span>
-                                <span class="page-link"
+                                <span class="page-link page-link-current"
                                       th:if="${!item.ellipsis and item.pageIndex == currentPage}"
                                       th:text="${item.pageIndex + 1}"
                                       th:attr="aria-current='page'"></span>


### PR DESCRIPTION
## Summary
- add a dedicated class to the active pagination spans in admin and app templates
- style the new class to highlight the current page and disable hover interactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d32d9bd25c832d980e21da182ad52d