### PR TITLE
feat: allow editing track numbers via API

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackController.java
@@ -1,15 +1,31 @@
 package com.project.tracking_system.controller;
 
 import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.dto.TrackNumberUpdateRequest;
+import com.project.tracking_system.dto.TrackNumberUpdateResponse;
+import com.project.tracking_system.dto.TrackParcelDTO;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.service.track.TrackViewService;
+import com.project.tracking_system.service.track.TrackParcelService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
+
+import java.util.Optional;
+
+import jakarta.validation.Valid;
 
 /**
  * REST-контроллер для выдачи сохранённой информации о треках.
@@ -20,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TrackController {
 
     private final TrackViewService trackViewService;
+    private final TrackParcelService trackParcelService;
 
     /**
      * Возвращает информацию о треке по его идентификатору.
@@ -34,6 +51,67 @@ public class TrackController {
             throw new AccessDeniedException("Пользователь не авторизован");
         }
         return trackViewService.getTrackDetails(id, user.getId());
+    }
+
+    /**
+     * Обновляет трек-номер посылки в статусах PRE_REGISTERED или ERROR.
+     *
+     * @param id      идентификатор посылки
+     * @param request данные с новым трек-номером
+     * @param user    текущий пользователь
+     * @return обновлённые данные для модалки и таблицы
+     */
+    @PatchMapping("/{id}/number")
+    public TrackNumberUpdateResponse updateTrackNumber(@PathVariable Long id,
+                                                       @RequestBody @Valid TrackNumberUpdateRequest request,
+                                                       @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        Long userId = user.getId();
+
+        TrackParcel parcel = resolveOwnedParcel(id, userId);
+        GlobalStatus status = parcel.getStatus();
+        if (status != GlobalStatus.PRE_REGISTERED && status != GlobalStatus.ERROR) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Редактирование недоступно для текущего статуса");
+        }
+
+        if (request == null || request.number() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Не указан трек-номер");
+        }
+
+        TrackDetailsDto detailsBefore = trackViewService.getTrackDetails(id, userId);
+        if (!detailsBefore.canEditTrack()) {
+            throw new AccessDeniedException("Редактирование недоступно для текущего пользователя");
+        }
+
+        try {
+            TrackParcel updated = trackParcelService.updateTrackNumber(id, userId, request.number());
+            TrackDetailsDto details = trackViewService.getTrackDetails(id, userId);
+            TrackParcelDTO summary = trackParcelService.mapToDto(updated, userId);
+            return new TrackNumberUpdateResponse(details, summary);
+        } catch (TrackNumberAlreadyExistsException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Загружает посылку и проверяет принадлежность пользователю.
+     */
+    private TrackParcel resolveOwnedParcel(Long id, Long userId) {
+        Optional<TrackParcel> owned = trackParcelService.findOwnedById(id, userId);
+        if (owned.isPresent()) {
+            return owned.get();
+        }
+        if (trackParcelService.findById(id).isPresent()) {
+            throw new AccessDeniedException("Посылка не принадлежит пользователю");
+        }
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Посылка не найдена");
     }
 }
 

--- a/src/main/java/com/project/tracking_system/dto/TrackNumberUpdateRequest.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackNumberUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.project.tracking_system.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Запрос на изменение трек-номера.
+ *
+ * @param number новое значение трек-номера
+ */
+public record TrackNumberUpdateRequest(@NotBlank(message = "Трек-номер обязателен") String number) {
+}

--- a/src/main/java/com/project/tracking_system/dto/TrackNumberUpdateResponse.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackNumberUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Ответ на изменение трек-номера.
+ *
+ * @param details обновлённые данные для модального окна
+ * @param summary обновлённые данные для таблицы отправлений
+ */
+public record TrackNumberUpdateResponse(TrackDetailsDto details, TrackParcelDTO summary) {
+}

