### PR TITLE
feat: allow editing reverse return comments in modal

### DIFF
--- a/src/test/js/return-requests.test.js
+++ b/src/test/js/return-requests.test.js
@@ -14,6 +14,7 @@ describe('return-requests table updates', () => {
                             <button type="button" data-return-track-number>Исходный трек</button>
                         </td>
                         <td>
+                            <span data-return-comment>Комментарий отсутствует</span>
                             <span data-return-reverse>Обратный трек: —</span>
                             <span data-return-confirmation>Получение ещё не подтверждено</span>
                         </td>
@@ -47,6 +48,21 @@ describe('return-requests table updates', () => {
         const reverseSpan = row.querySelector('[data-return-reverse]');
         expect(reverseSpan?.textContent).toBe('Обратный трек: RR000111222BY');
         expect(trackButton?.textContent).toBe('Исходный трек');
+    });
+
+    test('updates comment cell when payload contains comment', () => {
+        const row = document.querySelector('tr[data-return-request-row]');
+        expect(row).not.toBeNull();
+        const commentSpan = row.querySelector('[data-return-comment]');
+        expect(commentSpan?.textContent).toBe('Комментарий отсутствует');
+
+        global.window.returnRequests.updateRow({
+            parcelId: 44,
+            requestId: 7,
+            comment: 'Обновлённый комментарий'
+        });
+
+        expect(commentSpan?.textContent).toBe('Обновлённый комментарий');
     });
 
     test('updates confirmation label when receipt confirmed', () => {

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -189,7 +189,7 @@ describe('track-modal render', () => {
                 id: 5,
                 status: 'Зарегистрирована',
                 reason: 'Размер не подошёл',
-                comment: 'Свяжитесь со мной',
+                comment: 'Обновлённый комментарий',
                 requestedAt: '2024-02-02T10:00:00Z',
                 decisionAt: null,
                 closedAt: null,
@@ -262,6 +262,11 @@ describe('track-modal render', () => {
         expect(input).not.toBeNull();
         input.value = ' rr123456789by ';
 
+        const commentField = form.querySelector('textarea[name="comment"]');
+        expect(commentField).not.toBeNull();
+        expect(commentField.value).toBe('Свяжитесь со мной');
+        commentField.value = '  Обновлённый комментарий  ';
+
         form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
         await Promise.resolve();
@@ -271,17 +276,25 @@ describe('track-modal render', () => {
         expect(global.fetch).toHaveBeenCalledWith(
             '/api/v1/tracks/12/returns/5/reverse-track',
             expect.objectContaining({
-                method: 'PATCH'
+                method: 'PATCH',
+                body: JSON.stringify({
+                    reverseTrackNumber: 'RR123456789BY',
+                    comment: 'Обновлённый комментарий'
+                })
             })
         );
         expect(global.notifyUser).toHaveBeenCalledWith('Обратный трек сохранён', 'success');
         const reverseInfo = Array.from(document.querySelectorAll('dl dd'))
             .find((node) => node.textContent?.includes('RR123456789BY'));
         expect(reverseInfo).toBeDefined();
+        const commentInfo = Array.from(document.querySelectorAll('dl dd'))
+            .find((node) => node.textContent?.includes('Обновлённый комментарий'));
+        expect(commentInfo).toBeDefined();
         expect(global.window.returnRequests.updateRow).toHaveBeenCalledWith(expect.objectContaining({
             parcelId: 12,
             requestId: 5,
-            reverseTrackNumber: 'RR123456789BY'
+            reverseTrackNumber: 'RR123456789BY',
+            comment: 'Обновлённый комментарий'
         }));
     });
 


### PR DESCRIPTION
## Summary
- allow editing of reverse return request comments alongside reverse track updates in the modal and sync the action-required table with the response
- expand the reverse track workflow tests to cover comment editing and table synchronization

## Testing
- npx jest --runTestsByPath src/test/js/track-modal.test.js src/test/js/return-requests.test.js
- mvn test -DskipITs *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:4.10.0 returns 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68e6a71eb514832d9e6983a1ae1d5f47