### PR TITLE
Refine return and exchange action flows

### DIFF
--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -307,53 +307,43 @@
                                                     </div>
                                                 </td>
                                                 <td class="text-end">
-                                                    <div class="alert alert-warning text-start small mb-2"
-                                                         data-return-cancel-warning
-                                                         th:classappend="${request.cancelExchangeUnavailableReason == null} ? ' d-none' : ''"
-                                                         th:attr="aria-hidden=${request.cancelExchangeUnavailableReason == null}"
-                                                         role="status">
-                                                        <span data-return-cancel-warning-text
-                                                              th:text="${request.cancelExchangeUnavailableReason}"></span>
-                                                    </div>
                                                     <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end">
                                                         <button type="button"
-                                                                class="btn btn-primary btn-sm js-return-request-exchange"
-                                                                th:if="${request.canStartExchange}"
-                                                                th:data-action-label="${request.exchangeRequested ? 'Создать обменную посылку' : 'Перевести в обмен'}"
-                                                                th:text="${request.exchangeRequested ? 'Создать обменную посылку' : 'Перевести в обмен'}"
-                                                                th:disabled="${!request.canStartExchange}">
-                                                            Создать обменную посылку
+                                                                class="btn btn-success btn-sm js-return-request-confirm-return d-none"
+                                                                data-action-label="Принять возврат"
+                                                                aria-hidden="true">
+                                                            Принять возврат
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-sm js-return-request-close"
-                                                                th:classappend="${request.exchangeRequested ? ' btn-outline-secondary' : ' btn-success'}"
-                                                                th:if="${request.canCloseWithoutExchange}"
-                                                                th:data-action-label="${request.exchangeRequested ? 'Закрыть без обмена' : 'Принять возврат'}"
-                                                                th:text="${request.exchangeRequested ? 'Закрыть без обмена' : 'Принять возврат'}"
-                                                                th:disabled="${!request.canCloseWithoutExchange}">
-                                                            Закрыть без обмена
+                                                                class="btn btn-primary btn-sm js-return-request-to-exchange d-none"
+                                                                data-action-label="Перевести в обмен"
+                                                                aria-hidden="true">
+                                                            Перевести в обмен
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-outline-warning btn-sm js-return-request-reopen"
-                                                                th:if="${request.canReopenAsReturn}"
+                                                                class="btn btn-outline-secondary btn-sm js-return-request-close d-none"
+                                                                data-action-label="Закрыть обращение"
+                                                                aria-hidden="true">
+                                                            Закрыть обращение
+                                                        </button>
+                                                        <button type="button"
+                                                                class="btn btn-outline-primary btn-sm js-return-request-add-reverse d-none"
+                                                                data-action-label="Добавить трек обратной посылки"
+                                                                aria-hidden="true">
+                                                            Добавить трек обратной посылки
+                                                        </button>
+                                                        <button type="button"
+                                                                class="btn btn-outline-warning btn-sm js-return-request-to-return d-none"
                                                                 data-action-label="Перевести в возврат"
-                                                                th:disabled="${!request.canReopenAsReturn}">
+                                                                aria-hidden="true">
                                                             Перевести в возврат
                                                         </button>
-                                                      <button type="button"
-                                                              class="btn btn-outline-danger btn-sm js-return-request-cancel"
-                                                              th:if="${request.canCancelExchange}"
-                                                              data-action-label="Отменить обмен"
-                                                              th:disabled="${!request.canCancelExchange}">
-                                                          Отменить обмен
-                                                      </button>
-                                                      <button type="button"
-                                                              class="btn btn-outline-success btn-sm js-return-request-confirm"
-                                                              th:if="${request.canConfirmReceipt}"
-                                                              data-action-label="Подтвердить получение возврата"
-                                                              th:disabled="${!request.canConfirmReceipt}">
-                                                          Подтвердить получение
-                                                      </button>
+                                                        <button type="button"
+                                                                class="btn btn-success btn-sm js-return-request-confirm-reverse d-none"
+                                                                data-action-label="Принять обратную посылку"
+                                                                aria-hidden="true">
+                                                            Принять обратную посылку
+                                                        </button>
                                                     </div>
                                                 </td>
                                             </tr>

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -307,41 +307,60 @@
                                                     </div>
                                                 </td>
                                                 <td class="text-end">
