### PR TITLE
Refactor track details modal layout

### DIFF
--- a/src/main/resources/assets/scss/components/_timeline.scss
+++ b/src/main/resources/assets/scss/components/_timeline.scss
@@ -1,0 +1,45 @@
+.timeline {
+  position: relative;
+  margin-left: 0.5rem;
+  padding-left: 1.5rem;
+  border-left: 2px solid var(--bs-border-color);
+}
+
+.timeline-item {
+  position: relative;
+  padding-bottom: 1.5rem;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -0.9rem;
+  top: 0.35rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: var(--bs-secondary);
+}
+
+.timeline-item-current {
+  .timeline-marker {
+    background-color: var(--bs-primary);
+  }
+
+  .timeline-status {
+    color: var(--bs-primary);
+    font-weight: 600;
+  }
+}
+
+.timeline-status {
+  font-weight: 500;
+}
+
+.timeline-details {
+  margin-top: 0.25rem;
+  line-height: 1.4;
+}

--- a/src/main/resources/assets/scss/main.scss
+++ b/src/main/resources/assets/scss/main.scss
@@ -14,6 +14,7 @@
 @use 'components/forms';
 @use 'components/cards';
 @use 'components/modals';
+@use 'components/timeline';
 @use 'components/alerts';
 @use 'components/loading';
 @use 'components/progress-popup';

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1888,4 +1888,48 @@ body.loading {
   border-color: #ddd transparent transparent transparent;
 }
 
+.timeline {
+  position: relative;
+  margin-left: 0.5rem;
+  padding-left: 1.5rem;
+  border-left: 2px solid var(--bs-border-color);
+}
+
+.timeline-item {
+  position: relative;
+  padding-bottom: 1.5rem;
+}
+
+.timeline-item:last-child {
+  padding-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -0.9rem;
+  top: 0.35rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: var(--bs-secondary);
+}
+
+.timeline-item-current .timeline-marker {
+  background-color: var(--bs-primary);
+}
+
+.timeline-status {
+  font-weight: 500;
+}
+
+.timeline-item-current .timeline-status {
+  color: var(--bs-primary);
+  font-weight: 600;
+}
+
+.timeline-details {
+  margin-top: 0.25rem;
+  line-height: 1.4;
+}
+
 /*# sourceMappingURL=style.css.map */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -869,6 +869,48 @@ button:hover {
     max-width: 240px;
   }
 }
+.timeline {
+  position: relative;
+  margin-left: 0.5rem;
+  padding-left: 1.5rem;
+  border-left: 2px solid var(--bs-border-color);
+}
+
+.timeline-item {
+  position: relative;
+  padding-bottom: 1.5rem;
+}
+.timeline-item:last-child {
+  padding-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -0.9rem;
+  top: 0.35rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background-color: var(--bs-secondary);
+}
+
+.timeline-item-current .timeline-marker {
+  background-color: var(--bs-primary);
+}
+.timeline-item-current .timeline-status {
+  color: var(--bs-primary);
+  font-weight: 600;
+}
+
+.timeline-status {
+  font-weight: 500;
+}
+
+.timeline-details {
+  margin-top: 0.25rem;
+  line-height: 1.4;
+}
+
 .text-danger {
   margin-top: 0.5rem;
   display: block;
@@ -1887,49 +1929,3 @@ body.loading {
   border-style: solid;
   border-color: #ddd transparent transparent transparent;
 }
-
-.timeline {
-  position: relative;
-  margin-left: 0.5rem;
-  padding-left: 1.5rem;
-  border-left: 2px solid var(--bs-border-color);
-}
-
-.timeline-item {
-  position: relative;
-  padding-bottom: 1.5rem;
-}
-
-.timeline-item:last-child {
-  padding-bottom: 0;
-}
-
-.timeline-marker {
-  position: absolute;
-  left: -0.9rem;
-  top: 0.35rem;
-  width: 0.75rem;
-  height: 0.75rem;
-  border-radius: 50%;
-  background-color: var(--bs-secondary);
-}
-
-.timeline-item-current .timeline-marker {
-  background-color: var(--bs-primary);
-}
-
-.timeline-status {
-  font-weight: 500;
-}
-
-.timeline-item-current .timeline-status {
-  color: var(--bs-primary);
-  font-weight: 600;
-}
-
-.timeline-details {
-  margin-top: 0.25rem;
-  line-height: 1.4;
-}
-
-/*# sourceMappingURL=style.css.map */

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -38,31 +38,42 @@
             button.disabled = disabled;
             button.setAttribute('aria-disabled', String(disabled));
             countdown.textContent = text;
+            countdown.classList.toggle('visually-hidden', text.length === 0);
+            countdown.setAttribute('aria-hidden', text.length === 0 ? 'true' : 'false');
         };
 
