### PR TITLE
Add receipt confirmation fields for return requests

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
@@ -74,12 +74,19 @@ public class OrderReturnRequest {
 
     /**
      * Признак, что магазин подтвердил получение возврата вручную.
+     * <p>
+     * Флаг устанавливается сотрудником после проверки склада и исключает повторное подтверждение,
+     * помогая сервисам корректно ограничивать действия пользователей.
+     * </p>
      */
     @Column(name = "return_receipt_confirmed", nullable = false)
     private boolean returnReceiptConfirmed = false;
 
     /**
-     * Время, когда менеджер подтвердил получение возврата.
+     * Время, когда магазин зафиксировал подтверждение получения возврата.
+     * <p>
+     * Метка позволяет отображать точный момент проверки в интерфейсе и в уведомлениях клиентов.
+     * </p>
      */
     @Column(name = "return_receipt_confirmed_at")
     private ZonedDateTime returnReceiptConfirmedAt;
@@ -201,18 +208,38 @@ public class OrderReturnRequest {
         this.reverseTrackNumber = reverseTrackNumber;
     }
 
+    /**
+     * Возвращает признак ручного подтверждения возврата магазином.
+     *
+     * @return {@code true}, если склад уже подтвердил получение возврата
+     */
     public boolean isReturnReceiptConfirmed() {
         return returnReceiptConfirmed;
     }
 
+    /**
+     * Устанавливает признак ручного подтверждения возврата магазином.
+     *
+     * @param returnReceiptConfirmed новое значение флага подтверждения
+     */
     public void setReturnReceiptConfirmed(boolean returnReceiptConfirmed) {
         this.returnReceiptConfirmed = returnReceiptConfirmed;
     }
 
+    /**
+     * Возвращает время, когда магазин подтвердил получение возврата.
+     *
+     * @return метка времени подтверждения или {@code null}, если подтверждения не было
+     */
     public ZonedDateTime getReturnReceiptConfirmedAt() {
         return returnReceiptConfirmedAt;
     }
 
+    /**
+     * Устанавливает момент подтверждения возврата магазином.
+     *
+     * @param returnReceiptConfirmedAt новая метка времени подтверждения
+     */
     public void setReturnReceiptConfirmedAt(ZonedDateTime returnReceiptConfirmedAt) {
         this.returnReceiptConfirmedAt = returnReceiptConfirmedAt;
     }

--- a/src/main/resources/db/migration/V31__order_return_receipt_confirmation.sql
+++ b/src/main/resources/db/migration/V31__order_return_receipt_confirmation.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_order_return_requests
+    ADD COLUMN return_receipt_confirmed BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN return_receipt_confirmed_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary
- add a Flyway migration that records manual confirmation of return receipts
- document the confirmation flag and timestamp in the OrderReturnRequest entity

## Testing
- mvn -q -DskipTests package *(fails: dependency io.github.bucket4j.bucket4j:bucket4j-core:4.10.0 could not be downloaded from jitpack.io due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e788e1a9e4832d893025d15e415ecc