### PR TITLE
Simplify Telegram parcel info formatting

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TelegramParcelInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TelegramParcelInfoDTO.java
@@ -1,7 +1,5 @@
 package com.project.tracking_system.dto;
 
-import com.project.tracking_system.entity.GlobalStatus;
-import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**
@@ -15,25 +13,16 @@ public class TelegramParcelInfoDTO {
 
     private final String trackNumber;
     private final String storeName;
-    private final GlobalStatus status;
-    private final ZonedDateTime lastUpdate;
-
     /**
      * Создаёт DTO с основными данными о посылке для Telegram.
      *
      * @param trackNumber трек-номер посылки (может быть пустым)
      * @param storeName   название магазина, где оформлен заказ
-     * @param status      глобальный статус посылки, используемый для описания
-     * @param lastUpdate  дата последнего обновления статуса
      */
     public TelegramParcelInfoDTO(String trackNumber,
-                                 String storeName,
-                                 GlobalStatus status,
-                                 ZonedDateTime lastUpdate) {
+                                 String storeName) {
         this.trackNumber = trackNumber;
         this.storeName = storeName;
-        this.status = status;
-        this.lastUpdate = lastUpdate;
     }
 
     /**
@@ -50,20 +39,6 @@ public class TelegramParcelInfoDTO {
         return storeName;
     }
 
-    /**
-     * @return глобальный статус посылки для формирования текстового описания
-     */
-    public GlobalStatus getStatus() {
-        return status;
-    }
-
-    /**
-     * @return отметка времени последнего обновления статуса посылки
-     */
-    public ZonedDateTime getLastUpdate() {
-        return lastUpdate;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -73,13 +48,11 @@ public class TelegramParcelInfoDTO {
             return false;
         }
         return Objects.equals(trackNumber, that.trackNumber)
-                && Objects.equals(storeName, that.storeName)
-                && status == that.status
-                && Objects.equals(lastUpdate, that.lastUpdate);
+                && Objects.equals(storeName, that.storeName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(trackNumber, storeName, status, lastUpdate);
+        return Objects.hash(trackNumber, storeName);
     }
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -372,8 +372,7 @@ public class CustomerTelegramService {
      */
     private TelegramParcelInfoDTO toTelegramParcelInfo(TrackParcel parcel) {
         if (parcel == null) {
-            return new TelegramParcelInfoDTO("Без номера", "Магазин не указан",
-                    GlobalStatus.UNKNOWN_STATUS, ZonedDateTime.now(ZoneOffset.UTC));
+            return new TelegramParcelInfoDTO("Без номера", "Магазин не указан");
         }
 
         String trackNumber = parcel.getNumber();
@@ -385,14 +384,7 @@ public class CustomerTelegramService {
                 ? parcel.getStore().getName()
                 : "Магазин не указан";
 
-        GlobalStatus status = Optional.ofNullable(parcel.getStatus())
-                .orElse(GlobalStatus.UNKNOWN_STATUS);
-
-        ZonedDateTime lastUpdate = Optional.ofNullable(parcel.getLastUpdate())
-                .or(() -> Optional.ofNullable(parcel.getTimestamp()))
-                .orElse(ZonedDateTime.now(ZoneOffset.UTC));
-
-        return new TelegramParcelInfoDTO(trackNumber, storeName, status, lastUpdate);
+        return new TelegramParcelInfoDTO(trackNumber, storeName);
     }
 
 }

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -10,7 +10,6 @@ import com.project.tracking_system.entity.AdminNotification;
 import com.project.tracking_system.entity.BuyerBotScreen;
 import com.project.tracking_system.entity.BuyerChatState;
 import com.project.tracking_system.entity.Customer;
-import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.NameSource;
 import com.project.tracking_system.service.admin.AdminNotificationService;
 import com.project.tracking_system.service.customer.CustomerTelegramService;
@@ -326,18 +325,14 @@ class BuyerTelegramBotTest {
     }
 
     /**
-     * Проверяет, что список посылок группируется по магазину и отображает статус с датой.
+     * Проверяет, что список посылок группируется по магазину и выводит только трек-номера.
      */
     @Test
-    void shouldGroupParcelsByStoreWithStatusAndDate() throws Exception {
+    void shouldGroupParcelsByStoreWithTracksOnly() throws Exception {
         Long chatId = 901L;
-        ZonedDateTime now = ZonedDateTime.parse("2025-01-05T10:15:30Z");
-        TelegramParcelInfoDTO first = new TelegramParcelInfoDTO("TRACK-1", "Store Alpha",
-                GlobalStatus.IN_TRANSIT, now);
-        TelegramParcelInfoDTO second = new TelegramParcelInfoDTO("TRACK-2", "Store Beta",
-                GlobalStatus.WAITING_FOR_CUSTOMER, now.minusHours(2));
-        TelegramParcelInfoDTO third = new TelegramParcelInfoDTO("TRACK-3", "Store Alpha",
-                GlobalStatus.DELIVERED, null);
+        TelegramParcelInfoDTO first = new TelegramParcelInfoDTO("TRACK-1", "Store Alpha");
+        TelegramParcelInfoDTO second = new TelegramParcelInfoDTO("TRACK-2", "Store Beta");
+        TelegramParcelInfoDTO third = new TelegramParcelInfoDTO("TRACK-3", "Store Alpha");
 
         TelegramParcelsOverviewDTO overview = new TelegramParcelsOverviewDTO(
                 List.of(first, second, third),
@@ -355,10 +350,10 @@ class BuyerTelegramBotTest {
 
         assertTrue(text.startsWith("📬 Полученные посылки"),
                 "Сообщение должно начинаться с заголовка выбранной категории");
-        assertTrue(text.contains("**Store Alpha:**\n• TRACK-1 В пути 05.01.2025 10:15\n• TRACK-3 Вручена дата неизвестна"),
-                "Посылки одного магазина должны выводиться под общим заголовком");
-        assertTrue(text.contains("**Store Beta:**\n• TRACK-2 Ожидает клиента 05.01.2025 08:15"),
-                "Для каждого магазина ожидается собственный блок с посылками");
+        assertTrue(text.contains("**Store Alpha**\n• TRACK-1\n• TRACK-3"),
+                "Посылки одного магазина должны выводиться под общим заголовком и включать только треки");
+        assertTrue(text.contains("**Store Beta**\n• TRACK-2"),
+                "Для каждого магазина ожидается собственный блок с трек-номерами");
     }
 
     /**


### PR DESCRIPTION
## Summary
- drop status and timestamp fields from the Telegram parcel DTO, keeping only track number and store name
- adjust customer telegram service mapping to the leaner DTO
- update buyer bot parcel rendering to list bold store headings with track numbers only and refresh unit tests

## Testing
- mvn -q test *(fails: Could not transfer artifact io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 from jitpack.io - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d99ca9512c832d93284362606e0798