### PR TITLE
Handle missing return details link in track modal

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -2025,20 +2025,16 @@
                 const hintParagraph = document.createElement('p');
                 hintParagraph.className = 'text-muted small mb-0';
                 hintParagraph.textContent = hintText;
-                const moreLink = document.createElement('a');
-                moreLink.textContent = 'Подробнее';
-                moreLink.className = 'ms-1';
                 if (detailsUrl) {
+                    const moreLink = document.createElement('a');
+                    moreLink.textContent = 'Подробнее';
+                    moreLink.className = 'ms-1';
                     moreLink.href = detailsUrl;
                     moreLink.target = '_blank';
                     moreLink.rel = 'noreferrer noopener';
-                } else {
-                    moreLink.href = '#';
-                    moreLink.classList.add('disabled', 'pe-none');
-                    moreLink.setAttribute('aria-disabled', 'true');
+                    hintParagraph.append(' ');
+                    hintParagraph.appendChild(moreLink);
                 }
-                hintParagraph.append(' ');
-                hintParagraph.appendChild(moreLink);
                 actionsWrapper.appendChild(hintParagraph);
             }
 

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -351,6 +351,71 @@ describe('track-modal render', () => {
         expect(texts).toContain('Отменить обращение');
     });
 
+    test('does not render return details link without url', () => {
+        setupDom();
+
+        const expectedHint = 'Детали обращения доступны в личном кабинете.';
+        const data = {
+            id: 401,
+            number: 'BY2024005',
+            deliveryService: 'Belpost',
+            systemStatus: 'В обработке',
+            history: [],
+            refreshAllowed: true,
+            nextRefreshAt: null,
+            canEditTrack: false,
+            timeZone: 'UTC',
+            episodeNumber: null,
+            exchange: false,
+            returnShipment: false,
+            chain: [],
+            returnRequest: {
+                id: 901,
+                status: 'Зарегистрирована',
+                statusLabel: 'Зарегистрирована',
+                statusBadgeClass: 'bg-info-subtle text-info-emphasis',
+                reasonLabel: 'Причина',
+                reason: 'Покупатель сообщил о проблеме',
+                comment: null,
+                requestedAt: '2024-02-15T12:00:00Z',
+                decisionAt: null,
+                closedAt: null,
+                reverseTrackNumber: null,
+                requiresAction: false,
+                exchangeApproved: false,
+                exchangeRequested: false,
+                canStartExchange: false,
+                canCreateExchangeParcel: false,
+                canCloseWithoutExchange: false,
+                canReopenAsReturn: false,
+                canCancelExchange: false,
+                cancelExchangeUnavailableReason: null,
+                canConfirmReceipt: false,
+                returnReceiptConfirmed: false,
+                returnReceiptConfirmedAt: null,
+                hint: expectedHint,
+                warnings: [],
+                detailsUrl: '',
+                hintUrl: '',
+                helpUrl: ''
+            },
+            canRegisterReturn: false,
+            lifecycle: [],
+            requiresAction: false
+        };
+
+        global.window.trackModal.render(data);
+
+        const actionCard = Array.from(document.querySelectorAll('section.card'))
+            .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
+        expect(actionCard).toBeDefined();
+
+        const hintParagraph = actionCard?.querySelector('p.text-muted.small.mb-0');
+        expect(hintParagraph).toBeDefined();
+        expect(hintParagraph?.textContent?.trim()).toBe(expectedHint);
+        expect(hintParagraph?.querySelector('a')).toBeNull();
+    });
+
     test('shows reopen action for requested exchange without explicit flag', () => {
         setupDom();
 


### PR DESCRIPTION
## Summary
- skip rendering the return-request hint link when no details URL is provided
- add a unit test to ensure the hint keeps plain text when the URL is empty

## Testing
- npx jest track-modal.test.js --runInBand --testNamePattern="does not render return details link without url"

------
https://chatgpt.com/codex/tasks/task_e_68efbdae8e04832db8bac5dae1d51ce4