### PR TITLE
Align tracking modal SCSS with narrowed main column

### DIFF
--- a/src/main/resources/assets/scss/components/_modals.scss
+++ b/src/main/resources/assets/scss/components/_modals.scss
@@ -190,7 +190,7 @@
     0px
   );
   --track-modal-gap: 1.5rem;
-  --track-modal-main-width: clamp(480px, 54vw, 700px);
+  --track-modal-main-width: clamp(440px, 50vw, 640px);
   --track-modal-side-width: clamp(420px, 34vw, 520px);
   width: min(
     calc(
@@ -231,7 +231,7 @@
 
 .track-modal-container {
   display: grid;
-  grid-template-columns: minmax(0, var(--track-modal-main-width, 700px))
+  grid-template-columns: minmax(0, var(--track-modal-main-width, 640px))
     minmax(0, var(--track-modal-side-width, 520px));
   align-items: start;
   gap: var(--track-modal-gap, 1.5rem);
@@ -246,7 +246,7 @@
 .track-modal-main {
   grid-column: 1;
   grid-row: 1 / -1;
-  max-width: var(--track-modal-main-width, 700px);
+  max-width: var(--track-modal-main-width, 640px);
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -274,13 +274,14 @@
 
 @media (max-width: 1399.98px) {
   .track-modal-dialog {
-    --track-modal-main-width: clamp(460px, 56vw, 660px);
+    --track-modal-main-width: clamp(420px, 52vw, 600px);
     --track-modal-side-width: clamp(400px, 36vw, 500px);
   }
 }
 
 @media (max-width: 1199.98px) {
   .track-modal-dialog {
+    --track-modal-main-width: clamp(400px, 54vw, 560px);
     --track-modal-side-width: clamp(380px, 40vw, 480px);
   }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -870,7 +870,7 @@ button:hover {
     0px
   );
   --track-modal-gap: 1.5rem;
-  --track-modal-main-width: clamp(480px, 54vw, 700px);
+  --track-modal-main-width: clamp(440px, 50vw, 640px);
   --track-modal-side-width: clamp(420px, 34vw, 520px);
   width: min(var(--track-modal-main-width) + var(--track-modal-side-width) + var(--track-modal-gap), var(--track-modal-viewport-width));
   max-width: min(var(--track-modal-main-width) + var(--track-modal-side-width) + var(--track-modal-gap), var(--track-modal-viewport-width));
@@ -897,7 +897,7 @@ button:hover {
 
 .track-modal-container {
   display: grid;
-  grid-template-columns: minmax(0, var(--track-modal-main-width, 700px)) minmax(0, var(--track-modal-side-width, 520px));
+  grid-template-columns: minmax(0, var(--track-modal-main-width, 640px)) minmax(0, var(--track-modal-side-width, 520px));
   align-items: start;
   gap: var(--track-modal-gap, 1.5rem);
   width: 100%;
@@ -911,7 +911,7 @@ button:hover {
 .track-modal-main {
   grid-column: 1;
   grid-row: 1/-1;
-  max-width: var(--track-modal-main-width, 700px);
+  max-width: var(--track-modal-main-width, 640px);
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -939,12 +939,13 @@ button:hover {
 
 @media (max-width: 1399.98px) {
   .track-modal-dialog {
-    --track-modal-main-width: clamp(460px, 56vw, 660px);
+    --track-modal-main-width: clamp(420px, 52vw, 600px);
     --track-modal-side-width: clamp(400px, 36vw, 500px);
   }
 }
 @media (max-width: 1199.98px) {
   .track-modal-dialog {
+    --track-modal-main-width: clamp(400px, 54vw, 560px);
     --track-modal-side-width: clamp(380px, 40vw, 480px);
   }
 }


### PR DESCRIPTION
## Summary
- mirror the reduced clamp range for `--track-modal-main-width` and synchronized fallback values in the SCSS source so the grid respects the tightened layout
- refresh breakpoint-specific clamps in the SCSS to keep responsive behavior consistent with the updated modal sizing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeb706a050832d948acc6662b24e13