### PR TITLE
Align timeline timeline wrapping styles

### DIFF
--- a/src/main/resources/assets/scss/components/_timeline.scss
+++ b/src/main/resources/assets/scss/components/_timeline.scss
@@ -37,9 +37,13 @@
 
 .timeline-status {
   font-weight: 500;
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }
 
 .timeline-details {
   margin-top: 0.25rem;
   line-height: 1.4;
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1021,11 +1021,15 @@ button:hover {
 
 .timeline-status {
   font-weight: 500;
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }
 
 .timeline-details {
   margin-top: 0.25rem;
   line-height: 1.4;
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }
 
 .text-danger {


### PR DESCRIPTION
## Summary
- add word wrapping and hyphenation rules to the timeline SCSS so generated CSS keeps the behavior consistent

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68eeaebe39c4832d85a967da69e3f1d8