### PR TITLE
Add return store name column to buyer bot screen states

### DIFF
--- a/src/main/resources/db/migration/V27__buyer_return_store_name.sql
+++ b/src/main/resources/db/migration/V27__buyer_return_store_name.sql
@@ -1,0 +1,3 @@
+-- Добавляет хранение названия магазина для возврата
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN return_store_name VARCHAR(255);

--- a/src/test/resources/db/migration/h2/V7__buyer_return_store_name.sql
+++ b/src/test/resources/db/migration/h2/V7__buyer_return_store_name.sql
@@ -1,0 +1,3 @@
+-- Добавляет хранение названия магазина для возврата
+ALTER TABLE tb_buyer_bot_screen_states
+    ADD COLUMN IF NOT EXISTS return_store_name VARCHAR(255);


### PR DESCRIPTION
## Summary
- add a Flyway migration that introduces the return_store_name column to tb_buyer_bot_screen_states
- align the H2 test schema with a matching migration that uses IF NOT EXISTS

## Testing
- mvn test *(fails: dependency resolution blocked by jitpack.io 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e0103c1514832d9f314ed6808f300a