### PR TITLE
Add migration for buyer return request type state column

### DIFF
--- a/src/main/resources/db/migration/V26__buyer_return_request_type.sql
+++ b/src/main/resources/db/migration/V26__buyer_return_request_type.sql
@@ -1,0 +1,3 @@
+-- Добавляет тип заявки на возврат в состояние экранов покупательского бота
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN return_request_type VARCHAR(32);

--- a/src/test/resources/db/migration/h2/V6__buyer_return_request_type.sql
+++ b/src/test/resources/db/migration/h2/V6__buyer_return_request_type.sql
@@ -1,0 +1,3 @@
+-- Добавляет тип заявки на возврат для состояний бота в H2
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN IF NOT EXISTS return_request_type VARCHAR(32);


### PR DESCRIPTION
## Summary
- add a Flyway migration that introduces the return_request_type column to buyer bot screen states
- mirror the schema change in the H2 test migrations

## Testing
- mvn test *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 could not be downloaded from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68e00ddc4300832d87e016834d0baba2