### PR TITLE
fix: align track edit icon inline

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -219,7 +219,10 @@
         const trackInfo = document.createElement('div');
         trackInfo.className = 'd-flex flex-column';
 
-        const trackNumber = document.createElement('div');
+        const trackNumberRow = document.createElement('div');
+        trackNumberRow.className = 'd-flex align-items-center gap-2';
+
+        const trackNumber = document.createElement('span');
         trackNumber.className = 'fs-3 fw-semibold';
         const trackText = data?.number ? data.number : 'Трек не указан';
         trackNumber.textContent = trackText;
@@ -227,23 +230,33 @@
             trackNumber.classList.add('text-muted');
         }
 
+        trackNumberRow.appendChild(trackNumber);
+
         const serviceInfo = document.createElement('div');
         serviceInfo.className = 'text-muted small';
         serviceInfo.textContent = data?.deliveryService || 'Служба доставки не определена';
 
-        trackInfo.append(trackNumber, serviceInfo);
+        trackInfo.append(trackNumberRow, serviceInfo);
         parcelHeader.appendChild(trackInfo);
 
         if (data?.canEditTrack && data?.id !== undefined) {
             const editButton = document.createElement('button');
             editButton.type = 'button';
-            editButton.className = 'btn btn-outline-primary btn-sm align-self-start';
-            editButton.textContent = 'Редактировать номер';
+            editButton.className = 'btn btn-outline-primary btn-sm d-inline-flex align-items-center justify-content-center';
             editButton.setAttribute('aria-label', 'Редактировать трек-номер');
+            editButton.setAttribute('data-bs-toggle', 'tooltip');
+            editButton.setAttribute('data-bs-placement', 'top');
+            editButton.setAttribute('title', 'Редактировать трек-номер');
             editButton.addEventListener('click', () => {
                 promptTrackNumber(data.id, data.number || '');
             });
-            parcelHeader.appendChild(editButton);
+
+            const editIcon = document.createElement('i');
+            editIcon.className = 'bi bi-pencil';
+            editIcon.setAttribute('aria-hidden', 'true');
+            editButton.appendChild(editIcon);
+
+            trackNumberRow.appendChild(editButton);
         }
 
         parcelCard.body.appendChild(parcelHeader);
@@ -345,6 +358,15 @@
         layout.appendChild(historyCard.card);
 
         container.appendChild(layout);
+
+        // Активируем тултипы в модальном окне после обновления содержимого.
+        if (typeof window.enableTooltips === 'function') {
+            window.enableTooltips(container);
+        } else if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip) {
+            container.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((element) => {
+                bootstrap.Tooltip.getOrCreateInstance(element);
+            });
+        }
 
         const nextRefreshAt = data?.nextRefreshAt || null;
         const isFinalStatus = data?.refreshAllowed === false && !data?.nextRefreshAt;


### PR DESCRIPTION
## Summary
- place the track-number edit pencil inline with the displayed number using a flex row
- keep the tooltip-enabled button aligned with the number while preserving existing styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6dac088c832db674a4398af48d5c