### PR TITLE
Switch buyer bot to MarkdownV2 and improve escaping

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -84,7 +84,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
     private static final String NO_PARCELS_PLACEHOLDER = "• нет посылок";
 
-    private static final String TELEGRAM_PARSE_MODE = ParseMode.MARKDOWN;
+    private static final String TELEGRAM_PARSE_MODE = ParseMode.MARKDOWNV2;
 
     /**
      * Разделы списка посылок, где отображаются предупреждения и вспомогательные подписи.
@@ -906,7 +906,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             log.info("🔕 Команда {} получена от {}", text, chatId);
             boolean disabled = telegramService.disableNotifications(chatId);
             if (disabled) {
-                SendMessage confirm = new SendMessage(chatId.toString(),
+                SendMessage confirm = createPlainMessage(chatId,
                         "🔕 Уведомления отключены. Чтобы возобновить их, снова отправьте /start.");
                 try {
                     telegramClient.execute(confirm);
@@ -2305,7 +2305,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return;
         }
 
-        SendMessage message = new SendMessage(chatId.toString(),
+        SendMessage message = createPlainMessage(chatId,
                 "Клавиша быстрого доступа доступна на панели ниже: «🏠 Меню».");
         message.setReplyMarkup(createPersistentMenuKeyboard());
         message.setDisableNotification(true);
@@ -2483,12 +2483,29 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
      * @param text   текст сообщения
      */
     private void sendSimpleMessage(Long chatId, String text) {
-        SendMessage msg = new SendMessage(chatId.toString(), text);
+        if (chatId == null) {
+            return;
+        }
+        SendMessage msg = createPlainMessage(chatId, text);
         try {
             telegramClient.execute(msg);
         } catch (TelegramApiException e) {
             log.error("❌ Ошибка отправки сообщения", e);
         }
+    }
+
+    /**
+     * Создаёт объект {@link SendMessage} с установленным режимом MarkdownV2 и экранированным текстом.
+     *
+     * @param chatId идентификатор чата Telegram
+     * @param text   исходный текст, который требуется отправить как обычное сообщение
+     * @return подготовленный объект {@link SendMessage}
+     */
+    private SendMessage createPlainMessage(Long chatId, String text) {
+        String safeText = escapeMarkdown(text);
+        SendMessage message = new SendMessage(chatId.toString(), safeText);
+        message.setParseMode(TELEGRAM_PARSE_MODE);
+        return message;
     }
 
     /**
@@ -2550,7 +2567,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
         chatSessionRepository.markKeyboardHidden(chatId);
         chatSessionRepository.markContactRequestSent(chatId);
-        SendMessage message = new SendMessage(chatId.toString(), text);
+        SendMessage message = createPlainMessage(chatId, text);
         message.setReplyMarkup(createPhoneRequestKeyboard());
 
         try {
@@ -2652,13 +2669,27 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return value;
         }
         StringBuilder escaped = new StringBuilder(value.length());
-        for (char ch : value.toCharArray()) {
-            if (ch == '\\' || ch == '_' || ch == '*' || ch == '[' || ch == ']' || ch == '(' || ch == ')' || ch == '`') {
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (isMarkdownV2SpecialCharacter(ch)) {
                 escaped.append('\\');
             }
             escaped.append(ch);
         }
         return escaped.toString();
+    }
+
+    /**
+     * Проверяет, относится ли символ к специальным для MarkdownV2 и требует ли он экранирования.
+     *
+     * @param ch проверяемый символ
+     * @return {@code true}, если символ следует экранировать
+     */
+    private boolean isMarkdownV2SpecialCharacter(char ch) {
+        return switch (ch) {
+            case '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\' -> true;
+            default -> false;
+        };
     }
 
     /**
@@ -2812,7 +2843,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 ? "⌨️ Клавиатура скрыта. Меню появится в следующем сообщении."
                 : text;
 
-        SendMessage removalMessage = new SendMessage(chatId.toString(), safeText);
+        SendMessage removalMessage = createPlainMessage(chatId, safeText);
         ReplyKeyboardRemove removeMarkup = ReplyKeyboardRemove.builder()
                 .removeKeyboard(true)
                 .selective(false)

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -214,7 +214,7 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(editCaptor.capture());
         EditMessageText bannerEdit = editCaptor.getAllValues().get(editCaptor.getAllValues().size() - 1);
 
-        assertEquals(ParseMode.MARKDOWN, bannerEdit.getParseMode(),
+        assertEquals(ParseMode.MARKDOWNV2, bannerEdit.getParseMode(),
                 "Баннер объявления должен отправляться с включённым Markdown для корректной разметки");
         assertTrue(bannerEdit.getText().contains(notification.getTitle()),
                 "Текст баннера должен содержать заголовок объявления");
@@ -352,13 +352,13 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         String text = captor.getValue().getText();
 
-        assertEquals(ParseMode.MARKDOWN, captor.getValue().getParseMode(),
+        assertEquals(ParseMode.MARKDOWNV2, captor.getValue().getParseMode(),
                 "Список посылок должен отправляться в Markdown, чтобы заголовки магазинов были жирными");
         assertTrue(text.startsWith("📬 Полученные посылки"),
                 "Сообщение должно начинаться с заголовка выбранной категории");
-        assertTrue(text.contains("**Store Alpha**\n• TRACK-1\n• TRACK-3"),
+        assertTrue(text.contains("**Store Alpha**\n• TRACK\\-1\n• TRACK\\-3"),
                 "Посылки одного магазина должны выводиться под общим заголовком и включать только треки");
-        assertTrue(text.contains("**Store Beta**\n• TRACK-2"),
+        assertTrue(text.contains("**Store Beta**\n• TRACK\\-2"),
                 "Для каждого магазина ожидается собственный блок с трек-номерами");
     }
 
@@ -389,7 +389,7 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         SendMessage message = captor.getValue();
 
-        assertEquals(ParseMode.MARKDOWN, message.getParseMode(),
+        assertEquals(ParseMode.MARKDOWNV2, message.getParseMode(),
                 "Ответ по посылкам должен использовать Markdown для форматирования");
         String text = message.getText();
         assertTrue(text.contains("**Store\\_\\[Beta\\]\\(Promo\\)**"),
@@ -430,9 +430,9 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         String text = captor.getValue().getText();
 
-        assertTrue(text.contains("TRACK-ALERT — ⚠️ скоро уедет в магазин"),
+        assertTrue(text.contains("TRACK\\-ALERT — ⚠️ скоро уедет в магазин"),
                 "Посылка с проблемным статусом должна сопровождаться предупреждением");
-        assertTrue(text.contains("• TRACK-OK"),
+        assertTrue(text.contains("• TRACK\\-OK"),
                 "Обычные посылки должны оставаться без дополнительных подпесей");
     }
 


### PR DESCRIPTION
## Summary
- switch the buyer Telegram bot to use MarkdownV2 for all sent and edited messages and centralize plain message creation
- extend Markdown escaping to cover the full MarkdownV2 character set while keeping backslashes consistent
- update buyer bot tests to expect MarkdownV2 payloads and the new escaped track strings

## Testing
- mvn -q -DskipITs test *(fails: dependency download from jitpack.io returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bde32ae0832d8d9b14592db6965b