### PR TITLE
Добавить управление возвратами и обменами в карточке трека

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackController.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.controller;
 
+import com.project.tracking_system.dto.ReturnRegistrationRequest;
 import com.project.tracking_system.dto.TrackDetailsDto;
 import com.project.tracking_system.dto.TrackNumberUpdateRequest;
 import com.project.tracking_system.dto.TrackNumberUpdateResponse;
@@ -9,6 +10,7 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.service.track.TrackViewService;
 import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.order.OrderReturnRequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,6 +39,7 @@ public class TrackController {
 
     private final TrackViewService trackViewService;
     private final TrackParcelService trackParcelService;
+    private final OrderReturnRequestService orderReturnRequestService;
 
     /**
      * Возвращает информацию о треке по его идентификатору.
@@ -112,6 +115,72 @@ public class TrackController {
             throw new AccessDeniedException("Посылка не принадлежит пользователю");
         }
         throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Посылка не найдена");
+    }
+
+    /**
+     * Регистрирует заявку на возврат/обмен для посылки.
+     */
+    @PostMapping("/{id}/returns")
+    public TrackDetailsDto registerReturn(@PathVariable Long id,
+                                          @RequestBody @Valid ReturnRegistrationRequest request,
+                                          @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        try {
+            orderReturnRequestService.registerReturn(id, user, request.idempotencyKey());
+            return trackViewService.getTrackDetails(id, user.getId());
+        } catch (AccessDeniedException ex) {
+            throw ex;
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Одобряет запуск обмена по зарегистрированной заявке.
+     */
+    @PostMapping("/{id}/returns/{requestId}/exchange")
+    public TrackDetailsDto approveExchange(@PathVariable Long id,
+                                           @PathVariable Long requestId,
+                                           @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        try {
+            orderReturnRequestService.approveExchange(requestId, id, user);
+            return trackViewService.getTrackDetails(id, user.getId());
+        } catch (AccessDeniedException ex) {
+            throw ex;
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Закрывает заявку без запуска обмена.
+     */
+    @PostMapping("/{id}/returns/{requestId}/close")
+    public TrackDetailsDto closeWithoutExchange(@PathVariable Long id,
+                                                @PathVariable Long requestId,
+                                                @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        try {
+            orderReturnRequestService.closeWithoutExchange(requestId, id, user);
+            return trackViewService.getTrackDetails(id, user.getId());
+        } catch (AccessDeniedException ex) {
+            throw ex;
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        }
     }
 }
 

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -1,0 +1,26 @@
+package com.project.tracking_system.dto;
+
+/**
+ * DTO заявки на возврат/обмен для модального окна трека.
+ *
+ * @param id                     идентификатор заявки
+ * @param status                 человеко-читаемый статус
+ * @param createdAt              дата регистрации
+ * @param decisionAt             дата принятия решения об обмене
+ * @param closedAt               дата закрытия без обмена
+ * @param requiresAction         признак, что заявка ожидает действий
+ * @param exchangeApproved       признак, что обмен уже запущен
+ * @param canStartExchange       доступность кнопки запуска обмена
+ * @param canCloseWithoutExchange доступность закрытия без обмена
+ */
+public record OrderReturnRequestDto(Long id,
+                                    String status,
+                                    String createdAt,
+                                    String decisionAt,
+                                    String closedAt,
+                                    boolean requiresAction,
+                                    boolean exchangeApproved,
+                                    boolean canStartExchange,
+                                    boolean canCloseWithoutExchange) {
+}
+

--- a/src/main/java/com/project/tracking_system/dto/ReturnRegistrationRequest.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRegistrationRequest.java
@@ -1,0 +1,12 @@
+package com.project.tracking_system.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Запрос на регистрацию заявки возврата/обмена.
+ *
+ * @param idempotencyKey идемпотентный ключ для защиты от повторов
+ */
+public record ReturnRegistrationRequest(@NotBlank(message = "Идемпотентный ключ обязателен") String idempotencyKey) {
+}
+

--- a/src/main/java/com/project/tracking_system/dto/TrackDetailsDto.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackDetailsDto.java
@@ -19,6 +19,9 @@ import java.util.List;
  * @param episodeNumber  номер эпизода заказа, к которому относится посылка
  * @param exchange       признак оформления посылки как обмена
  * @param chain          цепочка связанных посылок в рамках эпизода
+ * @param returnRequest  текущая заявка на возврат/обмен
+ * @param canRegisterReturn признак доступности регистрации новой заявки
+ * @param requiresAction признак наличия незавершённых действий по посылке
  */
 public record TrackDetailsDto(Long id,
                               String number,
@@ -33,5 +36,8 @@ public record TrackDetailsDto(Long id,
                               String timeZone,
                               Long episodeNumber,
                               boolean exchange,
-                              List<TrackChainItemDto> chain) {
+                              List<TrackChainItemDto> chain,
+                              OrderReturnRequestDto returnRequest,
+                              boolean canRegisterReturn,
+                              boolean requiresAction) {
 }

--- a/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TrackParcelDTO.java
@@ -30,6 +30,10 @@ public class TrackParcelDTO {
     private String shortCustomerName;
     private String customerPhone;
     private NameSource nameSource;
+    /**
+     * Признак того, что по посылке есть незавершённые задачи (возвраты/обмены).
+     */
+    private boolean requiresAction;
 
     /**
      * Конструктор DTO на основе сущности TrackParcel.
@@ -58,5 +62,6 @@ public class TrackParcelDTO {
             this.customerPhone = customer.getPhone();
             this.nameSource = customer.getNameSource();
         }
+        this.requiresAction = false;
     }
 }

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
@@ -1,0 +1,200 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.*;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * Заявка на возврат или обмен по конкретной посылке.
+ * <p>
+ * Сущность фиксирует идемпотентный ключ, автора и время создания,
+ * а также результат рассмотрения: запуск обмена или закрытие без него.
+ * </p>
+ */
+@Entity
+@Table(name = "tb_order_return_requests",
+        uniqueConstraints = @UniqueConstraint(name = "ux_order_return_requests_key", columnNames = "idempotency_key"))
+public class OrderReturnRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Эпизод заказа, к которому относится заявка.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "episode_id", nullable = false)
+    private OrderEpisode episode;
+
+    /**
+     * Посылка, ставшая основанием для заявки.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "parcel_id", nullable = false)
+    private TrackParcel parcel;
+
+    /**
+     * Пользователь, зарегистрировавший заявку.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false, updatable = false)
+    private User createdBy;
+
+    /**
+     * Время регистрации заявки в UTC.
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt = ZonedDateTime.now(ZoneOffset.UTC);
+
+    /**
+     * Текущее состояние заявки.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OrderReturnRequestStatus status = OrderReturnRequestStatus.REGISTERED;
+
+    /**
+     * Пользователь, одобривший запуск обмена.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "decision_by")
+    private User decisionBy;
+
+    /**
+     * Время принятия решения об обмене.
+     */
+    @Column(name = "decision_at")
+    private ZonedDateTime decisionAt;
+
+    /**
+     * Пользователь, закрывший заявку без обмена.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "closed_by")
+    private User closedBy;
+
+    /**
+     * Время закрытия заявки.
+     */
+    @Column(name = "closed_at")
+    private ZonedDateTime closedAt;
+
+    /**
+     * Идемпотентный ключ, предотвращающий повторное создание одинаковых заявок.
+     */
+    @Column(name = "idempotency_key", nullable = false, updatable = false)
+    private String idempotencyKey;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+
+    public Long getId() {
+        return id;
+    }
+
+    public OrderEpisode getEpisode() {
+        return episode;
+    }
+
+    public void setEpisode(OrderEpisode episode) {
+        this.episode = episode;
+    }
+
+    public TrackParcel getParcel() {
+        return parcel;
+    }
+
+    public void setParcel(TrackParcel parcel) {
+        this.parcel = parcel;
+    }
+
+    public User getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(User createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public ZonedDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OrderReturnRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrderReturnRequestStatus status) {
+        this.status = status;
+    }
+
+    public User getDecisionBy() {
+        return decisionBy;
+    }
+
+    public void setDecisionBy(User decisionBy) {
+        this.decisionBy = decisionBy;
+    }
+
+    public ZonedDateTime getDecisionAt() {
+        return decisionAt;
+    }
+
+    public void setDecisionAt(ZonedDateTime decisionAt) {
+        this.decisionAt = decisionAt;
+    }
+
+    public User getClosedBy() {
+        return closedBy;
+    }
+
+    public void setClosedBy(User closedBy) {
+        this.closedBy = closedBy;
+    }
+
+    public ZonedDateTime getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(ZonedDateTime closedAt) {
+        this.closedAt = closedAt;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    /**
+     * Проверяет, ожидает ли заявка решения.
+     */
+    public boolean requiresAction() {
+        return status == OrderReturnRequestStatus.REGISTERED;
+    }
+
+    /**
+     * Проверяет, одобрен ли обмен.
+     */
+    public boolean isExchangeApproved() {
+        return status == OrderReturnRequestStatus.EXCHANGE_APPROVED;
+    }
+}
+

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequestStatus.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequestStatus.java
@@ -1,0 +1,36 @@
+package com.project.tracking_system.entity;
+
+/**
+ * Статусы заявки на возврат/обмен в рамках эпизода заказа.
+ */
+public enum OrderReturnRequestStatus {
+
+    /**
+     * Заявка зарегистрирована и ожидает решения по дальнейшим действиям.
+     */
+    REGISTERED("Зарегистрирована"),
+
+    /**
+     * Принято решение отправить обменную посылку.
+     */
+    EXCHANGE_APPROVED("Обмен запущен"),
+
+    /**
+     * Заявка закрыта без запуска обмена.
+     */
+    CLOSED_NO_EXCHANGE("Закрыта без обмена");
+
+    private final String displayName;
+
+    OrderReturnRequestStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Возвращает локализованное название статуса для отображения на UI.
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+}
+

--- a/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
@@ -1,0 +1,43 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Репозиторий заявок на возврат/обмен.
+ */
+public interface OrderReturnRequestRepository extends JpaRepository<OrderReturnRequest, Long> {
+
+    /**
+     * Возвращает заявку по идемпотентному ключу.
+     */
+    Optional<OrderReturnRequest> findByIdempotencyKey(String idempotencyKey);
+
+    /**
+     * Ищет активную заявку по посылке и статусам.
+     */
+    Optional<OrderReturnRequest> findFirstByParcel_IdAndStatusIn(Long parcelId, Collection<OrderReturnRequestStatus> statuses);
+
+    /**
+     * Проверяет, существует ли в эпизоде заявка с указанным статусом.
+     */
+    boolean existsByEpisode_IdAndStatus(Long episodeId, OrderReturnRequestStatus status);
+
+    /**
+     * Возвращает идентификаторы посылок пользователя, по которым есть заявки в статусе ожидания решения.
+     */
+    @Query("""
+            select r.parcel.id from OrderReturnRequest r
+            where r.parcel.user.id = :userId and r.status = :status
+            """)
+    List<Long> findParcelIdsByUserAndStatus(@Param("userId") Long userId,
+                                            @Param("status") OrderReturnRequestStatus status);
+}
+

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -1,0 +1,219 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.OrderEpisode;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.OrderReturnRequestRepository;
+import com.project.tracking_system.service.track.TrackParcelService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Сервис управления заявками на возврат и обмен.
+ * <p>
+ * Инкапсулирует проверки идемпотентности, прав доступа и бизнес-инварианты:
+ * запуск обмена возможен только один раз на эпизод и только из статуса «вручено».
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderReturnRequestService {
+
+    private static final Set<OrderReturnRequestStatus> ACTIVE_STATUSES =
+            Set.of(OrderReturnRequestStatus.REGISTERED, OrderReturnRequestStatus.EXCHANGE_APPROVED);
+
+    private final OrderReturnRequestRepository returnRequestRepository;
+    private final TrackParcelService trackParcelService;
+    private final OrderEpisodeLifecycleService episodeLifecycleService;
+
+    /**
+     * Регистрирует возврат для посылки, обеспечивая идемпотентность.
+     *
+     * @param parcelId        идентификатор посылки
+     * @param user            автор заявки
+     * @param idempotencyKey  внешний ключ, предотвращающий повторные регистрации
+     * @return созданная или ранее зарегистрированная заявка
+     */
+    @Transactional
+    public OrderReturnRequest registerReturn(Long parcelId, User user, String idempotencyKey) {
+        if (parcelId == null) {
+            throw new IllegalArgumentException("Не указан идентификатор посылки");
+        }
+        if (user == null || user.getId() == null) {
+            throw new IllegalArgumentException("Не указан пользователь");
+        }
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new IllegalArgumentException("Не указан идемпотентный ключ заявки");
+        }
+
+        Optional<OrderReturnRequest> existingByKey = returnRequestRepository.findByIdempotencyKey(idempotencyKey);
+        if (existingByKey.isPresent()) {
+            ensureOwnership(existingByKey.get(), user.getId());
+            return existingByKey.get();
+        }
+
+        TrackParcel parcel = trackParcelService.findOwnedById(parcelId, user.getId())
+                .orElseThrow(() -> new AccessDeniedException("Посылка не принадлежит пользователю"));
+
+        if (parcel.getStatus() != GlobalStatus.DELIVERED) {
+            throw new IllegalStateException("Заявка на возврат доступна только для статуса \"Вручена\"");
+        }
+
+        Optional<OrderReturnRequest> active = returnRequestRepository
+                .findFirstByParcel_IdAndStatusIn(parcelId, ACTIVE_STATUSES);
+        if (active.isPresent()) {
+            log.debug("По посылке {} уже есть активная заявка {}", parcelId, active.get().getId());
+            throw new IllegalStateException("У посылки уже есть активная заявка на возврат");
+        }
+
+        OrderEpisode episode = episodeLifecycleService.ensureEpisode(parcel);
+
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setEpisode(episode);
+        request.setParcel(parcel);
+        request.setCreatedBy(user);
+        request.setCreatedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setIdempotencyKey(idempotencyKey);
+
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        log.info("Зарегистрирована заявка на возврат {} для посылки {}", saved.getId(), parcelId);
+        return saved;
+    }
+
+    /**
+     * Одобряет запуск обмена по заявке.
+     *
+     * @param requestId идентификатор заявки
+     * @param parcelId  идентификатор посылки
+     * @param user      автор решения
+     * @return обновлённая заявка
+     */
+    @Transactional
+    public OrderReturnRequest approveExchange(Long requestId, Long parcelId, User user) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+
+        if (request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            throw new IllegalStateException("Заявка уже обработана");
+        }
+
+        Long episodeId = Optional.ofNullable(request.getEpisode())
+                .map(OrderEpisode::getId)
+                .orElse(null);
+        if (episodeId != null && returnRequestRepository.existsByEpisode_IdAndStatus(episodeId,
+                OrderReturnRequestStatus.EXCHANGE_APPROVED)) {
+            throw new IllegalStateException("В эпизоде уже запущен обмен");
+        }
+
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setDecisionBy(user);
+        request.setDecisionAt(ZonedDateTime.now(ZoneOffset.UTC));
+
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        log.info("Одобрен обмен по заявке {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Закрывает заявку без запуска обмена.
+     */
+    @Transactional
+    public OrderReturnRequest closeWithoutExchange(Long requestId, Long parcelId, User user) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+
+        if (request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            throw new IllegalStateException("Заявка уже обработана");
+        }
+
+        request.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
+        request.setClosedBy(user);
+        request.setClosedAt(ZonedDateTime.now(ZoneOffset.UTC));
+
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        log.info("Заявка {} закрыта без обмена", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Возвращает активную заявку по посылке, если она существует.
+     */
+    @Transactional(readOnly = true)
+    public Optional<OrderReturnRequest> findCurrentForParcel(Long parcelId) {
+        if (parcelId == null) {
+            return Optional.empty();
+        }
+        return returnRequestRepository.findFirstByParcel_IdAndStatusIn(parcelId, ACTIVE_STATUSES);
+    }
+
+    /**
+     * Проверяет, можно ли запускать обмен по заявке.
+     */
+    @Transactional(readOnly = true)
+    public boolean canStartExchange(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            return false;
+        }
+        OrderEpisode episode = request.getEpisode();
+        Long episodeId = episode != null ? episode.getId() : null;
+        if (episodeId == null) {
+            return true;
+        }
+        return !returnRequestRepository.existsByEpisode_IdAndStatus(episodeId,
+                OrderReturnRequestStatus.EXCHANGE_APPROVED);
+    }
+
+    /**
+     * Возвращает идентификаторы посылок пользователя, по которым требуются действия.
+     */
+    @Transactional(readOnly = true)
+    public List<Long> findParcelsRequiringAction(Long userId) {
+        if (userId == null) {
+            return List.of();
+        }
+        return returnRequestRepository.findParcelIdsByUserAndStatus(userId, OrderReturnRequestStatus.REGISTERED);
+    }
+
+    /**
+     * Загружает заявку и проверяет, что пользователь владеет посылкой.
+     */
+    private OrderReturnRequest loadOwnedRequest(Long requestId, Long parcelId, User user) {
+        if (requestId == null || parcelId == null) {
+            throw new IllegalArgumentException("Идентификаторы заявки и посылки обязательны");
+        }
+        if (user == null || user.getId() == null) {
+            throw new IllegalArgumentException("Не указан пользователь");
+        }
+        OrderReturnRequest request = returnRequestRepository.findById(requestId)
+                .orElseThrow(() -> new IllegalArgumentException("Заявка не найдена"));
+        ensureOwnership(request, user.getId());
+        if (!parcelId.equals(Optional.ofNullable(request.getParcel()).map(TrackParcel::getId).orElse(null))) {
+            throw new IllegalArgumentException("Заявка не относится к указанной посылке");
+        }
+        return request;
+    }
+
+    private void ensureOwnership(OrderReturnRequest request, Long userId) {
+        Long ownerId = Optional.ofNullable(request)
+                .map(OrderReturnRequest::getParcel)
+                .map(TrackParcel::getUser)
+                .map(User::getId)
+                .orElse(null);
+        if (ownerId == null || !ownerId.equals(userId)) {
+            throw new AccessDeniedException("Заявка принадлежит другому пользователю");
+        }
+    }
+}
+

--- a/src/main/java/com/project/tracking_system/service/track/TrackRefreshService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackRefreshService.java
@@ -164,7 +164,10 @@ public class TrackRefreshService {
                     details.timeZone(),
                     details.episodeNumber(),
                     details.exchange(),
-                    details.chain()
+                    details.chain(),
+                    details.returnRequest(),
+                    details.canRegisterReturn(),
+                    details.requiresAction()
             );
         }
 
@@ -186,7 +189,10 @@ public class TrackRefreshService {
                 details.timeZone(),
                 details.episodeNumber(),
                 details.exchange(),
-                details.chain()
+                details.chain(),
+                details.returnRequest(),
+                details.canRegisterReturn(),
+                details.requiresAction()
         );
     }
 

--- a/src/main/resources/db/migration/V24__order_return_requests.sql
+++ b/src/main/resources/db/migration/V24__order_return_requests.sql
@@ -1,0 +1,21 @@
+CREATE TABLE tb_order_return_requests (
+    id BIGSERIAL PRIMARY KEY,
+    episode_id BIGINT NOT NULL REFERENCES tb_order_episodes (id) ON DELETE RESTRICT,
+    parcel_id BIGINT NOT NULL REFERENCES tb_track_parcels (id) ON DELETE RESTRICT,
+    created_by BIGINT NOT NULL REFERENCES tb_users (id) ON DELETE RESTRICT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    status VARCHAR(50) NOT NULL,
+    decision_by BIGINT REFERENCES tb_users (id) ON DELETE SET NULL,
+    decision_at TIMESTAMPTZ,
+    closed_by BIGINT REFERENCES tb_users (id) ON DELETE SET NULL,
+    closed_at TIMESTAMPTZ,
+    idempotency_key VARCHAR(255) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0
+);
+
+ALTER TABLE tb_order_return_requests
+    ADD CONSTRAINT ux_order_return_requests_key UNIQUE (idempotency_key);
+
+CREATE INDEX idx_order_return_requests_episode_id ON tb_order_return_requests (episode_id);
+CREATE INDEX idx_order_return_requests_parcel_id ON tb_order_return_requests (parcel_id);
+CREATE INDEX idx_order_return_requests_status ON tb_order_return_requests (status);

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -147,6 +147,47 @@ function initTrackRefreshHandler() {
 document.addEventListener('DOMContentLoaded', initTrackRefreshHandler);
 
 /**
+ * Инициализирует вкладки фильтрации «Требуют действия».
+ * Метод не зависит от Bootstrap и управляет видимостью строк таблицы через классы.
+ */
+function initRequiresActionTabs() {
+    const tabContainer = document.getElementById('departuresActionTabs');
+    if (!tabContainer) {
+        return;
+    }
+    const tabs = Array.from(tabContainer.querySelectorAll('[data-filter-tab]'));
+    if (!tabs.length) {
+        return;
+    }
+
+    const applyFilter = (filter) => {
+        const rows = document.querySelectorAll('.history-table tbody tr');
+        rows.forEach((row) => {
+            if (!(row instanceof HTMLTableRowElement)) {
+                return;
+            }
+            const requiresAction = row.dataset.requiresAction === 'true';
+            const shouldShow = filter === 'requires-action' ? requiresAction : true;
+            row.classList.toggle('d-none', !shouldShow);
+        });
+    };
+
+    tabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+            tabs.forEach((item) => item.classList.remove('active'));
+            tab.classList.add('active');
+            const filter = tab.dataset.filterTab || 'all';
+            applyFilter(filter);
+        });
+    });
+
+    const initialTab = tabs.find((tab) => tab.classList.contains('active'));
+    applyFilter(initialTab ? initialTab.dataset.filterTab : 'all');
+}
+
+document.addEventListener('DOMContentLoaded', initRequiresActionTabs);
+
+/**
  * Инициализирует проверку трек-номера на стороне клиента.
  * Навешивает обработчик на поле ввода и управляет сообщением об ошибке.
  */

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -105,6 +105,22 @@
 
                     </div>
 
