### PR TITLE
Implement contextual navigation in buyer bot

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/BuyerBotScreenState.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerBotScreenState.java
@@ -64,5 +64,11 @@ public class BuyerBotScreenState {
      */
     @Column(name = "contact_request_sent")
     private Boolean contactRequestSent;
+
+    /**
+     * Последовательность экранов, составляющая путь навигации пользователя.
+     */
+    @Column(name = "navigation_path")
+    private String navigationPath;
 }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSessionRepository.java
@@ -4,6 +4,7 @@ import com.project.tracking_system.entity.BuyerBotScreen;
 import com.project.tracking_system.entity.BuyerChatState;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -55,13 +56,17 @@ public interface ChatSessionRepository {
     void updateAnchor(Long chatId, Integer anchorMessageId);
 
     /**
-     * Сохраняет идентификатор сообщения и экран, которые нужно восстановить после рестарта.
+     * Сохраняет идентификатор сообщения, экран и путь навигации для последующего восстановления интерфейса.
      *
      * @param chatId          идентификатор чата Telegram
      * @param anchorMessageId идентификатор якорного сообщения
      * @param screen          экран, который должен отрисовываться
+     * @param navigationPath  последовательность экранов для формирования кнопки «Назад»
      */
-    void updateAnchorAndScreen(Long chatId, Integer anchorMessageId, BuyerBotScreen screen);
+    void updateAnchorAndScreen(Long chatId,
+                               Integer anchorMessageId,
+                               BuyerBotScreen screen,
+                               List<BuyerBotScreen> navigationPath);
 
     /**
      * Сбрасывает информацию о якорном сообщении.

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -38,6 +38,8 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKe
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardButton;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardRow;
+
+import java.util.List;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
@@ -211,7 +213,10 @@ class BuyerTelegramBotStateIntegrationTest {
         customer.setNotificationsEnabled(true);
         customer.setFullName("Иван Иванов");
 
-        chatSessionRepository.updateAnchorAndScreen(chatId, anchorId, BuyerBotScreen.MENU);
+        chatSessionRepository.updateAnchorAndScreen(chatId,
+                anchorId,
+                BuyerBotScreen.MENU,
+                List.of(BuyerBotScreen.MENU));
         chatSessionRepository.updateState(chatId, BuyerChatState.IDLE);
         chatSessionRepository.markKeyboardVisible(chatId);
 
@@ -1024,7 +1029,10 @@ class BuyerTelegramBotStateIntegrationTest {
 
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        chatSessionRepository.updateAnchorAndScreen(chatId, previousAnchorId, BuyerBotScreen.MENU);
+        chatSessionRepository.updateAnchorAndScreen(chatId,
+                previousAnchorId,
+                BuyerBotScreen.MENU,
+                List.of(BuyerBotScreen.MENU));
         chatSessionRepository.markKeyboardVisible(chatId);
 
         AtomicInteger messageIdSequence = new AtomicInteger(500);

--- a/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/support/InMemoryChatSessionRepository.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.service.telegram.ChatSession;
 import com.project.tracking_system.service.telegram.ChatSessionRepository;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,7 +66,10 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
     }
 
     @Override
-    public void updateAnchorAndScreen(Long chatId, Integer anchorMessageId, BuyerBotScreen screen) {
+    public void updateAnchorAndScreen(Long chatId,
+                                      Integer anchorMessageId,
+                                      BuyerBotScreen screen,
+                                      List<BuyerBotScreen> navigationPath) {
         if (chatId == null) {
             return;
         }
@@ -73,6 +77,7 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
                 id -> new ChatSession(id, BuyerChatState.IDLE, null, null));
         session.setAnchorMessageId(anchorMessageId);
         session.setLastScreen(screen);
+        session.setNavigationPath(navigationPath);
     }
 
     @Override
@@ -233,6 +238,7 @@ public class InMemoryChatSessionRepository implements ChatSessionRepository {
         copy.setAnnouncementAnchorMessageId(session.getAnnouncementAnchorMessageId());
         copy.setAnnouncementSeen(session.isAnnouncementSeen());
         copy.setAnnouncementUpdatedAt(session.getAnnouncementUpdatedAt());
+        copy.setNavigationPath(session.getNavigationPath());
         return copy;
     }
 }


### PR DESCRIPTION
## Summary
- persist navigation history for buyer chat sessions and expose helper APIs
- update the buyer Telegram bot to render contextual back/menu buttons and handle a new navigation callback
- adjust in-memory/database repositories and integration tests to the new navigation tracking

## Testing
- mvn -q -DskipTests compile *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:4.10.0 returns 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d989562010832dbe9b9f439b88e2b6