### PR TITLE
Switch buyer bot to MarkdownV2 and improve escaping

### DIFF
--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -214,7 +214,7 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(editCaptor.capture());
         EditMessageText bannerEdit = editCaptor.getAllValues().get(editCaptor.getAllValues().size() - 1);
 
-        assertEquals(ParseMode.MARKDOWN, bannerEdit.getParseMode(),
+        assertEquals(ParseMode.MARKDOWNV2, bannerEdit.getParseMode(),
                 "Баннер объявления должен отправляться с включённым Markdown для корректной разметки");
         assertTrue(bannerEdit.getText().contains(notification.getTitle()),
                 "Текст баннера должен содержать заголовок объявления");
@@ -352,13 +352,13 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         String text = captor.getValue().getText();
 
-        assertEquals(ParseMode.MARKDOWN, captor.getValue().getParseMode(),
+        assertEquals(ParseMode.MARKDOWNV2, captor.getValue().getParseMode(),
                 "Список посылок должен отправляться в Markdown, чтобы заголовки магазинов были жирными");
         assertTrue(text.startsWith("📬 Полученные посылки"),
                 "Сообщение должно начинаться с заголовка выбранной категории");
-        assertTrue(text.contains("**Store Alpha**\n• TRACK-1\n• TRACK-3"),
+        assertTrue(text.contains("**Store Alpha**\n• TRACK\\-1\n• TRACK\\-3"),
                 "Посылки одного магазина должны выводиться под общим заголовком и включать только треки");
-        assertTrue(text.contains("**Store Beta**\n• TRACK-2"),
+        assertTrue(text.contains("**Store Beta**\n• TRACK\\-2"),
                 "Для каждого магазина ожидается собственный блок с трек-номерами");
     }
 
@@ -389,7 +389,7 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         SendMessage message = captor.getValue();
 
-        assertEquals(ParseMode.MARKDOWN, message.getParseMode(),
+        assertEquals(ParseMode.MARKDOWNV2, message.getParseMode(),
                 "Ответ по посылкам должен использовать Markdown для форматирования");
         String text = message.getText();
         assertTrue(text.contains("**Store\\_\\[Beta\\]\\(Promo\\)**"),
@@ -430,9 +430,9 @@ class BuyerTelegramBotTest {
         verify(telegramClient, atLeastOnce()).execute(captor.capture());
         String text = captor.getValue().getText();
 
-        assertTrue(text.contains("TRACK-ALERT — ⚠️ скоро уедет в магазин"),
+        assertTrue(text.contains("TRACK\\-ALERT — ⚠️ скоро уедет в магазин"),
                 "Посылка с проблемным статусом должна сопровождаться предупреждением");
-        assertTrue(text.contains("• TRACK-OK"),
+        assertTrue(text.contains("• TRACK\\-OK"),
                 "Обычные посылки должны оставаться без дополнительных подпесей");
     }
 


### PR DESCRIPTION
## Summary
- switch the buyer Telegram bot to use MarkdownV2 for all sent and edited messages and centralize plain message creation
- extend Markdown escaping to cover the full MarkdownV2 character set while keeping backslashes consistent
- update buyer bot tests to expect MarkdownV2 payloads and the new escaped track strings
- escape the static name status suffixes in menu and settings texts so parentheses are valid MarkdownV2 entities

## Testing
- mvn -q -DskipITs test *(fails: dependency download from jitpack.io returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bde32ae0832d8d9b14592db6965b