+                    <ul class="nav nav-tabs mb-3" id="departuresActionTabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" type="button" role="tab"
+                                    data-filter-tab="all" aria-selected="true">Все</button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" type="button" role="tab" data-filter-tab="requires-action"
+                                    aria-selected="false">
+                                Требуют действия
+                                <span class="badge rounded-pill bg-danger-subtle text-danger-emphasis ms-2"
+                                      th:text="${actionRequiredCount}" th:classappend="${actionRequiredCount == 0} ? ' visually-hidden' : ''"
+                                      aria-label="Количество посылок, требующих действий"></span>
+                            </button>
+                        </li>
+                    </ul>
+
                     <!-- Таблица истории -->
                     <div th:if="${trackParcelDTO != null and !trackParcelDTO.isEmpty()}" class="mt-3">
                         <form action="/app/departures/delete-selected" method="post">
@@ -128,7 +144,8 @@
                                     </tr>
                                     </thead>
                                     <tbody>
-                                    <tr th:each="item : ${trackParcelDTO}" th:attr="data-track-number=${item.number},data-track-id=${item.id}">
+                                    <tr th:each="item : ${trackParcelDTO}"
+                                        th:attr="data-track-number=${item.number},data-track-id=${item.id},data-requires-action=${item.requiresAction}">
                                         <td class="checkbox-column">
                                             <!-- Чекбокс выбора: при отсутствии номера используем ID -->
                                             <input type="checkbox" class="selectCheckbox"
