### PR TITLE
Allow exchange receipt confirmation button

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1916,7 +1916,6 @@
             }
 
             const allowReceiptConfirmationWithoutClosing = Boolean(returnRequest?.canConfirmReceipt)
-                && !exchangeContext
                 && !canCloseWithoutExchange
                 && trackId !== undefined
                 && returnRequest?.id !== undefined;


### PR DESCRIPTION
## Summary
- allow the receipt confirmation action to appear in exchange context while still hiding it when closing without exchange is permitted
- cover exchange-specific confirmation scenarios and ensure close-without-exchange keeps confirmation hidden in tests

## Testing
- npm test -- track-modal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ef9ecfd5b0832db3b0166b29ad73e8