### PR TITLE
Limit in-transit statuses for Telegram overview

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -44,8 +44,7 @@ public class CustomerTelegramService {
      * Предопределённые наборы статусов для формирования сводки Telegram.
      * <p>
      * «Получено» отражает финальные доставки, «Ожидает забора» содержит все варианты ожидания клиента,
-     * включая повторные напоминания, а «В пути» собирает предшествующие доставке статусы и контролирует
-     * проблемные ситуации до момента получения.
+     * а «В пути» ограничен ключевыми этапами движения отправления до момента выдачи.
      * </p>
      */
     private static final List<GlobalStatus> DELIVERED_STATUSES = List.of(GlobalStatus.DELIVERED);
@@ -56,9 +55,7 @@ public class CustomerTelegramService {
     private static final List<GlobalStatus> IN_TRANSIT_STATUSES = List.of(
             GlobalStatus.PRE_REGISTERED,
             GlobalStatus.REGISTERED,
-            GlobalStatus.IN_TRANSIT,
-            GlobalStatus.WAITING_FOR_CUSTOMER,
-            GlobalStatus.CUSTOMER_NOT_PICKING_UP
+            GlobalStatus.IN_TRANSIT
     );
 
     /**

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -149,9 +149,7 @@ class CustomerTelegramServiceTest {
         List<GlobalStatus> inTransitStatuses = List.of(
                 GlobalStatus.PRE_REGISTERED,
                 GlobalStatus.REGISTERED,
-                GlobalStatus.IN_TRANSIT,
-                GlobalStatus.WAITING_FOR_CUSTOMER,
-                GlobalStatus.CUSTOMER_NOT_PICKING_UP
+                GlobalStatus.IN_TRANSIT
         );
 
         when(trackParcelRepository.findByCustomerIdAndStatusIn(eq(customerId), anyList()))
@@ -164,7 +162,7 @@ class CustomerTelegramServiceTest {
                         return List.of(waitingParcel, notPickingParcel);
                     }
                     if (statuses.equals(inTransitStatuses)) {
-                        return List.of(preRegisteredParcel, registeredParcel, inTransitParcel, waitingParcel, notPickingParcel);
+                        return List.of(preRegisteredParcel, registeredParcel, inTransitParcel);
                     }
                     fail("Неожиданный набор статусов: " + statuses);
                     return List.of();
@@ -177,7 +175,7 @@ class CustomerTelegramServiceTest {
         TelegramParcelsOverviewDTO overview = result.get();
         assertEquals(1, overview.getDelivered().size(), "Раздел доставленных должен содержать одну посылку");
         assertEquals(2, overview.getWaitingForPickup().size(), "Раздел ожидания обязан включать оба статуса ожидания");
-        assertEquals(5, overview.getInTransit().size(), "Раздел в пути обязан включать ключевые статусы до выдачи");
+        assertEquals(3, overview.getInTransit().size(), "Раздел в пути обязан включать ключевые статусы до выдачи");
 
         verify(trackParcelRepository).findByCustomerIdAndStatusIn(customerId, deliveredStatuses);
         verify(trackParcelRepository).findByCustomerIdAndStatusIn(customerId, waitingStatuses);


### PR DESCRIPTION
## Summary
- restrict the Telegram "in transit" parcel group to the five allowed statuses
- update the parcel overview unit test to assert the narrowed in-transit list

## Testing
- mvn test *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 blocked with 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d99f483920832d991a46e34ef75147