@@ -145,7 +162,7 @@
                                         <td class="align-middle text-start">
                                             <!-- Ячейка выравнивает содержимое по левому краю -->
                                             <!-- Контейнер выравнивает иконку и номер по одному левому краю, сохраняя общую семантику таблицы (SRP) -->
-                                            <div class="d-inline-flex align-items-center justify-content-start">
+                                            <div class="d-inline-flex align-items-center justify-content-start gap-2">
                                                 <!-- Изменено: выводим готовое значение iconHtml из DTO -->
                                                 <span th:if="${item.iconHtml != null}" th:utext="${item.iconHtml}" class="status-icon"
                                                       th:attr="title=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'Добавьте трек-номер, чтобы начать обновлять' : null}, data-bs-toggle=${item.status == 'Предрегистрация' and #strings.isEmpty(item.number) ? 'tooltip' : null}"></span>
@@ -163,6 +180,9 @@
                                                         th:data-itemnumber="${item.number}"
                                                         th:data-track-id="${item.id}"
                                                         aria-label="Открыть детали посылки"></button>
+                                                <span th:if="${item.requiresAction}"
+                                                      class="badge rounded-pill bg-warning-subtle text-warning-emphasis"
+                                                      aria-label="По посылке требуется действие">Действие</span>
                                             </div>
                                         </td>
                                         <td class="align-middle text-center">

