### PR TITLE
Adjust modal dialog styles for track modal layout

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -12,7 +12,7 @@
     padding: 1rem;
   }
 
-  .modal-dialog {
+  .modal-dialog:not(.track-modal-dialog) {
     max-width: 600px;
     width: 100%;
     margin: auto;
@@ -62,7 +62,7 @@
   }
 
   @include ui.respond-to(md){
-    .modal-dialog {
+    .modal-dialog:not(.track-modal-dialog) {
       max-width: 90%;
     }
 
@@ -91,7 +91,7 @@
   }
 
   @include ui.respond-to(sm) {
-    .modal-dialog {
+    .modal-dialog:not(.track-modal-dialog) {
       max-width: 95%;
     }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -701,7 +701,7 @@ button:hover {
   min-height: 100vh;
   padding: 1rem;
 }
-.modal .modal-dialog {
+.modal .modal-dialog:not(.track-modal-dialog) {
   max-width: 600px;
   width: 100%;
   margin: auto;
@@ -743,7 +743,7 @@ button:hover {
   font-weight: 700;
 }
 @media (max-width: 768px) {
-  .modal .modal-dialog {
+  .modal .modal-dialog:not(.track-modal-dialog) {
     max-width: 90%;
   }
   .modal .modal-content {
@@ -766,7 +766,7 @@ button:hover {
   }
 }
 @media (max-width: 576px) {
-  .modal .modal-dialog {
+  .modal .modal-dialog:not(.track-modal-dialog) {
     max-width: 95%;
   }
   .modal .modal-title {
@@ -872,20 +872,8 @@ button:hover {
   --track-modal-gap: 1.5rem;
   --track-modal-main-width: clamp(520px, 58vw, 760px);
   --track-modal-side-width: clamp(420px, 34vw, 520px);
-  width: min(
-    calc(
-      var(--track-modal-main-width) + var(--track-modal-side-width) +
-        var(--track-modal-gap)
-    ),
-    var(--track-modal-viewport-width)
-  );
-  max-width: min(
-    calc(
-      var(--track-modal-main-width) + var(--track-modal-side-width) +
-        var(--track-modal-gap)
-    ),
-    var(--track-modal-viewport-width)
-  );
+  width: min(var(--track-modal-main-width) + var(--track-modal-side-width) + var(--track-modal-gap), var(--track-modal-viewport-width));
+  max-width: min(var(--track-modal-main-width) + var(--track-modal-side-width) + var(--track-modal-gap), var(--track-modal-viewport-width));
 }
 
 .track-modal-body {
@@ -952,13 +940,11 @@ button:hover {
     --track-modal-side-width: clamp(400px, 36vw, 500px);
   }
 }
-
 @media (max-width: 1199.98px) {
   .track-modal-dialog {
     --track-modal-side-width: clamp(380px, 40vw, 480px);
   }
 }
-
 @media (max-width: 991.98px) {
   .track-modal-dialog {
     --track-modal-horizontal-padding: 1.5rem;
@@ -979,7 +965,6 @@ button:hover {
     border-radius: 1.25rem;
   }
 }
-
 @media (max-width: 767.98px) {
   .track-modal-dialog {
     --track-modal-horizontal-padding: 1.25rem;
@@ -994,7 +979,6 @@ button:hover {
     border-radius: 1.25rem 1.25rem 0 0;
   }
 }
-
 @media (max-width: 576px) {
   .cookie-modal {
     width: 90%;


### PR DESCRIPTION
## Summary
- exclude the track modal dialog from the generic modal width constraint so its custom layout is preserved
- rebuild the compiled stylesheet so the track modal width variables control the combined width

## Testing
- npm run build:css
- mvn spring-boot:run *(fails: Could not transfer artifact io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 from/to jitpack.io (https://jitpack.io): status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ee6d94deb4832da484a9cfff7e6cbc