### PR TITLE
Refactor track modal side panel into drawer

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -225,35 +225,81 @@ header {
 }
 
 .track-modal-container {
+  position: relative;
   width: 100%;
   display: block;
+  --track-modal-drawer-width: min(380px, 92vw);
+  --track-modal-drawer-gap: 0.75rem;
 }
 
-.track-modal-layout {
-  margin: 0;
+.track-modal-main {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .track-modal-main > .card:last-child {
   margin-bottom: 0;
 }
 
-.track-modal-side {
-  position: relative;
+.track-modal-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--track-modal-drawer-width);
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem 1.25rem;
+  background-color: var(--bs-body-bg);
+  box-shadow: -12px 0 24px rgba(15, 23, 42, 0.15);
+  border-radius: 1rem 0 0 1rem;
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 5;
+  overflow-y: auto;
+}
+
+.track-modal-drawer--open,
+.track-modal-container--drawer-open .track-modal-drawer {
+  transform: translateX(0);
+}
+
+.track-modal-drawer-toggle {
+  position: absolute;
+  top: 50%;
+  right: calc(var(--track-modal-drawer-gap) * -1);
+  transform: translateY(-50%);
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  background-color: var(--bs-primary);
+  color: var(--bs-white);
+  border: none;
+  border-radius: 0.75rem 0.75rem 0 0;
+  padding: 1rem 0.5rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, right 0.3s ease-in-out;
+  z-index: 6;
+}
+
+.track-modal-drawer-toggle:hover,
+.track-modal-drawer-toggle:focus-visible {
+  background-color: var(--bs-primary-hover-bg, #0b5ed7);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+  outline: none;
+}
+
+.track-modal-container--drawer-open .track-modal-drawer-toggle {
+  right: calc(var(--track-modal-drawer-width) + var(--track-modal-drawer-gap));
 }
 
 .track-side-panel {
   background-color: transparent;
-}
-
-.track-side-panel--pinned {
-  position: sticky;
-  top: 1rem;
-}
-
-@media (max-width: 991.98px) {
-  .track-side-panel--pinned {
-    position: static;
-  }
 }
 
 .track-side-panel__header {
@@ -267,95 +313,69 @@ header {
   letter-spacing: 0.08em;
 }
 
-.track-side-panel__controls .btn {
-  padding: 0.25rem 0.5rem;
-  line-height: 1;
-  min-width: 2rem;
-}
-
-.track-side-panel__pin.active,
-.track-side-panel__pin[aria-pressed="true"] {
-  background-color: var(--bs-primary-bg-subtle);
-  border-color: var(--bs-primary-border-subtle);
-  color: var(--bs-primary-text-emphasis);
-}
-
-.track-side-panel__toggle-icon {
-  display: inline-block;
-  transition: transform 0.2s ease-in-out;
-}
-
-.track-side-panel__toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  transition: color 0.2s ease-in-out, border-color 0.2s ease-in-out, background-color 0.2s ease-in-out;
-}
-
-.track-side-panel__toggle:hover,
-.track-side-panel__toggle:focus-visible {
-  color: var(--bs-primary-text-emphasis);
-  border-color: var(--bs-primary-border-subtle);
-  background-color: var(--bs-primary-bg-subtle);
-}
-
-@media (min-width: 992px) {
-  .track-modal-layout {
-    flex-wrap: nowrap;
-  }
-
-  .track-modal-layout .track-modal-main,
-  .track-modal-layout .track-modal-side {
-    width: 50%;
-    flex: 0 0 50%;
-    max-width: 50%;
-  }
-
-  .track-modal-main--expanded {
-    width: auto;
-    flex: 1 1 auto;
-    max-width: 100%;
-  }
-
-  .track-modal-side--collapsed {
-    width: auto;
-    flex: 0 0 auto;
-    max-width: none;
-  }
-
-  .track-side-panel,
-  .track-side-panel__collapse {
-    width: 100%;
-  }
-
-  .track-modal-side--collapsed .track-side-panel,
-  .track-modal-side--collapsed .track-side-panel__collapse {
-    width: auto;
-  }
-
-  .track-side-panel__toggle {
-    margin-left: 0.75rem;
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
-  }
-}
-
-.track-side-panel__toggle[aria-expanded="true"] .track-side-panel__toggle-icon {
-  transform: rotate(90deg);
-}
-
-.track-side-panel__collapse {
-  width: 100%;
-}
-
 .track-side-panel__body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.track-modal-side .card:last-child {
-  margin-bottom: 0;
+@media (max-width: 1199.98px) {
+  .track-modal-container {
+    --track-modal-drawer-width: min(340px, 90vw);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .track-modal-container {
+    --track-modal-drawer-width: min(320px, 88vw);
+  }
+
+  .track-modal-drawer {
+    padding: 1.25rem 1rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .track-modal-container {
+    --track-modal-drawer-width: 100%;
+  }
+
+  .track-modal-drawer {
+    left: 0;
+    border-radius: 1rem 1rem 0 0;
+    box-shadow: 0 -12px 24px rgba(15, 23, 42, 0.18);
+    transform: translateY(100%);
+  }
+
+  .track-modal-drawer--open,
+  .track-modal-container--drawer-open .track-modal-drawer {
+    transform: translateY(0);
+  }
+
+  .track-modal-drawer-toggle {
+    top: auto;
+    bottom: 1rem;
+    right: 1rem;
+    transform: none;
+    writing-mode: horizontal-tb;
+    border-radius: 999px;
+    padding: 0.75rem 1.25rem;
+  }
+
+  .track-modal-container--drawer-open .track-modal-drawer-toggle {
+    right: 1rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .track-modal-drawer {
+    padding: 1rem;
+    border-radius: 0;
+  }
+
+  .track-modal-drawer-toggle {
+    bottom: 0.75rem;
+  }
 }
 header .container {
   display: flex;

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -7,9 +7,6 @@
     /** Счётчик для генерации уникальных идентификаторов элементов формы. */
     let elementSequence = 0;
 
-    /** Ключ хранилища для состояния закрепления правой панели. */
-    const SIDE_PANEL_PIN_KEY = 'trackModal.sidePanel.pinned';
-
     /** Ключ хранилища для состояния сворачивания правой панели. */
     const SIDE_PANEL_COLLAPSE_KEY = 'trackModal.sidePanel.collapsed';
 
@@ -229,211 +226,81 @@
     }
 
     /**
-     * Настраивает адаптивное поведение правой панели модального окна.
-     * Метод управляет закреплением и сворачиванием панели, соблюдая принцип единой ответственности.
+     * Настраивает выезжающий блок с информацией об обмене и возврате.
+     * Метод управляет состоянием панели и синхронизирует aria-атрибуты, соблюдая принцип SRP.
      * @param {Object} options параметры конфигурации
-     * @param {HTMLElement} options.panel контейнер панели
-     * @param {HTMLElement} options.collapse элемент collapse
-     * @param {HTMLButtonElement} options.pinButton кнопка закрепления
-     * @param {HTMLButtonElement} options.toggleButton кнопка сворачивания
-     * @param {HTMLElement} options.pinLabel скрытый текст кнопки закрепления
-     * @param {HTMLElement} options.toggleLabel скрытый текст кнопки сворачивания
+     * @param {HTMLElement} options.container основной контейнер модального окна
+     * @param {HTMLElement} options.drawer панель, выезжающая поверх основного контента
+     * @param {HTMLButtonElement} options.toggleButton кнопка управления состоянием панели
      * @returns {Function} функция очистки обработчиков
      */
     function setupSidePanelInteractions({
-        panel,
-        collapse,
-        pinButton,
-        toggleButton,
-        pinLabel,
-        toggleLabel
+        container,
+        drawer,
+        toggleButton
     }) {
-        if (!panel || !collapse || !pinButton || !toggleButton || !pinLabel || !toggleLabel) {
+        if (!container || !drawer || !toggleButton) {
             return () => {};
         }
 
-        const mediaQuery = window.matchMedia('(min-width: 992px)');
-        const collapseInstance = (typeof bootstrap !== 'undefined' && bootstrap.Collapse)
-            ? bootstrap.Collapse.getOrCreateInstance(collapse, { toggle: false })
-            : null;
+        const drawerId = drawer.id || `trackModalDrawer${++elementSequence}`;
+        drawer.id = drawerId;
+        toggleButton.setAttribute('aria-controls', drawerId);
 
-        const layout = panel.closest('.track-modal-layout');
-        const sideColumn = panel.closest('.track-modal-side');
-        const mainColumn = layout?.querySelector('.track-modal-main') || null;
-
-        let isPinned = readBooleanFromStorage(SIDE_PANEL_PIN_KEY, true);
-        let isCollapsed = readBooleanFromStorage(SIDE_PANEL_COLLAPSE_KEY, false);
-        let collapsePreference = isCollapsed;
-        let suppressStorageUpdate = false;
+        let isOpen = !readBooleanFromStorage(SIDE_PANEL_COLLAPSE_KEY, false);
 
         /**
-         * Синхронизирует классы колонок с состоянием collapse.
-         * Метод добавляет модификаторы, чтобы CSS растягивал основную колонку и сжимал боковую на широких экранах (OCP).
-         * @param {boolean} collapsed актуальное состояние панели
+         * Обновляет aria-атрибуты кнопки, чтобы отражать текущее состояние панели.
+         * Метод изолирует текстовые ресурсы, чтобы облегчить локализацию (OCP).
+         * @param {boolean} open актуальное состояние панели
          */
-        const syncLayoutWithCollapse = (collapsed) => {
-            if (!layout || !sideColumn || !mainColumn) {
-                return;
-            }
-            const shouldCollapse = Boolean(collapsed);
-            layout.classList.toggle('track-modal-layout--side-collapsed', shouldCollapse);
-            sideColumn.classList.toggle('track-modal-side--collapsed', shouldCollapse);
-            mainColumn.classList.toggle('track-modal-main--expanded', shouldCollapse);
+        const updateToggleAria = (open) => {
+            const label = open
+                ? 'Скрыть панель «Обмен/Возврат»'
+                : 'Показать панель «Обмен/Возврат»';
+            toggleButton.setAttribute('aria-label', label);
+            toggleButton.setAttribute('title', label);
         };
 
-        const updatePinVisual = (pinned) => {
-            pinButton.setAttribute('aria-pressed', String(pinned));
-            pinButton.setAttribute('aria-label', pinned ? 'Открепить панель' : 'Закрепить панель');
-            pinButton.setAttribute('title', pinned ? 'Открепить панель' : 'Закрепить панель');
-            pinLabel.textContent = pinned ? 'Открепить панель' : 'Закрепить панель';
-            pinButton.classList.toggle('active', pinned);
-            panel.classList.toggle('track-side-panel--pinned', pinned);
+        /**
+         * Применяет визуальное состояние панели и синхронизирует хранилище.
+         * Метод отвечает только за обновление DOM и не содержит побочных эффектов вне области ответственности.
+         * @param {boolean} open целевое состояние панели
+         */
+        const applyState = (open) => {
+            const shouldOpen = Boolean(open);
+            drawer.classList.toggle('track-modal-drawer--open', shouldOpen);
+            drawer.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+            container.classList.toggle('track-modal-container--drawer-open', shouldOpen);
+            toggleButton.setAttribute('aria-expanded', String(shouldOpen));
+            updateToggleAria(shouldOpen);
         };
 
-        const updateCollapseVisual = (collapsed) => {
-            toggleButton.classList.toggle('collapsed', collapsed);
-            toggleButton.setAttribute('aria-expanded', String(!collapsed));
-            toggleButton.setAttribute('title', collapsed ? 'Развернуть панель' : 'Свернуть панель');
-            toggleLabel.textContent = collapsed ? 'Развернуть панель' : 'Свернуть панель';
+        applyState(isOpen);
+
+        const handleToggleClick = (event) => {
+            event.preventDefault();
+            isOpen = !isOpen;
+            applyState(isOpen);
+            writeBooleanToStorage(SIDE_PANEL_COLLAPSE_KEY, !isOpen);
         };
 
-        if (isPinned) {
-            isCollapsed = false;
-        }
-
-        updatePinVisual(isPinned);
-        updateCollapseVisual(isCollapsed);
-        syncLayoutWithCollapse(isCollapsed);
-
-        if (collapseInstance) {
-            if (isCollapsed) {
-                suppressStorageUpdate = true;
-                collapseInstance.hide();
-            }
-        } else {
-            collapse.classList.toggle('show', !isCollapsed);
-        }
-
-        const handleCollapseShown = () => {
-            isCollapsed = false;
-            updateCollapseVisual(false);
-            syncLayoutWithCollapse(false);
-            if (!suppressStorageUpdate) {
-                collapsePreference = false;
-                writeBooleanToStorage(SIDE_PANEL_COLLAPSE_KEY, false);
-            }
-            suppressStorageUpdate = false;
-        };
-
-        const handleCollapseHidden = () => {
-            isCollapsed = true;
-            updateCollapseVisual(true);
-            syncLayoutWithCollapse(true);
-            if (!suppressStorageUpdate) {
-                collapsePreference = true;
+        const handleKeydown = (event) => {
+            if (event.key === 'Escape' && isOpen) {
+                isOpen = false;
+                applyState(isOpen);
                 writeBooleanToStorage(SIDE_PANEL_COLLAPSE_KEY, true);
             }
-            suppressStorageUpdate = false;
         };
 
-        collapse.addEventListener('shown.bs.collapse', handleCollapseShown);
-        collapse.addEventListener('hidden.bs.collapse', handleCollapseHidden);
-
-        let fallbackToggleHandler = null;
-        if (!collapseInstance) {
-            fallbackToggleHandler = (event) => {
-                event.preventDefault();
-                const shouldHide = collapse.classList.contains('show');
-                if (shouldHide) {
-                    collapse.classList.remove('show');
-                    handleCollapseHidden();
-                } else {
-                    collapse.classList.add('show');
-                    handleCollapseShown();
-                }
-            };
-            toggleButton.addEventListener('click', fallbackToggleHandler);
-        }
-
-        const handlePinClick = () => {
-            isPinned = !isPinned;
-            if (isPinned) {
-                isCollapsed = false;
-                updateCollapseVisual(false);
-                if (collapseInstance) {
-                    suppressStorageUpdate = true;
-                    collapseInstance.show();
-                } else {
-                    suppressStorageUpdate = true;
-                    collapse.classList.add('show');
-                    handleCollapseShown();
-                }
-            } else {
-                handleMediaChange(mediaQuery);
-            }
-            updatePinVisual(isPinned);
-            writeBooleanToStorage(SIDE_PANEL_PIN_KEY, isPinned);
-            syncLayoutWithCollapse(isCollapsed);
-        };
-
-        pinButton.addEventListener('click', handlePinClick);
-
-        const handleMediaChange = (event) => {
-            const matches = event.matches !== undefined ? event.matches : event.currentTarget.matches;
-            if (matches) {
-                suppressStorageUpdate = true;
-                if (collapseInstance) {
-                    collapseInstance.show();
-                } else {
-                    collapse.classList.add('show');
-                    handleCollapseShown();
-                }
-                updateCollapseVisual(false);
-            } else {
-                const shouldCollapse = collapsePreference;
-                isCollapsed = shouldCollapse;
-                suppressStorageUpdate = true;
-                if (shouldCollapse) {
-                    if (collapseInstance) {
-                        collapseInstance.hide();
-                    } else {
-                        collapse.classList.remove('show');
-                        handleCollapseHidden();
-                    }
-                } else if (collapseInstance) {
-                    collapseInstance.show();
-                } else {
-                    collapse.classList.add('show');
-                    handleCollapseShown();
-                }
-                updateCollapseVisual(shouldCollapse);
-            }
-            syncLayoutWithCollapse(isCollapsed);
-        };
-
-        if (typeof mediaQuery.addEventListener === 'function') {
-            mediaQuery.addEventListener('change', handleMediaChange);
-        } else if (typeof mediaQuery.addListener === 'function') {
-            mediaQuery.addListener(handleMediaChange);
-        }
-
-        handleMediaChange(mediaQuery);
+        toggleButton.addEventListener('click', handleToggleClick);
+        container.addEventListener('keydown', handleKeydown);
 
         return () => {
-            collapse.removeEventListener('shown.bs.collapse', handleCollapseShown);
-            collapse.removeEventListener('hidden.bs.collapse', handleCollapseHidden);
-            pinButton.removeEventListener('click', handlePinClick);
-            if (fallbackToggleHandler) {
-                toggleButton.removeEventListener('click', fallbackToggleHandler);
-            }
-            if (typeof mediaQuery.removeEventListener === 'function') {
-                mediaQuery.removeEventListener('change', handleMediaChange);
-            } else if (typeof mediaQuery.removeListener === 'function') {
-                mediaQuery.removeListener(handleMediaChange);
-            }
+            toggleButton.removeEventListener('click', handleToggleClick);
+            container.removeEventListener('keydown', handleKeydown);
         };
     }
-
     /**
      * Возвращает значение в формате datetime-local для указанной даты.
      * Метод обеспечивает совместимость с нативными контролами браузера.
@@ -1748,17 +1615,20 @@
 
         const exchangeItem = options?.exchangeItem || null;
 
-        const layoutRow = document.createElement('div');
-        layoutRow.className = 'row g-3 track-modal-layout';
         if (data?.id !== undefined) {
-            layoutRow.dataset.trackId = String(data.id);
+            container.dataset.trackId = String(data.id);
+        } else {
+            delete container.dataset.trackId;
         }
 
         const mainColumn = document.createElement('div');
-        mainColumn.className = 'col-12 col-lg-8 d-flex flex-column gap-3 track-modal-main';
+        mainColumn.className = 'track-modal-main d-flex flex-column gap-3';
 
-        const sideColumn = document.createElement('div');
-        sideColumn.className = 'col-12 col-lg-4 track-modal-side d-flex flex-column gap-3';
+        const drawer = document.createElement('aside');
+        drawer.className = 'track-modal-drawer';
+        drawer.setAttribute('role', 'complementary');
+        drawer.setAttribute('tabindex', '-1');
+        drawer.setAttribute('aria-hidden', 'true');
 
         const parcelCard = createCard('Трек');
         const parcelHeader = document.createElement('div');
@@ -2257,10 +2127,9 @@
         historyCard.body.appendChild(historySection.container);
         mainColumn.appendChild(historyCard.card);
 
-        const sidePanel = document.createElement('aside');
+        const sidePanel = document.createElement('div');
         sidePanel.className = 'track-side-panel d-flex flex-column gap-3';
-        sidePanel.setAttribute('role', 'complementary');
-        sidePanel.setAttribute('aria-label', 'Информация об обращении и этапах');
+        sidePanel.setAttribute('role', 'region');
 
         const sideHeader = document.createElement('div');
         sideHeader.className = 'track-side-panel__header d-flex align-items-center justify-content-between gap-2';
@@ -2270,56 +2139,7 @@
         sideTitle.className = 'track-side-panel__title mb-0 text-uppercase text-muted small';
         sideTitle.textContent = 'Обращение и этапы';
 
-        const controls = document.createElement('div');
-        controls.className = 'track-side-panel__controls d-flex align-items-center gap-1';
-
-        const pinButton = document.createElement('button');
-        pinButton.type = 'button';
-        pinButton.className = 'btn btn-sm btn-outline-secondary track-side-panel__pin';
-        pinButton.setAttribute('aria-pressed', 'false');
-        pinButton.setAttribute('title', 'Закрепить панель');
-
-        const pinIcon = document.createElement('span');
-        pinIcon.className = 'track-side-panel__pin-icon';
-        pinIcon.setAttribute('aria-hidden', 'true');
-        pinIcon.textContent = '📌';
-
-        const pinLabel = document.createElement('span');
-        pinLabel.className = 'visually-hidden';
-        pinLabel.textContent = 'Закрепить панель';
-
-        pinButton.append(pinIcon, pinLabel);
-
-        const collapseId = 'trackSidePanelCollapse';
-
-        const toggleButton = document.createElement('button');
-        toggleButton.type = 'button';
-        toggleButton.className = 'btn btn-sm btn-outline-secondary track-side-panel__toggle';
-        toggleButton.dataset.bsToggle = 'collapse';
-        toggleButton.dataset.bsTarget = `#${collapseId}`;
-        toggleButton.setAttribute('aria-controls', collapseId);
-        toggleButton.setAttribute('aria-expanded', 'true');
-        toggleButton.setAttribute('title', 'Свернуть панель');
-
-        const toggleIcon = document.createElement('span');
-        toggleIcon.className = 'track-side-panel__toggle-icon';
-        toggleIcon.setAttribute('aria-hidden', 'true');
-        toggleIcon.textContent = '⯈';
-
-        const toggleLabel = document.createElement('span');
-        toggleLabel.className = 'visually-hidden';
-        toggleLabel.textContent = 'Свернуть панель';
-
-        toggleButton.append(toggleIcon, toggleLabel);
-
-        controls.append(pinButton, toggleButton);
-        sideHeader.append(sideTitle, controls);
-
-        const collapseWrapper = document.createElement('div');
-        collapseWrapper.id = collapseId;
-        collapseWrapper.className = 'collapse show track-side-panel__collapse';
-        collapseWrapper.setAttribute('role', 'region');
-        collapseWrapper.setAttribute('aria-labelledby', sideTitle.id);
+        sideHeader.appendChild(sideTitle);
 
         const sideContent = document.createElement('div');
         sideContent.className = 'track-side-panel__body d-flex flex-column gap-3';
@@ -2328,20 +2148,25 @@
             sideContent.appendChild(lifecycleCard);
         }
 
-        collapseWrapper.appendChild(sideContent);
-        sidePanel.append(sideHeader, collapseWrapper);
-        sideColumn.appendChild(sidePanel);
+        sidePanel.append(sideHeader, sideContent);
+        drawer.setAttribute('aria-labelledby', sideTitle.id);
+        drawer.appendChild(sidePanel);
 
-        layoutRow.append(mainColumn, sideColumn);
-        container.appendChild(layoutRow);
+        container.appendChild(mainColumn);
+        container.appendChild(drawer);
+
+        const drawerToggle = document.createElement('button');
+        drawerToggle.type = 'button';
+        drawerToggle.className = 'track-modal-drawer-toggle';
+        drawerToggle.textContent = 'Обмен/Возврат';
+        drawerToggle.setAttribute('aria-expanded', 'false');
+
+        container.appendChild(drawerToggle);
 
         disposeSidePanelInteractions = setupSidePanelInteractions({
-            panel: sidePanel,
-            collapse: collapseWrapper,
-            pinButton,
-            toggleButton,
-            pinLabel,
-            toggleLabel
+            container,
+            drawer,
+            toggleButton: drawerToggle
         });
 
         const nextRefreshAt = data?.nextRefreshAt || null;


### PR DESCRIPTION
## Summary
- restructure the track modal to render the return/exchange details as a separate drawer with a vertical toggle
- manage drawer state with accessible aria attributes and persisted preferences in the modal renderer
- add responsive styling so the drawer slides in over the content and becomes full-screen on narrow screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec312fa8e8832d99b59a77b090cbae