--- a/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/GlobalStatus.java
@@ -22,6 +22,7 @@ public enum GlobalStatus {
     RETURN_IN_PROGRESS("Возврат в пути", "<i class='bi bi-truck status-icon return-progress'></i>"),
     RETURN_PENDING_PICKUP("Возврат ожидает забора", "<i class='bi bi-box-arrow-in-down-right status-icon return-pending'></i>"),
     RETURNED("Возврат забран", "<i class='bi bi-check2-circle status-icon returned'></i>"),
+    ERROR("Ошибка обработки", "<i class='bi bi-exclamation-triangle status-icon error'></i>"),
     PRE_REGISTERED("Предрегистрация", "<i class='bi bi-hourglass status-icon preregistered'></i>"),
     REGISTERED("Заявка зарегистрирована", "<i class='bi bi-file-earmark-text status-icon registered'></i>"),
     REGISTRATION_CANCELLED("Регистрация отменена", "<i class='bi bi-x-octagon status-icon registration-cancelled'></i>"),

--- a/src/main/java/com/project/tracking_system/entity/TrackNumberAudit.java
+++ b/src/main/java/com/project/tracking_system/entity/TrackNumberAudit.java
@@ -1,0 +1,98 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
+
+/**
+ * Запись аудита изменения трек-номера.
+ * <p>
+ * Фиксирует исходное и новое значение номера, а также идентификатор пользователя,
+ * выполнившего изменение. Используется для построения истории действий и
+ * расследования спорных ситуаций.
+ * </p>
+ */
+@Entity
+@Table(name = "tb_track_number_audit")
+public class TrackNumberAudit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Посылка, для которой выполнено изменение номера. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "track_parcel_id", nullable = false)
+    private TrackParcel trackParcel;
+
+    /** Номер до изменения. */
+    @Column(name = "old_number", nullable = true, length = 50)
+    private String oldNumber;
+
+    /** Номер после изменения. */
+    @Column(name = "new_number", nullable = false, length = 50)
+    private String newNumber;
+
+    /** Идентификатор пользователя, выполнившего изменение. */
+    @Column(name = "changed_by", nullable = false)
+    private Long changedBy;
+
+    /** Момент изменения в часовом поясе UTC. */
+    @Column(name = "changed_at", nullable = false)
+    private ZonedDateTime changedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public TrackParcel getTrackParcel() {
+        return trackParcel;
+    }
+
+    public void setTrackParcel(TrackParcel trackParcel) {
+        this.trackParcel = trackParcel;
+    }
+
+    public String getOldNumber() {
+        return oldNumber;
+    }
+
+    public void setOldNumber(String oldNumber) {
+        this.oldNumber = oldNumber;
+    }
+
+    public String getNewNumber() {
+        return newNumber;
+    }
+
+    public void setNewNumber(String newNumber) {
+        this.newNumber = newNumber;
+    }
+
+    public Long getChangedBy() {
+        return changedBy;
+    }
+
+    public void setChangedBy(Long changedBy) {
+        this.changedBy = changedBy;
+    }
+
+    public ZonedDateTime getChangedAt() {
+        return changedAt;
+    }
+
+    public void setChangedAt(ZonedDateTime changedAt) {
+        this.changedAt = changedAt;
+    }
+}

