### PR TITLE
Refine buyer active request navigation

### DIFF
--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -77,7 +77,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     private static final String BUTTON_MENU = "🏠 Меню";
     private static final String BUTTON_BACK = "⬅️ Назад";
     private static final String BUTTON_OUTCOME_OK = "Ок";
-    private static final String BUTTON_OUTCOME_BACK = "Назад";
 
     private static final String CALLBACK_BACK_TO_MENU = "menu:back";
     private static final String CALLBACK_MENU_SHOW_STATS = "menu:stats";
@@ -105,7 +104,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX = "returns:active:cancel:";
     private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_EXCHANGE_PREFIX = "returns:active:cancel_exchange:";
     private static final String CALLBACK_RETURNS_ACTIVE_CONVERT_PREFIX = "returns:active:convert:";
-    private static final String CALLBACK_RETURNS_ACTIVE_BACK_TO_LIST = "returns:active:list";
     private static final String CALLBACK_RETURNS_DONE = "returns:done";
     private static final String CALLBACK_SETTINGS_TOGGLE_NOTIFICATIONS = "settings:toggle_notifications";
     private static final String CALLBACK_SETTINGS_CONFIRM_NAME = "settings:confirm_name";
@@ -206,7 +204,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             "⚠️ Комментарий не должен быть пустым. Напишите текст или «Нет» для очистки.";
     private static final String RETURNS_ACTIVE_UPDATE_FAILED =
             "⚠️ Не удалось сохранить изменения. Попробуйте ещё раз позже или обратитесь в поддержку.";
-    private static final String BUTTON_RETURNS_BACK_TO_LIST = "↩️ Вернуться к списку";
     private static final String BUTTON_RETURNS_ACTION_TRACK = "📮 Указать трек";
     private static final String BUTTON_RETURNS_ACTION_COMMENT = "💬 Комментарий";
     private static final String BUTTON_RETURNS_ACTION_CANCEL_RETURN = "🚫 Отменить возврат";
@@ -619,11 +616,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
 
         if (data.startsWith(CALLBACK_RETURNS_ACTIVE_CONVERT_PREFIX)) {
             handleActiveRequestConvert(chatId, callbackQuery, data);
-            return;
-        }
-
-        if (CALLBACK_RETURNS_ACTIVE_BACK_TO_LIST.equals(data)) {
-            handleActiveRequestBackToList(chatId, callbackQuery);
             return;
         }
 
@@ -1232,8 +1224,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                     rows.add(new InlineKeyboardRow(button));
                 }
             }
-        } else {
-            rows.add(buildBackToListRow());
         }
 
         if (selected != null && selected.requestId() != null && selected.parcelId() != null) {
@@ -1288,18 +1278,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         return rows;
     }
 