--- a/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
+++ b/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
@@ -1,0 +1,122 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.entity.Role;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackViewService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Тесты REST-эндпоинтов возвратов/обменов {@link TrackController}.
+ */
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(TrackController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TrackControllerReturnTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TrackViewService trackViewService;
+    @MockBean
+    private TrackParcelService trackParcelService;
+    @MockBean
+    private OrderReturnRequestService orderReturnRequestService;
+
+    @Test
+    void registerReturn_ReturnsUpdatedDetails() throws Exception {
+        User principal = buildUser();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                principal.getPassword(),
+                principal.getAuthorities()
+        );
+
+        TrackDetailsDto dto = new TrackDetailsDto(
+                5L,
+                "AB123",
+                "Belpost",
+                "Вручена",
+                null,
+                null,
+                List.of(),
+                true,
+                null,
+                false,
+                "UTC",
+                10L,
+                false,
+                List.of(),
+                null,
+                false,
+                false
+        );
+
+        when(trackViewService.getTrackDetails(5L, 1L)).thenReturn(dto);
+
+        mockMvc.perform(post("/api/v1/tracks/5/returns")
+                        .with(authentication(auth))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"idempotencyKey\":\"key\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5L))
+                .andExpect(jsonPath("$.canRegisterReturn").value(false));
+
+        Mockito.verify(orderReturnRequestService).registerReturn(eq(5L), eq(principal), eq("key"));
+    }
+
+    @Test
+    void approveExchange_WhenConflict_Returns409() throws Exception {
+        User principal = buildUser();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                principal.getPassword(),
+                principal.getAuthorities()
+        );
+
+        when(orderReturnRequestService.approveExchange(eq(7L), eq(9L), eq(principal)))
+                .thenThrow(new IllegalStateException("В эпизоде уже запущен обмен"));
+
+        mockMvc.perform(post("/api/v1/tracks/9/returns/7/exchange")
+                        .with(authentication(auth))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
+
+        Mockito.verify(orderReturnRequestService).approveExchange(eq(7L), eq(9L), eq(principal));
+        Mockito.verify(trackViewService, Mockito.never()).getTrackDetails(any(), any());
+    }
+
+    private User buildUser() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("user@example.com");
+        user.setPassword("secret");
+        user.setRole(Role.ROLE_USER);
+        user.setTimeZone("UTC");
+        return user;
+    }
+}
+

