### PR TITLE
Handle lifecycle display without return request

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -149,7 +149,7 @@ public class TrackViewService {
                 ? null
                 : formatNullableTimestamp(resolveStatusMoment(parcel), userZone);
         String outboundTrackNumber = normalizeTrackNumber(parcel.getNumber());
-        stages.add(new TrackLifecycleStageDto(
+        TrackLifecycleStageDto outboundStage = new TrackLifecycleStageDto(
                 "OUTBOUND",
                 "Отправление магазина",
                 "Магазин",
@@ -158,7 +158,8 @@ public class TrackViewService {
                 outboundMoment,
                 outboundTrackNumber,
                 "Исходная посылка"
-        ));
+        );
+        stages.add(outboundStage);
 
         if (requestOpt.isEmpty()) {
             return stages;

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -937,10 +937,13 @@
             return null;
         }
 
-        const hasOnlyOutboundStage = stages.length === 1
-            && stages[0]
-            && typeof stages[0] === 'object'
-            && stages[0].code === 'OUTBOUND';
+        const normalizedStages = stages.filter((stage) => stage && typeof stage === 'object');
+        if (normalizedStages.length === 0) {
+            return null;
+        }
+
+        const hasOnlyOutboundStage = normalizedStages.length === 1
+            && normalizedStages[0].code === 'OUTBOUND';
         if (hasOnlyOutboundStage) {
             return null;
         }
@@ -950,11 +953,7 @@
         list.className = 'list-unstyled d-flex flex-column gap-3 mb-0';
         list.setAttribute('role', 'list');
 
-        stages.forEach((stage, index) => {
-            if (!stage || typeof stage !== 'object') {
-                return;
-            }
-
+        normalizedStages.forEach((stage, index) => {
             const item = document.createElement('li');
             item.className = 'd-flex flex-column flex-lg-row gap-2 gap-lg-3 align-items-lg-center';
             item.setAttribute('role', 'listitem');

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -140,7 +140,10 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(24L, 4L);
 
         assertThat(details.lifecycle()).hasSize(1);
-        assertThat(details.lifecycle().get(0).code()).isEqualTo("OUTBOUND");
+        TrackLifecycleStageDto onlyStage = details.lifecycle().get(0);
+        assertThat(onlyStage.code()).isEqualTo("OUTBOUND");
+        assertThat(onlyStage.trackNumber()).isEqualTo("TRK24");
+        assertThat(onlyStage.trackContext()).isEqualTo("Исходная посылка");
     }
 
     /**
@@ -431,7 +434,7 @@ class TrackViewServiceTest {
     private static TrackParcel buildParcel(Long id, GlobalStatus status, ZonedDateTime update) {
         TrackParcel parcel = new TrackParcel();
         parcel.setId(id);
-        parcel.setNumber("A1");
+        parcel.setNumber("TRK" + id);
         parcel.setStatus(status);
         parcel.setLastUpdate(update);
         parcel.setTimestamp(update);

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -346,6 +346,8 @@ describe('track-modal render', () => {
         const lifecycleCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Жизненный цикл заказа');
         expect(lifecycleCard).toBeUndefined();
+        const lifecycleList = document.querySelector('ol[role="list"]');
+        expect(lifecycleList).toBeNull();
     });
 
     test('shows register button when return can be created', () => {


### PR DESCRIPTION
## Summary
- ensure the lifecycle builder returns only the outbound stage when no return request exists
- normalize lifecycle rendering on the front end and skip cards for outbound-only data
- extend backend and frontend tests to cover parcels without return requests

## Testing
- npm test -- track-modal.test.js
- mvn -Dtest=TrackViewServiceTest test *(fails: dependency download forbidden for io.github.bucket4j.bucket4j:bucket4j-core:4.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e6764e1aa4832da6f032d32ea0b21e