### PR TITLE
Add returns menu and active request handling to buyer Telegram bot

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/TelegramReturnRequestInfoDTO.java
+++ b/src/main/java/com/project/tracking_system/dto/TelegramReturnRequestInfoDTO.java
@@ -1,0 +1,22 @@
+package com.project.tracking_system.dto;
+
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Представление активной заявки на возврат или обмен для Telegram.
+ * <p>
+ * DTO содержит безопасные для отображения поля и избавляет слой бота от
+ * зависимостей на JPA-сущности, что соответствует принципу единственной
+ * ответственности.
+ * </p>
+ */
+public record TelegramReturnRequestInfoDTO(Long requestId,
+                                           Long parcelId,
+                                           String trackNumber,
+                                           String storeName,
+                                           OrderReturnRequestStatus status,
+                                           ZonedDateTime requestedAt) {
+}
+

--- a/src/main/java/com/project/tracking_system/entity/BuyerBotScreen.java
+++ b/src/main/java/com/project/tracking_system/entity/BuyerBotScreen.java
@@ -20,6 +20,21 @@ public enum BuyerBotScreen {
     PARCELS,
 
     /**
+     * Меню возвратов и обменов.
+     */
+    RETURNS_MENU,
+
+    /**
+     * Экран с перечнем активных заявок на возврат.
+     */
+    RETURNS_ACTIVE_REQUESTS,
+
+    /**
+     * Экран выбора посылки для новой заявки на возврат или обмен.
+     */
+    RETURNS_CREATE_REQUEST,
+
+    /**
      * Экран настроек уведомлений и ФИО.
      */
     SETTINGS,

--- a/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
@@ -63,5 +63,18 @@ public interface OrderReturnRequestRepository extends JpaRepository<OrderReturnR
             """)
     List<OrderReturnRequest> findActiveRequestsWithDetails(@Param("userId") Long userId,
                                                            @Param("statuses") Collection<OrderReturnRequestStatus> statuses);
+
+    /**
+     * Возвращает активные заявки покупателя с данными посылок и магазинов.
+     */
+    @Query("""
+            select distinct r from OrderReturnRequest r
+            join fetch r.parcel p
+            left join fetch p.store
+            where p.customer.id = :customerId and r.status in :statuses
+            order by r.createdAt desc
+            """)
+    List<OrderReturnRequest> findActiveRequestsByCustomerWithDetails(@Param("customerId") Long customerId,
+                                                                     @Param("statuses") Collection<OrderReturnRequestStatus> statuses);
 }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -162,6 +162,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             "🔁 Возвраты и обмены\n\nВыберите действие:";
     private static final String RETURNS_ACTIVE_TITLE = "📂 Текущие заявки";
     private static final String RETURNS_ACTIVE_EMPTY_PLACEHOLDER = "• активных заявок нет";
+    private static final String RETURNS_ACTIVE_CONTACT_HINT = "📱 Привяжите номер телефона командой /start, чтобы видеть активные заявки в этом разделе.";
     private static final String RETURNS_CREATE_TITLE = "🆕 Создание заявки";
     private static final String RETURNS_CREATE_HINT =
             "Выберите посылку для оформления возврата или обмена. Активные заявки будут отмечены замком.";
@@ -896,13 +897,27 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
     /**
      * Отображает экран с активными заявками возврата или обмена.
+     * <p>
+     * Если чат ещё не привязан к покупателю, бот сообщает об этом и повторно
+     * отправляет запрос на номер телефона, не обращаясь к сервису за данными.
+     * </p>
      *
      * @param chatId идентификатор чата Telegram
      */
     private void sendActiveReturnRequestsScreen(Long chatId) {
-        List<TelegramReturnRequestInfoDTO> requests = telegramService.getActiveReturnRequests(chatId);
         List<BuyerBotScreen> navigationPath = computeNavigationPath(chatId, BuyerBotScreen.RETURNS_ACTIVE_REQUESTS);
         InlineKeyboardMarkup markup = buildNavigationKeyboard(navigationPath);
+
+        if (telegramService.findByChatId(chatId).isEmpty()) {
+            String text = escapeMarkdown(RETURNS_ACTIVE_TITLE)
+                    + "\n\n"
+                    + escapeMarkdown(RETURNS_ACTIVE_CONTACT_HINT);
+            sendInlineMessage(chatId, text, markup, BuyerBotScreen.RETURNS_ACTIVE_REQUESTS, navigationPath);
+            remindContactRequired(chatId);
+            return;
+        }
+
+        List<TelegramReturnRequestInfoDTO> requests = telegramService.getActiveReturnRequests(chatId);
         String text = buildActiveReturnRequestsText(requests);
         sendInlineMessage(chatId, text, markup, BuyerBotScreen.RETURNS_ACTIVE_REQUESTS, navigationPath);
     }

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotLoggingTest.java
@@ -59,6 +59,7 @@ class BuyerTelegramBotLoggingTest {
             throw new RuntimeException(e);
         }
         when(adminNotificationService.findActiveNotification()).thenReturn(Optional.empty());
+        when(customerTelegramService.getActiveReturnRequests(anyLong())).thenReturn(List.of());
         logger = (Logger) LoggerFactory.getLogger(BuyerTelegramBot.class);
         appender = new ListAppender<>();
         appender.start();

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -91,6 +91,7 @@ class BuyerTelegramBotStateIntegrationTest {
                 fullNameValidator, chatSessionRepository, new ObjectMapper());
         lenient().when(adminNotificationService.findActiveNotification()).thenReturn(Optional.empty());
         lenient().when(telegramService.findByChatId(anyLong())).thenReturn(Optional.empty());
+        lenient().when(telegramService.getActiveReturnRequests(anyLong())).thenReturn(List.of());
         lenient().when(telegramService.registerReturnRequestFromTelegram(anyLong(), anyLong(), anyString(), any(), any(), any(), any()))
                 .thenReturn(new OrderReturnRequest());
         lenient().when(telegramService.approveExchangeFromTelegram(anyLong(), anyLong(), anyLong())).thenReturn(null);

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStatePersistenceIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStatePersistenceIntegrationTest.java
@@ -58,6 +58,7 @@ class BuyerTelegramBotStatePersistenceIntegrationTest {
         AdminNotificationService adminNotificationService = mock(AdminNotificationService.class);
         when(telegramClient.execute(any(SendMessage.class))).thenReturn(null);
         when(adminNotificationService.findActiveNotification()).thenReturn(Optional.empty());
+        when(telegramService.getActiveReturnRequests(anyLong())).thenReturn(List.of());
 
         Customer customer = new Customer();
         customer.setTelegramConfirmed(false);
@@ -112,6 +113,7 @@ class BuyerTelegramBotStatePersistenceIntegrationTest {
         menuMessage.setMessageId(555);
         when(initialClient.execute(any(SendMessage.class))).thenReturn(menuMessage);
         when(adminNotificationService.findActiveNotification()).thenReturn(Optional.empty());
+        when(telegramService.getActiveReturnRequests(anyLong())).thenReturn(List.of());
 
         Customer customer = new Customer();
         customer.setTelegramConfirmed(true);


### PR DESCRIPTION
## Summary
- add a returns and exchanges entry to the buyer bot main menu with dedicated screens and navigation
- expose active return requests through a Telegram-specific DTO and repository method
- adapt tests to the new flows and ensure the delivered section no longer emits return/exchange callbacks

## Testing
- mvn -q -DskipITs test *(fails: jitpack.io 403 while downloading bucket4j-core)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd6e5ea40832d908ebde7fb91f751