### PR TITLE
Add customer full name support to parcel search

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -335,7 +335,7 @@ public class DeparturesController {
                                                      Long userId,
                                                      String sortOrder) {
         if (query != null && !query.isBlank()) {
-            return trackParcelService.searchByNumberOrPhone(storeIds, status, query, pageIndex, size, userId, sortOrder);
+            return trackParcelService.searchByNumberPhoneOrName(storeIds, status, query, pageIndex, size, userId, sortOrder);
         }
 
         if (status != null) {

--- a/src/main/java/com/project/tracking_system/utils/NameSearchUtils.java
+++ b/src/main/java/com/project/tracking_system/utils/NameSearchUtils.java
@@ -1,0 +1,70 @@
+package com.project.tracking_system.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Вспомогательные методы для работы с поиском по ФИО покупателя.
+ * <p>
+ * Класс отвечает только за извлечение и подготовку токенов, что позволяет
+ * повторно использовать логику в разных частях приложения и облегчает тестирование.
+ * </p>
+ */
+public final class NameSearchUtils {
+
+    /**
+     * Регулярное выражение для выделения последовательностей букв в поисковом запросе.
+     * Поддерживает кириллицу и латиницу благодаря использованию {@code \p{L}}.
+     */
+    private static final Pattern NAME_TOKEN_PATTERN = Pattern.compile("\\p{L}+");
+
+    private NameSearchUtils() {
+        // Утилитарный класс не предполагает создание экземпляров.
+    }
+
+    /**
+     * Извлекает последовательности букв из пользовательского запроса.
+     * <p>
+     * Метод пропускает цифры и специальные символы, позволяя использовать его
+     * как для поиска по ФИО, так и для комбинированных запросов, где встречаются
+     * номера телефонов или трек-номера.
+     * </p>
+     *
+     * @param query исходная строка поиска
+     * @return неизменяемый список токенов в порядке появления, либо пустой список
+     */
+    public static List<String> extractNameTokens(String query) {
+        if (query == null || query.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        Matcher matcher = NAME_TOKEN_PATTERN.matcher(query);
+        List<String> tokens = new ArrayList<>();
+        while (matcher.find()) {
+            tokens.add(matcher.group());
+        }
+        return Collections.unmodifiableList(tokens);
+    }
+
+    /**
+     * Возвращает токен по индексу или пустую строку, если токена нет.
+     * <p>
+     * Используется при формировании запросов к базе данных, где требуется
+     * фиксированное количество параметров.
+     * </p>
+     *
+     * @param tokens список токенов ФИО
+     * @param index  индекс требуемого токена
+     * @return токен в нижнем регистре либо пустая строка
+     */
+    public static String getTokenOrEmpty(List<String> tokens, int index) {
+        if (tokens == null || index < 0 || index >= tokens.size()) {
+            return "";
+        }
+        return tokens.get(index).toLowerCase();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend repository search query to include customer name tokens alongside track and phone search
- add service-level token extraction using a dedicated utility to support flexible name queries
- update controller wiring so departures search leverages the enhanced service method

## Testing
- `mvn -q test` *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 cannot be resolved due to HTTP 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d959cd2bd8832da1ae71f8c75affb8