+        const showActiveState = () => applyState('', false);
+
         if (!nextRefreshAt || refreshAllowed) {
-            applyState(refreshAllowed ? 'Можно обновить' : 'Обновление недоступно', !refreshAllowed);
+            if (refreshAllowed) {
+                showActiveState();
+            } else {
+                applyState('Обновление недоступно', true);
+            }
             return;
         }
 
         const target = Date.parse(nextRefreshAt);
         if (Number.isNaN(target)) {
-            applyState('Можно обновить', false);
+            showActiveState();
             return;
         }
 
         const tick = () => {
             const diff = target - Date.now();
             if (diff <= 0) {
-                applyState('Можно обновить', false);
+                showActiveState();
                 clearRefreshTimer();
                 return;
             }
             const totalSeconds = Math.ceil(diff / 1000);
-            const minutes = Math.floor(totalSeconds / 60);
+            const hours = Math.floor(totalSeconds / 3600);
+            const minutes = Math.floor((totalSeconds % 3600) / 60);
             const seconds = totalSeconds % 60;
-            const formatted = `${minutes}:${String(seconds).padStart(2, '0')}`;
-            applyState(`Доступно через ${formatted}`, true);
+            const formatted = [hours, minutes, seconds]
+                .map((part) => String(part).padStart(2, '0'))
+                .join(':');
+            applyState(`Можно выполнить через ${formatted}`, true);
         };
 
         tick();
