### PR TITLE
Block exchange cancellation when store tracking exists

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/DeparturesController.java
+++ b/src/main/java/com/project/tracking_system/controller/DeparturesController.java
@@ -372,6 +372,9 @@ public class DeparturesController {
 
         boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
         boolean canCloseWithoutExchange = status == OrderReturnRequestStatus.REGISTERED;
+        String cancelExchangeReason = orderReturnRequestService
+                .getExchangeCancellationBlockReason(request)
+                .orElse(null);
 
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
@@ -387,7 +390,8 @@ public class DeparturesController {
                 request.getComment(),
                 request.getReverseTrackNumber(),
                 canStartExchange,
-                canCloseWithoutExchange
+                canCloseWithoutExchange,
+                cancelExchangeReason
         );
     }
 

--- a/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
@@ -23,6 +23,7 @@ import com.project.tracking_system.entity.OrderReturnRequestStatus;
  * @param reverseTrackNumber        трек обратной отправки, если указан
  * @param canStartExchange          признак доступности запуска обмена
  * @param canCloseWithoutExchange   признак доступности закрытия без обмена
+ * @param cancelExchangeUnavailableReason сообщение о недоступности отмены обмена
  */
 public record ActionRequiredReturnRequestDto(Long requestId,
                                              Long parcelId,
@@ -37,5 +38,6 @@ public record ActionRequiredReturnRequestDto(Long requestId,
                                              String comment,
                                              String reverseTrackNumber,
                                              boolean canStartExchange,
-                                             boolean canCloseWithoutExchange) {
+                                             boolean canCloseWithoutExchange,
+                                             String cancelExchangeUnavailableReason) {
 }

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -15,6 +15,7 @@ package com.project.tracking_system.dto;
  * @param exchangeApproved         признак, что обмен уже запущен
  * @param canStartExchange         доступность кнопки запуска обмена
  * @param canCloseWithoutExchange  доступность закрытия без обмена
+ * @param cancelExchangeUnavailableReason сообщение для пользователя, если отмена обмена недоступна
  */
 public record OrderReturnRequestDto(Long id,
                                     String status,
@@ -27,6 +28,7 @@ public record OrderReturnRequestDto(Long id,
                                     boolean requiresAction,
                                     boolean exchangeApproved,
                                     boolean canStartExchange,
-                                    boolean canCloseWithoutExchange) {
+                                    boolean canCloseWithoutExchange,
+                                    String cancelExchangeUnavailableReason) {
 }
 

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -609,6 +609,9 @@ public class CustomerTelegramService {
 
         boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
         boolean canCloseWithoutExchange = status == OrderReturnRequestStatus.REGISTERED;
+        String cancelExchangeReason = orderReturnRequestService
+                .getExchangeCancellationBlockReason(request)
+                .orElse(null);
 
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
@@ -624,7 +627,8 @@ public class CustomerTelegramService {
                 request.getComment(),
                 request.getReverseTrackNumber(),
                 canStartExchange,
-                canCloseWithoutExchange
+                canCloseWithoutExchange,
+                cancelExchangeReason
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -134,6 +134,10 @@ public class TrackViewService {
             requestedAt = formatNullableTimestamp(request.getCreatedAt(), userZone);
         }
 
+        String cancelExchangeReason = orderReturnRequestService
+                .getExchangeCancellationBlockReason(request)
+                .orElse(null);
+
         return new OrderReturnRequestDto(
                 request.getId(),
                 request.getStatus().getDisplayName(),
@@ -146,7 +150,8 @@ public class TrackViewService {
                 request.requiresAction(),
                 request.isExchangeApproved(),
                 canStartExchange,
-                canCloseWithoutExchange
+                canCloseWithoutExchange,
+                cancelExchangeReason
         );
     }
 

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -852,6 +852,14 @@
 
             returnCard.body.appendChild(infoList);
 
+            if (returnRequest.cancelExchangeUnavailableReason) {
+                const warning = document.createElement('div');
+                warning.className = 'alert alert-warning mt-3 mb-0';
+                warning.setAttribute('role', 'status');
+                warning.textContent = returnRequest.cancelExchangeUnavailableReason;
+                returnCard.body.appendChild(warning);
+            }
+
             if (exchangeItem && exchangeItem.id !== undefined) {
                 const exchangeNotice = document.createElement('div');
                 exchangeNotice.className = 'alert alert-info d-flex flex-wrap align-items-center justify-content-between gap-2 mt-3';

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -302,6 +302,11 @@
                                                     </div>
                                                 </td>
                                                 <td class="text-end">
+                                                    <div th:if="${request.cancelExchangeUnavailableReason != null}"
+                                                         class="alert alert-warning text-start small mb-2"
+                                                         role="status">
+                                                        <span th:text="${request.cancelExchangeUnavailableReason}"></span>
+                                                    </div>
                                                     <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end">
                                                         <button type="button"
                                                                 class="btn btn-success btn-sm js-return-request-accept"

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -92,7 +92,8 @@ describe('track-modal render', () => {
                 { id: 10, number: 'RB111222333CN', exchange: false, current: false }
             ],
             returnRequest: { id: 5, status: 'Зарегистрирована', decisionAt: null, closedAt: null,
-                requiresAction: true, exchangeApproved: false, canStartExchange: true, canCloseWithoutExchange: true },
+                requiresAction: true, exchangeApproved: false, canStartExchange: true, canCloseWithoutExchange: true,
+                cancelExchangeUnavailableReason: null },
             canRegisterReturn: false,
             requiresAction: true
         };


### PR DESCRIPTION
## Summary
- add a guard in `OrderExchangeService` that prevents cancelling an exchange once the store-provided tracking number is present and expose the reason to callers
- propagate the cancellation block reason through return-request DTOs, the departures page, the modal dialog and the Telegram bot so users see why the action is unavailable
- extend unit tests for order services, the Telegram bot and the track modal to cover the new branches

## Testing
- `mvn -q test` *(fails: jitpack.io returned HTTP 403 for bucket4j-core)*
- `npm test -- --runInBand` *(fails: jest binary is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e18f0696f8832d927b6e1443a3e10b