-    /**
-     * Создаёт строку с кнопкой возврата к списку заявок после выбора конкретной заявки.
-     *
-     * @return строка клавиатуры с кнопкой возврата
-     */
-    private InlineKeyboardRow buildBackToListRow() {
-        InlineKeyboardButton backButton = InlineKeyboardButton.builder()
-                .text(BUTTON_RETURNS_BACK_TO_LIST)
-                .callbackData(CALLBACK_RETURNS_ACTIVE_BACK_TO_LIST)
-                .build();
-        return new InlineKeyboardRow(backButton);
-    }
     /**
      * Возвращает отображаемое название магазина для таблицы активных заявок.
      *
@@ -1912,20 +1890,6 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         sendActiveReturnRequestsScreen(chatId);
     }
 
-    /**
-     * Очищает выбранную заявку и возвращает пользователя к списку активных заявок.
-     *
-     * @param chatId        идентификатор чата Telegram
-     * @param callbackQuery исходный callback-запрос
-     */
-    private void handleActiveRequestBackToList(Long chatId, CallbackQuery callbackQuery) {
-        answerCallbackQuery(callbackQuery, "Возвращаемся к списку");
-        ChatSession session = ensureChatSession(chatId);
-        session.clearActiveReturnRequestContext();
-        chatSessionRepository.save(session);
-        sendActiveReturnRequestsScreen(chatId);
-    }
-
     private void handleActiveRequestTrack(Long chatId, CallbackQuery callbackQuery, String data) {
         Optional<RequestActionContext> contextOptional = parseActionContext(data, CALLBACK_RETURNS_ACTIVE_TRACK_PREFIX);
         if (contextOptional.isEmpty()) {
@@ -1969,16 +1933,16 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         ChatSession session = ensureChatSession(chatId);
         try {
             telegramService.closeReturnRequestFromTelegram(chatId, context.parcelId(), context.requestId());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_CANCEL_RETURN_SUCCESS, BUTTON_OUTCOME_OK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_CANCEL_RETURN_SUCCESS);
         } catch (AccessDeniedException ex) {
             log.warn("⚠️ Попытка отменить чужую заявку {} в чате {}", context.requestId(), chatId);
-            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED);
         } catch (IllegalArgumentException | IllegalStateException ex) {
             log.warn("⚠️ Ошибка отмены возврата {}: {}", context.requestId(), ex.getMessage());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         } catch (Exception ex) {
             log.error("❌ Не удалось отменить возврат {}", context.requestId(), ex);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         }
     }
 
@@ -1993,16 +1957,16 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         ChatSession session = ensureChatSession(chatId);
         try {
             telegramService.cancelExchangeFromTelegram(chatId, context.parcelId(), context.requestId());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_CANCEL_EXCHANGE_SUCCESS, BUTTON_OUTCOME_OK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_CANCEL_EXCHANGE_SUCCESS);
         } catch (AccessDeniedException ex) {
             log.warn("⚠️ Попытка отменить чужой обмен {} в чате {}", context.requestId(), chatId);
-            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED);
         } catch (IllegalArgumentException | IllegalStateException ex) {
             log.warn("⚠️ Ошибка отмены обмена {}: {}", context.requestId(), ex.getMessage());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         } catch (Exception ex) {
             log.error("❌ Не удалось отменить обмен {}", context.requestId(), ex);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         }
     }
 
@@ -2017,16 +1981,16 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         ChatSession session = ensureChatSession(chatId);
         try {
             telegramService.convertExchangeToReturnFromTelegram(chatId, context.parcelId(), context.requestId());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_CONVERT_SUCCESS, BUTTON_OUTCOME_OK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_CONVERT_SUCCESS);
         } catch (AccessDeniedException ex) {
             log.warn("⚠️ Попытка изменить чужой обмен {} в чате {}", context.requestId(), chatId);
-            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED);
         } catch (IllegalArgumentException | IllegalStateException ex) {
             log.warn("⚠️ Ошибка преобразования обмена {}: {}", context.requestId(), ex.getMessage());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         } catch (Exception ex) {
             log.error("❌ Не удалось перевести обмен {} в возврат", context.requestId(), ex);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         }
     }
 
@@ -2077,26 +2041,26 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                                     String text) {
         String normalized = text == null ? "" : text.strip();
         if (normalized.isEmpty()) {
-            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_UPDATE_INVALID_TRACK, BUTTON_OUTCOME_BACK);
+            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_UPDATE_INVALID_TRACK);
             return;
         }
         String newTrack = isSkipWord(normalized) ? null : normalized;
         String comment = requestInfo.comment();
         try {
             telegramService.updateReturnRequestDetailsFromTelegram(chatId, parcelId, requestId, newTrack, comment);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_TRACK_SAVED, BUTTON_OUTCOME_OK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_TRACK_SAVED);
         } catch (AccessDeniedException ex) {
             log.warn("⚠️ Попытка обновить чужую заявку {} в чате {}", requestId, chatId);
-            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED);
         } catch (IllegalArgumentException ex) {
             log.warn("⚠️ Некорректный трек для заявки {}: {}", requestId, ex.getMessage());
-            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_UPDATE_INVALID_TRACK, BUTTON_OUTCOME_BACK);
+            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_UPDATE_INVALID_TRACK);
         } catch (IllegalStateException ex) {
             log.warn("⚠️ Заявку {} нельзя обновить: {}", requestId, ex.getMessage());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         } catch (Exception ex) {
             log.error("❌ Ошибка обновления заявки {}", requestId, ex);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_UPDATE_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_UPDATE_FAILED);
         }
     }
 
