### PR TITLE
Refine Telegram exchange cancellation UX

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
@@ -23,6 +23,7 @@ import com.project.tracking_system.entity.OrderReturnRequestStatus;
  * @param reverseTrackNumber        трек обратной отправки, если указан
  * @param canStartExchange          признак доступности запуска обмена
  * @param canCloseWithoutExchange   признак доступности закрытия без обмена
+ * @param exchangeCancellationMessage пояснение, почему отмена обмена недоступна, если применимо
  */
 public record ActionRequiredReturnRequestDto(Long requestId,
                                              Long parcelId,
@@ -37,5 +38,6 @@ public record ActionRequiredReturnRequestDto(Long requestId,
                                              String comment,
                                              String reverseTrackNumber,
                                              boolean canStartExchange,
-                                             boolean canCloseWithoutExchange) {
+                                             boolean canCloseWithoutExchange,
+                                             String exchangeCancellationMessage) {
 }

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -16,6 +16,7 @@ package com.project.tracking_system.dto;
  * @param exchangeApproved         признак, что обмен уже запущен
  * @param canStartExchange         доступность кнопки запуска обмена
  * @param canCloseWithoutExchange  доступность закрытия без обмена
+ * @param exchangeCancellationMessage пояснение, почему отмена обмена недоступна, если применимо
  */
 public record OrderReturnRequestDto(Long id,
                                     String status,
@@ -29,6 +30,7 @@ public record OrderReturnRequestDto(Long id,
                                     boolean requiresAction,
                                     boolean exchangeApproved,
                                     boolean canStartExchange,
-                                    boolean canCloseWithoutExchange) {
+                                    boolean canCloseWithoutExchange,
+                                    String exchangeCancellationMessage) {
 }
 

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -780,6 +780,15 @@
 
         parcelCard.body.appendChild(parcelHeader);
 
+        const exchangeCancellationMessage = returnRequest?.exchangeCancellationMessage;
+        if (exchangeCancellationMessage) {
+            const warning = document.createElement('div');
+            warning.className = 'alert alert-warning d-flex align-items-center gap-2 mt-3 mb-0';
+            warning.setAttribute('role', 'alert');
+            warning.textContent = exchangeCancellationMessage;
+            parcelCard.body.appendChild(warning);
+        }
+
         const chainNav = createChainNavigation(
             Array.isArray(data?.chain) ? data.chain : [],
             (item) => {

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -319,6 +319,10 @@
                                                             Закрыть без обмена
                                                         </button>
                                                     </div>
+                                                    <div th:if="${request.exchangeCancellationMessage != null}"
+                                                         class="alert alert-warning mt-2 mb-0 py-2 px-3 text-start"
+                                                         role="alert"
+                                                         th:text="${request.exchangeCancellationMessage}"></div>
                                                 </td>
                                             </tr>
                                             </tbody>

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -15,10 +15,12 @@ import com.project.tracking_system.repository.CustomerRepository;
 import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.OrderReturnRequestRepository;
 import com.project.tracking_system.service.order.ExchangeApprovalResult;
+import com.project.tracking_system.service.order.OrderExchangeService;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
 import com.project.tracking_system.service.telegram.FullNameValidator;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import org.springframework.security.access.AccessDeniedException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -62,12 +64,20 @@ class CustomerTelegramServiceTest {
     private OrderReturnRequestRepository returnRequestRepository;
     @Mock
     private OrderReturnRequestService orderReturnRequestService;
+    @Mock
+    private OrderExchangeService orderExchangeService;
 
     @Spy
     private FullNameValidator fullNameValidator = new FullNameValidator();
 
     @InjectMocks
     private CustomerTelegramService customerTelegramService;
+
+    @BeforeEach
+    void initDefaults() {
+        lenient().when(orderExchangeService.findLatestExchangeAndEnsureTrackNotProvided(any()))
+                .thenReturn(null);
+    }
 
     /**
      * Убеждаемся, что при подтверждении существующего ФИО источник обновляется до USER_CONFIRMED.

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -137,7 +137,7 @@ describe('track-modal render', () => {
         expect(buttons[0].getAttribute('aria-current')).toBe('true');
     });
 
-    test('shows register button when return can be created', () => {
+    test('shows registration form when return can be created', () => {
         setupDom();
         const data = {
             id: 7,
@@ -161,8 +161,54 @@ describe('track-modal render', () => {
 
         global.window.trackModal.render(data);
 
-        const button = document.querySelector('button.btn-outline-warning');
-        expect(button).not.toBeNull();
-        expect(button?.textContent).toContain('Зарегистрировать возврат');
+        const form = document.querySelector('form');
+        expect(form).not.toBeNull();
+        const submitButton = form?.querySelector('button.btn.btn-warning');
+        expect(submitButton).not.toBeNull();
+        expect(submitButton?.textContent).toContain('Отправить заявку');
+    });
+
+    test('shows exchange cancellation warning when message provided', () => {
+        setupDom();
+        const data = {
+            id: 55,
+            number: 'BY555555555BY',
+            deliveryService: 'Belpost',
+            systemStatus: 'В пути',
+            history: [],
+            refreshAllowed: false,
+            nextRefreshAt: null,
+            canEditTrack: false,
+            timeZone: 'UTC',
+            episodeNumber: 12,
+            exchange: true,
+            chain: [
+                { id: 55, number: 'BY555555555BY', exchange: true, current: true }
+            ],
+            returnRequest: {
+                id: 700,
+                status: 'Обмен одобрен',
+                reason: 'Не подошёл размер',
+                comment: null,
+                requestedAt: null,
+                createdAt: null,
+                decisionAt: null,
+                closedAt: null,
+                reverseTrackNumber: null,
+                requiresAction: true,
+                exchangeApproved: true,
+                canStartExchange: false,
+                canCloseWithoutExchange: false,
+                exchangeCancellationMessage: 'Магазин уже отправил обменную посылку'
+            },
+            canRegisterReturn: false,
+            requiresAction: true
+        };
+
+        global.window.trackModal.render(data);
+
+        const warning = document.querySelector('.alert.alert-warning');
+        expect(warning).not.toBeNull();
+        expect(warning?.textContent).toContain('Магазин уже отправил обменную посылку');
     });
 });


### PR DESCRIPTION
## Summary
- add a guard in `OrderExchangeService` to prevent cancelling exchanges once a real track number is present and reuse it in return request flows
- expose exchange-cancellation warnings through DTOs, keep the Telegram message inline, and remove the cancel button when the store has already provided a track
- expand unit and UI tests to cover the new blocked-cancellation scenario, including Telegram inline menu behaviour

## Testing
- mvn -Dtest=BuyerTelegramBotTest test *(fails: bucket4j-core dependency blocked with 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68e184f3c3d4832d8546015544f30298