### PR TITLE
Update cancel request button label

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1989,10 +1989,11 @@
             }
 
             if (returnRequest?.canCancelExchange && trackId !== undefined && returnRequest.id !== undefined) {
+                const cancelActionLabel = 'Отменить обращение';
                 const cancelButton = createActionButton({
-                    text: 'Отменить обмен',
+                    text: cancelActionLabel,
                     variant: 'outline-danger',
-                    ariaLabel: 'Отменить обмен и закрыть заявку',
+                    ariaLabel: cancelActionLabel,
                     onClick: (button) => runButtonAction(button,
                         () => handleCancelExchangeAction(trackId, returnRequest.id, {
                             successMessage: 'Обмен отменён и заявка закрыта',

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -347,7 +347,7 @@ describe('track-modal render', () => {
         expect(confirmButton).toBeDefined();
 
         expect(texts).toContain('Перевести в возврат');
-        expect(texts).toContain('Отменить обмен');
+        expect(texts).toContain('Отменить обращение');
     });
 
     test('shows reopen action for requested exchange without explicit flag', () => {


### PR DESCRIPTION
## Summary
- update the cancel action in the track modal to use the unified «Отменить обращение» label and aria text
- keep the danger styling while reusing the label constant for both button caption and aria attributes
- align track modal tests with the updated button copy

## Testing
- npm test -- track-modal

------
https://chatgpt.com/codex/tasks/task_e_68efb748f028832da5d597555f19bdb0