### PR TITLE
feat: allow manual confirmation of return receipt

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackController.java
@@ -203,6 +203,28 @@ public class TrackController {
     }
 
     /**
+     * Подтверждает вручную получение возврата без закрытия заявки.
+     */
+    @PostMapping("/{id}/returns/{requestId}/confirm-receipt")
+    public TrackDetailsDto confirmReturnReceipt(@PathVariable Long id,
+                                                @PathVariable Long requestId,
+                                                @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        try {
+            orderReturnRequestService.confirmReturnReceipt(requestId, id, user);
+            return trackViewService.getTrackDetails(id, user.getId());
+        } catch (AccessDeniedException ex) {
+            throw ex;
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
+        }
+    }
+
+    /**
      * Обновляет обратный трек и комментарий активной заявки на возврат.
      * <p>
      * Метод проверяет авторизацию пользователя, делегирует бизнес-проверки

--- a/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
@@ -28,6 +28,9 @@ import com.project.tracking_system.entity.OrderReturnRequestStatus;
  * @param canCancelExchange         признак доступности отмены обмена
  * @param exchangeShipmentDispatched признак, что обменная посылка уже отправлена
  * @param cancelExchangeUnavailableReason сообщение о недоступности отмены обмена
+ * @param returnReceiptConfirmed признак, что магазин подтвердил получение возврата
+ * @param returnReceiptConfirmedAt дата подтверждения возврата
+ * @param canConfirmReceipt доступность ручного подтверждения приёма
  */
 public record ActionRequiredReturnRequestDto(Long requestId,
                                              Long parcelId,
@@ -47,5 +50,8 @@ public record ActionRequiredReturnRequestDto(Long requestId,
                                              boolean canReopenAsReturn,
                                              boolean canCancelExchange,
                                              boolean exchangeShipmentDispatched,
-                                             String cancelExchangeUnavailableReason) {
+                                             String cancelExchangeUnavailableReason,
+                                             boolean returnReceiptConfirmed,
+                                             String returnReceiptConfirmedAt,
+                                             boolean canConfirmReceipt) {
 }

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -19,6 +19,9 @@ package com.project.tracking_system.dto;
  * @param canReopenAsReturn        доступность перевода обмена обратно в возврат
  * @param canCancelExchange        доступность отмены обмена
  * @param cancelExchangeUnavailableReason сообщение для пользователя, если отмена обмена недоступна
+ * @param returnReceiptConfirmed   признак ручного подтверждения возврата магазином
+ * @param returnReceiptConfirmedAt дата подтверждения возврата
+ * @param canConfirmReceipt        доступность кнопки подтверждения возврата
  */
 public record OrderReturnRequestDto(Long id,
                                     String status,
@@ -35,7 +38,10 @@ public record OrderReturnRequestDto(Long id,
                                     boolean canCloseWithoutExchange,
                                     boolean canReopenAsReturn,
                                     boolean canCancelExchange,
-                                    String cancelExchangeUnavailableReason) {
+                                    String cancelExchangeUnavailableReason,
+                                    boolean returnReceiptConfirmed,
+                                    String returnReceiptConfirmedAt,
+                                    boolean canConfirmReceipt) {
 
     /**
      * Совместимый с фронтендом аксессор, чтобы не ломать проверку {@code isExchangeRequest}.

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
@@ -73,6 +73,18 @@ public class OrderReturnRequest {
     private String reverseTrackNumber;
 
     /**
+     * Признак, что магазин подтвердил получение возврата вручную.
+     */
+    @Column(name = "return_receipt_confirmed", nullable = false)
+    private boolean returnReceiptConfirmed = false;
+
+    /**
+     * Время, когда менеджер подтвердил получение возврата.
+     */
+    @Column(name = "return_receipt_confirmed_at")
+    private ZonedDateTime returnReceiptConfirmedAt;
+
+    /**
      * Признак, что пользователь запросил обмен при регистрации заявки.
      */
     @Column(name = "exchange_requested", nullable = false)
@@ -187,6 +199,22 @@ public class OrderReturnRequest {
 
     public void setReverseTrackNumber(String reverseTrackNumber) {
         this.reverseTrackNumber = reverseTrackNumber;
+    }
+
+    public boolean isReturnReceiptConfirmed() {
+        return returnReceiptConfirmed;
+    }
+
+    public void setReturnReceiptConfirmed(boolean returnReceiptConfirmed) {
+        this.returnReceiptConfirmed = returnReceiptConfirmed;
+    }
+
+    public ZonedDateTime getReturnReceiptConfirmedAt() {
+        return returnReceiptConfirmedAt;
+    }
+
+    public void setReturnReceiptConfirmedAt(ZonedDateTime returnReceiptConfirmedAt) {
+        this.returnReceiptConfirmedAt = returnReceiptConfirmedAt;
     }
 
     public boolean isExchangeRequested() {

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -668,6 +668,7 @@ public class CustomerTelegramService {
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);
         boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
+        boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
 
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
@@ -688,7 +689,10 @@ public class CustomerTelegramService {
                 canReopenAsReturn,
                 canCancelExchange,
                 exchangeShipmentDispatched,
-                cancelExchangeReason
+                cancelExchangeReason,
+                request.isReturnReceiptConfirmed(),
+                formatRequestMoment(request.getReturnReceiptConfirmedAt()),
+                canConfirmReceipt
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
@@ -54,6 +54,7 @@ public class ReturnRequestActionMapper {
         boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
         boolean canReopenAsReturn = orderReturnRequestService.canReopenAsReturn(request);
         boolean canCancelExchange = orderReturnRequestService.canCancelExchange(request);
+        boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
 
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
@@ -74,7 +75,10 @@ public class ReturnRequestActionMapper {
                 canReopenAsReturn,
                 canCancelExchange,
                 exchangeShipmentDispatched,
-                cancelExchangeReason
+                cancelExchangeReason,
+                request.isReturnReceiptConfirmed(),
+                formatRequestMoment(request.getReturnReceiptConfirmedAt(), userZone),
+                canConfirmReceipt
         );
     }
 

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -299,8 +299,11 @@
                                                               th:text="${request.reason != null ? request.reason : 'Причина не указана'}"></span>
                                                         <span class="text-muted small" data-return-comment
                                                               th:text="${request.comment != null ? request.comment : 'Комментарий отсутствует'}"></span>
-                                                        <span class="text-muted small" data-return-reverse
-                                                              th:text="${request.reverseTrackNumber != null ? 'Обратный трек: ' + request.reverseTrackNumber : 'Обратный трек: —'}"></span>
+                                                      <span class="text-muted small" data-return-reverse
+                                                            th:text="${request.reverseTrackNumber != null ? 'Обратный трек: ' + request.reverseTrackNumber : 'Обратный трек: —'}"></span>
+                                                      <span class="text-muted small" data-return-confirmation
+                                                            th:classappend="${request.returnReceiptConfirmed} ? ' text-success' : ''"
+                                                            th:text="${request.returnReceiptConfirmed ? 'Получение подтверждено: ' + (request.returnReceiptConfirmedAt != null ? request.returnReceiptConfirmedAt : '—') : 'Получение ещё не подтверждено'}"></span>
                                                     </div>
                                                 </td>
                                                 <td class="text-end">
@@ -337,13 +340,20 @@
                                                                 th:disabled="${!request.canReopenAsReturn}">
                                                             Перевести в возврат
                                                         </button>
-                                                        <button type="button"
-                                                                class="btn btn-outline-danger btn-sm js-return-request-cancel"
-                                                                th:if="${request.canCancelExchange}"
-                                                                data-action-label="Отменить обмен"
-                                                                th:disabled="${!request.canCancelExchange}">
-                                                            Отменить обмен
-                                                        </button>
+                                                      <button type="button"
+                                                              class="btn btn-outline-danger btn-sm js-return-request-cancel"
+                                                              th:if="${request.canCancelExchange}"
+                                                              data-action-label="Отменить обмен"
+                                                              th:disabled="${!request.canCancelExchange}">
+                                                          Отменить обмен
+                                                      </button>
+                                                      <button type="button"
+                                                              class="btn btn-outline-success btn-sm js-return-request-confirm"
+                                                              th:if="${request.canConfirmReceipt}"
+                                                              data-action-label="Подтвердить получение возврата"
+                                                              th:disabled="${!request.canConfirmReceipt}">
+                                                          Подтвердить получение
+                                                      </button>
                                                     </div>
                                                 </td>
                                             </tr>

--- a/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
+++ b/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
@@ -198,6 +198,48 @@ class TrackControllerReturnTest {
     }
 
     @Test
+    void confirmReturnReceipt_ReturnsUpdatedDetails() throws Exception {
+        User principal = buildUser();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                principal.getPassword(),
+                principal.getAuthorities()
+        );
+
+        TrackDetailsDto dto = new TrackDetailsDto(
+                9L,
+                "AB123",
+                "Belpost",
+                "Вручена",
+                null,
+                null,
+                List.of(),
+                true,
+                null,
+                false,
+                "UTC",
+                10L,
+                false,
+                List.of(),
+                null,
+                false,
+                List.of(),
+                false
+        );
+
+        when(trackViewService.getTrackDetails(9L, 1L)).thenReturn(dto);
+
+        mockMvc.perform(post("/api/v1/tracks/9/returns/7/confirm-receipt")
+                        .with(authentication(auth))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(9L));
+
+        Mockito.verify(orderReturnRequestService).confirmReturnReceipt(7L, 9L, principal);
+        Mockito.verify(trackViewService).getTrackDetails(9L, 1L);
+    }
+
+    @Test
     void approveExchange_ReturnsDetailsAndExchangeItem() throws Exception {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -589,7 +589,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -731,7 +734,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -817,7 +823,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -864,7 +873,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                warning
+                warning,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -922,7 +934,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 true,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -977,7 +992,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -1042,7 +1060,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 true,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -1098,7 +1119,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -1151,7 +1175,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -1204,7 +1231,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 true,
-                null
+                null,
+                false,
+                null,
+                false
         );
 
         when(telegramService.getReturnRequestsRequiringAction(chatId))
@@ -1266,7 +1296,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
         when(telegramService.getReturnRequestsRequiringAction(chatId))
                 .thenReturn(List.of(requestDto))
@@ -1316,7 +1349,10 @@ class BuyerTelegramBotTest {
                 false,
                 false,
                 false,
-                null
+                null,
+                false,
+                null,
+                false
         );
         when(telegramService.getReturnRequestsRequiringAction(chatId))
                 .thenReturn(List.of(requestDto))

--- a/src/test/js/return-requests.test.js
+++ b/src/test/js/return-requests.test.js
@@ -15,6 +15,7 @@ describe('return-requests table updates', () => {
                         </td>
                         <td>
                             <span data-return-reverse>Обратный трек: —</span>
+                            <span data-return-confirmation>Получение ещё не подтверждено</span>
                         </td>
                     </tr>
                 </tbody>
@@ -46,5 +47,23 @@ describe('return-requests table updates', () => {
         const reverseSpan = row.querySelector('[data-return-reverse]');
         expect(reverseSpan?.textContent).toBe('Обратный трек: RR000111222BY');
         expect(trackButton?.textContent).toBe('Исходный трек');
+    });
+
+    test('updates confirmation label when receipt confirmed', () => {
+        const row = document.querySelector('tr[data-return-request-row]');
+        expect(row).not.toBeNull();
+        const confirmation = row.querySelector('[data-return-confirmation]');
+        expect(confirmation?.textContent).toContain('не подтверждено');
+
+        global.window.returnRequests.updateRow({
+            parcelId: 44,
+            requestId: 7,
+            returnReceiptConfirmed: true,
+            returnReceiptConfirmedAt: '2024-05-01T10:00:00Z',
+            canConfirmReceipt: false
+        });
+
+        expect(confirmation?.textContent).toContain('2024-05-01T10:00:00Z');
+        expect(confirmation?.classList.contains('text-success')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- add manual confirmation flags for return receipt and expose them via DTOs, services, and Telegram notifications
- update merchant track lifecycle logic to treat returns as processed only after manual confirmation or final parcel status
- surface confirmation controls in the UI and extend backend/frontend tests for the new flow

## Testing
- `mvn test` *(fails: jitpack.io returns 403 for io.github.bucket4j.bucket4j:bucket4j-core:4.10.0)*
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68e67aa481c0832db56f0d6dbb79934f