### PR TITLE
Use static action labels for exchange action buttons

### DIFF
--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -333,16 +333,14 @@
                                                         <button type="button"
                                                                 class="btn btn-outline-warning btn-sm js-return-request-reopen"
                                                                 th:if="${request.canReopenAsReturn}"
-                                                                th:data-action-label="Перевести в возврат"
-                                                                th:text="Перевести в возврат"
+                                                                data-action-label="Перевести в возврат"
                                                                 th:disabled="${!request.canReopenAsReturn}">
                                                             Перевести в возврат
                                                         </button>
                                                         <button type="button"
                                                                 class="btn btn-outline-danger btn-sm js-return-request-cancel"
                                                                 th:if="${request.canCancelExchange}"
-                                                                th:data-action-label="Отменить обмен"
-                                                                th:text="Отменить обмен"
+                                                                data-action-label="Отменить обмен"
                                                                 th:disabled="${!request.canCancelExchange}">
                                                             Отменить обмен
                                                         </button>


### PR DESCRIPTION
## Summary
- replace the Thymeleaf attributes on the reopen and cancel exchange buttons with static data-action-label values and static text so the JavaScript no longer needs to parse literals

## Testing
- npm test
- UI smoke tests (not run in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6368b8768832da9f6ea6d52d32985