--- a/src/main/java/com/project/tracking_system/repository/TrackNumberAuditRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/TrackNumberAuditRepository.java
@@ -1,0 +1,10 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.TrackNumberAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Репозиторий для сохранения записей аудита изменения трек-номеров.
+ */
+public interface TrackNumberAuditRepository extends JpaRepository<TrackNumberAudit, Long> {
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackNumberAuditService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackNumberAuditService.java
@@ -1,0 +1,44 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.TrackNumberAudit;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.repository.TrackNumberAuditRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * Сервис записи аудита изменений трек-номеров.
+ * <p>
+ * Выделен в отдельный компонент, чтобы {@link TrackParcelService}
+ * не зависел напрямую от деталей хранения аудита (принцип SRP/DIP).
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class TrackNumberAuditService {
+
+    private final TrackNumberAuditRepository trackNumberAuditRepository;
+
+    /**
+     * Сохраняет запись об изменении трек-номера.
+     *
+     * @param parcel    посылка, для которой выполнено изменение
+     * @param oldNumber прежнее значение трек-номера (может быть {@code null})
+     * @param newNumber новое значение трек-номера
+     * @param userId    идентификатор пользователя, выполнившего действие
+     */
+    @Transactional
+    public void recordChange(TrackParcel parcel, String oldNumber, String newNumber, Long userId) {
+        TrackNumberAudit audit = new TrackNumberAudit();
+        audit.setTrackParcel(parcel);
+        audit.setOldNumber(oldNumber);
+        audit.setNewNumber(newNumber);
+        audit.setChangedBy(userId);
+        audit.setChangedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        trackNumberAuditRepository.save(audit);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -167,7 +167,7 @@ public class TrackViewService {
         if (status == null) {
             return true;
         }
-        return status == GlobalStatus.PRE_REGISTERED || !status.isFinal();
+        return status == GlobalStatus.PRE_REGISTERED || status == GlobalStatus.ERROR;
     }
 
     /**

--- a/src/main/resources/db/migration/V22__create_track_number_audit.sql
+++ b/src/main/resources/db/migration/V22__create_track_number_audit.sql
@@ -1,0 +1,11 @@
+CREATE TABLE tb_track_number_audit (
+    id BIGSERIAL PRIMARY KEY,
+    track_parcel_id BIGINT NOT NULL REFERENCES tb_track_parcels (id) ON DELETE CASCADE,
+    old_number VARCHAR(50),
+    new_number VARCHAR(50) NOT NULL,
+    changed_by BIGINT NOT NULL,
+    changed_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_track_number_audit_parcel ON tb_track_number_audit (track_parcel_id);
+CREATE INDEX idx_track_number_audit_changed_at ON tb_track_number_audit (changed_at);

--- a/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceAssignNumberTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceAssignNumberTest.java
@@ -5,8 +5,10 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
+import com.project.tracking_system.repository.DeliveryHistoryRepository;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.track.TrackServiceClassifier;
+import com.project.tracking_system.service.track.TrackNumberAuditService;
 import com.project.tracking_system.entity.PostalServiceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,14 +32,27 @@ class TrackParcelServiceAssignNumberTest {
     @Mock
     private UserSubscriptionRepository userSubscriptionRepository;
 
+    @Mock
+    private DeliveryHistoryRepository deliveryHistoryRepository;
+
     private TrackParcelService service;
 
     @Mock
     private TrackServiceClassifier trackServiceClassifier;
 
+    @Mock
+    private TrackNumberAuditService trackNumberAuditService;
+
     @BeforeEach
     void setUp() {
-        service = new TrackParcelService(userService, trackParcelRepository, userSubscriptionRepository, trackServiceClassifier);
+        service = new TrackParcelService(
+                userService,
+                trackParcelRepository,
+                userSubscriptionRepository,
+                trackServiceClassifier,
+                deliveryHistoryRepository,
+                trackNumberAuditService
+        );
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceSortingTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceSortingTest.java
@@ -6,8 +6,10 @@ import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.UserSubscriptionRepository;
+import com.project.tracking_system.repository.DeliveryHistoryRepository;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.track.TrackServiceClassifier;
+import com.project.tracking_system.service.track.TrackNumberAuditService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +40,12 @@ class TrackParcelServiceSortingTest {
     @Mock
     private TrackServiceClassifier trackServiceClassifier;
 
+    @Mock
+    private DeliveryHistoryRepository deliveryHistoryRepository;
+
+    @Mock
+    private TrackNumberAuditService trackNumberAuditService;
+
     private TrackParcelService service;
 
     /**
@@ -49,7 +57,9 @@ class TrackParcelServiceSortingTest {
                 userService,
                 trackParcelRepository,
                 userSubscriptionRepository,
-                trackServiceClassifier
+                trackServiceClassifier,
+                deliveryHistoryRepository,
+                trackNumberAuditService
         );
     }
 

--- a/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceUpdateNumberTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackParcelServiceUpdateNumberTest.java
@@ -1,0 +1,140 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.entity.DeliveryHistory;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.PostalServiceType;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
+import com.project.tracking_system.repository.DeliveryHistoryRepository;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.UserSubscriptionRepository;
+import com.project.tracking_system.service.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты метода {@link TrackParcelService#updateTrackNumber(Long, Long, String)}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackParcelServiceUpdateNumberTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private UserSubscriptionRepository userSubscriptionRepository;
+    @Mock
+    private TrackServiceClassifier trackServiceClassifier;
+    @Mock
+    private DeliveryHistoryRepository deliveryHistoryRepository;
+    @Mock
+    private TrackNumberAuditService trackNumberAuditService;
+
+    private TrackParcelService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TrackParcelService(
+                userService,
+                trackParcelRepository,
+                userSubscriptionRepository,
+                trackServiceClassifier,
+                deliveryHistoryRepository,
+                trackNumberAuditService
+        );
+    }
+
+    /**
+     * Успешное обновление номера сохраняет изменения и пишет аудит.
+     */
+    @Test
+    void updateTrackNumber_Success_UpdatesEntities() {
+        Long parcelId = 5L;
+        Long userId = 10L;
+        TrackParcel parcel = buildParcel(parcelId, userId, GlobalStatus.PRE_REGISTERED, "OLD123");
+        DeliveryHistory history = new DeliveryHistory();
+        history.setTrackParcel(parcel);
+        history.setPostalService(PostalServiceType.BELPOST);
+
+        when(trackParcelRepository.findByIdWithStoreAndUser(parcelId)).thenReturn(parcel);
+        when(trackServiceClassifier.detect("NEW789")).thenReturn(PostalServiceType.CDEK);
+        when(trackParcelRepository.existsByNumberAndUserId("NEW789", userId)).thenReturn(false);
+        when(deliveryHistoryRepository.findByTrackParcelId(parcelId)).thenReturn(Optional.of(history));
+
+        TrackParcel result = service.updateTrackNumber(parcelId, userId, "new789");
+
+        assertThat(result.getNumber()).isEqualTo("NEW789");
+        assertThat(result.getLastUpdate()).isNotNull();
+        verify(trackParcelRepository).save(parcel);
+        verify(deliveryHistoryRepository).save(history);
+        verify(trackNumberAuditService).recordChange(parcel, "OLD123", "NEW789", userId);
+    }
+
+    /**
+     * Попытка обновить номер в неподдерживаемом статусе выбрасывает исключение.
+     */
+    @Test
+    void updateTrackNumber_StatusNotAllowed_ThrowsException() {
+        Long parcelId = 7L;
+        Long userId = 3L;
+        TrackParcel parcel = buildParcel(parcelId, userId, GlobalStatus.IN_TRANSIT, "OLD");
+        when(trackParcelRepository.findByIdWithStoreAndUser(parcelId)).thenReturn(parcel);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.updateTrackNumber(parcelId, userId, "NEW"));
+        verify(trackParcelRepository, never()).save(any());
+        verify(trackNumberAuditService, never()).recordChange(any(), any(), any(), any());
+    }
+
+    /**
+     * При попытке использовать занятый номер выбрасывается {@link TrackNumberAlreadyExistsException}.
+     */
+    @Test
+    void updateTrackNumber_Duplicate_ThrowsConflict() {
+        Long parcelId = 9L;
+        Long userId = 4L;
+        TrackParcel parcel = buildParcel(parcelId, userId, GlobalStatus.PRE_REGISTERED, "OLD");
+        when(trackParcelRepository.findByIdWithStoreAndUser(parcelId)).thenReturn(parcel);
+        when(trackServiceClassifier.detect("DUP"))
+                .thenReturn(PostalServiceType.BELPOST);
+        when(trackParcelRepository.existsByNumberAndUserId("DUP", userId)).thenReturn(true);
+
+        assertThrows(TrackNumberAlreadyExistsException.class,
+                () -> service.updateTrackNumber(parcelId, userId, "dup"));
+        verify(trackParcelRepository, never()).save(any());
+    }
+
+    /**
+     * Создаёт тестовую посылку с необходимыми полями.
+     */
+    private static TrackParcel buildParcel(Long parcelId,
+                                           Long userId,
+                                           GlobalStatus status,
+                                           String number) {
+        TrackParcel parcel = new TrackParcel();
+        parcel.setId(parcelId);
+        parcel.setNumber(number);
+        parcel.setStatus(status);
+        parcel.setLastUpdate(ZonedDateTime.now());
+        Store store = new Store();
+        store.setId(2L);
+        parcel.setStore(store);
+        User user = new User();
+        user.setId(userId);
+        parcel.setUser(user);
+        return parcel;
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -141,6 +141,22 @@ class TrackViewServiceTest {
     }
 
     /**
+     * Проверяем, что редактирование разрешено только для статусов PRE_REGISTERED и ERROR.
+     */
+    @Test
+    void getTrackDetails_DisablesEditForTransitStatus() {
+        TrackParcel parcel = buildParcel(42L, GlobalStatus.IN_TRANSIT, ZonedDateTime.now(ZoneOffset.UTC));
+        when(trackParcelService.findOwnedById(42L, 8L)).thenReturn(Optional.of(parcel));
+        when(applicationSettingsService.getTrackUpdateIntervalHours()).thenReturn(4);
+        when(userService.getUserZone(8L)).thenReturn(ZoneId.of("UTC"));
+        when(trackStatusEventService.findEvents(42L)).thenReturn(List.of());
+
+        TrackDetailsDto details = service.getTrackDetails(42L, 8L);
+
+        assertThat(details.canEditTrack()).isFalse();
+    }
+
+    /**
      * Создаёт тестовую посылку.
      */
     private static TrackParcel buildParcel(Long id, GlobalStatus status, ZonedDateTime update) {


### PR DESCRIPTION
## Summary
- add PATCH /api/v1/tracks/{id}/number endpoint with ACL and status checks
- persist track number change audits and update delivery analytics metadata
- update modal client to submit PATCH requests and refresh UI without reload
- cover TrackParcelService update workflow with new unit tests

## Testing
- `mvn -Dtest=TrackParcelServiceAssignNumberTest,TrackParcelServiceSortingTest,TrackParcelServiceUpdateNumberTest,TrackViewServiceTest test` *(fails: dependency resolution blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3c1f56a0832d8820715b22270ce1