### PR TITLE
Fix return request message formatting

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1109,12 +1109,15 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 });
     }
 
+    /**
+     * Формирует сообщение с информацией об активных заявках на возврат и подсказками по выбранной заявке.
+     */
     private String buildActiveReturnRequestsMessage(List<ActionRequiredReturnRequestDto> requests,
                                                     ActionRequiredReturnRequestDto selected) {
         StringBuilder builder = new StringBuilder();
-        builder.append(escapeMarkdown(RETURNS_ACTIVE_TITLE)).append('
-').append('
-');
+        builder.append(escapeMarkdown(RETURNS_ACTIVE_TITLE))
+                .append(System.lineSeparator())
+                .append(System.lineSeparator());
 
         if (requests == null || requests.isEmpty()) {
             builder.append(RETURNS_ACTIVE_EMPTY_PLACEHOLDER);
@@ -1126,12 +1129,13 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return builder.toString();
         }
 
-        builder.append('*').append(escapeMarkdown(RETURNS_ACTIVE_SELECTED_HEADER)).append('*').append('
-');
+        builder.append('*')
+                .append(escapeMarkdown(RETURNS_ACTIVE_SELECTED_HEADER))
+                .append('*')
+                .append(System.lineSeparator());
         builder.append(formatSelectedRequestDetails(selected));
-        builder.append('
-').append('
-');
+        builder.append(System.lineSeparator())
+                .append(System.lineSeparator());
         String actionsHint = selected.status() == OrderReturnRequestStatus.EXCHANGE_APPROVED
                 ? RETURNS_ACTIVE_ACTIONS_EXCHANGE
                 : RETURNS_ACTIVE_ACTIONS_RETURN;


### PR DESCRIPTION
## Summary
- replace character-literal based new line appends with System.lineSeparator in the active return requests message builder
- add a Russian documentation comment explaining the method purpose

## Testing
- `mvn -q -DskipTests compile` *(fails: status code: 403, reason phrase: Forbidden (403) while resolving io.github.bucket4j.bucket4j:bucket4j-core)*

------
https://chatgpt.com/codex/tasks/task_e_68e052f01fe4832d8a2427f3097becb1