@@ -2108,41 +2072,40 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                                       String text) {
         String normalized = text == null ? "" : text.strip();
         if (normalized.isEmpty()) {
-            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_COMMENT_INVALID, BUTTON_OUTCOME_BACK);
+            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_COMMENT_INVALID);
             return;
         }
         String newComment = isSkipWord(normalized) ? null : normalized;
         String reverseTrack = requestInfo.reverseTrackNumber();
         try {
             telegramService.updateReturnRequestDetailsFromTelegram(chatId, parcelId, requestId, reverseTrack, newComment);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_COMMENT_SAVED, BUTTON_OUTCOME_OK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_COMMENT_SAVED);
         } catch (AccessDeniedException ex) {
             log.warn("⚠️ Попытка обновить чужую заявку {} в чате {}", requestId, chatId);
-            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, PARCEL_RETURN_ACCESS_DENIED);
         } catch (IllegalArgumentException ex) {
             log.warn("⚠️ Некорректный комментарий для заявки {}: {}", requestId, ex.getMessage());
-            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_COMMENT_INVALID, BUTTON_OUTCOME_BACK);
+            sendActiveRequestOutcomeMessage(chatId, RETURNS_ACTIVE_COMMENT_INVALID);
         } catch (IllegalStateException ex) {
             log.warn("⚠️ Заявку {} нельзя обновить: {}", requestId, ex.getMessage());
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_FAILED);
         } catch (Exception ex) {
             log.error("❌ Ошибка обновления заявки {}", requestId, ex);
-            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_UPDATE_FAILED, BUTTON_OUTCOME_BACK);
+            finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_UPDATE_FAILED);
         }
     }
 
     /**
      * Завершает редактирование активной заявки, очищая контекст и показывая итоговое сообщение.
      *
-     * @param chatId     идентификатор чата Telegram
-     * @param session    сохранённая сессия пользователя
-     * @param message    текст уведомления о результате операции
-     * @param buttonLabel подпись для кнопки возврата к списку заявок
+     * @param chatId   идентификатор чата Telegram
+     * @param session  сохранённая сессия пользователя
+     * @param message  текст уведомления о результате операции
      */