--- a/src/test/java/com/project/tracking_system/controller/TrackRefreshControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/TrackRefreshControllerTest.java
@@ -58,7 +58,10 @@ class TrackRefreshControllerTest {
                 "Europe/Minsk",
                 15L,
                 false,
-                List.of()
+                List.of(),
+                null,
+                false,
+                false
         );
         when(trackRefreshService.refreshTrack(eq(7L), eq(3L))).thenReturn(cooldownDetails);
 

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -1,0 +1,181 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.OrderEpisode;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.OrderReturnRequestRepository;
+import com.project.tracking_system.service.track.TrackParcelService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты сервиса {@link OrderReturnRequestService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrderReturnRequestServiceTest {
+
+    @Mock
+    private OrderReturnRequestRepository repository;
+    @Mock
+    private TrackParcelService trackParcelService;
+    @Mock
+    private OrderEpisodeLifecycleService episodeLifecycleService;
+
+    private OrderReturnRequestService service;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        service = new OrderReturnRequestService(repository, trackParcelService, episodeLifecycleService);
+        user = new User();
+        user.setId(5L);
+    }
+
+    @Test
+    void registerReturn_CreatesRequest_WhenDelivered() {
+        TrackParcel parcel = buildParcel(10L, GlobalStatus.DELIVERED);
+        when(trackParcelService.findOwnedById(10L, 5L)).thenReturn(Optional.of(parcel));
+        when(repository.findByIdempotencyKey("key-1")).thenReturn(Optional.empty());
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(10L), any())).thenReturn(Optional.empty());
+        OrderEpisode episode = parcel.getEpisode();
+        when(episodeLifecycleService.ensureEpisode(parcel)).thenReturn(episode);
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> {
+            OrderReturnRequest request = invocation.getArgument(0);
+            request.setId(100L);
+            return request;
+        });
+
+        OrderReturnRequest saved = service.registerReturn(10L, user, "key-1");
+
+        assertThat(saved.getId()).isEqualTo(100L);
+        assertThat(saved.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
+        assertThat(saved.getCreatedBy()).isEqualTo(user);
+        assertThat(saved.getCreatedAt()).isNotNull();
+
+        ArgumentCaptor<OrderReturnRequest> captor = ArgumentCaptor.forClass(OrderReturnRequest.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getParcel()).isEqualTo(parcel);
+    }
+
+    @Test
+    void registerReturn_ThrowsWhenStatusNotDelivered() {
+        TrackParcel parcel = buildParcel(11L, GlobalStatus.IN_TRANSIT);
+        when(trackParcelService.findOwnedById(11L, 5L)).thenReturn(Optional.of(parcel));
+        when(repository.findByIdempotencyKey("key-2")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.registerReturn(11L, user, "key-2"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("доступна только для статуса");
+    }
+
+    @Test
+    void approveExchange_ThrowsWhenEpisodeAlreadyHasApproved() {
+        TrackParcel parcel = buildParcel(12L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(200L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+
+        when(repository.findById(200L)).thenReturn(Optional.of(request));
+        when(repository.existsByEpisode_IdAndStatus(parcel.getEpisode().getId(), OrderReturnRequestStatus.EXCHANGE_APPROVED))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> service.approveExchange(200L, 12L, user))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("уже запущен обмен");
+    }
+
+    @Test
+    void closeWithoutExchange_ChangesStatusToClosed() {
+        TrackParcel parcel = buildParcel(13L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(300L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+
+        when(repository.findById(300L)).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        OrderReturnRequest result = service.closeWithoutExchange(300L, 13L, user);
+
+        assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
+        assertThat(result.getClosedBy()).isEqualTo(user);
+        assertThat(result.getClosedAt()).isNotNull();
+    }
+
+    @Test
+    void registerReturn_ReturnsExistingByIdempotencyKey() {
+        TrackParcel parcel = buildParcel(14L, GlobalStatus.DELIVERED);
+        OrderReturnRequest existing = new OrderReturnRequest();
+        existing.setId(400L);
+        existing.setParcel(parcel);
+        existing.setEpisode(parcel.getEpisode());
+        existing.setStatus(OrderReturnRequestStatus.REGISTERED);
+        existing.setCreatedBy(user);
+
+        when(repository.findByIdempotencyKey("same")).thenReturn(Optional.of(existing));
+
+        OrderReturnRequest result = service.registerReturn(14L, user, "same");
+
+        assertThat(result).isEqualTo(existing);
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void registerReturn_ThrowsWhenRequestBelongsToAnotherUser() {
+        TrackParcel parcel = buildParcel(15L, GlobalStatus.DELIVERED);
+        User another = new User();
+        another.setId(9L);
+        parcel.setUser(another);
+        when(trackParcelService.findOwnedById(15L, 5L)).thenReturn(Optional.of(parcel));
+        when(repository.findByIdempotencyKey("conflict")).thenReturn(Optional.empty());
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(15L), any())).thenReturn(Optional.empty());
+
+        // emulate request saved earlier by other user
+        OrderReturnRequest existing = new OrderReturnRequest();
+        existing.setParcel(parcel);
+        existing.setEpisode(parcel.getEpisode());
+        existing.setStatus(OrderReturnRequestStatus.REGISTERED);
+        existing.setCreatedBy(another);
+
+        when(repository.findByIdempotencyKey("reuse")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.registerReturn(15L, user, "reuse"))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    private TrackParcel buildParcel(Long id, GlobalStatus status) {
+        TrackParcel parcel = new TrackParcel();
+        parcel.setId(id);
+        parcel.setStatus(status);
+        parcel.setLastUpdate(ZonedDateTime.now(ZoneOffset.UTC));
+        parcel.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC));
+        OrderEpisode episode = new OrderEpisode();
+        episode.setId(500L + id);
+        parcel.setEpisode(episode);
+        parcel.setUser(user);
+        return parcel;
+    }
+}
+

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -22,6 +22,7 @@ describe('track-modal render', () => {
         global.notifyUser = jest.fn();
         global.promptTrackNumber = jest.fn();
         global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+        global.crypto = { randomUUID: jest.fn(() => 'test-uuid') };
         require('../../main/resources/static/js/track-modal.js');
     }
 
@@ -32,6 +33,7 @@ describe('track-modal render', () => {
         delete global.notifyUser;
         delete global.promptTrackNumber;
         delete global.fetch;
+        delete global.crypto;
     });
 
     test('renders episode number and single chain item for base parcel', () => {
@@ -52,7 +54,10 @@ describe('track-modal render', () => {
             exchange: false,
             chain: [
                 { id: 1, number: 'AB123456789BY', exchange: false, current: true }
-            ]
+            ],
+            returnRequest: null,
+            canRegisterReturn: false,
+            requiresAction: false
         };
 
         global.window.trackModal.render(data);
@@ -85,7 +90,11 @@ describe('track-modal render', () => {
             chain: [
                 { id: 11, number: 'RB987654321CN', exchange: true, current: true },
                 { id: 10, number: 'RB111222333CN', exchange: false, current: false }
-            ]
+            ],
+            returnRequest: { id: 5, status: 'Зарегистрирована', createdAt: null, decisionAt: null, closedAt: null,
+                requiresAction: true, exchangeApproved: false, canStartExchange: true, canCloseWithoutExchange: true },
+            canRegisterReturn: false,
+            requiresAction: true
         };
 
         global.window.trackModal.render(data);
@@ -114,7 +123,10 @@ describe('track-modal render', () => {
             exchange: false,
             chain: [
                 { id: 5, number: 'BY555555555BY', exchange: false, current: true }
-            ]
+            ],
+            returnRequest: null,
+            canRegisterReturn: false,
+            requiresAction: false
         };
 
         global.window.trackModal.render(data);
@@ -123,5 +135,34 @@ describe('track-modal render', () => {
         expect(buttons).toHaveLength(1);
         expect(buttons[0].textContent).not.toContain('обмен');
         expect(buttons[0].getAttribute('aria-current')).toBe('true');
+    });
+
+    test('shows register button when return can be created', () => {
+        setupDom();
+        const data = {
+            id: 7,
+            number: 'RR123',
+            deliveryService: 'Belpost',
+            systemStatus: 'Вручена',
+            history: [],
+            refreshAllowed: false,
+            nextRefreshAt: null,
+            canEditTrack: false,
+            timeZone: 'UTC',
+            episodeNumber: 12,
+            exchange: false,
+            chain: [
+                { id: 7, number: 'RR123', exchange: false, current: true }
+            ],
+            returnRequest: null,
+            canRegisterReturn: true,
+            requiresAction: false
+        };
+
+        global.window.trackModal.render(data);
+
+        const button = document.querySelector('button.btn-outline-warning');
+        expect(button).not.toBeNull();
+        expect(button?.textContent).toContain('Зарегистрировать возврат');
     });
 });


### PR DESCRIPTION
## Summary
- Добавлена сущность, репозиторий и сервис для заявок возврата/обмена с идемпотентностью и проверками доступа. 【F:src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java†L1-L192】【F:src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java†L35-L217】
- Обновлены TrackController, TrackViewService и DTO, чтобы отдавать сведения о заявках и предоставить REST-эндпоинты регистрации, запуска обмена и закрытия. 【F:src/main/java/com/project/tracking_system/controller/TrackController.java†L120-L184】【F:src/main/java/com/project/tracking_system/service/track/TrackViewService.java†L53-L151】【F:src/main/java/com/project/tracking_system/dto/TrackDetailsDto.java†L22-L42】
- Улучшен интерфейс: вкладка «Требуют действия», кнопки управления в модалке трека, расширенные сценарии в JS и шаблоне. 【F:src/main/java/com/project/tracking_system/controller/DeparturesController.java†L139-L172】【F:src/main/resources/templates/app/departures.html†L108-L185】【F:src/main/resources/static/js/track-modal.js†L167-L345】【F:src/main/resources/static/js/app.js†L149-L186】
- Добавлены и обновлены тесты backend и frontend, покрывающие регистрацию возврата, запуск обмена и закрытие заявок без обмена. 【F:src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java†L53-L179】【F:src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java†L49-L110】【F:src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java†L252-L295】【F:src/test/js/track-modal.test.js†L10-L166】

## Testing
- ⚠️ `mvn -q test` *(зависимость io.github.bucket4j недоступна: 403 Forbidden с jitpack.io)* 【06ea8c†L1-L13】
- ⚠️ `npx --yes jest track-modal --runInBand` *(jest-environment-jsdom отсутствует в окружении)* 【29b73a†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68dec2751980832db858785bfc830502