### PR TITLE
Refine track modal layout when side panel collapses

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -300,6 +300,39 @@ header {
 }
 
 @media (min-width: 992px) {
+  .track-modal-layout {
+    flex-wrap: nowrap;
+  }
+
+  .track-modal-layout .track-modal-main,
+  .track-modal-layout .track-modal-side {
+    width: 50%;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+
+  .track-modal-main--expanded {
+    width: auto;
+    flex: 1 1 auto;
+    max-width: 100%;
+  }
+
+  .track-modal-side--collapsed {
+    width: auto;
+    flex: 0 0 auto;
+    max-width: none;
+  }
+
+  .track-side-panel,
+  .track-side-panel__collapse {
+    width: 100%;
+  }
+
+  .track-modal-side--collapsed .track-side-panel,
+  .track-modal-side--collapsed .track-side-panel__collapse {
+    width: auto;
+  }
+
   .track-side-panel__toggle {
     margin-left: 0.75rem;
     padding-left: 0.75rem;

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -257,10 +257,29 @@
             ? bootstrap.Collapse.getOrCreateInstance(collapse, { toggle: false })
             : null;
 
+        const layout = panel.closest('.track-modal-layout');
+        const sideColumn = panel.closest('.track-modal-side');
+        const mainColumn = layout?.querySelector('.track-modal-main') || null;
+
         let isPinned = readBooleanFromStorage(SIDE_PANEL_PIN_KEY, true);
         let isCollapsed = readBooleanFromStorage(SIDE_PANEL_COLLAPSE_KEY, false);
         let collapsePreference = isCollapsed;
         let suppressStorageUpdate = false;
+
+        /**
+         * Синхронизирует классы колонок с состоянием collapse.
+         * Метод добавляет модификаторы, чтобы CSS растягивал основную колонку и сжимал боковую на широких экранах (OCP).
+         * @param {boolean} collapsed актуальное состояние панели
+         */
+        const syncLayoutWithCollapse = (collapsed) => {
+            if (!layout || !sideColumn || !mainColumn) {
+                return;
+            }
+            const shouldCollapse = Boolean(collapsed);
+            layout.classList.toggle('track-modal-layout--side-collapsed', shouldCollapse);
+            sideColumn.classList.toggle('track-modal-side--collapsed', shouldCollapse);
+            mainColumn.classList.toggle('track-modal-main--expanded', shouldCollapse);
+        };
 
         const updatePinVisual = (pinned) => {
             pinButton.setAttribute('aria-pressed', String(pinned));
@@ -284,6 +303,7 @@
 
         updatePinVisual(isPinned);
         updateCollapseVisual(isCollapsed);
+        syncLayoutWithCollapse(isCollapsed);
 
         if (collapseInstance) {
             if (isCollapsed) {
@@ -297,6 +317,7 @@
         const handleCollapseShown = () => {
             isCollapsed = false;
             updateCollapseVisual(false);
+            syncLayoutWithCollapse(false);
             if (!suppressStorageUpdate) {
                 collapsePreference = false;
                 writeBooleanToStorage(SIDE_PANEL_COLLAPSE_KEY, false);
@@ -307,6 +328,7 @@
         const handleCollapseHidden = () => {
             isCollapsed = true;
             updateCollapseVisual(true);
+            syncLayoutWithCollapse(true);
             if (!suppressStorageUpdate) {
                 collapsePreference = true;
                 writeBooleanToStorage(SIDE_PANEL_COLLAPSE_KEY, true);
@@ -351,6 +373,7 @@
             }
             updatePinVisual(isPinned);
             writeBooleanToStorage(SIDE_PANEL_PIN_KEY, isPinned);
+            syncLayoutWithCollapse(isCollapsed);
         };
 
         pinButton.addEventListener('click', handlePinClick);
@@ -385,6 +408,7 @@
                 }
                 updateCollapseVisual(shouldCollapse);
             }
+            syncLayoutWithCollapse(isCollapsed);
         };
 
         if (typeof mediaQuery.addEventListener === 'function') {


### PR DESCRIPTION
## Summary
- enforce 50/50 column widths for the track modal layout on large screens
- ensure the side panel containers span the full column width to avoid intrinsic sizing
- adjust layout classes when the side panel collapses so the main column expands and the header keeps readable sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec27da39b0832da5f1eb3f612d00a1