### PR TITLE
Ensure buyer bot inline messages use markdown parse mode

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -20,6 +20,7 @@ import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsume
 import org.telegram.telegrambots.longpolling.starter.SpringLongPollingBot;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
 import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
+import org.telegram.telegrambots.meta.api.methods.ParseMode;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageReplyMarkup;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
@@ -81,6 +82,8 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     private static final String CALLBACK_NAVIGATE_BACK = "nav:back";
 
     private static final String NO_PARCELS_PLACEHOLDER = "• нет посылок";
+
+    private static final String TELEGRAM_PARSE_MODE = ParseMode.MARKDOWN;
 
     /**
      * Разделы списка посылок, где отображаются предупреждения и вспомогательные подписи.
@@ -2356,6 +2359,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                     .chatId(chatId.toString())
                     .messageId(messageId)
                     .text(text)
+                    .parseMode(TELEGRAM_PARSE_MODE)
                     .replyMarkup(markup)
                     .build();
             try {
@@ -2388,6 +2392,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         SendMessage message = new SendMessage(chatId.toString(), text);
         message.setReplyMarkup(markup);
         message.setDisableNotification(true);
+        message.setParseMode(TELEGRAM_PARSE_MODE);
         try {
             Message sent = telegramClient.execute(message);
             Integer newAnchorId = sent != null ? sent.getMessageId() : null;

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
+import org.telegram.telegrambots.meta.api.methods.ParseMode;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.chat.Chat;
@@ -213,6 +214,8 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(editCaptor.capture());
         EditMessageText bannerEdit = editCaptor.getAllValues().get(editCaptor.getAllValues().size() - 1);
 
+        assertEquals(ParseMode.MARKDOWN, bannerEdit.getParseMode(),
+                "Баннер объявления должен отправляться с включённым Markdown для корректной разметки");
         assertTrue(bannerEdit.getText().contains(notification.getTitle()),
                 "Текст баннера должен содержать заголовок объявления");
         assertTrue(bannerEdit.getText().contains("Первый пункт"));
@@ -349,6 +352,8 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         String text = captor.getValue().getText();
 
+        assertEquals(ParseMode.MARKDOWN, captor.getValue().getParseMode(),
+                "Список посылок должен отправляться в Markdown, чтобы заголовки магазинов были жирными");
         assertTrue(text.startsWith("📬 Полученные посылки"),
                 "Сообщение должно начинаться с заголовка выбранной категории");
         assertTrue(text.contains("**Store Alpha**\n• TRACK-1\n• TRACK-3"),


### PR DESCRIPTION
## Summary
- add a shared Telegram parse mode constant for inline buyer bot responses
- send inline messages and edits with Markdown parsing so bold formatting works
- extend buyer bot tests to assert that inline responses use the configured parse mode

## Testing
- mvn -q -Dtest=BuyerTelegramBotTest test *(fails: dependency download blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b0923468832dad6cb7c789c9d30c