### PR TITLE
Wrap track modal side content in dedicated container

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -257,11 +257,19 @@
   margin-bottom: 0;
 }
 
-.track-modal-container > .card {
+.track-modal-container > .card,
+.track-modal-side {
   grid-column: 2;
+  grid-row: 1 / -1;
   max-width: var(--track-modal-side-width, 520px);
   width: 100%;
   min-width: 0;
+}
+
+.track-modal-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--track-modal-gap, 1.5rem);
 }
 
 @media (max-width: 1399.98px) {
@@ -291,7 +299,8 @@
     gap: 1.25rem;
   }
 
-  .track-modal-container > .card {
+  .track-modal-container > .card,
+  .track-modal-side {
     max-width: 100%;
     width: 100%;
   }
@@ -306,7 +315,8 @@
     gap: 1rem;
   }
 
-  .track-modal-container > .card {
+  .track-modal-container > .card,
+  .track-modal-side > .card {
     margin-left: -1rem;
     margin-right: -1rem;
     width: calc(100% + 2rem);

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -922,11 +922,19 @@ button:hover {
   margin-bottom: 0;
 }
 
-.track-modal-container > .card {
+.track-modal-container > .card,
+.track-modal-side {
   grid-column: 2;
+  grid-row: 1/-1;
   max-width: var(--track-modal-side-width, 520px);
   width: 100%;
   min-width: 0;
+}
+
+.track-modal-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--track-modal-gap, 1.5rem);
 }
 
 @media (max-width: 1399.98px) {
@@ -952,7 +960,8 @@ button:hover {
     flex-direction: column;
     gap: 1.25rem;
   }
-  .track-modal-container > .card {
+  .track-modal-container > .card,
+  .track-modal-side {
     max-width: 100%;
     width: 100%;
   }
@@ -964,7 +973,8 @@ button:hover {
   .track-modal-container {
     gap: 1rem;
   }
-  .track-modal-container > .card {
+  .track-modal-container > .card,
+  .track-modal-side > .card {
     margin-left: -1rem;
     margin-right: -1rem;
     width: calc(100% + 2rem);

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -2102,9 +2102,25 @@
             .filter((cardInfo) => Boolean(cardInfo));
 
         if (sideCards.length > 0) {
-            const sideFragment = document.createDocumentFragment();
-            sideCards.forEach((cardInfo) => sideFragment.appendChild(cardInfo.card));
-            container.appendChild(sideFragment);
+            /**
+             * Создаёт правую колонку модального окна и наполняет её карточками.
+             * Метод формирует единый контейнер, чтобы сетка корректно выравнивала
+             * вспомогательные блоки и их позиция не менялась при изменении контента.
+             * @returns {HTMLElement} обёртка с карточками правой части
+             */
+            const createSideColumn = () => {
+                const sideColumn = document.createElement('aside');
+                sideColumn.className = 'track-modal-side d-flex flex-column gap-3';
+                sideColumn.setAttribute('aria-label', 'Дополнительные сведения о треке');
+                sideCards.forEach((cardInfo) => {
+                    if (cardInfo?.card instanceof HTMLElement) {
+                        sideColumn.appendChild(cardInfo.card);
+                    }
+                });
+                return sideColumn;
+            };
+
+            container.appendChild(createSideColumn());
         }
 
         const nextRefreshAt = data?.nextRefreshAt || null;


### PR DESCRIPTION
## Summary
- group the track modal side cards into a dedicated aside container so the grid treats them as one column
- add CSS and SCSS styles for the new wrapper to preserve spacing and responsive behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eeb1dca2e0832db7aeb4c0ef239eb7