### PR TITLE
Relocate track modal width adjustments into SCSS

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -194,6 +194,9 @@
     var(--track-modal-dialog-base-width),
     var(--track-modal-viewport-width)
   );
+  --track-modal-drawer-gap: 0.75rem;
+  --track-modal-drawer-width: min(380px, 92vw);
+  --track-modal-tab-peek: 1.5rem;
   --track-modal-dialog-open-width: min(
     calc(
       var(--track-modal-main-width) + var(--track-modal-drawer-gap, 0px) +
@@ -231,9 +234,6 @@
   width: 100%;
   display: block;
   overflow-x: hidden;
-  --track-modal-drawer-width: min(380px, 92vw);
-  --track-modal-drawer-gap: 0.75rem;
-  --track-modal-tab-peek: 1.5rem;
 }
 
 .track-modal-dialog.track-modal-dialog--drawer-open,
@@ -385,7 +385,7 @@
 }
 
 @media (max-width: 1199.98px) {
-  .track-modal-container {
+  .track-modal-dialog {
     --track-modal-drawer-width: min(340px, 90vw);
   }
 }
@@ -465,7 +465,7 @@
 }
 
 @media (max-width: 991.98px) {
-  .track-modal-container {
+  .track-modal-dialog {
     --track-modal-drawer-width: min(320px, 88vw);
   }
 
@@ -489,7 +489,7 @@
 }
 
 @media (max-width: 767.98px) {
-  .track-modal-container {
+  .track-modal-dialog {
     --track-modal-drawer-width: 100%;
   }
 

--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -184,7 +184,25 @@
 }
 
 .track-modal-dialog {
-  max-width: 1140px;
+  --track-modal-dialog-base-width: 1140px;
+  --track-modal-dialog-horizontal-padding: 2rem;
+  --track-modal-viewport-width: max(
+    calc(100vw - var(--track-modal-dialog-horizontal-padding)),
+    0px
+  );
+  --track-modal-main-width: min(
+    var(--track-modal-dialog-base-width),
+    var(--track-modal-viewport-width)
+  );
+  --track-modal-dialog-open-width: min(
+    calc(
+      var(--track-modal-main-width) + var(--track-modal-drawer-gap, 0px) +
+        var(--track-modal-drawer-width, 0px)
+    ),
+    var(--track-modal-viewport-width)
+  );
+  width: min(100%, var(--track-modal-main-width));
+  max-width: var(--track-modal-main-width);
 }
 
 .track-modal-body {
@@ -218,11 +236,17 @@
   --track-modal-tab-peek: 1.5rem;
 }
 
+.track-modal-dialog.track-modal-dialog--drawer-open,
+.track-modal-container--drawer-open .track-modal-dialog {
+  width: min(100%, var(--track-modal-dialog-open-width));
+  max-width: var(--track-modal-dialog-open-width);
+}
+
 .track-modal-main-shell {
   position: relative;
   display: flex;
-  flex: 1 1 auto;
-  width: 100%;
+  flex: 0 0 var(--track-modal-main-width);
+  width: min(100%, var(--track-modal-main-width));
   min-width: 0;
   align-items: stretch;
   overflow: visible;
@@ -241,7 +265,8 @@
 
 .track-modal-main-wrapper {
   position: relative;
-  flex: 1 1 auto;
+  flex: 0 0 var(--track-modal-main-width);
+  width: min(100%, var(--track-modal-main-width));
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -261,6 +286,12 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.track-modal-container--drawer-open .track-modal-main-shell,
+.track-modal-container--drawer-open .track-modal-main-wrapper {
+  flex-shrink: 0;
+  max-width: var(--track-modal-main-width);
 }
 
 .track-modal-main > .card:last-child {
@@ -366,17 +397,15 @@
     gap: 0;
   }
 
-  .track-modal-main-shell {
-    flex: 1 1 auto;
-  }
-
   .track-modal-main-layout {
     flex: 1 1 auto;
     min-width: 0;
   }
 
+  .track-modal-main-shell,
   .track-modal-main-wrapper {
-    flex: 1 1 auto;
+    flex: 0 0 var(--track-modal-main-width);
+    max-width: var(--track-modal-main-width);
     min-width: 0;
   }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -874,6 +874,9 @@ button:hover {
     var(--track-modal-dialog-base-width),
     var(--track-modal-viewport-width)
   );
+  --track-modal-drawer-gap: 0.75rem;
+  --track-modal-drawer-width: min(380px, 92vw);
+  --track-modal-tab-peek: 1.5rem;
   --track-modal-dialog-open-width: min(
     calc(
       var(--track-modal-main-width) + var(--track-modal-drawer-gap, 0px) +
@@ -909,9 +912,6 @@ button:hover {
   width: 100%;
   display: block;
   overflow-x: hidden;
-  --track-modal-drawer-width: min(380px, 92vw);
-  --track-modal-drawer-gap: 0.75rem;
-  --track-modal-tab-peek: 1.5rem;
 }
 
 .track-modal-dialog.track-modal-dialog--drawer-open,
@@ -1060,7 +1060,7 @@ button:hover {
 }
 
 @media (max-width: 1199.98px) {
-  .track-modal-container {
+  .track-modal-dialog {
     --track-modal-drawer-width: min(340px, 90vw);
   }
 }
@@ -1127,7 +1127,7 @@ button:hover {
   }
 }
 @media (max-width: 991.98px) {
-  .track-modal-container {
+  .track-modal-dialog {
     --track-modal-drawer-width: min(320px, 88vw);
   }
   .track-modal-drawer {
@@ -1146,7 +1146,7 @@ button:hover {
   }
 }
 @media (max-width: 767.98px) {
-  .track-modal-container {
+  .track-modal-dialog {
     --track-modal-drawer-width: 100%;
   }
   .track-modal-drawer {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -864,7 +864,25 @@ button:hover {
 }
 
 .track-modal-dialog {
-  max-width: 1140px;
+  --track-modal-dialog-base-width: 1140px;
+  --track-modal-dialog-horizontal-padding: 2rem;
+  --track-modal-viewport-width: max(
+    calc(100vw - var(--track-modal-dialog-horizontal-padding)),
+    0px
+  );
+  --track-modal-main-width: min(
+    var(--track-modal-dialog-base-width),
+    var(--track-modal-viewport-width)
+  );
+  --track-modal-dialog-open-width: min(
+    calc(
+      var(--track-modal-main-width) + var(--track-modal-drawer-gap, 0px) +
+        var(--track-modal-drawer-width, 0px)
+    ),
+    var(--track-modal-viewport-width)
+  );
+  width: min(100%, var(--track-modal-main-width));
+  max-width: var(--track-modal-main-width);
 }
 
 .track-modal-body {
@@ -896,11 +914,17 @@ button:hover {
   --track-modal-tab-peek: 1.5rem;
 }
 
+.track-modal-dialog.track-modal-dialog--drawer-open,
+.track-modal-container--drawer-open .track-modal-dialog {
+  width: min(100%, var(--track-modal-dialog-open-width));
+  max-width: var(--track-modal-dialog-open-width);
+}
+
 .track-modal-main-shell {
   position: relative;
   display: flex;
-  flex: 1 1 auto;
-  width: 100%;
+  flex: 0 0 var(--track-modal-main-width);
+  width: min(100%, var(--track-modal-main-width));
   min-width: 0;
   align-items: stretch;
   overflow: visible;
@@ -919,7 +943,8 @@ button:hover {
 
 .track-modal-main-wrapper {
   position: relative;
-  flex: 1 1 auto;
+  flex: 0 0 var(--track-modal-main-width);
+  width: min(100%, var(--track-modal-main-width));
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -939,6 +964,12 @@ button:hover {
   min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.track-modal-container--drawer-open .track-modal-main-shell,
+.track-modal-container--drawer-open .track-modal-main-wrapper {
+  flex-shrink: 0;
+  max-width: var(--track-modal-main-width);
 }
 
 .track-modal-main > .card:last-child {
@@ -1039,15 +1070,14 @@ button:hover {
     align-items: stretch;
     gap: 0;
   }
-  .track-modal-main-shell {
-    flex: 1 1 auto;
-  }
   .track-modal-main-layout {
     flex: 1 1 auto;
     min-width: 0;
   }
+  .track-modal-main-shell,
   .track-modal-main-wrapper {
-    flex: 1 1 auto;
+    flex: 0 0 var(--track-modal-main-width);
+    max-width: var(--track-modal-main-width);
     min-width: 0;
   }
   .track-modal-main {

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -233,13 +233,15 @@
      * @param {HTMLElement} options.drawer панель, выезжающая поверх основного контента
      * @param {Array<HTMLElement>} options.toggleButtons коллекция кнопок управления панелью
      * @param {boolean} [options.drawerDisabled] начальный признак недоступности панели
+     * @param {HTMLElement|null} [options.dialog] ссылка на элемент диалога для переключения модификатора
      * @returns {Function} функция очистки обработчиков
      */
     function setupSidePanelInteractions({
         container,
         drawer,
         toggleButtons,
-        drawerDisabled = false
+        drawerDisabled = false,
+        dialog = null
     }) {
         const buttons = Array.isArray(toggleButtons)
             ? toggleButtons.filter((button) => button instanceof HTMLElement)
@@ -292,6 +294,9 @@
             const shouldOpen = !isDrawerDisabled && Boolean(open);
             drawer.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
             container.classList.toggle('track-modal-container--drawer-open', shouldOpen);
+            if (dialog instanceof HTMLElement) {
+                dialog.classList.toggle('track-modal-dialog--drawer-open', shouldOpen);
+            }
             buttons.forEach((button) => {
                 const isButtonDisabled = button.getAttribute('aria-disabled') === 'true';
                 const expandedValue = shouldOpen && !isButtonDisabled;
@@ -1797,11 +1802,17 @@
         }
 
         const modal = document.getElementById('infoModal');
+        const dialog = modal?.querySelector('.track-modal-dialog') || null;
+        if (dialog) {
+            dialog.classList.remove('track-modal-dialog--drawer-open');
+        }
         const container = document.getElementById('trackModalContent')
             || modal?.querySelector('.modal-body');
         if (!container) {
             return;
         }
+
+        container.classList.remove('track-modal-container--drawer-open');
 
         const timeZone = data?.timeZone;
         const format = (value) => formatDateTime(value, timeZone);
@@ -2396,7 +2407,8 @@
             container,
             drawer,
             toggleButtons: [inlineDrawerToggle, sideCloseButton],
-            drawerDisabled: shouldDisableDrawer
+            drawerDisabled: shouldDisableDrawer,
+            dialog
         });
 
         const nextRefreshAt = data?.nextRefreshAt || null;


### PR DESCRIPTION
## Summary
- port the track modal width custom properties and drawer-open sizing rules into the SCSS source
- ensure the main column keeps its width when the drawer opens by updating shared flex constraints in SCSS and compiled CSS

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68ee2056ec70832d9a1c7d84f654ea34