### PR TITLE
Refine final status update grace period

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackUpdateEligibilityService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackUpdateEligibilityService.java
@@ -41,7 +41,13 @@ public class TrackUpdateEligibilityService {
             return true;
         }
         if (parcel.getStatus().isFinal()) {
-            return false;
+            ZonedDateTime statusTimestamp = parcel.getTimestamp() != null
+                    ? parcel.getTimestamp()
+                    : parcel.getLastUpdate();
+            ZonedDateTime finalThreshold = ZonedDateTime.now(ZoneOffset.UTC).minusHours(24);
+            if (statusTimestamp != null && statusTimestamp.isBefore(finalThreshold)) {
+                return false;
+            }
         }
         int interval = applicationSettingsService.getTrackUpdateIntervalHours();
         ZonedDateTime threshold = ZonedDateTime.now(ZoneOffset.UTC).minusHours(interval);


### PR DESCRIPTION
## Summary
- remove the dedicated final-status marker from parcels and rely on the existing status timestamp
- update the eligibility check to enforce the 24-hour grace period using the status timestamp with a last-update fallback
- adjust the unit coverage to reflect the timestamp-based handling of final-status parcels

## Testing
- mvn test -DskipITs *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:4.10.0 is forbidden on jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68dd65a8d6cc832dada108f35f6ecfdc