@@ -112,17 +123,67 @@
     }
 
     /**
+     * Создаёт карточку модального окна с заголовком и телом.
+     * Метод устраняет дублирование разметки и упрощает расширение модалки (OCP).
+     * @param {string} title заголовок карточки
+     * @returns {{card: HTMLElement, body: HTMLElement}} карточка и контейнер содержимого
+     */
+    function createCard(title) {
+        const card = document.createElement('section');
+        card.className = 'card shadow-sm border-0 rounded-4 mb-3';
+        const body = document.createElement('div');
+        body.className = 'card-body';
+        if (title) {
+            const heading = document.createElement('h6');
+            heading.className = 'text-uppercase text-muted small mb-3';
+            heading.textContent = title;
+            body.appendChild(heading);
+        }
+        card.appendChild(body);
+        return { card, body };
+    }
+
+    /**
      * Отрисовывает содержимое модального окна с деталями трека.
-     * Метод отвечает только за манипуляцию DOM и не выполняет сетевые запросы (SRP).
+     * Метод собирает карточки интерфейса и обновляет заголовок без сетевых обращений (SRP).
      * @param {Object} data DTO с сервера
      */
     function renderTrackModal(data) {
         clearRefreshTimer();
 
+        const modal = document.getElementById('infoModal');
         const container = document.getElementById('trackModalContent')
-            || document.querySelector('#infoModal .modal-body');
+            || modal?.querySelector('.modal-body');
         if (!container) {
             return;
+        }
+
+        const headerNumber = modal?.querySelector('#trackModalNumber');
+        if (headerNumber) {
+            headerNumber.textContent = data?.number || '—';
+        }
+
+        const headerService = modal?.querySelector('#trackModalService');
+        if (headerService) {
+            headerService.textContent = data?.deliveryService || 'Служба доставки не определена';
+        }
+
+        const editButton = modal?.querySelector('#trackModalEditButton');
+        if (editButton) {
+            const canEdit = Boolean(data?.canEditTrack);
+            editButton.classList.toggle('d-none', !canEdit);
+            editButton.setAttribute('aria-hidden', canEdit ? 'false' : 'true');
+            if (canEdit && data?.id !== undefined) {
+                editButton.dataset.trackId = String(data.id);
+                editButton.dataset.currentNumber = data?.number || '';
+                editButton.onclick = () => {
+                    promptTrackNumber(data.id, data.number || '');
+                };
+            } else {
+                editButton.removeAttribute('data-track-id');
+                editButton.removeAttribute('data-current-number');
+                editButton.onclick = null;
+            }
         }
 
         const timeZone = data?.timeZone;
@@ -131,54 +192,44 @@
 
         container.replaceChildren();
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'w-100';
+        const layout = document.createElement('div');
+        layout.className = 'd-flex flex-column gap-3';
         if (data?.id !== undefined) {
-            wrapper.dataset.trackId = String(data.id);
+            layout.dataset.trackId = String(data.id);
         }
 
-        const headerBlock = document.createElement('div');
-        headerBlock.className = 'd-flex align-items-start gap-3 mb-3';
+        const parcelCard = createCard('Данные о посылке');
+        const detailsList = document.createElement('dl');
+        detailsList.className = 'row mb-0 g-2 small';
 
-        const infoBlock = document.createElement('div');
+        const idLabel = document.createElement('dt');
+        idLabel.className = 'col-sm-4 text-muted';
+        idLabel.textContent = 'ID посылки';
+        const idValue = document.createElement('dd');
+        idValue.className = 'col-sm-8';
+        idValue.textContent = data?.id !== undefined ? String(data.id) : '—';
 
-        const trackLabel = document.createElement('div');
-        trackLabel.className = 'text-muted small';
-        trackLabel.textContent = 'Трек-номер';
-        infoBlock.appendChild(trackLabel);
+        const numberLabel = document.createElement('dt');
+        numberLabel.className = 'col-sm-4 text-muted';
+        numberLabel.textContent = 'Трек-номер';
+        const numberValue = document.createElement('dd');
+        numberValue.className = 'col-sm-8';
+        numberValue.textContent = data?.number || '—';
 
-        const trackValue = document.createElement('div');
-        trackValue.className = 'fs-5 fw-semibold';
-        trackValue.textContent = data?.number || '—';
-        infoBlock.appendChild(trackValue);
+        const serviceLabel = document.createElement('dt');
+        serviceLabel.className = 'col-sm-4 text-muted';
+        serviceLabel.textContent = 'Служба доставки';
+        const serviceValue = document.createElement('dd');
+        serviceValue.className = 'col-sm-8';
+        serviceValue.textContent = data?.deliveryService || 'Не указана';
 
-        const deliveryValue = document.createElement('div');
-        deliveryValue.className = 'text-muted';
-        deliveryValue.textContent = data?.deliveryService || 'Служба доставки не определена';
-        infoBlock.appendChild(deliveryValue);
+        detailsList.append(idLabel, idValue, numberLabel, numberValue, serviceLabel, serviceValue);
+        parcelCard.body.appendChild(detailsList);
+        layout.appendChild(parcelCard.card);
 
-        headerBlock.appendChild(infoBlock);
-
-        let editButton;
-        if (data?.canEditTrack) {
-            editButton = document.createElement('button');
-            editButton.type = 'button';
-            editButton.className = 'btn btn-outline-primary btn-sm ms-auto';
-            editButton.id = 'trackModalEditBtn';
-            editButton.textContent = 'Редактировать трек';
-            if (data?.id !== undefined) {
-                editButton.dataset.trackId = String(data.id);
-            }
-            if (data?.number) {
-                editButton.dataset.currentNumber = data.number;
-            }
-            headerBlock.appendChild(editButton);
-        }
-
-        wrapper.appendChild(headerBlock);
-
+        const refreshCard = createCard('Обновление');
         const refreshSection = document.createElement('div');
-        refreshSection.className = 'd-flex flex-wrap align-items-center gap-3 mb-3';
+        refreshSection.className = 'd-flex flex-wrap align-items-center gap-3';
 
         const refreshButton = document.createElement('button');
         refreshButton.type = 'button';
@@ -187,117 +238,94 @@
         refreshButton.dataset.loadingText = 'Обновляем…';
         refreshButton.setAttribute('aria-label', 'Обновить данные трека');
         refreshButton.setAttribute('aria-controls', 'trackModalContent');
+        refreshButton.setAttribute('data-bs-toggle', 'tooltip');
+        refreshButton.setAttribute('data-bs-placement', 'top');
+        refreshButton.setAttribute('title', 'Нажмите, чтобы обновить трек');
         if (data?.id !== undefined) {
             refreshButton.dataset.trackId = String(data.id);
         }
 
         const countdown = document.createElement('span');
         countdown.id = 'trackRefreshCountdown';
-        countdown.className = 'text-muted small';
+        countdown.className = 'text-muted small visually-hidden';
         countdown.setAttribute('role', 'status');
         countdown.setAttribute('aria-live', 'polite');
+        countdown.setAttribute('aria-hidden', 'true');
 
-        refreshSection.appendChild(refreshButton);
-        refreshSection.appendChild(countdown);
-        wrapper.appendChild(refreshSection);
+        refreshSection.append(refreshButton, countdown);
+        refreshCard.body.appendChild(refreshSection);
+        layout.appendChild(refreshCard.card);
 
+        const statusCard = createCard('Текущий статус');
         if (data?.currentStatus) {
-            const currentStatusBlock = document.createElement('div');
-            currentStatusBlock.className = 'mb-3';
+            const statusValue = document.createElement('div');
+            statusValue.className = 'fs-6 fw-semibold';
+            statusValue.textContent = data.currentStatus.status || '—';
 
-            const currentLabel = document.createElement('div');
-            currentLabel.className = 'text-muted small';
-            currentLabel.textContent = 'Текущий статус';
-            currentStatusBlock.appendChild(currentLabel);
+            const statusTime = document.createElement('div');
+            statusTime.className = 'text-muted small';
+            statusTime.textContent = format(data.currentStatus.timestamp);
 
-            const currentValue = document.createElement('div');
-            currentValue.className = 'fw-semibold';
-            currentValue.textContent = data.currentStatus.status || '—';
-            currentStatusBlock.appendChild(currentValue);
-
-            const currentTime = document.createElement('div');
-            currentTime.className = 'text-muted';
-            currentTime.textContent = format(data.currentStatus.timestamp);
-            currentStatusBlock.appendChild(currentTime);
-
-            wrapper.appendChild(currentStatusBlock);
-        }
-
-        const refreshBlock = document.createElement('div');
-        refreshBlock.classList.add('alert', 'mb-3');
-        refreshBlock.setAttribute('role', 'alert');
-
-        if (data?.refreshAllowed) {
-            refreshBlock.classList.add('alert-success');
-            refreshBlock.textContent = 'Обновление доступно — выполните его из модального окна.';
-        } else if (data?.nextRefreshAt) {
-            refreshBlock.classList.add('alert-warning');
-            refreshBlock.textContent = `Повторное обновление будет доступно после ${format(data.nextRefreshAt)}.`;
+            statusCard.body.append(statusValue, statusTime);
         } else {
-            refreshBlock.classList.add('alert-secondary');
-            refreshBlock.textContent = 'Обновление недоступно для текущего статуса.';
+            const noStatus = document.createElement('div');
+            noStatus.className = 'text-muted';
+            noStatus.textContent = 'Статус ещё не определён';
+            statusCard.body.appendChild(noStatus);
         }
+        layout.appendChild(statusCard.card);
 
-        wrapper.appendChild(refreshBlock);
+        const historyCard = createCard('История трека');
+        if (history.length === 0) {
+            const emptyHistory = document.createElement('p');
+            emptyHistory.className = 'text-muted mb-0';
+            emptyHistory.textContent = 'История пока пуста';
+            historyCard.body.appendChild(emptyHistory);
+        } else {
+            const timeline = document.createElement('div');
+            timeline.className = 'timeline';
+
+            history.forEach((event, index) => {
+                const item = document.createElement('div');
+                item.className = 'timeline-item';
+                if (index === 0) {
+                    item.classList.add('timeline-item-current');
+                }
+
+                const marker = document.createElement('span');
+                marker.className = 'timeline-marker';
+                item.appendChild(marker);
+
+                const dateEl = document.createElement('div');
+                dateEl.className = 'timeline-date text-muted small';
+                dateEl.textContent = format(event.timestamp);
+                item.appendChild(dateEl);
+
+                const statusEl = document.createElement('div');
+                statusEl.className = 'timeline-status';
+                statusEl.textContent = event.status || '—';
+                item.appendChild(statusEl);
+
+                if (event.details) {
+                    const detailsEl = document.createElement('div');
+                    detailsEl.className = 'timeline-details text-muted small';
+                    detailsEl.textContent = event.details;
+                    item.appendChild(detailsEl);
+                }
+
+                timeline.appendChild(item);
+            });
+
+            historyCard.body.appendChild(timeline);
+        }
+        layout.appendChild(historyCard.card);
+
+        container.appendChild(layout);
 
         startRefreshTimer(refreshButton, countdown, data?.nextRefreshAt || null, Boolean(data?.refreshAllowed));
 
-        const tableWrapper = document.createElement('div');
-        tableWrapper.className = 'table-responsive';
-
-        const table = document.createElement('table');
-        table.className = 'table table-striped';
-
-        const thead = document.createElement('thead');
-        const headRow = document.createElement('tr');
-
-        const dateHeader = document.createElement('th');
-        dateHeader.textContent = 'Дата';
-        headRow.appendChild(dateHeader);
-
-        const statusHeader = document.createElement('th');
-        statusHeader.textContent = 'Статус';
-        headRow.appendChild(statusHeader);
-
-        thead.appendChild(headRow);
-        table.appendChild(thead);
-
-        const tbody = document.createElement('tbody');
-
-        if (history.length === 0) {
-            const emptyRow = document.createElement('tr');
-            const emptyCell = document.createElement('td');
-            emptyCell.colSpan = 2;
-            emptyCell.className = 'text-center text-muted';
-            emptyCell.textContent = 'История отсутствует';
-            emptyRow.appendChild(emptyCell);
-            tbody.appendChild(emptyRow);
-        } else {
-            history.forEach(event => {
-                const row = document.createElement('tr');
-
-                const dateCell = document.createElement('td');
-                dateCell.textContent = format(event.timestamp);
-                row.appendChild(dateCell);
-
-                const statusCell = document.createElement('td');
-                statusCell.textContent = event.status || '—';
-                row.appendChild(statusCell);
-
-                tbody.appendChild(row);
-            });
-        }
-
-        table.appendChild(tbody);
-        tableWrapper.appendChild(table);
-        wrapper.appendChild(tableWrapper);
-
-        container.appendChild(wrapper);
-
-        if (editButton && data?.id) {
-            editButton.addEventListener('click', () => {
-                promptTrackNumber(data.id, editButton.dataset.currentNumber || data.number || '');
-            });
+        if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip && typeof bootstrap.Tooltip.getOrCreateInstance === 'function') {
+            bootstrap.Tooltip.getOrCreateInstance(refreshButton);
         }
     }
 

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -270,12 +270,23 @@
 
 <div layout:fragment="afterFooter">
     <!-- Модальное окно -->
