### PR TITLE
feat: add exchange parcel creation flow

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/ExchangeApprovalResponse.java
+++ b/src/main/java/com/project/tracking_system/dto/ExchangeApprovalResponse.java
@@ -1,0 +1,11 @@
+package com.project.tracking_system.dto;
+
+/**
+ * DTO ответа при запуске обменной посылки.
+ *
+ * @param details   обновлённые данные исходной посылки
+ * @param exchange  элемент цепочки с новой обменной посылкой
+ */
+public record ExchangeApprovalResponse(TrackDetailsDto details,
+                                       TrackChainItemDto exchange) {
+}

--- a/src/main/java/com/project/tracking_system/service/order/ExchangeApprovalResult.java
+++ b/src/main/java/com/project/tracking_system/service/order/ExchangeApprovalResult.java
@@ -1,0 +1,14 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.TrackParcel;
+
+/**
+ * Результат одобрения обмена.
+ *
+ * @param request        обновлённая заявка на возврат/обмен
+ * @param exchangeParcel созданная обменная посылка
+ */
+public record ExchangeApprovalResult(OrderReturnRequest request,
+                                     TrackParcel exchangeParcel) {
+}

--- a/src/main/java/com/project/tracking_system/service/order/OrderExchangeService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderExchangeService.java
@@ -1,0 +1,93 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+/**
+ * Сервис создания обменных посылок.
+ * <p>
+ * Инкапсулирует логику копирования исходных данных и регистрации
+ * обмена в жизненном цикле эпизода, чтобы соблюсти SRP: сервис
+ * возвращает готовую сущность, а orchestration происходит во внешнем
+ * слое.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderExchangeService {
+
+    private final TrackParcelRepository trackParcelRepository;
+    private final OrderEpisodeLifecycleService episodeLifecycleService;
+
+    /**
+     * Создаёт посылку-обмен на основании заявки.
+     * <p>
+     * Метод проверяет корректность входных данных, копирует магазин,
+     * пользователя и покупателя из исходной посылки, создаёт новую
+     * запись со статусом {@link GlobalStatus#PRE_REGISTERED}, а затем
+     * делегирует регистрацию обмена {@link OrderEpisodeLifecycleService}.
+     * </p>
+     *
+     * @param request заявка, по которой запускается обмен
+     * @return сохранённая посылка обмена
+     */
+    @Transactional
+    public TrackParcel createExchangeParcel(OrderReturnRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Не передана заявка на обмен");
+        }
+        TrackParcel originalParcel = Optional.ofNullable(request.getParcel())
+                .orElseThrow(() -> new IllegalArgumentException("Заявка не содержит исходную посылку"));
+
+        TrackParcel replacement = buildReplacementFrom(originalParcel);
+        episodeLifecycleService.registerExchange(replacement, originalParcel);
+        TrackParcel saved = trackParcelRepository.save(replacement);
+        log.info("Создана обменная посылка {} для заявки {}", saved.getId(), request.getId());
+        return saved;
+    }
+
+    /**
+     * Подготавливает сущность обменной посылки на основе исходной.
+     *
+     * @param originalParcel исходная посылка, инициировавшая обмен
+     * @return несохранённая сущность обмена
+     */
+    private TrackParcel buildReplacementFrom(TrackParcel originalParcel) {
+        TrackParcel replacement = new TrackParcel();
+        replacement.setStatus(GlobalStatus.PRE_REGISTERED);
+        replacement.setNumber(null);
+
+        Store store = originalParcel.getStore();
+        if (store != null) {
+            replacement.setStore(store);
+        }
+        User user = originalParcel.getUser();
+        if (user != null) {
+            replacement.setUser(user);
+        }
+        Customer customer = originalParcel.getCustomer();
+        if (customer != null) {
+            replacement.setCustomer(customer);
+        }
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        replacement.setLastUpdate(now);
+        replacement.setTimestamp(now);
+        replacement.setIncludedInStatistics(false);
+        return replacement;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -220,6 +220,28 @@ public class TrackViewService {
     }
 
     /**
+     * Преобразует посылку в элемент цепочки эпизода.
+     *
+     * @param parcel        посылка, которую нужно представить в цепочке
+     * @param currentParcel идентификатор текущей посылки для вычисления признака выбранности
+     * @return DTO элемента цепочки или {@code null}, если посылка отсутствует
+     */
+    @Transactional(readOnly = true)
+    public TrackChainItemDto toChainItem(TrackParcel parcel, Long currentParcel) {
+        if (parcel == null) {
+            return null;
+        }
+        Long parcelId = parcel.getId();
+        boolean isCurrent = parcelId != null && parcelId.equals(currentParcel);
+        return new TrackChainItemDto(
+                parcelId,
+                parcel.getNumber(),
+                parcel.isExchange(),
+                isCurrent
+        );
+    }
+
+    /**
      * Загружает посылку и проверяет права доступа.
      */
     private TrackParcel loadParcel(Long trackId, Long userId) {

--- a/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
+++ b/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
@@ -1,8 +1,11 @@
 package com.project.tracking_system.controller;
 
+import com.project.tracking_system.dto.TrackChainItemDto;
 import com.project.tracking_system.dto.TrackDetailsDto;
 import com.project.tracking_system.entity.Role;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.service.order.ExchangeApprovalResult;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackViewService;
@@ -131,6 +134,62 @@ class TrackControllerReturnTest {
 
         Mockito.verify(orderReturnRequestService).approveExchange(eq(7L), eq(9L), eq(principal));
         Mockito.verify(trackViewService, Mockito.never()).getTrackDetails(any(), any());
+        Mockito.verify(trackViewService, Mockito.never()).toChainItem(any(), any());
+    }
+
+    @Test
+    void approveExchange_ReturnsDetailsAndExchangeItem() throws Exception {
+        User principal = buildUser();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                principal.getPassword(),
+                principal.getAuthorities()
+        );
+
+        TrackDetailsDto dto = new TrackDetailsDto(
+                9L,
+                "AB123",
+                "Belpost",
+                "Вручена",
+                null,
+                null,
+                List.of(),
+                true,
+                null,
+                false,
+                "UTC",
+                10L,
+                false,
+                List.of(),
+                null,
+                false,
+                false
+        );
+
+        TrackParcel replacement = new TrackParcel();
+        replacement.setId(33L);
+        replacement.setNumber("EX123");
+        replacement.setExchange(true);
+
+        ExchangeApprovalResult result = new ExchangeApprovalResult(null, replacement);
+
+        when(orderReturnRequestService.approveExchange(eq(7L), eq(9L), eq(principal)))
+                .thenReturn(result);
+        when(trackViewService.getTrackDetails(9L, 1L)).thenReturn(dto);
+        TrackChainItemDto chainItemDto = new TrackChainItemDto(33L, "EX123", true, false);
+        when(trackViewService.toChainItem(replacement, 9L)).thenReturn(chainItemDto);
+
+        mockMvc.perform(post("/api/v1/tracks/9/returns/7/exchange")
+                        .with(authentication(auth))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.details.id").value(9L))
+                .andExpect(jsonPath("$.exchange.id").value(33L))
+                .andExpect(jsonPath("$.exchange.exchange").value(true));
+
+        Mockito.verify(orderReturnRequestService).approveExchange(eq(7L), eq(9L), eq(principal));
+        Mockito.verify(trackViewService).getTrackDetails(9L, 1L);
+        Mockito.verify(trackViewService).toChainItem(replacement, 9L);
     }
 
     private User buildUser() {

--- a/src/test/java/com/project/tracking_system/service/order/OrderExchangeServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderExchangeServiceTest.java
@@ -1,0 +1,98 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.Customer;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.Store;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.TrackParcelRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+/**
+ * Тесты сервиса {@link OrderExchangeService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class OrderExchangeServiceTest {
+
+    @Mock
+    private TrackParcelRepository trackParcelRepository;
+    @Mock
+    private OrderEpisodeLifecycleService episodeLifecycleService;
+
+    private OrderExchangeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new OrderExchangeService(trackParcelRepository, episodeLifecycleService);
+    }
+
+    @Test
+    void createExchangeParcel_CopiesBaseAttributes() {
+        Store store = new Store();
+        store.setId(1L);
+        Customer customer = new Customer();
+        customer.setId(2L);
+        User user = new User();
+        user.setId(3L);
+
+        TrackParcel original = new TrackParcel();
+        original.setId(10L);
+        original.setStore(store);
+        original.setCustomer(customer);
+        original.setUser(user);
+        original.setStatus(GlobalStatus.DELIVERED);
+
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(20L);
+        request.setParcel(original);
+
+        ArgumentCaptor<TrackParcel> savedCaptor = ArgumentCaptor.forClass(TrackParcel.class);
+        doAnswer(invocation -> {
+            TrackParcel parcel = invocation.getArgument(0);
+            parcel.setExchange(true);
+            return null;
+        }).when(episodeLifecycleService).registerExchange(any(TrackParcel.class), eq(original));
+        when(trackParcelRepository.save(any(TrackParcel.class))).thenAnswer(invocation -> {
+            TrackParcel parcel = invocation.getArgument(0);
+            parcel.setId(99L);
+            return parcel;
+        });
+
+        TrackParcel exchange = service.createExchangeParcel(request);
+
+        verify(episodeLifecycleService).registerExchange(savedCaptor.capture(), eq(original));
+        TrackParcel prepared = savedCaptor.getValue();
+        assertThat(prepared.getStore()).isEqualTo(store);
+        assertThat(prepared.getCustomer()).isEqualTo(customer);
+        assertThat(prepared.getUser()).isEqualTo(user);
+        assertThat(prepared.getStatus()).isEqualTo(GlobalStatus.PRE_REGISTERED);
+        assertThat(exchange.getId()).isEqualTo(99L);
+        assertThat(exchange.isExchange()).isTrue();
+    }
+
+    @Test
+    void createExchangeParcel_ThrowsWhenRequestMissingParcel() {
+        OrderReturnRequest request = new OrderReturnRequest();
+
+        assertThatThrownBy(() -> service.createExchangeParcel(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("не содержит исходную посылку");
+    }
+
+    @Test
+    void createExchangeParcel_ThrowsWhenRequestNull() {
+        assertThatThrownBy(() -> service.createExchangeParcel(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Не передана");
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.service.track;
 
+import com.project.tracking_system.dto.TrackChainItemDto;
 import com.project.tracking_system.dto.TrackDetailsDto;
 import com.project.tracking_system.dto.TrackStatusEventDto;
 import com.project.tracking_system.entity.DeliveryHistory;
@@ -293,6 +294,18 @@ class TrackViewServiceTest {
         assertThat(details.returnRequest()).isNotNull();
         assertThat(details.returnRequest().requiresAction()).isTrue();
         assertThat(details.returnRequest().canStartExchange()).isTrue();
+    }
+
+    @Test
+    void toChainItem_BuildsDtoForExchangeParcel() {
+        TrackParcel parcel = buildParcel(90L, GlobalStatus.PRE_REGISTERED, ZonedDateTime.now(ZoneOffset.UTC));
+        parcel.setExchange(true);
+
+        TrackChainItemDto dto = service.toChainItem(parcel, 10L);
+
+        assertThat(dto.id()).isEqualTo(90L);
+        assertThat(dto.exchange()).isTrue();
+        assertThat(dto.current()).isFalse();
     }
 
     /**


### PR DESCRIPTION
## Summary
- create a dedicated exchange parcel service and extend the return workflow to issue ExchangeApprovalResponse payloads
- expose chain item mapping utilities and refresh controller/service tests around exchange approval
- update the track modal to surface a link to the newly created exchange parcel and keep the episode chain in sync

## Testing
- mvn -q test *(fails: dependency download blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dee440b2e4832d894140cd18145647