### PR TITLE
feat: support exchange option in return registration modal

### DIFF
--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -106,6 +106,14 @@ describe('track-modal render', () => {
         expect(buttons[0].textContent).toContain('обмен');
         buttons[1].click();
         expect(loadSpy).toHaveBeenCalledWith(10);
+
+        const returnCard = Array.from(document.querySelectorAll('section.card'))
+            .find((card) => card.querySelector('h6')?.textContent === 'Возврат / обмен');
+        expect(returnCard).toBeDefined();
+        const definitions = returnCard?.querySelector('dl');
+        expect(definitions?.textContent).toContain('Тип обращения');
+        const typeHint = returnCard?.querySelector('p.text-muted.small');
+        expect(typeHint?.textContent).toContain('Заявка оформлена как обмен');
     });
 
     test('renders return without exchange as single current item', () => {
@@ -165,5 +173,19 @@ describe('track-modal render', () => {
         const button = document.querySelector('form button[type="submit"]');
         expect(button).not.toBeNull();
         expect(button?.textContent).toContain('Отправить заявку');
+
+        const radios = document.querySelectorAll('form input[type="radio"][name^="return-type"]');
+        expect(radios).toHaveLength(2);
+        const radioLabels = Array.from(document.querySelectorAll('form label.form-check-label'))
+            .map((label) => label.textContent);
+        expect(radioLabels).toEqual(expect.arrayContaining(['Возврат', 'Обмен']));
+
+        const reasonSelect = document.querySelector('form select[name="reason"]');
+        expect(reasonSelect).not.toBeNull();
+        const reasonOptions = Array.from(reasonSelect?.options || []).map((option) => option.textContent);
+        expect(reasonOptions).toEqual(expect.arrayContaining(['Не подошло', 'Брак', 'Не понравилось', 'Другое']));
+
+        const reverseTrackInput = document.querySelector('form input[name="reverseTrackNumber"]');
+        expect(reverseTrackInput).not.toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- add a dedicated type switcher and unified reason selector to the return/exchange form, hiding the reverse track field when it is already provided
- include request type, automatic timestamping, and optional reverse track handling in the payload while auto-starting exchanges after registration with updated user messaging
- refresh the "Возврат / обмен" card hints and adjust front-end tests for the new flow

## Testing
- npm test -- track-modal

------
https://chatgpt.com/codex/tasks/task_e_68e23eceb9f4832dbb0c81ef8760f35e