### PR TITLE
Hide active request list when actions are shown

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1216,18 +1216,20 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         List<InlineKeyboardRow> rows = new ArrayList<>();
         boolean hasRequests = requests != null && !requests.isEmpty();
 
-        if (hasRequests && selected == null) {
-            for (ActionRequiredReturnRequestDto request : requests) {
-                if (request == null || request.requestId() == null || request.parcelId() == null) {
-                    continue;
+        if (selected == null) {
+            if (hasRequests) {
+                for (ActionRequiredReturnRequestDto request : requests) {
+                    if (request == null || request.requestId() == null || request.parcelId() == null) {
+                        continue;
+                    }
+                    InlineKeyboardButton button = InlineKeyboardButton.builder()
+                            .text(buildRequestSelectionLabel(request, null))
+                            .callbackData(CALLBACK_RETURNS_ACTIVE_SELECT_PREFIX + request.requestId() + ':' + request.parcelId())
+                            .build();
+                    rows.add(new InlineKeyboardRow(button));
                 }
-                InlineKeyboardButton button = InlineKeyboardButton.builder()
-                        .text(buildRequestSelectionLabel(request, null))
-                        .callbackData(CALLBACK_RETURNS_ACTIVE_SELECT_PREFIX + request.requestId() + ':' + request.parcelId())
-                        .build();
-                rows.add(new InlineKeyboardRow(button));
             }
-        } else if (selected != null) {
+        } else {
             rows.add(buildBackToListRow());
         }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/ChatSession.java
@@ -226,6 +226,10 @@ public class ChatSession {
         BuyerBotScreen current = projected.get(projected.size() - 1);
         if (current != screen) {
             projected.add(screen);
+            if (allowDuplicate && screen == BuyerBotScreen.RETURNS_ACTIVE_REQUESTS) {
+                // Для экрана активных заявок добавляем дубликат шага, чтобы «Назад» возвращал список заявок.
+                projected.add(screen);
+            }
         } else if (allowDuplicate) {
             projected.add(screen);
         }

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -73,6 +73,7 @@ class BuyerTelegramBotTest {
     private static final String MENU_BUTTON_TEXT = "🏠 Меню";
     private static final String BACK_BUTTON_TEXT = "⬅️ Назад";
     private static final String ACTIVE_BACK_TO_LIST_TEXT = "↩️ Вернуться к списку";
+    private static final String NAVIGATE_BACK_CALLBACK = "nav:back";
     private static final String OUTCOME_OK_TEXT = "Ок";
     private static final String OUTCOME_BACK_TEXT = "Назад";
 
@@ -631,6 +632,8 @@ class BuyerTelegramBotTest {
         List<InlineKeyboardButton> navigationRow = keyboard.get(keyboard.size() - 1);
         assertTrue(navigationRow.stream().anyMatch(button -> BACK_BUTTON_TEXT.equals(button.getText())),
                 "Последняя строка клавиатуры должна оставаться навигационной");
+        assertTrue(navigationRow.stream().anyMatch(button -> MENU_BUTTON_TEXT.equals(button.getText())),
+                "Навигационная строка обязана содержать кнопку перехода в меню");
 
         boolean hasTrackAction = keyboard.stream()
                 .filter(Objects::nonNull)
@@ -651,6 +654,34 @@ class BuyerTelegramBotTest {
         assertTrue(hasTrackAction, "Клавиатура должна содержать действие обновления трека");
         assertTrue(hasCommentAction, "Клавиатура должна содержать действие обновления комментария");
         assertTrue(hasCancelAction, "Клавиатура должна содержать действие отмены возврата");
+
+        Integer anchorMessageId = editMessage.getMessageId();
+        assertNotNull(anchorMessageId,
+                "Обновление сообщения после выбора заявки должно указывать идентификатор сообщения");
+
+        clearInvocations(telegramClient);
+
+        bot.consume(mockCallbackUpdate(chatId, NAVIGATE_BACK_CALLBACK, anchorMessageId));
+
+        ArgumentCaptor<EditMessageText> backCaptor = ArgumentCaptor.forClass(EditMessageText.class);
+        verify(telegramClient).execute(backCaptor.capture());
+
+        EditMessageText backMessage = backCaptor.getValue();
+        assertTrue(backMessage.getText().contains("Выберите заявку"),
+                "После нажатия «Назад» бот обязан показать список заявок");
+
+        InlineKeyboardMarkup backMarkup = backMessage.getReplyMarkup();
+        assertNotNull(backMarkup, "Список заявок должен сопровождаться инлайн-клавиатурой");
+        boolean hasSelectionButtonsAfterBack = backMarkup.getKeyboard().stream()
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .anyMatch(button -> {
+                    String callback = button.getCallbackData();
+                    return callback != null && callback.startsWith("returns:active:select:");
+                });
+        assertTrue(hasSelectionButtonsAfterBack,
+                "Клавиатура после возврата должна снова содержать список заявок");
     }
 
     /**


### PR DESCRIPTION
## Summary
- update the active requests keyboard builder to skip rendering the request list when a request is selected
- ensure the navigation row keeps the back and menu buttons and that navigating back restores the request list
- extend the active request selection test to cover the updated keyboard behavior and navigation back handling

## Testing
- mvn -Dtest=BuyerTelegramBotTest test *(fails: dependency resolution blocked by 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68e1701feb68832d8c2c8d49ccd230dd