-    private void finalizeRequestUpdate(Long chatId, ChatSession session, String message, String buttonLabel) {
+    private void finalizeRequestUpdate(Long chatId, ChatSession session, String message) {
         session = session != null ? session : ensureChatSession(chatId);
         resetActiveRequestContext(session);
-        sendActiveRequestOutcomeMessage(chatId, message, buttonLabel);
+        sendActiveRequestOutcomeMessage(chatId, message);
     }
 
     /**
@@ -2160,27 +2123,22 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     }
 
     /**
-     * Показывает результат операции над активной заявкой с кнопкой возврата к списку.
+     * Показывает результат операции над активной заявкой, используя стандартную навигацию.
+     * <p>
+     * Метод строит клавиатуру только из навигационной строки, чтобы кнопка «⬅️ Назад»
+     * возвращала пользователя к списку заявок без отдельной служебной кнопки.
+     * </p>
      *
-     * @param chatId      идентификатор чата Telegram
-     * @param text        сообщение для пользователя
-     * @param buttonLabel подпись кнопки подтверждения результата
+     * @param chatId идентификатор чата Telegram
+     * @param text   сообщение для пользователя
      */
-    private void sendActiveRequestOutcomeMessage(Long chatId, String text, String buttonLabel) {
+    private void sendActiveRequestOutcomeMessage(Long chatId, String text) {
         if (chatId == null) {
             return;
         }
         String safeText = escapeMarkdown(text == null ? "" : text);
-        String safeButtonLabel = (buttonLabel == null || buttonLabel.isBlank()) ? BUTTON_OUTCOME_BACK : buttonLabel;
-        InlineKeyboardButton button = InlineKeyboardButton.builder()
-                .text(safeButtonLabel)
-                .callbackData(CALLBACK_RETURNS_ACTIVE_BACK_TO_LIST)
-                .build();
-        InlineKeyboardRow row = new InlineKeyboardRow(button);
-        InlineKeyboardMarkup markup = InlineKeyboardMarkup.builder()
-                .keyboard(List.of(row))
-                .build();
         List<BuyerBotScreen> navigationPath = computeNavigationPath(chatId, BuyerBotScreen.RETURNS_ACTIVE_REQUESTS);
+        InlineKeyboardMarkup markup = buildNavigationKeyboard(navigationPath);
         sendInlineMessage(chatId, safeText, markup, BuyerBotScreen.RETURNS_ACTIVE_REQUESTS, navigationPath);
     }
     /**

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -72,10 +72,7 @@ class BuyerTelegramBotTest {
 
     private static final String MENU_BUTTON_TEXT = "🏠 Меню";
     private static final String BACK_BUTTON_TEXT = "⬅️ Назад";
-    private static final String ACTIVE_BACK_TO_LIST_TEXT = "↩️ Вернуться к списку";
     private static final String NAVIGATE_BACK_CALLBACK = "nav:back";
-    private static final String OUTCOME_OK_TEXT = "Ок";
-    private static final String OUTCOME_BACK_TEXT = "Назад";
 
     @Mock
     private TelegramClient telegramClient;
@@ -612,11 +609,9 @@ class BuyerTelegramBotTest {
         assertTrue(messageText.contains("Текущая заявка на возврат"),
                 "Заголовок выбранной заявки должен указывать на оформление возврата");
 
-        InlineKeyboardButton backToList = keyboard.get(0).get(0);
-        assertEquals(ACTIVE_BACK_TO_LIST_TEXT, backToList.getText(),
-                "Первая строка должна содержать кнопку возврата к списку");
-        assertEquals("returns:active:list", backToList.getCallbackData(),
-                "Callback кнопки возврата к списку должен быть корректным");
+        InlineKeyboardButton firstAction = keyboard.get(0).get(0);
+        assertEquals("📮 Указать трек", firstAction.getText(),
+                "Первая строка после выбора должна начинаться с действий по заявке");
 
         boolean hasSelectionButtons = keyboard.stream()
                 .filter(Objects::nonNull)
@@ -629,9 +624,23 @@ class BuyerTelegramBotTest {
         assertFalse(hasSelectionButtons,
                 "После выбора заявки список заявок не должен отображаться в клавиатуре");
 
+        boolean hasForbiddenCallback = keyboard.stream()
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .map(InlineKeyboardButton::getCallbackData)
+                .filter(Objects::nonNull)
+                .anyMatch("returns:active:list"::equals);
+        assertFalse(hasForbiddenCallback,
+                "После выбора заявки не должно оставаться кнопок со старым callback возврата к списку");
+
         List<InlineKeyboardButton> navigationRow = keyboard.get(keyboard.size() - 1);
-        assertTrue(navigationRow.stream().anyMatch(button -> BACK_BUTTON_TEXT.equals(button.getText())),
-                "Последняя строка клавиатуры должна оставаться навигационной");
+        InlineKeyboardButton backButton = navigationRow.stream()
+                .filter(button -> BACK_BUTTON_TEXT.equals(button.getText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Навигационная строка обязана содержать кнопку «Назад»"));
+        assertEquals(NAVIGATE_BACK_CALLBACK, backButton.getCallbackData(),
+                "Кнопка навигации «Назад» должна использовать стандартный callback");
         assertTrue(navigationRow.stream().anyMatch(button -> MENU_BUTTON_TEXT.equals(button.getText())),
                 "Навигационная строка обязана содержать кнопку перехода в меню");
 
@@ -914,11 +923,19 @@ class BuyerTelegramBotTest {
         InlineKeyboardMarkup markup = editMessage.getReplyMarkup();
         assertNotNull(markup, "Для результата операции ожидается инлайн-клавиатура");
         List<List<InlineKeyboardButton>> keyboard = markup.getKeyboard();
-        assertEquals(1, keyboard.size(), "Клавиатура результата должна содержать одну строку");
-        InlineKeyboardButton outcomeButton = keyboard.get(0).get(0);
-        assertEquals(OUTCOME_OK_TEXT, outcomeButton.getText(), "Кнопка подтверждения должна называться «Ок»");
-        assertEquals("returns:active:list", outcomeButton.getCallbackData(),
-                "Нажатие должно возвращать пользователя к списку заявок");
+        assertEquals(1, keyboard.size(), "Клавиатура результата должна содержать одну навигационную строку");
+        List<InlineKeyboardButton> navRow = keyboard.get(0);
+        InlineKeyboardButton backButton = navRow.stream()
+                .filter(button -> BACK_BUTTON_TEXT.equals(button.getText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Результат операции обязан содержать кнопку «Назад»"));
+        assertEquals(NAVIGATE_BACK_CALLBACK, backButton.getCallbackData(),
+                "Кнопка возврата должна использовать стандартный callback навигации");
+        boolean legacyCallbackPresent = navRow.stream()
+                .map(InlineKeyboardButton::getCallbackData)
+                .filter(Objects::nonNull)
+                .anyMatch("returns:active:list"::equals);
+        assertFalse(legacyCallbackPresent, "Клавиатура результата не должна содержать устаревший callback возврата к списку");
 
         assertEquals(BuyerChatState.IDLE, chatSessionRepository.getState(chatId));
         ChatSession stored = chatSessionRepository.find(chatId).orElseThrow();
@@ -976,10 +993,18 @@ class BuyerTelegramBotTest {
 
         InlineKeyboardMarkup markup = editMessage.getReplyMarkup();
         assertNotNull(markup, "Для ошибки также требуется инлайн-клавиатура");
-        InlineKeyboardButton button = markup.getKeyboard().get(0).get(0);
-        assertEquals(OUTCOME_BACK_TEXT, button.getText(), "В случае ошибки должна быть кнопка «Назад»");
-        assertEquals("returns:active:list", button.getCallbackData(),
-                "Callback должен приводить к повторному открытию списка заявок");
+        List<InlineKeyboardButton> navRow = markup.getKeyboard().get(0);
+        InlineKeyboardButton backButton = navRow.stream()
+                .filter(button -> BACK_BUTTON_TEXT.equals(button.getText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("При ошибке должна отображаться кнопка «Назад»"));
+        assertEquals(NAVIGATE_BACK_CALLBACK, backButton.getCallbackData(),
+                "Кнопка возврата после ошибки обязана использовать стандартный callback");
+        boolean containsLegacyCallback = navRow.stream()
+                .map(InlineKeyboardButton::getCallbackData)
+                .filter(Objects::nonNull)
+                .anyMatch("returns:active:list"::equals);
+        assertFalse(containsLegacyCallback, "Клавиатура ошибки не должна содержать устаревший callback возврата к списку");
 
         assertEquals(BuyerChatState.IDLE, chatSessionRepository.getState(chatId));
         ChatSession stored = chatSessionRepository.find(chatId).orElseThrow();


### PR DESCRIPTION
## Summary
- remove the bespoke "back to list" button from the active return request keyboard and rely on the standard navigation row
- reuse the shared navigation flow when sending outcome messages after request updates instead of a dedicated callback
- adjust telegram bot tests to expect navigation-based actions and verify the legacy callback is absent

## Testing
- mvn -q -DskipITs test *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 cannot be resolved due to 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68e176139798832dbe60efef79ccd446