### PR TITLE
Update parcels screen prompts

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -983,7 +983,8 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
      */
     private String buildEmptyParcelsText() {
         return "📦 Мои посылки\n\n" +
-                "Сейчас в системе нет активных отправлений. Как только появятся новые «📬 Полученные», «🏬 Ждут забора» или «🚚 В пути» посылки, они будут отображены здесь.";
+                "Выберите категорию:\n" +
+                "Пока нет активных посылок";
     }
 
     /**
@@ -995,6 +996,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     private String buildParcelsScreenText(TelegramParcelsOverviewDTO overview) {
         StringBuilder builder = new StringBuilder();
         builder.append("📦 Мои посылки\n\n");
+        builder.append("Выберите категорию:\n\n");
         appendParcelsSection(builder, "Полученные", overview.getDelivered());
         appendParcelsSection(builder, "Ждут забора", overview.getWaitingForPickup());
         appendParcelsSection(builder, "В пути", overview.getInTransit());


### PR DESCRIPTION
## Summary
- add a category prompt to the parcels screen text so category lists appear under the hint
- update the empty parcels message to include the same guidance for users without active shipments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97ee53938832d805d09a97d067462