### PR TITLE
Adjust track modal layout for desktop drawer

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -307,6 +307,38 @@ header {
   }
 }
 
+@media (min-width: 992px) {
+  .track-modal-container {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--track-modal-drawer-gap);
+  }
+
+  .track-modal-main {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .track-modal-container--drawer-open {
+    align-items: stretch;
+  }
+
+  .track-modal-container--drawer-open .track-modal-main {
+    padding-right: 0;
+    flex-basis: calc(100% - var(--track-modal-drawer-width) - var(--track-modal-drawer-gap));
+  }
+
+  .track-modal-container--drawer-open .track-modal-drawer {
+    position: relative;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    flex: 0 0 var(--track-modal-drawer-width);
+    max-width: var(--track-modal-drawer-width);
+    transform: none;
+  }
+}
+
 @media (max-width: 991.98px) {
   .track-modal-container {
     --track-modal-drawer-width: min(320px, 88vw);


### PR DESCRIPTION
## Summary
- add a desktop flex layout to the track modal container with a fixed-width drawer column and spacing between panels
- ensure the track modal main content reserves space when the drawer opens while keeping the overlay behavior on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed402941a4832dad433d41dd3ab8a1