### PR TITLE
Adjust track modal header layout spacing

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -229,8 +229,16 @@
         }
 
         const trackTitleRow = document.createElement('div');
-        trackTitleRow.className = 'd-flex align-items-center gap-2';
-        trackTitleRow.appendChild(trackNumber);
+        trackTitleRow.className = 'd-flex align-items-center gap-2 justify-content-between w-100';
+
+        const trackTitleColumn = document.createElement('div');
+        trackTitleColumn.className = 'd-flex align-items-center flex-grow-1';
+        trackTitleColumn.appendChild(trackNumber);
+
+        const trackActions = document.createElement('div');
+        trackActions.className = 'd-flex justify-content-end flex-grow-1 gap-2';
+
+        trackTitleRow.append(trackTitleColumn, trackActions);
 
         const serviceInfo = document.createElement('div');
         serviceInfo.className = 'text-muted small';
@@ -279,7 +287,7 @@
                 promptTrackNumber(data.id, data.number || '');
             });
             activateTooltip(editButton);
-            trackTitleRow.appendChild(editButton);
+            trackActions.appendChild(editButton);
         }
 
         parcelCard.body.appendChild(parcelHeader);


### PR DESCRIPTION
## Summary
- wrap the track number and actions in dedicated flex containers for better spacing
- keep the edit button inside the actions container so it aligns to the right edge cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd82438cbc832d94dc8873aa57837a