### PR TITLE
Refactor track modal layout to remove side wrapper

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -228,11 +228,12 @@
   gap: 0.5rem;
 }
 
+
 .track-modal-container {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-  justify-content: stretch;
+  display: grid;
+  grid-template-columns: minmax(0, var(--track-modal-main-width, 640px))
+    minmax(0, var(--track-modal-side-width, 480px));
+  align-items: start;
   gap: var(--track-modal-gap, 1.5rem);
   width: 100%;
   min-width: 0;
@@ -243,7 +244,8 @@
 }
 
 .track-modal-main {
-  flex: 1 1 var(--track-modal-main-width, 640px);
+  grid-column: 1;
+  grid-row: 1 / -1;
   max-width: var(--track-modal-main-width, 640px);
   min-width: 0;
   display: flex;
@@ -255,16 +257,11 @@
   margin-bottom: 0;
 }
 
-.track-modal-side {
-  flex: 0 0 var(--track-modal-side-width, 480px);
+.track-modal-container > .card {
+  grid-column: 2;
   max-width: var(--track-modal-side-width, 480px);
+  width: 100%;
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  background-color: var(--bs-body-bg);
-  border-radius: 1.25rem;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
-  padding: 1.5rem 1.25rem;
 }
 
 @media (max-width: 1399.98px) {
@@ -289,17 +286,14 @@
   }
 
   .track-modal-container {
+    display: flex;
     flex-direction: column;
     gap: 1.25rem;
   }
 
-  .track-modal-side {
-    flex: 0 0 auto;
+  .track-modal-container > .card {
     max-width: 100%;
     width: 100%;
-    padding: 1.5rem 1.25rem;
-    box-shadow: 0 -16px 32px rgba(15, 23, 42, 0.18);
-    border-radius: 1.25rem;
   }
 }
 
@@ -312,7 +306,7 @@
     gap: 1rem;
   }
 
-  .track-modal-side {
+  .track-modal-container > .card {
     margin-left: -1rem;
     margin-right: -1rem;
     width: calc(100% + 2rem);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -896,10 +896,9 @@ button:hover {
 }
 
 .track-modal-container {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-  justify-content: stretch;
+  display: grid;
+  grid-template-columns: minmax(0, var(--track-modal-main-width, 640px)) minmax(0, var(--track-modal-side-width, 480px));
+  align-items: start;
   gap: var(--track-modal-gap, 1.5rem);
   width: 100%;
   min-width: 0;
@@ -910,7 +909,8 @@ button:hover {
 }
 
 .track-modal-main {
-  flex: 1 1 var(--track-modal-main-width, 640px);
+  grid-column: 1;
+  grid-row: 1/-1;
   max-width: var(--track-modal-main-width, 640px);
   min-width: 0;
   display: flex;
@@ -922,16 +922,11 @@ button:hover {
   margin-bottom: 0;
 }
 
-.track-modal-side {
-  flex: 0 0 var(--track-modal-side-width, 480px);
+.track-modal-container > .card {
+  grid-column: 2;
   max-width: var(--track-modal-side-width, 480px);
+  width: 100%;
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  background-color: var(--bs-body-bg);
-  border-radius: 1.25rem;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
-  padding: 1.5rem 1.25rem;
 }
 
 @media (max-width: 1399.98px) {
@@ -953,16 +948,13 @@ button:hover {
     max-width: min(var(--track-modal-viewport-width), var(--track-modal-main-width));
   }
   .track-modal-container {
+    display: flex;
     flex-direction: column;
     gap: 1.25rem;
   }
-  .track-modal-side {
-    flex: 0 0 auto;
+  .track-modal-container > .card {
     max-width: 100%;
     width: 100%;
-    padding: 1.5rem 1.25rem;
-    box-shadow: 0 -16px 32px rgba(15, 23, 42, 0.18);
-    border-radius: 1.25rem;
   }
 }
 @media (max-width: 767.98px) {
@@ -972,7 +964,7 @@ button:hover {
   .track-modal-container {
     gap: 1rem;
   }
-  .track-modal-side {
+  .track-modal-container > .card {
     margin-left: -1rem;
     margin-right: -1rem;
     width: calc(100% + 2rem);

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -2104,24 +2104,7 @@
         if (sideCards.length > 0) {
             const sideFragment = document.createDocumentFragment();
             sideCards.forEach((cardInfo) => sideFragment.appendChild(cardInfo.card));
-
-            const labelTargets = sideCards
-                .map((cardInfo) => cardInfo.heading?.id)
-                .filter((id) => Boolean(id));
-
-            const sideRegion = document.createElement('div');
-            sideRegion.className = 'track-modal-side';
-            sideRegion.setAttribute('role', 'complementary');
-            sideRegion.setAttribute('tabindex', '-1');
-
-            if (labelTargets.length > 0) {
-                sideRegion.setAttribute('aria-labelledby', labelTargets.join(' '));
-            } else {
-                sideRegion.removeAttribute('aria-labelledby');
-            }
-
-            sideRegion.appendChild(sideFragment);
-            container.appendChild(sideRegion);
+            container.appendChild(sideFragment);
         }
 
         const nextRefreshAt = data?.nextRefreshAt || null;


### PR DESCRIPTION
## Summary
- remove the side region wrapper in the track modal script and append cards directly to the container
- refactor modal styles to rely on grid layout and responsive tweaks without the side wrapper
- rebuild the compiled CSS bundle to match the updated structure

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68eea3e8169c832dbd5c8ac90d7cf3f5