### PR TITLE
Add history and lifecycle endpoints

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/TrackController.java
+++ b/src/main/java/com/project/tracking_system/controller/TrackController.java
@@ -7,9 +7,11 @@ import com.project.tracking_system.dto.ReturnRequestReverseTrackUpdateRequest;
 import com.project.tracking_system.dto.ReturnRequestActionResponse;
 import com.project.tracking_system.dto.TrackChainItemDto;
 import com.project.tracking_system.dto.TrackDetailsDto;
+import com.project.tracking_system.dto.TrackLifecycleStageDto;
 import com.project.tracking_system.dto.TrackNumberUpdateRequest;
 import com.project.tracking_system.dto.TrackNumberUpdateResponse;
 import com.project.tracking_system.dto.TrackParcelDTO;
+import com.project.tracking_system.dto.TrackStatusEventDto;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderReturnRequest;
@@ -30,6 +32,7 @@ import com.project.tracking_system.exception.TrackNumberAlreadyExistsException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.validation.Valid;
@@ -60,6 +63,42 @@ public class TrackController {
             throw new AccessDeniedException("Пользователь не авторизован");
         }
         return trackViewService.getTrackDetails(id, user.getId());
+    }
+
+    /**
+     * Возвращает историю статусов посылки для текущего пользователя.
+     * Метод повторно использует доменную логику {@link TrackViewService},
+     * чтобы гарантировать единообразные проверки прав и форматирование времени.
+     *
+     * @param id   идентификатор посылки
+     * @param user текущий пользователь
+     * @return упорядоченный список событий; при отсутствии данных возвращается пустой список
+     */
+    @GetMapping("/{id}/history")
+    public List<TrackStatusEventDto> getTrackHistory(@PathVariable Long id,
+                                                     @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        return trackViewService.getTrackHistory(id, user.getId());
+    }
+
+    /**
+     * Возвращает этапы жизненного цикла посылки для текущего пользователя.
+     * Метод использует {@link TrackViewService}, чтобы переиспользовать все проверки
+     * доступа и форматирование дат, а также получить согласованный набор этапов.
+     *
+     * @param id   идентификатор посылки
+     * @param user текущий пользователь
+     * @return жизненный цикл посылки; при отсутствии этапов возвращается пустой список
+     */
+    @GetMapping("/{id}/lifecycle")
+    public List<TrackLifecycleStageDto> getTrackLifecycle(@PathVariable Long id,
+                                                          @AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new AccessDeniedException("Пользователь не авторизован");
+        }
+        return trackViewService.getTrackLifecycle(id, user.getId());
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/controller/TrackControllerHistoryLifecycleTest.java
+++ b/src/test/java/com/project/tracking_system/controller/TrackControllerHistoryLifecycleTest.java
@@ -1,0 +1,108 @@
+package com.project.tracking_system.controller;
+
+import com.project.tracking_system.entity.Role;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.order.ReturnRequestActionMapper;
+import com.project.tracking_system.service.track.TrackParcelService;
+import com.project.tracking_system.service.track.TrackViewService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Тесты эндпоинтов истории и жизненного цикла {@link TrackController}.
+ */
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(TrackController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TrackControllerHistoryLifecycleTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TrackViewService trackViewService;
+    @MockBean
+    private TrackParcelService trackParcelService;
+    @MockBean
+    private OrderReturnRequestService orderReturnRequestService;
+    @MockBean
+    private ReturnRequestActionMapper returnRequestActionMapper;
+
+    /**
+     * Проверяет, что при отсутствии событий возвращается пустой массив.
+     */
+    @Test
+    void getTrackHistory_WhenNoEvents_ReturnsEmptyArray() throws Exception {
+        User principal = buildUser();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                principal.getPassword(),
+                principal.getAuthorities()
+        );
+
+        when(trackViewService.getTrackHistory(5L, 1L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/tracks/5/history")
+                        .with(authentication(auth))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+
+        Mockito.verify(trackViewService).getTrackHistory(eq(5L), eq(1L));
+    }
+
+    /**
+     * Проверяет, что при отсутствии этапов жизненного цикла возвращается пустой массив.
+     */
+    @Test
+    void getTrackLifecycle_WhenNoStages_ReturnsEmptyArray() throws Exception {
+        User principal = buildUser();
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                principal.getPassword(),
+                principal.getAuthorities()
+        );
+
+        when(trackViewService.getTrackLifecycle(7L, 1L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/tracks/7/lifecycle")
+                        .with(authentication(auth))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+
+        Mockito.verify(trackViewService).getTrackLifecycle(eq(7L), eq(1L));
+    }
+
+    private User buildUser() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("user@example.com");
+        user.setPassword("secret");
+        user.setRole(Role.ROLE_USER);
+        user.setTimeZone("UTC");
+        return user;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated REST endpoints to fetch track history and lifecycle data via TrackViewService
- expose reusable service methods for history and lifecycle retrieval with consistent access checks
- cover empty history and lifecycle responses with a controller WebMvcTest

## Testing
- mvn -Dtest=TrackControllerHistoryLifecycleTest test *(fails: dependency download from jitpack.io returns 403 for bucket4j-core 4.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0677ca58832d8c19390fdfe14d7d