### PR TITLE
Fix duplicate return request date in track modal

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -7,8 +7,7 @@ package com.project.tracking_system.dto;
  * @param status                   человеко-читаемый статус
  * @param reason                   причина оформления возврата
  * @param comment                  дополнительный комментарий пользователя
- * @param requestedAt              дата, указанная пользователем при обращении
- * @param createdAt                дата регистрации в системе
+ * @param requestedAt              дата, указанная пользователем при обращении (или дата регистрации при её отсутствии)
  * @param decisionAt               дата принятия решения об обмене
  * @param closedAt                 дата закрытия без обмена
  * @param reverseTrackNumber       трек обратной отправки, если указан
@@ -22,7 +21,6 @@ public record OrderReturnRequestDto(Long id,
                                     String reason,
                                     String comment,
                                     String requestedAt,
-                                    String createdAt,
                                     String decisionAt,
                                     String closedAt,
                                     String reverseTrackNumber,

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -128,13 +128,18 @@ public class TrackViewService {
     private OrderReturnRequestDto mapReturnRequest(OrderReturnRequest request, ZoneId userZone) {
         boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
         boolean canCloseWithoutExchange = request.getStatus() == OrderReturnRequestStatus.REGISTERED;
+        String requestedAt = formatNullableTimestamp(request.getRequestedAt(), userZone);
+        // Подставляем дату регистрации, если пользовательское обращение отсутствует, чтобы модалка не показывала дубль.
+        if (requestedAt == null) {
+            requestedAt = formatNullableTimestamp(request.getCreatedAt(), userZone);
+        }
+
         return new OrderReturnRequestDto(
                 request.getId(),
                 request.getStatus().getDisplayName(),
                 request.getReason(),
                 request.getComment(),
-                formatNullableTimestamp(request.getRequestedAt(), userZone),
-                formatNullableTimestamp(request.getCreatedAt(), userZone),
+                requestedAt,
                 formatNullableTimestamp(request.getDecisionAt(), userZone),
                 formatNullableTimestamp(request.getClosedAt(), userZone),
                 request.getReverseTrackNumber(),

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -846,7 +846,6 @@
             appendDefinitionItem(infoList, 'Причина', returnRequest.reason || '—');
             appendDefinitionItem(infoList, 'Комментарий', returnRequest.comment || '—');
             appendDefinitionItem(infoList, 'Дата обращения', format(returnRequest.requestedAt));
-            appendDefinitionItem(infoList, 'Дата регистрации', format(returnRequest.createdAt));
             appendDefinitionItem(infoList, 'Дата решения', format(returnRequest.decisionAt));
             appendDefinitionItem(infoList, 'Дата закрытия', format(returnRequest.closedAt));
             appendDefinitionItem(infoList, 'Трек обратной отправки', returnRequest.reverseTrackNumber || '—');

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -91,7 +91,7 @@ describe('track-modal render', () => {
                 { id: 11, number: 'RB987654321CN', exchange: true, current: true },
                 { id: 10, number: 'RB111222333CN', exchange: false, current: false }
             ],
-            returnRequest: { id: 5, status: 'Зарегистрирована', createdAt: null, decisionAt: null, closedAt: null,
+            returnRequest: { id: 5, status: 'Зарегистрирована', decisionAt: null, closedAt: null,
                 requiresAction: true, exchangeApproved: false, canStartExchange: true, canCloseWithoutExchange: true },
             canRegisterReturn: false,
             requiresAction: true
@@ -161,8 +161,8 @@ describe('track-modal render', () => {
 
         global.window.trackModal.render(data);
 
-        const button = document.querySelector('button.btn-outline-warning');
+        const button = document.querySelector('form button[type="submit"]');
         expect(button).not.toBeNull();
-        expect(button?.textContent).toContain('Зарегистрировать возврат');
+        expect(button?.textContent).toContain('Отправить заявку');
     });
 });


### PR DESCRIPTION
## Summary
- remove the duplicate registration date field from the return request DTO used by the track modal
- fall back to the registration timestamp when the user supplied date is absent and stop rendering the duplicate field in the modal
- refresh the Jest tests to use the updated payload shape and button lookup

## Testing
- npm test
- mvn -q test *(fails: dependency download blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e185204ee8832db38daeb3d8d26ab2