### PR TITLE
Add exchange flag to return registration request DTO

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackController.java
@@ -129,6 +129,7 @@ public class TrackController {
         }
         try {
             ZonedDateTime requestedAt = request.requestedAt().atZoneSameInstant(ZoneOffset.UTC);
+            // Флаг запроса обмена пока не передаётся в сервис, чтобы сохранить обратную совместимость REST-контракта.
             orderReturnRequestService.registerReturn(
                     id,
                     user,

--- a/src/main/java/com/project/tracking_system/dto/ReturnRegistrationRequest.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRegistrationRequest.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
@@ -15,13 +16,16 @@ import java.time.OffsetDateTime;
  * @param requestedAt         момент запроса возврата пользователем
  * @param comment             дополнительный комментарий
  * @param reverseTrackNumber  трек-номер обратной отправки, если известен
+ * @param isExchange          признак того, что пользователь сразу запрашивает обмен;
+ *                             если значение не передано, оно считается равным {@code false}
  */
 public record ReturnRegistrationRequest(
         @NotBlank(message = "Идемпотентный ключ обязателен") String idempotencyKey,
         @NotBlank(message = "Причина возврата обязательна") @Size(max = 255, message = "Причина не должна превышать 255 символов") String reason,
         @NotNull(message = "Дата запроса обязательна") @PastOrPresent(message = "Дата запроса не может быть из будущего") OffsetDateTime requestedAt,
         @Size(max = 2000, message = "Комментарий не должен превышать 2000 символов") String comment,
-        @Size(max = 64, message = "Трек обратной отправки не должен превышать 64 символа") String reverseTrackNumber
+        @Size(max = 64, message = "Трек обратной отправки не должен превышать 64 символа") String reverseTrackNumber,
+        @JsonProperty("isExchange") boolean isExchange
 ) {
 }
 


### PR DESCRIPTION
## Summary
- add the isExchange flag to return registration payload documentation and schema with default false handling
- document in the controller that the exchange flag is intentionally ignored by the service for backward compatibility

## Testing
- mvn test *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 is not accessible from jitpack.io due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e24fe9b028832d956ecde4de08edc5