### PR TITLE
Implement manual track refresh endpoint and modal refresh UI

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackRefreshController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackRefreshController.java
@@ -1,0 +1,38 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.track.TrackRefreshService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST-контроллер для ручного обновления одного трека из модального окна.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tracks")
+public class TrackRefreshController {
+
+    private final TrackRefreshService trackRefreshService;
+
+    /**
+     * Запускает обновление трека и возвращает свежие данные для модального окна.
+     *
+     * @param id   идентификатор посылки
+     * @param user текущий пользователь
+     * @return DTO с обновлёнными данными
+     */
+    @PostMapping("/{id}/refresh")
+    public TrackDetailsDto refresh(@PathVariable Long id, @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        return trackRefreshService.refreshTrack(id, user.getId());
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackRefreshService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackRefreshService.java
@@ -1,0 +1,138 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.service.SubscriptionService;
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Сервис ручного обновления трека из модального окна.
+ * <p>
+ * Инкапсулирует проверку прав доступа, ограничений по времени и тарифным лимитам,
+ * обеспечивая идемпотентный запуск обновления: повторные запросы к одному и тому же
+ * треку выполняют единственный сетевой вызов.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrackRefreshService {
+
+    private static final String CACHE_NAME = "track-details";
+
+    private final TrackParcelService trackParcelService;
+    private final TrackProcessingService trackProcessingService;
+    private final TrackViewService trackViewService;
+    private final ApplicationSettingsService applicationSettingsService;
+    private final SubscriptionService subscriptionService;
+    private final CacheManager cacheManager;
+
+    /** Карта блокировок на идентификатор посылки для обеспечения идемпотентности. */
+    private final Map<Long, Object> parcelLocks = new ConcurrentHashMap<>();
+
+    /**
+     * Выполняет обновление трека пользователя.
+     *
+     * @param trackId идентификатор посылки
+     * @param userId  идентификатор владельца
+     * @return обновлённый DTO для модального окна
+     */
+    public TrackDetailsDto refreshTrack(Long trackId, Long userId) {
+        Object lock = parcelLocks.computeIfAbsent(trackId, id -> new Object());
+        synchronized (lock) {
+            try {
+                return doRefresh(trackId, userId);
+            } finally {
+                parcelLocks.remove(trackId, lock);
+            }
+        }
+    }
+
+    /**
+     * Содержит основную бизнес-логику: проверки и запуск обновления.
+     */
+    private TrackDetailsDto doRefresh(Long trackId, Long userId) {
+        TrackParcel parcel = resolveOwnedParcel(trackId, userId);
+        ensureRefreshAllowed(parcel);
+
+        int allowedUpdates = subscriptionService.canUpdateTracks(userId, 1);
+        if (allowedUpdates < 1) {
+            log.info("Лимит обновлений исчерпан для userId={}", userId);
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS,
+                    "Лимит обновлений на сегодня исчерпан.");
+        }
+
+        log.info("♻️ Запущено ручное обновление трека {} (parcelId={}) для userId={}",
+                parcel.getNumber(), parcel.getId(), userId);
+        trackProcessingService.processTrack(parcel.getNumber(), parcel.getStore().getId(), userId, true);
+
+        evictDetailsCache(trackId, userId);
+        return trackViewService.getTrackDetails(trackId, userId);
+    }
+
+    /**
+     * Находит посылку и убеждается, что она принадлежит пользователю.
+     */
+    private TrackParcel resolveOwnedParcel(Long trackId, Long userId) {
+        return trackParcelService.findOwnedById(trackId, userId)
+                .orElseGet(() -> {
+                    if (trackParcelService.findById(trackId).isPresent()) {
+                        throw new AccessDeniedException("Посылка не принадлежит пользователю");
+                    }
+                    log.warn("Не найдена посылка id={} для пользователя {} при попытке обновления", trackId, userId);
+                    throw new EntityNotFoundException("Посылка не найдена");
+                });
+    }
+
+    /**
+     * Проверяет, что обновление допустимо по статусу и тайм-ауту.
+     */
+    private void ensureRefreshAllowed(TrackParcel parcel) {
+        if (parcel.getNumber() == null || parcel.getNumber().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Добавьте трек-номер, чтобы выполнить обновление.");
+        }
+        if (parcel.getStatus() != null && parcel.getStatus().isFinal()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Обновление недоступно для посылки в финальном статусе.");
+        }
+
+        ZonedDateTime lastUpdate = parcel.getLastUpdate();
+        if (lastUpdate == null) {
+            return;
+        }
+        int interval = applicationSettingsService.getTrackUpdateIntervalHours();
+        ZonedDateTime nextAllowed = lastUpdate.plusHours(interval);
+        if (nextAllowed.isAfter(ZonedDateTime.now(ZoneOffset.UTC))) {
+            String formatted = nextAllowed.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS,
+                    "Повторное обновление будет доступно после " + formatted);
+        }
+    }
+
+    /**
+     * Инвалидирует кэш модального окна, чтобы вернуть пользователю свежие данные.
+     */
+    private void evictDetailsCache(Long trackId, Long userId) {
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        if (cache != null) {
+            cache.evict(userId + ":" + trackId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a REST controller and service that refresh a track with ACL checks, cooldown validation, subscription limits, and cache eviction before returning the updated DTO
- expose a refresh button with a countdown inside the track modal and wire it to the new endpoint via delegated handlers, loading states, and toast notifications

## Testing
- ./mvnw -q test *(fails: .mvn/wrapper/maven-wrapper.properties missing in repository)*
- mvn -q test *(fails: dependency download from jitpack.io is blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dba2e69814832db6c22efe5e78386b