### PR TITLE
Remove Bootstrap gap from track modal drawer

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1583,7 +1583,6 @@
         drawer.className = 'track-modal-drawer';
         drawer.setAttribute('role', 'complementary');
         drawer.setAttribute('tabindex', '-1');
-        drawer.classList.add('gap-3');
 
         const parcelCard = createCard('Трек');
         const parcelHeader = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove the unused Bootstrap gap class from the track modal drawer so spacing relies on existing card margins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee97514d74832db04e801b2ea1ae20