### PR TITLE
Adjust track modal drawer layout

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -183,6 +183,164 @@
   hyphens: auto;
 }
 
+.track-modal-container {
+  position: relative;
+  width: 100%;
+  display: block;
+  --track-modal-drawer-width: min(380px, 92vw);
+  --track-modal-drawer-gap: 0.75rem;
+}
+
+.track-modal-main {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.track-modal-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem 1.25rem;
+  width: var(--track-modal-drawer-width);
+  max-width: var(--track-modal-drawer-width);
+  border-radius: 1rem;
+  background-color: var(--bs-body-bg);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.24);
+  transform: translateX(100%);
+  transition: transform 0.3s ease-in-out;
+  overflow: hidden;
+  overflow-y: auto;
+  z-index: 5;
+}
+
+.track-modal-drawer--open,
+.track-modal-container--drawer-open .track-modal-drawer {
+  transform: translateX(0);
+}
+
+.track-side-panel {
+  background-color: transparent;
+}
+
+.track-side-panel__header {
+  background-color: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+}
+
+.track-side-panel__close {
+  margin-left: auto;
+  color: var(--bs-secondary-color);
+  text-decoration: none;
+  font-weight: 500;
+
+  &:focus,
+  &:hover {
+    color: var(--bs-secondary-color);
+    text-decoration: underline;
+  }
+}
+
+.track-side-panel__title {
+  letter-spacing: 0.08em;
+}
+
+.track-side-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (max-width: 1199.98px) {
+  .track-modal-container {
+    --track-modal-drawer-width: min(340px, 90vw);
+  }
+}
+
+@media (min-width: 992px) {
+  .track-modal-container {
+    display: flex;
+    align-items: stretch;
+    overflow-x: hidden;
+    gap: 0;
+  }
+
+  .track-modal-main {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .track-modal-container--drawer-open {
+    gap: var(--track-modal-drawer-gap);
+  }
+
+  .track-modal-drawer {
+    position: relative;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    transform: none;
+    flex: 0 0 var(--track-modal-drawer-width);
+    max-width: var(--track-modal-drawer-width);
+    width: var(--track-modal-drawer-width);
+    overflow: hidden;
+    overflow-y: auto;
+    transition: flex-basis 0.3s ease-in-out, max-width 0.3s ease-in-out,
+      width 0.3s ease-in-out, padding 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  }
+
+  .track-modal-container:not(.track-modal-container--drawer-open) .track-modal-drawer {
+    flex-basis: 0;
+    max-width: 0;
+    width: 0;
+    opacity: 0;
+    padding-left: 0;
+    padding-right: 0;
+    pointer-events: none;
+  }
+
+  .track-modal-container--drawer-open .track-modal-drawer {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .track-modal-container {
+    --track-modal-drawer-width: min(320px, 88vw);
+  }
+
+  .track-modal-drawer {
+    padding: 1.25rem 1rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .track-modal-container {
+    --track-modal-drawer-width: 100%;
+  }
+
+  .track-modal-drawer {
+    left: 0;
+    border-radius: 1rem 1rem 0 0;
+    box-shadow: 0 -12px 24px rgba(15, 23, 42, 0.18);
+    transform: translateY(100%);
+  }
+
+  .track-modal-drawer--open,
+  .track-modal-container--drawer-open .track-modal-drawer {
+    transform: translateY(0);
+  }
+}
+
 // Стили вертикального таба панели обмена/возврата вынесены отдельно,
 // чтобы упростить поддержку и повторное использование компонентов модального окна.
 .track-modal-tab {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -385,8 +385,9 @@ header {
 @media (min-width: 992px) {
   .track-modal-container {
     display: flex;
-    align-items: flex-start;
-    gap: var(--track-modal-drawer-gap);
+    align-items: stretch;
+    overflow-x: hidden;
+    gap: 0;
   }
 
   .track-modal-main {
@@ -395,22 +396,38 @@ header {
   }
 
   .track-modal-container--drawer-open {
-    align-items: stretch;
+    gap: var(--track-modal-drawer-gap);
   }
 
-  .track-modal-container--drawer-open .track-modal-main {
-    padding-right: 0;
-    flex-basis: calc(100% - var(--track-modal-drawer-width) - var(--track-modal-drawer-gap));
-  }
-
-  .track-modal-container--drawer-open .track-modal-drawer {
+  .track-modal-drawer {
     position: relative;
     top: auto;
     right: auto;
     bottom: auto;
+    left: auto;
+    transform: none;
     flex: 0 0 var(--track-modal-drawer-width);
     max-width: var(--track-modal-drawer-width);
-    transform: none;
+    width: var(--track-modal-drawer-width);
+    overflow: hidden;
+    overflow-y: auto;
+    transition: flex-basis 0.3s ease-in-out, max-width 0.3s ease-in-out,
+      width 0.3s ease-in-out, padding 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  }
+
+  .track-modal-container:not(.track-modal-container--drawer-open) .track-modal-drawer {
+    flex-basis: 0;
+    max-width: 0;
+    width: 0;
+    opacity: 0;
+    padding-left: 0;
+    padding-right: 0;
+    pointer-events: none;
+  }
+
+  .track-modal-container--drawer-open .track-modal-drawer {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -290,7 +290,6 @@
          */
         const applyState = (open) => {
             const shouldOpen = !isDrawerDisabled && Boolean(open);
-            drawer.classList.toggle('track-modal-drawer--open', shouldOpen);
             drawer.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
             container.classList.toggle('track-modal-container--drawer-open', shouldOpen);
             buttons.forEach((button) => {


### PR DESCRIPTION
## Summary
- refactor the desktop track modal container into a flex wrapper with hidden overflow to support inline drawer animation
- add a collapsed drawer state so the main content keeps its width until the panel expands
- update the side panel setup to rely on the container modifier while keeping aria-hidden in sync
- mirror the drawer layout refinements in the SCSS source so future builds stay in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed5eb550fc832d97d5928d4380f798