### PR TITLE
Adjust track modal layout widths

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -190,7 +190,7 @@
     0px
   );
   --track-modal-gap: 1.5rem;
-  --track-modal-main-width: clamp(520px, 58vw, 760px);
+  --track-modal-main-width: clamp(480px, 54vw, 700px);
   --track-modal-side-width: clamp(420px, 34vw, 520px);
   width: min(
     calc(
@@ -231,8 +231,8 @@
 
 .track-modal-container {
   display: grid;
-  grid-template-columns: minmax(0, var(--track-modal-main-width, 640px))
-    minmax(0, var(--track-modal-side-width, 480px));
+  grid-template-columns: minmax(0, var(--track-modal-main-width, 700px))
+    minmax(0, var(--track-modal-side-width, 520px));
   align-items: start;
   gap: var(--track-modal-gap, 1.5rem);
   width: 100%;
@@ -246,7 +246,7 @@
 .track-modal-main {
   grid-column: 1;
   grid-row: 1 / -1;
-  max-width: var(--track-modal-main-width, 640px);
+  max-width: var(--track-modal-main-width, 700px);
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -259,14 +259,14 @@
 
 .track-modal-container > .card {
   grid-column: 2;
-  max-width: var(--track-modal-side-width, 480px);
+  max-width: var(--track-modal-side-width, 520px);
   width: 100%;
   min-width: 0;
 }
 
 @media (max-width: 1399.98px) {
   .track-modal-dialog {
-    --track-modal-main-width: clamp(500px, 60vw, 720px);
+    --track-modal-main-width: clamp(460px, 56vw, 660px);
     --track-modal-side-width: clamp(400px, 36vw, 500px);
   }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -870,7 +870,7 @@ button:hover {
     0px
   );
   --track-modal-gap: 1.5rem;
-  --track-modal-main-width: clamp(520px, 58vw, 760px);
+  --track-modal-main-width: clamp(480px, 54vw, 700px);
   --track-modal-side-width: clamp(420px, 34vw, 520px);
   width: min(var(--track-modal-main-width) + var(--track-modal-side-width) + var(--track-modal-gap), var(--track-modal-viewport-width));
   max-width: min(var(--track-modal-main-width) + var(--track-modal-side-width) + var(--track-modal-gap), var(--track-modal-viewport-width));
@@ -897,7 +897,7 @@ button:hover {
 
 .track-modal-container {
   display: grid;
-  grid-template-columns: minmax(0, var(--track-modal-main-width, 640px)) minmax(0, var(--track-modal-side-width, 480px));
+  grid-template-columns: minmax(0, var(--track-modal-main-width, 700px)) minmax(0, var(--track-modal-side-width, 520px));
   align-items: start;
   gap: var(--track-modal-gap, 1.5rem);
   width: 100%;
@@ -911,7 +911,7 @@ button:hover {
 .track-modal-main {
   grid-column: 1;
   grid-row: 1/-1;
-  max-width: var(--track-modal-main-width, 640px);
+  max-width: var(--track-modal-main-width, 700px);
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -924,14 +924,14 @@ button:hover {
 
 .track-modal-container > .card {
   grid-column: 2;
-  max-width: var(--track-modal-side-width, 480px);
+  max-width: var(--track-modal-side-width, 520px);
   width: 100%;
   min-width: 0;
 }
 
 @media (max-width: 1399.98px) {
   .track-modal-dialog {
-    --track-modal-main-width: clamp(500px, 60vw, 720px);
+    --track-modal-main-width: clamp(460px, 56vw, 660px);
     --track-modal-side-width: clamp(400px, 36vw, 500px);
   }
 }


### PR DESCRIPTION
## Summary
- narrow the track modal main column by reducing its default clamp range in the SCSS source
- align grid column fallbacks with the updated width settings to preserve spacing
- tune the wide breakpoint clamp values to maintain the secondary column layout

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68eea9bbf158832d91b36eef6c829385