### PR TITLE
Refine track modal side drawer layout

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1583,6 +1583,7 @@
         drawer.className = 'track-modal-drawer';
         drawer.setAttribute('role', 'complementary');
         drawer.setAttribute('tabindex', '-1');
+        drawer.classList.add('gap-3');
 
         const parcelCard = createCard('Трек');
         const parcelHeader = document.createElement('div');
@@ -2101,27 +2102,20 @@
         historyCard.body.appendChild(historySection.container);
         mainColumn.appendChild(historyCard.card);
 
-        const sidePanel = document.createElement('div');
-        sidePanel.className = 'track-side-panel d-flex flex-column gap-3';
-        sidePanel.setAttribute('role', 'region');
-
-        [returnCard, lifecycleCard]
-            .filter((cardInfo) => Boolean(cardInfo))
-            .forEach((cardInfo) => sidePanel.appendChild(cardInfo.card));
-
         const labelTargets = [returnCard?.heading, lifecycleCard?.heading]
             .filter((heading) => heading?.id)
             .map((heading) => heading.id);
 
         if (labelTargets.length > 0) {
             const labelledBy = labelTargets.join(' ');
-            sidePanel.setAttribute('aria-labelledby', labelledBy);
             drawer.setAttribute('aria-labelledby', labelledBy);
         } else {
-            sidePanel.removeAttribute('aria-labelledby');
             drawer.removeAttribute('aria-labelledby');
         }
-        drawer.appendChild(sidePanel);
+
+        [returnCard, lifecycleCard]
+            .filter((cardInfo) => Boolean(cardInfo))
+            .forEach((cardInfo) => drawer.appendChild(cardInfo.card));
 
         container.appendChild(mainColumn);
         container.appendChild(drawer);


### PR DESCRIPTION
## Summary
- append the return and lifecycle cards directly into the track modal drawer without the extra wrapper
- keep accessibility metadata on the drawer itself while preserving spacing between cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee8a6bc7e0832da7d0e3f279f72b58