### PR TITLE
Fix OffsetDateTime deserialization in return endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
             <version>3.2.0</version>

--- a/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
+++ b/src/main/java/com/project/tracking_system/configuration/AppConfiguration.java
@@ -1,6 +1,8 @@
 package com.project.tracking_system.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -42,14 +44,18 @@ public class AppConfiguration {
     /**
      * Создает бин {@link ObjectMapper} для работы с JSON данными.
      * <p>
-     * {@link ObjectMapper} используется для сериализации и десериализации JSON данных в Java объекты.
+     * {@link ObjectMapper} используется для сериализации и десериализации JSON данных в Java объекты,
+     * регистрируя модуль {@link JavaTimeModule} для корректной работы с типами даты и времени Java 8.
      * </p>
      *
      * @return Экземпляр {@link ObjectMapper}.
      */
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
     }
 
     /**


### PR DESCRIPTION
## Summary
- register the Jackson JavaTimeModule in the shared ObjectMapper bean to handle Java 8 date-time types
- disable timestamp serialization for OffsetDateTime values and add the jackson-datatype-jsr310 dependency to expose the module

## Testing
- mvn test *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:4.10.0 could not be resolved from jitpack.io due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e2490048d4832d9f0c6aeca2fabd00