### PR TITLE
Adjust track modal tab positioning

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -247,6 +247,15 @@
   flex-direction: column;
 }
 
+.track-modal-main-column-shell {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+  overflow: visible;
+}
+
 .track-modal-main {
   flex: 1 1 auto;
   min-width: 0;
@@ -376,6 +385,11 @@
     min-width: 0;
   }
 
+  .track-modal-main-column-shell {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
   .track-modal-tab-slot .track-modal-drawer-toggle {
     transform: none;
   }
@@ -434,6 +448,10 @@
     position: static;
     width: auto;
     pointer-events: auto;
+  }
+
+  .track-modal-main-column-shell {
+    overflow: visible;
   }
 
   .track-modal-tab-slot .track-modal-drawer-toggle {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -925,6 +925,15 @@ button:hover {
   flex-direction: column;
 }
 
+.track-modal-main-column-shell {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+  overflow: visible;
+}
+
 .track-modal-main {
   flex: 1 1 auto;
   min-width: 0;
@@ -1045,6 +1054,10 @@ button:hover {
     flex: 1 1 auto;
     min-width: 0;
   }
+  .track-modal-main-column-shell {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
   .track-modal-tab-slot .track-modal-drawer-toggle {
     transform: none;
   }
@@ -1094,6 +1107,9 @@ button:hover {
     position: static;
     width: auto;
     pointer-events: auto;
+  }
+  .track-modal-main-column-shell {
+    overflow: visible;
   }
   .track-modal-tab-slot .track-modal-drawer-toggle {
     transform: none;

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1785,6 +1785,8 @@
      * Отрисовывает содержимое модального окна с деталями трека.
      * Метод собирает карточки интерфейса и обновляет заголовок без сетевых обращений (SRP).
      * @param {Object} data DTO с сервера
+     * @param {Object} [options] дополнительные настройки от вызывающего кода
+     * @param {Object|null} [options.exchangeItem] данные обменной посылки для отображения
      */
     function renderTrackModal(data, options = {}) {
         clearRefreshTimer();
@@ -1824,10 +1826,14 @@
         const mainWrapper = document.createElement('div');
         mainWrapper.className = 'track-modal-main-wrapper';
 
+        const mainColumnShell = document.createElement('div');
+        mainColumnShell.className = 'track-modal-main-column-shell';
+
         const mainColumn = document.createElement('div');
         mainColumn.className = 'track-modal-main d-flex flex-column gap-3';
         mainWrapper.appendChild(mainColumn);
-        mainLayout.appendChild(mainWrapper);
+        mainColumnShell.appendChild(mainWrapper);
+        mainLayout.appendChild(mainColumnShell);
 
         const drawer = document.createElement('aside');
         drawer.className = 'track-modal-drawer';
@@ -1873,7 +1879,8 @@
         const toggleSlot = document.createElement('div');
         toggleSlot.className = 'track-modal-tab-slot';
         toggleSlot.appendChild(inlineDrawerToggle);
-        mainShell.append(mainLayout, toggleSlot);
+        mainColumnShell.appendChild(toggleSlot);
+        mainShell.appendChild(mainLayout);
 
         const trackId = data?.id;
         const returnRequest = data?.returnRequest || null;


### PR DESCRIPTION
## Summary
- wrap the track modal main column with a dedicated container so the tab slot can live outside the column
- update modal styles in the SCSS source to anchor the drawer tab relative to the new wrapper and keep overflow handling intact on desktop and mobile

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68ed96442268832db983255a413b3ade