-    <div class="modal fade" id="infoModal" tabindex="-1" aria-labelledby="infoModalLabel" aria-hidden="true">
+    <div class="modal fade" id="infoModal" tabindex="-1" aria-labelledby="trackModalNumber" aria-hidden="true">
         <div class="modal-dialog modal-lg modal-dialog-centered">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="infoModalLabel">Детали посылки</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+                <div class="modal-header flex-wrap align-items-start">
+                    <div class="me-auto">
+                        <div id="trackModalNumber" class="fs-3 fw-semibold mb-1">—</div>
+                        <div id="trackModalService" class="text-muted small">Служба доставки не определена</div>
+                    </div>
+                    <div class="d-flex align-items-start gap-2">
+                        <button type="button"
+                                id="trackModalEditButton"
+                                class="btn btn-outline-primary btn-sm d-none"
+                                aria-label="Редактировать номер">
+                            Редактировать номер
+                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+                    </div>
                 </div>
                 <div class="modal-body">
                     <div id="trackModalContent" class="d-flex justify-content-center align-items-center text-muted">


### PR DESCRIPTION
## Summary
- redesign the track details modal header to emphasize the track number and optional edit action
- rebuild the modal content into card-based sections with a tooltip-enabled refresh control and timeline history
- add timeline styling and HH:mm:ss countdown formatting for the refresh cooldown

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc5ebc0674832d90ad7c1f03eee2a0