### PR TITLE
Показывать кнопку «Назад» в детальном списке посылок

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -676,12 +676,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
         Optional<TelegramParcelsOverviewDTO> overviewOptional = telegramService.getParcelsOverview(chatId);
 
-        InlineKeyboardMarkup markup = overviewOptional
-                .filter(overview -> hasParcels(overview.getDelivered())
-                        || hasParcels(overview.getWaitingForPickup())
-                        || hasParcels(overview.getInTransit()))
-                .map(this::buildParcelsOverviewKeyboard)
-                .orElseGet(this::createBackInlineKeyboard);
+        InlineKeyboardMarkup markup = createBackInlineKeyboard();
 
         List<TelegramParcelInfoDTO> parcels = overviewOptional
                 .map(extractor)


### PR DESCRIPTION
## Summary
- использовать единый метод createBackInlineKeyboard для детального списка посылок
- передавать клавиатуру с одной кнопкой «Назад» при отправке сообщений категории посылок

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d974488a90832db66bf4f2fd05ba2c