### PR TITLE
Handle menu button during return reason prompt

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -438,6 +438,12 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         String trimmed = text.trim();
+
+        if (BUTTON_MENU.equals(trimmed) || "/menu".equals(trimmed)) {
+            handleMenuCommand(chatId);
+            return;
+        }
+
         BuyerChatState state = getState(chatId);
 
         if (state == BuyerChatState.AWAITING_CONTACT) {
@@ -452,11 +458,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             }
 
             handleAwaitedPhoneText(chatId, trimmed);
-            return;
-        }
-
-        if ("/menu".equals(trimmed)) {
-            handleMenuCommand(chatId);
             return;
         }
 
@@ -2124,6 +2125,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
     /**
      * Показывает главное меню и возвращает сценарий в состояние IDLE.
+     * <p>
+     * Метод очищает временный контекст возвратов и обменов, чтобы прекратить
+     * дополнительные подсказки, и тем самым гарантирует корректное отображение меню.
+     * </p>
      *
      * @param chatId идентификатор чата Telegram
      */
@@ -2172,8 +2177,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
 
         if (BUTTON_MENU.equals(text)) {
-            resetMenuAnchorIfAlreadyShown(chatId);
-            sendMainMenu(chatId);
+            handleMenuCommand(chatId);
             return;
         }
 


### PR DESCRIPTION
## Summary
- handle the persistent "🏠 Меню" button before state-specific branches so the return/exchange flow resets immediately
- route menu button handling through the common helper and document that it clears temporary context
- add an integration test ensuring tapping the menu button during the return reason prompt restores the main menu without reminders

## Testing
- `mvn -Dtest=BuyerTelegramBotStateIntegrationTest test` *(fails: cannot download io.github.bucket4j.bucket4j:bucket4j-core from jitpack.io, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e03dc21360832d8915bbeb46a04489