### PR TITLE
Make side panel toggle visible on desktop

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -285,6 +285,28 @@ header {
   transition: transform 0.2s ease-in-out;
 }
 
+.track-side-panel__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  transition: color 0.2s ease-in-out, border-color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.track-side-panel__toggle:hover,
+.track-side-panel__toggle:focus-visible {
+  color: var(--bs-primary-text-emphasis);
+  border-color: var(--bs-primary-border-subtle);
+  background-color: var(--bs-primary-bg-subtle);
+}
+
+@media (min-width: 992px) {
+  .track-side-panel__toggle {
+    margin-left: 0.75rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+
 .track-side-panel__toggle[aria-expanded="true"] .track-side-panel__toggle-icon {
   transform: rotate(90deg);
 }

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -2270,7 +2270,7 @@
 
         const toggleButton = document.createElement('button');
         toggleButton.type = 'button';
-        toggleButton.className = 'btn btn-sm btn-outline-secondary track-side-panel__toggle d-lg-none';
+        toggleButton.className = 'btn btn-sm btn-outline-secondary track-side-panel__toggle';
         toggleButton.dataset.bsToggle = 'collapse';
         toggleButton.dataset.bsTarget = `#${collapseId}`;
         toggleButton.setAttribute('aria-controls', collapseId);


### PR DESCRIPTION
## Summary
- make the side panel collapse toggle visible on all breakpoints
- add desktop-specific spacing and hover feedback for the toggle button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec2600c7f8832dbbdf79c5f45a1b3e