### PR TITLE
Adjust track info layout width

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -218,7 +218,7 @@
         parcelHeader.className = 'd-flex flex-wrap justify-content-between align-items-start gap-3';
 
         const trackInfo = document.createElement('div');
-        trackInfo.className = 'd-flex flex-column';
+        trackInfo.className = 'd-flex flex-column w-100 flex-grow-1';
 
         const trackNumber = document.createElement('div');
         trackNumber.className = 'fs-3 fw-semibold';


### PR DESCRIPTION
## Summary
- expand the track info container to fill the card width
- allow the edit button block to align to the right while staying within padding

## Testing
- not run (UI layout change)


------
https://chatgpt.com/codex/tasks/task_e_68dd87de3d60832d96bf4d745c6e22ce