-                                                    <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end">
+                                                    <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end"
+                                                         th:with="isExchangeApproved=${request.status == T(com.project.tracking_system.entity.OrderReturnRequestStatus).EXCHANGE_APPROVED},
+                                                                  allowConfirm=${request.canConfirmReceipt},
+                                                                  allowConvertToExchange=${request.canStartExchange},
+                                                                  allowClose=${request.canCloseWithoutExchange},
+                                                                  hasReverse=${request.reverseTrackNumber != null and !#strings.isEmpty(request.reverseTrackNumber)},
+                                                                  allowConvertToReturn=${request.canReopenAsReturn},
+                                                                  allowUpdateReverse=${isExchangeApproved and !hasReverse}">
                                                         <button type="button"
-                                                                class="btn btn-success btn-sm js-return-request-confirm-return d-none"
+                                                                class="btn btn-success btn-sm js-return-request-confirm-return"
+                                                                th:classappend="${allowConfirm and !isExchangeApproved} ? '' : ' d-none'"
                                                                 data-action-label="Принять возврат"
-                                                                aria-hidden="true">
+                                                                th:attr="aria-hidden=${allowConfirm and !isExchangeApproved ? false : true}"
+                                                                th:disabled="${!(allowConfirm and !isExchangeApproved)}">
                                                             Принять возврат
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-primary btn-sm js-return-request-to-exchange d-none"
+                                                                class="btn btn-primary btn-sm js-return-request-to-exchange"
+                                                                th:classappend="${allowConvertToExchange} ? '' : ' d-none'"
                                                                 data-action-label="Перевести в обмен"
-                                                                aria-hidden="true">
+                                                                th:attr="aria-hidden=${allowConvertToExchange ? false : true}"
+                                                                th:disabled="${!allowConvertToExchange}">
                                                             Перевести в обмен
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-outline-secondary btn-sm js-return-request-close d-none"
+                                                                class="btn btn-outline-secondary btn-sm js-return-request-close"
+                                                                th:classappend="${allowClose} ? '' : ' d-none'"
                                                                 data-action-label="Закрыть обращение"
-                                                                aria-hidden="true">
+                                                                th:attr="aria-hidden=${allowClose ? false : true}"
+                                                                th:disabled="${!allowClose}">
                                                             Закрыть обращение
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-outline-primary btn-sm js-return-request-add-reverse d-none"
+                                                                class="btn btn-outline-primary btn-sm js-return-request-add-reverse"
+                                                                th:classappend="${allowUpdateReverse} ? '' : ' d-none'"
                                                                 data-action-label="Добавить трек обратной посылки"
-                                                                aria-hidden="true">
+                                                                th:attr="aria-hidden=${allowUpdateReverse ? false : true}"
+                                                                th:disabled="${!allowUpdateReverse}">
                                                             Добавить трек обратной посылки
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-outline-warning btn-sm js-return-request-to-return d-none"
+                                                                class="btn btn-outline-warning btn-sm js-return-request-to-return"
+                                                                th:classappend="${allowConvertToReturn} ? '' : ' d-none'"
                                                                 data-action-label="Перевести в возврат"
-                                                                aria-hidden="true">
+                                                                th:attr="aria-hidden=${allowConvertToReturn ? false : true}"
+                                                                th:disabled="${!allowConvertToReturn}">
                                                             Перевести в возврат
                                                         </button>
                                                         <button type="button"
-                                                                class="btn btn-success btn-sm js-return-request-confirm-reverse d-none"
+                                                                class="btn btn-success btn-sm js-return-request-confirm-reverse"
+                                                                th:classappend="${allowConfirm and isExchangeApproved} ? '' : ' d-none'"
                                                                 data-action-label="Принять обратную посылку"
-                                                                aria-hidden="true">
+                                                                th:attr="aria-hidden=${allowConfirm and isExchangeApproved ? false : true}"
+                                                                th:disabled="${!(allowConfirm and isExchangeApproved)}">
                                                             Принять обратную посылку
                                                         </button>
                                                     </div>


### PR DESCRIPTION
## Summary
- rebuild the return/exchange action stacks in the track modal with mode-specific buttons and permissions
- align return request table buttons, prompts, and aria labels with the new action set
- update front-end tests to cover the streamlined flows and API usage

## Testing
- npm test -- track-modal

------
https://chatgpt.com/codex/tasks/task_e_68efcf4dee58832d8167938674813549