### PR TITLE
feat: broadcast admin announcements to telegram

### DIFF
--- a/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/CustomerRepository.java
@@ -3,12 +3,12 @@ package com.project.tracking_system.repository;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.BuyerReputation;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Optional;
 
 /**
  * Репозиторий для работы с сущностью {@link Customer}.
@@ -138,4 +138,21 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
      * @return число покупателей с Telegram
      */
     long countByTelegramChatIdNotNull();
+
+    /**
+     * Получить идентификаторы чатов подтверждённых покупателей в Telegram.
+     * <p>
+     * Метод возвращает только те чаты, где покупатель подтвердил связку с ботом, что
+     * позволяет выполнять рассылки без загрузки полного профиля клиента.
+     * </p>
+     *
+     * @return список идентификаторов чатов Telegram
+     */
+    @Query("""
+        SELECT c.telegramChatId
+        FROM Customer c
+        WHERE c.telegramChatId IS NOT NULL
+          AND c.telegramConfirmed = true
+    """)
+    List<Long> findConfirmedTelegramChatIds();
 }

--- a/src/main/java/com/project/tracking_system/service/admin/event/AdminAnnouncementEvent.java
+++ b/src/main/java/com/project/tracking_system/service/admin/event/AdminAnnouncementEvent.java
@@ -1,0 +1,24 @@
+package com.project.tracking_system.service.admin.event;
+
+/**
+ * Событие изменения активного административного объявления.
+ * <p>
+ * Публикуется сервисом уведомлений при активации или принудительном сбросе баннера,
+ * чтобы связанные компоненты могли синхронно обновить пользователей Telegram.
+ * </p>
+ *
+ * @param notificationId идентификатор уведомления, вызвавшего событие
+ * @param type           тип изменения (активация или сброс)
+ */
+public record AdminAnnouncementEvent(Long notificationId, AdminAnnouncementEventType type) {
+
+    /**
+     * Тип события для обработки широковещательной рассылки объявлений.
+     */
+    public enum AdminAnnouncementEventType {
+        /** Уведомление переведено в активное состояние. */
+        ACTIVATED,
+        /** Администратор запросил принудительный сброс просмотров. */
+        RESET_REQUESTED
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
  */
 @Component
 @Slf4j
-public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingleThreadUpdateConsumer {
+public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingleThreadUpdateConsumer, TelegramAnnouncementSender {
 
     private static final String BUTTON_STATS = "📊 Статистика";
     private static final String BUTTON_PARCELS = "📦 Мои посылки";
@@ -1955,7 +1955,19 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         sendInlineMessage(chatId, text, markup, BuyerBotScreen.MENU, forceResendOnNotModified, navigationPath);
 
         ensurePersistentKeyboard(chatId);
-        renderActiveAnnouncement(chatId, resolvedCustomer);
+        if (resolvedCustomer != null && resolvedCustomer.isTelegramConfirmed()) {
+            showActiveAnnouncement(chatId);
+        }
+    }
+
+    /**
+     * Отрисовывает активное объявление администратора для указанного подтверждённого чата.
+     *
+     * @param chatId идентификатор чата Telegram, в который следует отправить баннер
+     */
+    @Override
+    public void showActiveAnnouncement(Long chatId) {
+        renderActiveAnnouncement(chatId);
     }
 
     /**
@@ -2054,11 +2066,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
      * переотправляет баннер, чтобы покупатель получил изменённую информацию.
      * </p>
      *
-     * @param chatId   идентификатор чата Telegram
-     * @param customer покупатель, привязанный к чату
+     * @param chatId идентификатор чата Telegram подтверждённого покупателя
      */
-    private void renderActiveAnnouncement(Long chatId, Customer customer) {
-        if (chatId == null || customer == null || !customer.isTelegramConfirmed()) {
+    private void renderActiveAnnouncement(Long chatId) {
+        if (chatId == null) {
             return;
         }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramAnnouncementBroadcaster.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramAnnouncementBroadcaster.java
@@ -1,0 +1,49 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.service.admin.AdminNotificationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Компонент, выполняющий широковещательную рассылку активного объявления в Telegram.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TelegramAnnouncementBroadcaster {
+
+    private final AdminNotificationService adminNotificationService;
+    private final CustomerRepository customerRepository;
+    private final TelegramAnnouncementSender announcementSender;
+
+    /**
+     * Отправить активное объявление всем подтверждённым подписчикам Telegram.
+     * <p>
+     * Метод запрашивает актуальный баннер у сервиса административных уведомлений и,
+     * только если объявление существует, перебирает идентификаторы подтверждённых чатов.
+     * Для каждого адресата вызывается публичный метод бота, повторно использующий
+     * логику отрисовки баннера без загрузки лишних данных о покупателе.
+     * </p>
+     *
+     * @param notificationId идентификатор уведомления, инициировавшего рассылку
+     */
+    public void broadcastActiveAnnouncement(Long notificationId) {
+        adminNotificationService.findActiveNotification().ifPresentOrElse(activeNotification -> {
+            Long activeId = activeNotification.getId();
+            List<Long> chatIds = customerRepository.findConfirmedTelegramChatIds();
+            if (chatIds.isEmpty()) {
+                log.debug("Нет подтверждённых чатов для рассылки объявления {}", activeId);
+                return;
+            }
+            chatIds.forEach(chatId -> {
+                if (chatId == null) {
+                    return;
+                }
+                announcementSender.showActiveAnnouncement(chatId);
+            });
+        }, () -> log.warn("Рассылка объявления {} отменена: активное уведомление отсутствует", notificationId));
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramAnnouncementEventListener.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramAnnouncementEventListener.java
@@ -1,0 +1,30 @@
+package com.project.tracking_system.service.telegram;
+
+import com.project.tracking_system.service.admin.event.AdminAnnouncementEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Обработчик доменных событий административных объявлений для запуска рассылки в Telegram.
+ */
+@Component
+@RequiredArgsConstructor
+public class TelegramAnnouncementEventListener {
+
+    private final TelegramAnnouncementBroadcaster announcementBroadcaster;
+
+    /**
+     * Реагирует на подтверждённую активацию или сброс объявления после фиксации транзакции.
+     *
+     * @param event событие изменения административного объявления
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAdminAnnouncement(AdminAnnouncementEvent event) {
+        if (event == null) {
+            return;
+        }
+        announcementBroadcaster.broadcastActiveAnnouncement(event.notificationId());
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/telegram/TelegramAnnouncementSender.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/TelegramAnnouncementSender.java
@@ -1,0 +1,14 @@
+package com.project.tracking_system.service.telegram;
+
+/**
+ * Контракт для компонентов, способных отрисовать активное объявление администратора в чате Telegram.
+ */
+public interface TelegramAnnouncementSender {
+
+    /**
+     * Показать актуальное административное объявление подтверждённому покупателю.
+     *
+     * @param chatId идентификатор чата Telegram, в который необходимо отправить баннер
+     */
+    void showActiveAnnouncement(Long chatId);
+}

--- a/src/test/java/com/project/tracking_system/service/telegram/TelegramAnnouncementBroadcasterTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/TelegramAnnouncementBroadcasterTest.java
@@ -1,0 +1,103 @@
+package com.project.tracking_system.service.telegram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.project.tracking_system.entity.AdminNotification;
+import com.project.tracking_system.repository.CustomerRepository;
+import com.project.tracking_system.service.admin.AdminNotificationService;
+import com.project.tracking_system.service.telegram.support.InMemoryChatSessionRepository;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Модульные тесты широковещательного сервиса рассылки административных объявлений.
+ */
+class TelegramAnnouncementBroadcasterTest {
+
+    private AdminNotificationService adminNotificationService;
+    private CustomerRepository customerRepository;
+    private RecordingAnnouncementSender announcementSender;
+    private InMemoryChatSessionRepository chatSessionRepository;
+    private TelegramAnnouncementBroadcaster broadcaster;
+
+    @BeforeEach
+    void setUp() {
+        adminNotificationService = mock(AdminNotificationService.class);
+        customerRepository = mock(CustomerRepository.class);
+        chatSessionRepository = new InMemoryChatSessionRepository();
+        announcementSender = new RecordingAnnouncementSender(chatSessionRepository);
+        broadcaster = new TelegramAnnouncementBroadcaster(adminNotificationService, customerRepository, announcementSender);
+    }
+
+    /**
+     * Проверяет, что рассылка выполняется только по подтверждённым чатам и сбрасывает флаг просмотра.
+     */
+    @Test
+    void shouldBroadcastToConfirmedChatsAndResetSeenFlag() {
+        AdminNotification notification = new AdminNotification();
+        notification.setId(55L);
+        notification.setTitle("Важно");
+        notification.setUpdatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+
+        when(adminNotificationService.findActiveNotification()).thenReturn(Optional.of(notification));
+        when(customerRepository.findConfirmedTelegramChatIds()).thenReturn(List.of(101L, 202L));
+
+        chatSessionRepository.markAnnouncementSeen(101L);
+        chatSessionRepository.markAnnouncementSeen(202L);
+
+        broadcaster.broadcastActiveAnnouncement(notification.getId());
+
+        assertEquals(List.of(101L, 202L), announcementSender.getInvokedChatIds(),
+                "Должны обрабатываться только подтверждённые чаты");
+        assertFalse(chatSessionRepository.isAnnouncementSeen(101L),
+                "После рассылки признак просмотра должен сбрасываться");
+        assertFalse(chatSessionRepository.isAnnouncementSeen(202L),
+                "После рассылки признак просмотра должен сбрасываться");
+    }
+
+    /**
+     * Убеждается, что при отсутствии активного объявления рассылка не запускается.
+     */
+    @Test
+    void shouldSkipBroadcastWhenNoActiveNotification() {
+        when(adminNotificationService.findActiveNotification()).thenReturn(Optional.empty());
+
+        broadcaster.broadcastActiveAnnouncement(99L);
+
+        verifyNoInteractions(customerRepository);
+        assertEquals(List.of(), announcementSender.getInvokedChatIds(),
+                "Не должно быть вызовов рендеринга без активного уведомления");
+    }
+
+    /**
+     * Записывает список обработанных чатов и обновляет состояние объявлений через репозиторий.
+     */
+    private static final class RecordingAnnouncementSender implements TelegramAnnouncementSender {
+
+        private final InMemoryChatSessionRepository repository;
+        private final List<Long> invokedChatIds = new ArrayList<>();
+
+        private RecordingAnnouncementSender(InMemoryChatSessionRepository repository) {
+            this.repository = repository;
+        }
+
+        @Override
+        public void showActiveAnnouncement(Long chatId) {
+            invokedChatIds.add(chatId);
+            repository.updateAnnouncement(chatId, 777L, null, ZonedDateTime.now(ZoneOffset.UTC));
+        }
+
+        private List<Long> getInvokedChatIds() {
+            return List.copyOf(invokedChatIds);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose confirmed Telegram chat identifiers in `CustomerRepository`
- add a Telegram announcement broadcaster, listener, and bot entrypoint that reuse the banner rendering logic
- publish events from `AdminNotificationService` on activation/reset and cover the flow with unit tests

## Testing
- `mvn test` *(fails: jitpack.io dependency download returns HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9cb90cf2c832da60dea9c3ee00185