### PR TITLE
Refactor track modal drawer handle layout

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -263,6 +263,15 @@
   overflow: visible;
 }
 
+.track-modal-main-body {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+  overflow: visible;
+}
+
 .track-modal-main-wrapper {
   position: relative;
   flex: 0 0 var(--track-modal-main-width);
@@ -289,7 +298,8 @@
 }
 
 .track-modal-container--drawer-open .track-modal-main-shell,
-.track-modal-container--drawer-open .track-modal-main-wrapper {
+.track-modal-container--drawer-open .track-modal-main-wrapper,
+.track-modal-container--drawer-open .track-modal-main-body {
   flex-shrink: 0;
   max-width: var(--track-modal-main-width);
 }
@@ -403,7 +413,8 @@
   }
 
   .track-modal-main-shell,
-  .track-modal-main-wrapper {
+  .track-modal-main-wrapper,
+  .track-modal-main-body {
     flex: 0 0 var(--track-modal-main-width);
     max-width: var(--track-modal-main-width);
     min-width: 0;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -941,6 +941,15 @@ button:hover {
   overflow: visible;
 }
 
+.track-modal-main-body {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+  overflow: visible;
+}
+
 .track-modal-main-wrapper {
   position: relative;
   flex: 0 0 var(--track-modal-main-width);
@@ -967,7 +976,8 @@ button:hover {
 }
 
 .track-modal-container--drawer-open .track-modal-main-shell,
-.track-modal-container--drawer-open .track-modal-main-wrapper {
+.track-modal-container--drawer-open .track-modal-main-wrapper,
+.track-modal-container--drawer-open .track-modal-main-body {
   flex-shrink: 0;
   max-width: var(--track-modal-main-width);
 }
@@ -1075,7 +1085,8 @@ button:hover {
     min-width: 0;
   }
   .track-modal-main-shell,
-  .track-modal-main-wrapper {
+  .track-modal-main-wrapper,
+  .track-modal-main-body {
     flex: 0 0 var(--track-modal-main-width);
     max-width: var(--track-modal-main-width);
     min-width: 0;

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -276,11 +276,13 @@
                 }
                 if (isButtonDisabled) {
                     button.setAttribute('title', disabledTitle);
+                    button.setAttribute('data-bs-original-title', disabledTitle);
                     button.setAttribute('aria-label', `${toggleLabelCollapsed}. ${disabledTitle}`);
                 } else {
                     const label = open ? toggleLabelExpanded : toggleLabelCollapsed;
                     button.setAttribute('aria-label', label);
                     button.setAttribute('title', label);
+                    button.setAttribute('data-bs-original-title', label);
                 }
             });
         };
@@ -478,11 +480,14 @@
         if (isDisabled) {
             button.classList.add('track-modal-tab--disabled');
             button.setAttribute('title', disabledTitle);
+            button.setAttribute('data-bs-original-title', disabledTitle);
             button.setAttribute('aria-label', `${collapsedLabel}. ${disabledTitle}`);
+            button.setAttribute('aria-expanded', 'false');
         } else {
             button.classList.remove('track-modal-tab--disabled');
             const title = button.dataset.toggleLabelCollapsed || collapsedLabel;
             button.setAttribute('title', title);
+            button.setAttribute('data-bs-original-title', title);
             button.setAttribute('aria-label', title);
         }
     }
@@ -1844,7 +1849,12 @@
         mainColumn.className = 'track-modal-main d-flex flex-column gap-3';
         mainWrapper.appendChild(mainColumn);
         mainColumnShell.appendChild(mainWrapper);
-        mainLayout.appendChild(mainColumnShell);
+
+        const mainBody = document.createElement('div');
+        mainBody.className = 'track-modal-main-body';
+        mainBody.appendChild(mainColumnShell);
+
+        mainLayout.appendChild(mainBody);
 
         const drawer = document.createElement('aside');
         drawer.className = 'track-modal-drawer';
@@ -1890,7 +1900,7 @@
         const toggleSlot = document.createElement('div');
         toggleSlot.className = 'track-modal-tab-slot';
         toggleSlot.appendChild(inlineDrawerToggle);
-        mainColumnShell.appendChild(toggleSlot);
+        mainBody.appendChild(toggleSlot);
         mainShell.appendChild(mainLayout);
 
         const trackId = data?.id;


### PR DESCRIPTION
## Summary
- restructure the track modal DOM to wrap the main column in a dedicated shell and mount the drawer tab alongside it
- update the CSS and SCSS so the tab slot is positioned relative to the new wrapper while keeping desktop and responsive behavior intact
- keep drawer toggle accessibility metadata and tooltips in sync when availability or expansion state changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee4b8f5b4c832d84f646c07e310547