### PR TITLE
Restore exchange stage gating for manual parcels

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -176,11 +176,16 @@ public class OrderReturnRequestService {
 
     /**
      * Одобряет запуск обмена по заявке.
+     * <p>
+     * Метод переводит заявку в статус обмена и фиксирует менеджера, принявшего решение.
+     * Создание обменной посылки выполняется отдельным действием через {@link #createExchangeParcel(Long, Long, User)},
+     * чтобы соблюсти SRP и дать менеджеру время на проверку данных перед оформлением отправления.
+     * </p>
      *
      * @param requestId идентификатор заявки
      * @param parcelId  идентификатор посылки
      * @param user      автор решения
-     * @return результат с обновлённой заявкой и созданной обменной посылкой
+     * @return обновлённая заявка после одобрения обмена
      */
     @Transactional
     public OrderReturnRequest approveExchange(Long requestId, Long parcelId, User user) {

--- a/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
+++ b/src/test/java/com/project/tracking_system/controller/TrackControllerReturnTest.java
@@ -3,9 +3,10 @@ package com.project.tracking_system.controller;
 import com.project.tracking_system.dto.ReturnRequestUpdateResponse;
 import com.project.tracking_system.dto.TrackChainItemDto;
 import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.Role;
-import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackViewService;
@@ -269,7 +270,7 @@ class TrackControllerReturnTest {
         );
 
         when(orderReturnRequestService.approveExchange(eq(7L), eq(9L), eq(principal)))
-                .thenReturn(new TrackParcel());
+                .thenReturn(new OrderReturnRequest());
         when(trackViewService.getTrackDetails(9L, 1L)).thenReturn(dto);
 
         mockMvc.perform(post("/api/v1/tracks/9/returns/7/exchange")


### PR DESCRIPTION
## Summary
- reinstate exchange lifecycle stage activation when only a final status is present without a tracking number
- keep the exchange context label visible once the stage starts progressing even if the track number is still missing

## Testing
- npm test -- --runTestsByPath src/test/js/track-modal.test.js
- mvn -q -DskipITs test *(fails: jitpack.io denied access to bucket4j-core 4.10.0 descriptor)*

------
https://chatgpt.com/codex/tasks/task_e_68e773279dd4832d9e9923adc481e845