### PR TITLE
Add return and exchange flow buttons for delivered parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TelegramParcelInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TelegramParcelInfoDTO.java
@@ -12,9 +12,11 @@ import java.util.Objects;
  */
 public class TelegramParcelInfoDTO {
 
+    private final Long parcelId;
     private final String trackNumber;
     private final String storeName;
     private final GlobalStatus status;
+    private final boolean activeReturnRequest;
     /**
      * Создаёт DTO с основными данными о посылке для Telegram.
      *
@@ -23,7 +25,7 @@ public class TelegramParcelInfoDTO {
      */
     public TelegramParcelInfoDTO(String trackNumber,
                                  String storeName) {
-        this(trackNumber, storeName, null);
+        this(null, trackNumber, storeName, null, false);
     }
 
     /**
@@ -36,9 +38,35 @@ public class TelegramParcelInfoDTO {
     public TelegramParcelInfoDTO(String trackNumber,
                                  String storeName,
                                  GlobalStatus status) {
+        this(null, trackNumber, storeName, status, false);
+    }
+
+    /**
+     * Создаёт DTO с идентификатором посылки и признаком активной заявки на возврат.
+     *
+     * @param parcelId             идентификатор посылки
+     * @param trackNumber          трек-номер посылки
+     * @param storeName            название магазина
+     * @param status               актуальный глобальный статус
+     * @param activeReturnRequest  признак наличия активной заявки на возврат/обмен
+     */
+    public TelegramParcelInfoDTO(Long parcelId,
+                                 String trackNumber,
+                                 String storeName,
+                                 GlobalStatus status,
+                                 boolean activeReturnRequest) {
+        this.parcelId = parcelId;
         this.trackNumber = trackNumber;
         this.storeName = storeName;
         this.status = status;
+        this.activeReturnRequest = activeReturnRequest;
+    }
+
+    /**
+     * @return идентификатор посылки в базе данных
+     */
+    public Long getParcelId() {
+        return parcelId;
     }
 
     /**
@@ -62,6 +90,13 @@ public class TelegramParcelInfoDTO {
         return status;
     }
 
+    /**
+     * @return {@code true}, если по посылке уже зарегистрирована активная заявка
+     */
+    public boolean hasActiveReturnRequest() {
+        return activeReturnRequest;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -70,13 +105,15 @@ public class TelegramParcelInfoDTO {
         if (!(o instanceof TelegramParcelInfoDTO that)) {
             return false;
         }
-        return Objects.equals(trackNumber, that.trackNumber)
+        return Objects.equals(parcelId, that.parcelId)
+                && Objects.equals(trackNumber, that.trackNumber)
                 && Objects.equals(storeName, that.storeName)
-                && status == that.status;
+                && status == that.status
+                && activeReturnRequest == that.activeReturnRequest;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(trackNumber, storeName, status);
+        return Objects.hash(parcelId, trackNumber, storeName, status, activeReturnRequest);
     }
 }

--- a/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
@@ -41,6 +41,16 @@ public interface OrderReturnRequestRepository extends JpaRepository<OrderReturnR
                                             @Param("status") OrderReturnRequestStatus status);
 
     /**
+     * Возвращает идентификаторы посылок покупателя, по которым есть активные заявки.
+     */
+    @Query("""
+            select r.parcel.id from OrderReturnRequest r
+            where r.parcel.customer.id = :customerId and r.status in :statuses
+            """)
+    List<Long> findParcelIdsByCustomerAndStatusIn(@Param("customerId") Long customerId,
+                                                  @Param("statuses") Collection<OrderReturnRequestStatus> statuses);
+
+    /**
      * Возвращает активные заявки пользователя вместе с данными посылок.
      */
     @Query("""

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1216,18 +1216,34 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                                                                List<BuyerBotScreen> navigationPath) {
         List<InlineKeyboardRow> rows = new ArrayList<>();
 
-        if (parcels != null) {
-            parcels.stream()
-                    .map(this::buildParcelActionsRow)
-                    .filter(Objects::nonNull)
-                    .forEach(rows::add);
-        }
+        collectParcelsInDisplayOrder(parcels).stream()
+                .map(this::buildParcelActionsRow)
+                .filter(Objects::nonNull)
+                .forEach(rows::add);
 
         appendNavigationRow(rows, navigationPath);
 
         return InlineKeyboardMarkup.builder()
                 .keyboard(rows)
                 .build();
+    }
+
+    /**
+     * Возвращает посылки в том же порядке, что и в тексте, чтобы кнопки совпадали с маркерами.
+     *
+     * @param parcels исходный список доставленных посылок
+     * @return упорядоченный список для отображения клавиатуры
+     */
+    private List<TelegramParcelInfoDTO> collectParcelsInDisplayOrder(List<TelegramParcelInfoDTO> parcels) {
+        if (parcels == null || parcels.isEmpty()) {
+            return List.of();
+        }
+
+        return groupParcelsByStore(parcels).values().stream()
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceLoggingTest.java
@@ -8,6 +8,7 @@ import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.repository.CustomerNotificationLogRepository;
 import com.project.tracking_system.repository.CustomerRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.OrderReturnRequestRepository;
 import com.project.tracking_system.service.telegram.FullNameValidator;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import org.junit.jupiter.api.AfterEach;
@@ -42,6 +43,8 @@ class CustomerTelegramServiceLoggingTest {
     private CustomerNotificationLogRepository notificationLogRepository;
     @Mock
     private TelegramNotificationService telegramNotificationService;
+    @Mock
+    private OrderReturnRequestRepository returnRequestRepository;
 
     @Spy
     private FullNameValidator fullNameValidator = new FullNameValidator();

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -9,6 +9,7 @@ import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.repository.CustomerNotificationLogRepository;
 import com.project.tracking_system.repository.CustomerRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
+import com.project.tracking_system.repository.OrderReturnRequestRepository;
 import com.project.tracking_system.service.telegram.FullNameValidator;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,6 +48,8 @@ class CustomerTelegramServiceTest {
     private CustomerNotificationLogRepository notificationLogRepository;
     @Mock
     private TelegramNotificationService telegramNotificationService;
+    @Mock
+    private OrderReturnRequestRepository returnRequestRepository;
 
     @Spy
     private FullNameValidator fullNameValidator = new FullNameValidator();
@@ -130,16 +134,22 @@ class CustomerTelegramServiceTest {
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
 
         TrackParcel deliveredParcel = parcelWithStatus("DEL-1", GlobalStatus.DELIVERED, ZonedDateTime.now(ZoneOffset.UTC));
+        deliveredParcel.setId(101L);
         TrackParcel waitingParcel = parcelWithStatus("WAIT-1", GlobalStatus.WAITING_FOR_CUSTOMER,
                 ZonedDateTime.now(ZoneOffset.UTC).minusHours(2));
+        waitingParcel.setId(102L);
         TrackParcel notPickingParcel = parcelWithStatus("NOT-PICK", GlobalStatus.CUSTOMER_NOT_PICKING_UP,
                 ZonedDateTime.now(ZoneOffset.UTC).minusHours(3));
+        notPickingParcel.setId(103L);
         TrackParcel preRegisteredParcel = parcelWithStatus("PRE-1", GlobalStatus.PRE_REGISTERED,
                 ZonedDateTime.now(ZoneOffset.UTC).minusDays(1));
+        preRegisteredParcel.setId(104L);
         TrackParcel registeredParcel = parcelWithStatus("REG-1", GlobalStatus.REGISTERED,
                 ZonedDateTime.now(ZoneOffset.UTC).minusHours(5));
+        registeredParcel.setId(105L);
         TrackParcel inTransitParcel = parcelWithStatus("TRANS-1", GlobalStatus.IN_TRANSIT,
                 ZonedDateTime.now(ZoneOffset.UTC).minusHours(6));
+        inTransitParcel.setId(106L);
 
         List<GlobalStatus> deliveredStatuses = List.of(GlobalStatus.DELIVERED);
         List<GlobalStatus> waitingStatuses = List.of(
@@ -168,6 +178,9 @@ class CustomerTelegramServiceTest {
                     return List.of();
                 });
 
+        when(returnRequestRepository.findParcelIdsByCustomerAndStatusIn(eq(customerId), anyCollection()))
+                .thenReturn(List.of(deliveredParcel.getId()));
+
         Optional<TelegramParcelsOverviewDTO> result = customerTelegramService.getParcelsOverview(chatId);
 
         assertTrue(result.isPresent(), "Сводка должна формироваться для известного чата");
@@ -176,10 +189,13 @@ class CustomerTelegramServiceTest {
         assertEquals(1, overview.getDelivered().size(), "Раздел доставленных должен содержать одну посылку");
         assertEquals(2, overview.getWaitingForPickup().size(), "Раздел ожидания обязан включать оба статуса ожидания");
         assertEquals(3, overview.getInTransit().size(), "Раздел в пути обязан включать ключевые статусы до выдачи");
+        assertTrue(overview.getDelivered().get(0).hasActiveReturnRequest(),
+                "У доставленной посылки должен отмечаться активный запрос возврата");
 
         verify(trackParcelRepository).findByCustomerIdAndStatusIn(customerId, deliveredStatuses);
         verify(trackParcelRepository).findByCustomerIdAndStatusIn(customerId, waitingStatuses);
         verify(trackParcelRepository).findByCustomerIdAndStatusIn(customerId, inTransitStatuses);
+        verify(returnRequestRepository).findParcelIdsByCustomerAndStatusIn(eq(customerId), anyCollection());
     }
 
     private TrackParcel parcelWithStatus(String number, GlobalStatus status, ZonedDateTime lastUpdate) {


### PR DESCRIPTION
## Summary
- add inline return and exchange actions for delivered parcels and process new callbacks in BuyerTelegramBot
- enrich Telegram parcel DTOs and customer service with parcel identifiers and active request flags sourced from return request repository
- extend customer and bot tests to cover new buttons, callback flows, and active request handling

## Testing
- `mvn -DskipITs test` *(fails: dependency download from jitpack.io returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68defd762af8832dbac38cff1a4503f6