### PR TITLE
Add cache eviction for track details after return updates

### DIFF
--- a/src/main/java/com/project/tracking_system/service/track/TrackViewCacheInvalidator.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewCacheInvalidator.java
@@ -33,12 +33,36 @@ public class TrackViewCacheInvalidator {
      * </p>
      */
     @Scheduled(fixedDelay = 8_000)
-    public void evictTrackDetails() {
+    public void evictAllTrackDetails() {
         Cache cache = cacheManager.getCache(CACHE_NAME);
         if (cache != null) {
             cache.clear();
             log.trace("Очистка кэша {} выполнена", CACHE_NAME);
         }
+    }
+
+    /**
+     * Удаляет из кэша детали конкретной посылки пользователя.
+     * <p>
+     * Метод вызывается сервисами, которые меняют состояние возврата/обмена,
+     * чтобы соблюсти принцип актуальности данных: повторное открытие модалки
+     * сразу получит обновлённые детали без устаревших кэшированных значений.
+     * </p>
+     *
+     * @param userId   идентификатор владельца посылки
+     * @param parcelId идентификатор посылки
+     */
+    public void evictTrackDetails(Long userId, Long parcelId) {
+        if (userId == null || parcelId == null) {
+            return;
+        }
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        if (cache == null) {
+            return;
+        }
+        String cacheKey = userId + ":" + parcelId;
+        cache.evict(cacheKey);
+        log.trace("Удалена запись {} из кэша {}", cacheKey, CACHE_NAME);
     }
 }
 

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.OrderReturnRequestActionRequestRepository;
 import com.project.tracking_system.repository.OrderReturnRequestRepository;
 import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackViewCacheInvalidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +58,8 @@ class OrderReturnRequestServiceTest {
     private OrderEpisodeLifecycleService episodeLifecycleService;
     @Mock
     private OrderExchangeService orderExchangeService;
+    @Mock
+    private TrackViewCacheInvalidator trackViewCacheInvalidator;
 
     private OrderReturnRequestService service;
 
@@ -65,7 +68,7 @@ class OrderReturnRequestServiceTest {
     @BeforeEach
     void setUp() {
         service = new OrderReturnRequestService(repository, actionRequestRepository, trackParcelService,
-                episodeLifecycleService, orderExchangeService);
+                episodeLifecycleService, orderExchangeService, trackViewCacheInvalidator);
         user = new User();
         user.setId(5L);
     }
@@ -110,6 +113,7 @@ class OrderReturnRequestServiceTest {
         assertThat(captor.getValue().getReverseTrackNumber()).isEqualTo(DEFAULT_REVERSE_TRACK);
         assertThat(captor.getValue().isExchangeRequested()).isFalse();
         verifyNoInteractions(orderExchangeService);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -140,6 +144,7 @@ class OrderReturnRequestServiceTest {
         assertThat(saved.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
         verify(repository).save(any(OrderReturnRequest.class));
         verifyNoInteractions(orderExchangeService);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -232,6 +237,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isFalse();
         assertThat(result.getReturnReceiptConfirmedAt()).isNull();
         verify(orderExchangeService, never()).createExchangeParcel(any());
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -294,6 +300,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getClosedAt()).isNotNull();
         assertThat(result.isReturnReceiptConfirmed()).isFalse();
         assertThat(result.getReturnReceiptConfirmedAt()).isNull();
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -313,6 +320,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isTrue();
         assertThat(result.getReturnReceiptConfirmedAt()).isNotNull();
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -369,6 +377,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isTrue();
         assertThat(result.getReturnReceiptConfirmedAt()).isNotNull();
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -396,6 +405,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getReturnReceiptConfirmedAt()).isNull();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -620,6 +630,7 @@ class OrderReturnRequestServiceTest {
         assertThat(response.comment()).isEqualTo("комментарий");
         assertThat(response.requestId()).isEqualTo(801L);
         verify(repository).save(any(OrderReturnRequest.class));
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -673,6 +684,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isExchangeRequested()).isFalse();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
@@ -1,0 +1,252 @@
+package com.project.tracking_system.service.track;
+
+import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.entity.GlobalStatus;
+import com.project.tracking_system.entity.OrderEpisode;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.OrderReturnRequestActionRequestRepository;
+import com.project.tracking_system.repository.OrderReturnRequestRepository;
+import com.project.tracking_system.service.admin.ApplicationSettingsService;
+import com.project.tracking_system.service.order.OrderEpisodeLifecycleService;
+import com.project.tracking_system.service.order.OrderExchangeService;
+import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.user.UserService;
+import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackStatusEventService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Интеграционный тест проверяет, что модалка трека получает актуальные данные после инвалидации кэша.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TrackViewCacheEvictionIntegrationTest.Config.class)
+class TrackViewCacheEvictionIntegrationTest {
+
+    @Autowired
+    private TrackViewService trackViewService;
+    @Autowired
+    private OrderReturnRequestService orderReturnRequestService;
+    @Autowired
+    private TrackParcelService trackParcelService;
+    @Autowired
+    private TrackStatusEventService trackStatusEventService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private ApplicationSettingsService applicationSettingsService;
+    @Autowired
+    private OrderReturnRequestRepository orderReturnRequestRepository;
+    @Autowired
+    private OrderExchangeService orderExchangeService;
+
+    /**
+     * Моделирует сценарий «открыли модалку → одобрили обмен → снова открыли модалку».
+     * <p>
+     * Первый вызов {@link TrackViewService#getTrackDetails(Long, Long)} кэшируется. После
+     * изменения заявки через {@link OrderReturnRequestService#approveExchange(Long, Long, User)}
+     * проверяем, что повторный вызов возвращает статус обмена и признак обмена в DTO.
+     * </p>
+     */
+    @Test
+    void getTrackDetails_RecalculatedAfterExchangeApprovalWhenCacheEvicted() {
+        Long parcelId = 42L;
+        Long userId = 7L;
+
+        User owner = new User();
+        owner.setId(userId);
+
+        TrackParcel parcel = new TrackParcel();
+        parcel.setId(parcelId);
+        parcel.setNumber("TRK42");
+        parcel.setStatus(GlobalStatus.DELIVERED);
+        parcel.setTimestamp(ZonedDateTime.now(ZoneOffset.UTC).minusHours(2));
+        parcel.setLastUpdate(ZonedDateTime.now(ZoneOffset.UTC).minusHours(1));
+        parcel.setUser(owner);
+        OrderEpisode episode = new OrderEpisode();
+        episode.setId(900L);
+        parcel.setEpisode(episode);
+
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(555L);
+        request.setParcel(parcel);
+        request.setEpisode(episode);
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setCreatedAt(ZonedDateTime.now(ZoneOffset.UTC).minusHours(3));
+        request.setCreatedBy(owner);
+
+        when(trackParcelService.findOwnedById(parcelId, userId)).thenReturn(Optional.of(parcel));
+        when(trackParcelService.findEpisodeParcels(episode.getId(), userId)).thenReturn(List.of(parcel));
+        when(trackStatusEventService.findEvents(parcelId)).thenReturn(List.of());
+        when(applicationSettingsService.getTrackUpdateIntervalHours()).thenReturn(4);
+        when(userService.getUserZone(userId)).thenReturn(ZoneId.of("UTC"));
+        when(orderReturnRequestRepository.findFirstByParcel_IdAndStatusIn(eq(parcelId), anyCollection()))
+                .thenReturn(Optional.of(request));
+        when(orderReturnRequestRepository.existsByEpisode_IdAndStatus(episode.getId(),
+                OrderReturnRequestStatus.EXCHANGE_APPROVED)).thenReturn(false);
+        when(orderReturnRequestRepository.findById(request.getId())).thenReturn(Optional.of(request));
+        when(orderReturnRequestRepository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(orderExchangeService.findLatestExchangeParcel(any())).thenReturn(Optional.empty());
+        when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(any())).thenReturn(Optional.empty());
+
+        TrackDetailsDto initialDetails = trackViewService.getTrackDetails(parcelId, userId);
+
+        assertThat(initialDetails.returnRequest()).isNotNull();
+        assertThat(initialDetails.returnRequest().status())
+                .isEqualTo(OrderReturnRequestStatus.REGISTERED.getDisplayName());
+        assertThat(initialDetails.returnRequest().exchangeApproved()).isFalse();
+
+        orderReturnRequestService.approveExchange(request.getId(), parcelId, owner);
+
+        TrackDetailsDto refreshedDetails = trackViewService.getTrackDetails(parcelId, userId);
+
+        assertThat(refreshedDetails.returnRequest()).isNotNull();
+        assertThat(refreshedDetails.returnRequest().status())
+                .isEqualTo(OrderReturnRequestStatus.EXCHANGE_APPROVED.getDisplayName());
+        assertThat(refreshedDetails.returnRequest().exchangeApproved()).isTrue();
+
+        verify(orderReturnRequestRepository, times(2)).findFirstByParcel_IdAndStatusIn(eq(parcelId), anyCollection());
+    }
+
+    /**
+     * Тестовая конфигурация поднимает минимальный контекст с включённым кэшированием.
+     */
+    @Configuration
+    @EnableCaching
+    static class Config {
+
+        /**
+         * Предоставляет потокобезопасный менеджер кэшей для тестов.
+         */
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("track-details");
+        }
+
+        /**
+         * Создаёт инвалидатор, который будет очищать кэш после изменений заявок.
+         */
+        @Bean
+        TrackViewCacheInvalidator trackViewCacheInvalidator(CacheManager cacheManager) {
+            return new TrackViewCacheInvalidator(cacheManager);
+        }
+
+        /**
+         * Возвращает мок сервиса посылок для подстановки тестовых данных.
+         */
+        @Bean
+        TrackParcelService trackParcelService() {
+            return mock(TrackParcelService.class);
+        }
+
+        /**
+         * Возвращает мок сервиса статусов, чтобы тест не зависел от БД.
+         */
+        @Bean
+        TrackStatusEventService trackStatusEventService() {
+            return mock(TrackStatusEventService.class);
+        }
+
+        /**
+         * Возвращает мок сервиса пользователей.
+         */
+        @Bean
+        UserService userService() {
+            return mock(UserService.class);
+        }
+
+        /**
+         * Возвращает мок сервиса настроек приложения.
+         */
+        @Bean
+        ApplicationSettingsService applicationSettingsService() {
+            return mock(ApplicationSettingsService.class);
+        }
+
+        /**
+         * Возвращает мок репозитория заявок для контроля возвращаемых данных.
+         */
+        @Bean
+        OrderReturnRequestRepository orderReturnRequestRepository() {
+            return mock(OrderReturnRequestRepository.class);
+        }
+
+        /**
+         * Возвращает мок репозитория запросов действий.
+         */
+        @Bean
+        OrderReturnRequestActionRequestRepository orderReturnRequestActionRequestRepository() {
+            return mock(OrderReturnRequestActionRequestRepository.class);
+        }
+
+        /**
+         * Возвращает мок сервиса управления эпизодами.
+         */
+        @Bean
+        OrderEpisodeLifecycleService orderEpisodeLifecycleService() {
+            return mock(OrderEpisodeLifecycleService.class);
+        }
+
+        /**
+         * Возвращает мок сервиса обменных посылок.
+         */
+        @Bean
+        OrderExchangeService orderExchangeService() {
+            return mock(OrderExchangeService.class);
+        }
+
+        /**
+         * Создаёт сервис заявок с внедрёнными зависимостями.
+         */
+        @Bean
+        OrderReturnRequestService orderReturnRequestService(OrderReturnRequestRepository repository,
+                                                            OrderReturnRequestActionRequestRepository actionRepository,
+                                                            TrackParcelService trackParcelService,
+                                                            OrderEpisodeLifecycleService episodeLifecycleService,
+                                                            OrderExchangeService orderExchangeService,
+                                                            TrackViewCacheInvalidator trackViewCacheInvalidator) {
+            return new OrderReturnRequestService(repository, actionRepository, trackParcelService,
+                    episodeLifecycleService, orderExchangeService, trackViewCacheInvalidator);
+        }
+
+        /**
+         * Создаёт сервис просмотра треков, который будет участвовать в тесте кэширования.
+         */
+        @Bean
+        TrackViewService trackViewService(TrackParcelService trackParcelService,
+                                          TrackStatusEventService trackStatusEventService,
+                                          UserService userService,
+                                          ApplicationSettingsService applicationSettingsService,
+                                          OrderReturnRequestService orderReturnRequestService,
+                                          OrderExchangeService orderExchangeService) {
+            return new TrackViewService(trackParcelService, trackStatusEventService, userService,
+                    applicationSettingsService, orderReturnRequestService, orderExchangeService);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- inject the track view cache invalidator into `OrderReturnRequestService` and clear the cached entry after each state-changing save
- extend the cache invalidator with a key-based eviction method so track details refresh immediately for a specific user and parcel
- cover the behavior with updated unit tests and a caching integration test that verifies exchange approval invalidates the cache

## Testing
- `mvn -q test` *(fails: jitpack.io returned 403 for io.github.bucket4j.bucket4j:bucket4j-core:4.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e78e3acf6c832da515bd1a9a596d06