### PR TITLE
Refine track modal drawer toggle layout

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -215,6 +215,7 @@
   overflow-x: hidden;
   --track-modal-drawer-width: min(380px, 92vw);
   --track-modal-drawer-gap: 0.75rem;
+  --track-modal-tab-peek: 1.5rem;
 }
 
 .track-modal-main-shell {
@@ -261,7 +262,7 @@
 .track-modal-tab-slot {
   position: absolute;
   top: 0;
-  right: 0;
+  right: calc(var(--track-modal-tab-peek, 1.5rem) * -1);
   bottom: 0;
   display: flex;
   justify-content: flex-end;
@@ -375,17 +376,13 @@
     min-width: 0;
   }
 
-  .track-modal-tab-slot {
-    right: 0;
-  }
-
   .track-modal-tab-slot .track-modal-drawer-toggle {
-    transform: translateX(calc(100% + var(--track-modal-drawer-gap, 0.75rem)));
+    transform: none;
   }
 
   .track-modal-tab-slot .track-modal-drawer-toggle[aria-expanded='true'],
   .track-modal-container--drawer-open .track-modal-tab-slot .track-modal-drawer-toggle {
-    transform: translateX(0);
+    transform: translateX(calc(var(--track-modal-tab-peek, 1.5rem) * -1));
   }
 
   .track-modal-container--drawer-open {

--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -212,14 +212,26 @@
   position: relative;
   width: 100%;
   display: block;
+  overflow-x: hidden;
   --track-modal-drawer-width: min(380px, 92vw);
   --track-modal-drawer-gap: 0.75rem;
+}
+
+.track-modal-main-shell {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  align-items: stretch;
+  overflow: visible;
 }
 
 .track-modal-main-layout {
   position: relative;
   width: 100%;
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: nowrap;
   align-items: flex-start;
   gap: 0;
@@ -247,13 +259,16 @@
 
 
 .track-modal-tab-slot {
-  position: relative;
-  flex: 0 0 auto;
-  width: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
+  width: 0;
   overflow: visible;
+  pointer-events: none;
 }
 
 .track-modal-drawer-toggle {
@@ -261,8 +276,10 @@
   top: 1.5rem;
   flex: 0 0 auto;
   margin-left: 0;
-  transform: translateX(var(--track-modal-drawer-gap, 0.75rem));
   z-index: 2;
+  transform: none;
+  transition: transform 0.3s ease-in-out;
+  pointer-events: auto;
 }
 
 .track-modal-drawer {
@@ -336,8 +353,11 @@
   .track-modal-container {
     display: flex;
     align-items: stretch;
-    overflow-x: hidden;
     gap: 0;
+  }
+
+  .track-modal-main-shell {
+    flex: 1 1 auto;
   }
 
   .track-modal-main-layout {
@@ -353,6 +373,19 @@
   .track-modal-main {
     flex: 1 1 auto;
     min-width: 0;
+  }
+
+  .track-modal-tab-slot {
+    right: 0;
+  }
+
+  .track-modal-tab-slot .track-modal-drawer-toggle {
+    transform: translateX(calc(100% + var(--track-modal-drawer-gap, 0.75rem)));
+  }
+
+  .track-modal-tab-slot .track-modal-drawer-toggle[aria-expanded='true'],
+  .track-modal-container--drawer-open .track-modal-tab-slot .track-modal-drawer-toggle {
+    transform: translateX(0);
   }
 
   .track-modal-container--drawer-open {
@@ -398,6 +431,16 @@
 
   .track-modal-drawer {
     padding: 1.25rem 1rem;
+  }
+
+  .track-modal-tab-slot {
+    position: static;
+    width: auto;
+    pointer-events: auto;
+  }
+
+  .track-modal-tab-slot .track-modal-drawer-toggle {
+    transform: none;
   }
 }
 
@@ -453,7 +496,7 @@
   }
 
   &[aria-expanded='true'] {
-    transform: translateX(calc(var(--track-modal-drawer-gap, 0.75rem) - 0.25rem));
+    transform: translateX(0);
     background-color: var(--bs-primary);
     color: #fff;
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.2);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -893,6 +893,7 @@ button:hover {
   overflow-x: hidden;
   --track-modal-drawer-width: min(380px, 92vw);
   --track-modal-drawer-gap: 0.75rem;
+  --track-modal-tab-peek: 1.5rem;
 }
 
 .track-modal-main-shell {
@@ -938,7 +939,7 @@ button:hover {
 .track-modal-tab-slot {
   position: absolute;
   top: 0;
-  right: 0;
+  right: calc(var(--track-modal-tab-peek, 1.5rem) * -1);
   bottom: 0;
   display: flex;
   justify-content: flex-end;
@@ -1044,15 +1045,12 @@ button:hover {
     flex: 1 1 auto;
     min-width: 0;
   }
-  .track-modal-tab-slot {
-    right: 0;
-  }
   .track-modal-tab-slot .track-modal-drawer-toggle {
-    transform: translateX(calc(100% + var(--track-modal-drawer-gap, 0.75rem)));
+    transform: none;
   }
   .track-modal-tab-slot .track-modal-drawer-toggle[aria-expanded=true],
   .track-modal-container--drawer-open .track-modal-tab-slot .track-modal-drawer-toggle {
-    transform: translateX(0);
+    transform: translateX(calc(var(--track-modal-tab-peek, 1.5rem) * -1));
   }
   .track-modal-container--drawer-open {
     gap: var(--track-modal-drawer-gap);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -890,14 +890,26 @@ button:hover {
   position: relative;
   width: 100%;
   display: block;
+  overflow-x: hidden;
   --track-modal-drawer-width: min(380px, 92vw);
   --track-modal-drawer-gap: 0.75rem;
+}
+
+.track-modal-main-shell {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  align-items: stretch;
+  overflow: visible;
 }
 
 .track-modal-main-layout {
   position: relative;
   width: 100%;
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: nowrap;
   align-items: flex-start;
   gap: 0;
@@ -924,13 +936,16 @@ button:hover {
 }
 
 .track-modal-tab-slot {
-  position: relative;
-  flex: 0 0 auto;
-  width: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
+  width: 0;
   overflow: visible;
+  pointer-events: none;
 }
 
 .track-modal-drawer-toggle {
@@ -938,8 +953,10 @@ button:hover {
   top: 1.5rem;
   flex: 0 0 auto;
   margin-left: 0;
-  transform: translateX(var(--track-modal-drawer-gap, 0.75rem));
   z-index: 2;
+  transform: none;
+  transition: transform 0.3s ease-in-out;
+  pointer-events: auto;
 }
 
 .track-modal-drawer {
@@ -1012,6 +1029,9 @@ button:hover {
     align-items: stretch;
     gap: 0;
   }
+  .track-modal-main-shell {
+    flex: 1 1 auto;
+  }
   .track-modal-main-layout {
     flex: 1 1 auto;
     min-width: 0;
@@ -1023,6 +1043,16 @@ button:hover {
   .track-modal-main {
     flex: 1 1 auto;
     min-width: 0;
+  }
+  .track-modal-tab-slot {
+    right: 0;
+  }
+  .track-modal-tab-slot .track-modal-drawer-toggle {
+    transform: translateX(calc(100% + var(--track-modal-drawer-gap, 0.75rem)));
+  }
+  .track-modal-tab-slot .track-modal-drawer-toggle[aria-expanded=true],
+  .track-modal-container--drawer-open .track-modal-tab-slot .track-modal-drawer-toggle {
+    transform: translateX(0);
   }
   .track-modal-container--drawer-open {
     gap: var(--track-modal-drawer-gap);
@@ -1062,6 +1092,14 @@ button:hover {
   .track-modal-drawer {
     padding: 1.25rem 1rem;
   }
+  .track-modal-tab-slot {
+    position: static;
+    width: auto;
+    pointer-events: auto;
+  }
+  .track-modal-tab-slot .track-modal-drawer-toggle {
+    transform: none;
+  }
 }
 @media (max-width: 767.98px) {
   .track-modal-container {
@@ -1079,6 +1117,8 @@ button:hover {
   }
 }
 .track-modal-tab {
+  position: sticky;
+  top: 1.5rem;
   align-self: flex-start;
   display: inline-flex;
   flex-direction: column;
@@ -1093,8 +1133,7 @@ button:hover {
   background-color: var(--bs-body-bg);
   color: var(--bs-primary);
   box-shadow: 0 8px 20px rgba(13, 110, 253, 0.15);
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
-    transform 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   text-decoration: none;
   letter-spacing: 0.08em;
 }
@@ -1106,7 +1145,7 @@ button:hover {
   box-shadow: 0 10px 24px rgba(13, 110, 253, 0.22);
 }
 .track-modal-tab[aria-expanded=true] {
-  transform: translateX(calc(var(--track-modal-drawer-gap, 0.75rem) - 0.25rem));
+  transform: translateX(0);
   background-color: var(--bs-primary);
   color: #fff;
   box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.2);
@@ -1114,17 +1153,14 @@ button:hover {
 .track-modal-tab[aria-expanded=true] .track-modal-tab__symbol {
   color: inherit;
 }
-.track-modal-tab[aria-disabled=true], .track-modal-tab.track-modal-tab--disabled,
-.track-modal-tab:disabled {
+.track-modal-tab[aria-disabled=true], .track-modal-tab.track-modal-tab--disabled, .track-modal-tab:disabled {
   color: var(--bs-secondary-color);
   background-color: var(--bs-tertiary-bg);
   border-color: var(--bs-border-color);
   box-shadow: none;
   cursor: not-allowed;
 }
-.track-modal-tab[aria-disabled=true]:focus, .track-modal-tab[aria-disabled=true]:focus-visible,
-.track-modal-tab.track-modal-tab--disabled:focus, .track-modal-tab.track-modal-tab--disabled:focus-visible,
-.track-modal-tab:disabled:focus, .track-modal-tab:disabled:focus-visible {
+.track-modal-tab[aria-disabled=true]:focus, .track-modal-tab[aria-disabled=true]:focus-visible, .track-modal-tab.track-modal-tab--disabled:focus, .track-modal-tab.track-modal-tab--disabled:focus-visible, .track-modal-tab:disabled:focus, .track-modal-tab:disabled:focus-visible {
   outline: none;
 }
 .track-modal-tab__label {

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1815,6 +1815,9 @@
             delete container.dataset.trackId;
         }
 
+        const mainShell = document.createElement('div');
+        mainShell.className = 'track-modal-main-shell';
+
         const mainLayout = document.createElement('div');
         mainLayout.className = 'track-modal-main-layout';
 
@@ -1870,7 +1873,7 @@
         const toggleSlot = document.createElement('div');
         toggleSlot.className = 'track-modal-tab-slot';
         toggleSlot.appendChild(inlineDrawerToggle);
-        mainLayout.appendChild(toggleSlot);
+        mainShell.append(mainLayout, toggleSlot);
 
         const trackId = data?.id;
         const returnRequest = data?.returnRequest || null;
@@ -2379,7 +2382,7 @@
         drawer.setAttribute('aria-labelledby', sideTitle.id);
         drawer.appendChild(sidePanel);
 
-        container.appendChild(mainLayout);
+        container.appendChild(mainShell);
         container.appendChild(drawer);
 
         disposeSidePanelInteractions = setupSidePanelInteractions({


### PR DESCRIPTION
## Summary
- move the track modal tab slot into a new `.track-modal-main-shell` wrapper and adjust SCSS so the toggle can sit outside the main column without causing scroll
- update responsive rules to slide the toggle handle in and out beside the drawer while keeping overlay behaviour on narrow viewports, then rebuild the compiled CSS

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68ed829a1338832db62d6eb597c02103