### PR TITLE
Add exchange request support for return registration

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackController.java
@@ -136,7 +136,8 @@ public class TrackController {
                     request.reason(),
                     request.comment(),
                     requestedAt,
-                    request.reverseTrackNumber()
+                    request.reverseTrackNumber(),
+                    request.isExchange()
             );
             return trackViewService.getTrackDetails(id, user.getId());
         } catch (AccessDeniedException ex) {

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -13,6 +13,7 @@ package com.project.tracking_system.dto;
  * @param reverseTrackNumber       трек обратной отправки, если указан
  * @param requiresAction           признак, что заявка ожидает действий
  * @param exchangeApproved         признак, что обмен уже запущен
+ * @param exchangeRequested        признак, что обмен был запрошен при регистрации
  * @param canStartExchange         доступность кнопки запуска обмена
  * @param canCloseWithoutExchange  доступность закрытия без обмена
  * @param cancelExchangeUnavailableReason сообщение для пользователя, если отмена обмена недоступна
@@ -27,8 +28,16 @@ public record OrderReturnRequestDto(Long id,
                                     String reverseTrackNumber,
                                     boolean requiresAction,
                                     boolean exchangeApproved,
+                                    boolean exchangeRequested,
                                     boolean canStartExchange,
                                     boolean canCloseWithoutExchange,
                                     String cancelExchangeUnavailableReason) {
+
+    /**
+     * Совместимый с фронтендом аксессор, чтобы не ломать проверку {@code isExchangeRequest}.
+     */
+    public boolean isExchangeRequest() {
+        return exchangeRequested;
+    }
 }
 

--- a/src/main/java/com/project/tracking_system/dto/ReturnRegistrationRequest.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRegistrationRequest.java
@@ -1,5 +1,6 @@
 package com.project.tracking_system.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
@@ -15,13 +16,21 @@ import java.time.OffsetDateTime;
  * @param requestedAt         момент запроса возврата пользователем
  * @param comment             дополнительный комментарий
  * @param reverseTrackNumber  трек-номер обратной отправки, если известен
+ * @param exchange            признак, что пользователь сразу просит оформить обмен
  */
 public record ReturnRegistrationRequest(
         @NotBlank(message = "Идемпотентный ключ обязателен") String idempotencyKey,
         @NotBlank(message = "Причина возврата обязательна") @Size(max = 255, message = "Причина не должна превышать 255 символов") String reason,
         @NotNull(message = "Дата запроса обязательна") @PastOrPresent(message = "Дата запроса не может быть из будущего") OffsetDateTime requestedAt,
         @Size(max = 2000, message = "Комментарий не должен превышать 2000 символов") String comment,
-        @Size(max = 64, message = "Трек обратной отправки не должен превышать 64 символа") String reverseTrackNumber
+        @Size(max = 64, message = "Трек обратной отправки не должен превышать 64 символа") String reverseTrackNumber,
+        @JsonProperty("isExchange") Boolean exchange
 ) {
+    /**
+     * Возвращает признак, что пользователь сразу просит оформить обмен.
+     */
+    public boolean isExchange() {
+        return Boolean.TRUE.equals(exchange);
+    }
 }
 

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
@@ -73,6 +73,12 @@ public class OrderReturnRequest {
     private String reverseTrackNumber;
 
     /**
+     * Признак, что пользователь запросил обмен при регистрации заявки.
+     */
+    @Column(name = "exchange_requested", nullable = false)
+    private boolean exchangeRequested = false;
+
+    /**
      * Текущее состояние заявки.
      */
     @Enumerated(EnumType.STRING)
@@ -181,6 +187,14 @@ public class OrderReturnRequest {
 
     public void setReverseTrackNumber(String reverseTrackNumber) {
         this.reverseTrackNumber = reverseTrackNumber;
+    }
+
+    public boolean isExchangeRequested() {
+        return exchangeRequested;
+    }
+
+    public void setExchangeRequested(boolean exchangeRequested) {
+        this.exchangeRequested = exchangeRequested;
     }
 
     public OrderReturnRequestStatus getStatus() {

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -411,7 +411,8 @@ public class CustomerTelegramService {
                 reason,
                 null,
                 requestedAt,
-                null
+                null,
+                false
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -149,6 +149,7 @@ public class TrackViewService {
                 request.getReverseTrackNumber(),
                 request.requiresAction(),
                 request.isExchangeApproved(),
+                request.isExchangeRequested(),
                 canStartExchange,
                 canCloseWithoutExchange,
                 cancelExchangeReason

--- a/src/main/resources/db/migration/V30__order_return_exchange_flag.sql
+++ b/src/main/resources/db/migration/V30__order_return_exchange_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_order_return_requests
+    ADD COLUMN exchange_requested BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -241,7 +241,7 @@ class CustomerTelegramServiceTest {
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
         when(trackParcelRepository.findById(parcelId)).thenReturn(Optional.of(parcel));
         ArgumentCaptor<ZonedDateTime> requestedAtCaptor = ArgumentCaptor.forClass(ZonedDateTime.class);
-        when(orderReturnRequestService.registerReturn(eq(parcelId), eq(owner), eq(key), eq(reason), isNull(), any(ZonedDateTime.class), isNull()))
+        when(orderReturnRequestService.registerReturn(eq(parcelId), eq(owner), eq(key), eq(reason), isNull(), any(ZonedDateTime.class), isNull(), eq(false)))
                 .thenReturn(request);
 
         OrderReturnRequest result = customerTelegramService.registerReturnRequestFromTelegram(
@@ -252,7 +252,7 @@ class CustomerTelegramServiceTest {
         );
 
         assertSame(request, result, "Метод обязан возвращать заявку, полученную от доменного сервиса");
-        verify(orderReturnRequestService).registerReturn(eq(parcelId), eq(owner), eq(key), eq(reason), isNull(), requestedAtCaptor.capture(), isNull());
+        verify(orderReturnRequestService).registerReturn(eq(parcelId), eq(owner), eq(key), eq(reason), isNull(), requestedAtCaptor.capture(), isNull(), eq(false));
         ZonedDateTime capturedRequestedAt = requestedAtCaptor.getValue();
         assertNotNull(capturedRequestedAt, "Дата регистрации должна вычисляться автоматически");
         assertEquals(ZoneOffset.UTC, capturedRequestedAt.getZone(), "Дата должна фиксироваться в UTC");
@@ -288,7 +288,7 @@ class CustomerTelegramServiceTest {
                 "key",
                 "Причина"
         ));
-        verify(orderReturnRequestService, never()).registerReturn(any(), any(), any(), any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).registerReturn(any(), any(), any(), any(), any(), any(), any(), anyBoolean());
     }
 
     /**


### PR DESCRIPTION
## Summary
- persist the exchange request flag on order return requests and add a migration for the new column
- surface the flag through DTOs, the track view, and controller/service entry points for frontend compatibility
- enforce idempotency for the new flag and extend controller, service, and telegram tests to cover exchange scenarios

## Testing
- mvn -Dtest=OrderReturnRequestServiceTest,TrackControllerReturnTest,CustomerTelegramServiceTest test *(fails: dependency download blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e2552ce66c832d815f93d583f4d320