### PR TITLE
Remove floating toggle in track modal side panel

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -278,6 +278,19 @@ header {
   padding: 0.75rem 1rem;
 }
 
+.track-side-panel__close {
+  margin-left: auto;
+  color: var(--bs-secondary-color);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.track-side-panel__close:focus,
+.track-side-panel__close:hover {
+  color: var(--bs-secondary-color);
+  text-decoration: underline;
+}
+
 .track-side-panel__title {
   letter-spacing: 0.08em;
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -267,37 +267,6 @@ header {
   transform: translateX(0);
 }
 
-.track-modal-drawer-toggle {
-  position: absolute;
-  top: 50%;
-  right: calc(var(--track-modal-drawer-gap) * -1);
-  transform: translateY(-50%);
-  writing-mode: vertical-rl;
-  text-orientation: mixed;
-  letter-spacing: 0.12em;
-  font-weight: 600;
-  background-color: var(--bs-primary);
-  color: var(--bs-white);
-  border: none;
-  border-radius: 0.75rem 0.75rem 0 0;
-  padding: 1rem 0.5rem;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, right 0.3s ease-in-out;
-  z-index: 6;
-}
-
-.track-modal-drawer-toggle:hover,
-.track-modal-drawer-toggle:focus-visible {
-  background-color: var(--bs-primary-hover-bg, #0b5ed7);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
-  outline: none;
-}
-
-.track-modal-container--drawer-open .track-modal-drawer-toggle {
-  right: calc(var(--track-modal-drawer-width) + var(--track-modal-drawer-gap));
-}
-
 .track-side-panel {
   background-color: transparent;
 }
@@ -352,29 +321,12 @@ header {
     transform: translateY(0);
   }
 
-  .track-modal-drawer-toggle {
-    top: auto;
-    bottom: 1rem;
-    right: 1rem;
-    transform: none;
-    writing-mode: horizontal-tb;
-    border-radius: 999px;
-    padding: 0.75rem 1.25rem;
-  }
-
-  .track-modal-container--drawer-open .track-modal-drawer-toggle {
-    right: 1rem;
-  }
 }
 
 @media (max-width: 575.98px) {
   .track-modal-drawer {
     padding: 1rem;
     border-radius: 0;
-  }
-
-  .track-modal-drawer-toggle {
-    bottom: 0.75rem;
   }
 }
 header .container {

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -409,6 +409,22 @@
     }
 
     /**
+     * Создаёт кнопку закрытия панели обмена и возврата.
+     * Метод подготавливает визуальное оформление и ARIA-атрибуты, позволяя переиспользовать кнопку в любом контейнере.
+     * @returns {HTMLButtonElement} кнопка закрытия панели
+     */
+    function createDrawerCloseButton() {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-link btn-sm track-side-panel__close';
+        button.textContent = 'Закрыть';
+        button.setAttribute('aria-expanded', 'false');
+        button.setAttribute('aria-label', 'Скрыть панель «Обмен/Возврат»');
+        button.setAttribute('title', 'Скрыть панель «Обмен/Возврат»');
+        return button;
+    }
+
+    /**
      * Формирует подписанный контрол формы с необязательным описанием.
      * @param {string} labelText текст подписи
      * @param {HTMLElement} control элемент управления
@@ -2181,7 +2197,9 @@
         sideTitle.className = 'track-side-panel__title mb-0 text-uppercase text-muted small';
         sideTitle.textContent = 'Обращение и этапы';
 
-        sideHeader.appendChild(sideTitle);
+        const sideCloseButton = createDrawerCloseButton();
+
+        sideHeader.append(sideTitle, sideCloseButton);
 
         const sideContent = document.createElement('div');
         sideContent.className = 'track-side-panel__body d-flex flex-column gap-3';
@@ -2200,7 +2218,7 @@
         disposeSidePanelInteractions = setupSidePanelInteractions({
             container,
             drawer,
-            toggleButtons: [inlineDrawerToggle]
+            toggleButtons: [inlineDrawerToggle, sideCloseButton]
         });
 
         const nextRefreshAt = data?.nextRefreshAt || null;


### PR DESCRIPTION
## Summary
- allow the side-panel wiring to work with a list of toggle buttons and keep focus after closing with Escape
- insert the inline drawer control button into the modal header and stop rendering the floating toggle element
- drop the obsolete `.track-modal-drawer-toggle` styles now that the inline control is the only trigger

## Testing
- npm test *(fails: track-modal render suite contains pre-existing timeout and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ece0fb4264832d974b17a62f727727