### PR TITLE
Enable convert-to-return fallback for exchange flows

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1489,15 +1489,20 @@
             };
         };
 
-        const permissions = returnRequest?.actionPermissions
-            ? returnRequest.actionPermissions
+        const rawPermissions = returnRequest?.actionPermissions;
+        const hasStructuredPermissions = rawPermissions
+            && typeof rawPermissions === 'object'
+            && !Array.isArray(rawPermissions);
+        const permissions = hasStructuredPermissions
+            ? rawPermissions
             : derivePermissions(returnRequest);
         const allowConfirmReceipt = Boolean(permissions?.allowConfirmReceipt);
         const allowConvertToExchange = Boolean(permissions?.allowConvertToExchange);
         const allowCloseRequest = Boolean(permissions?.allowCloseRequest);
         const allowCancelExchange = Boolean(permissions?.allowCancelExchange);
         const allowUpdateReverse = Boolean(permissions?.allowUpdateReverseTrack);
-        const allowConvertToReturn = Boolean(permissions?.allowConvertToReturn);
+        const allowConvertToReturn = Boolean(permissions?.allowConvertToReturn)
+            || shouldShowReopenAsReturn(returnRequest, normalizedMode);
 
         container.replaceChildren();
 

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -602,6 +602,8 @@ describe('track-modal render', () => {
         const reopenButton = Array.from(actionCard?.querySelectorAll('button') || [])
             .find((btn) => btn.textContent?.trim() === 'Перевести в возврат');
         expect(reopenButton).toBeDefined();
+        expect(reopenButton?.classList.contains('d-none')).toBe(false);
+        expect(reopenButton?.getAttribute('aria-hidden')).toBe('false');
         expect(reopenButton?.getAttribute('aria-label'))
             .toBe('Перевести обращение из обмена обратно в возврат');
     });
@@ -663,6 +665,79 @@ describe('track-modal render', () => {
         const reopenButton = Array.from(actionCard?.querySelectorAll('button') || [])
             .find((btn) => btn.textContent?.trim() === 'Перевести в возврат');
         expect(reopenButton).toBeDefined();
+        expect(reopenButton?.classList.contains('d-none')).toBe(false);
+        expect(reopenButton?.getAttribute('aria-hidden')).toBe('false');
+        expect(reopenButton?.getAttribute('aria-label'))
+            .toBe('Перевести обращение из обмена обратно в возврат');
+    });
+
+    test('shows reopen action when permissions deny conversion but обменные признаки присутствуют', () => {
+        setupDom();
+
+        const data = {
+            id: 103,
+            number: 'BY2024005',
+            deliveryService: 'Belpost',
+            systemStatus: 'Обмен в работе',
+            history: [],
+            refreshAllowed: true,
+            nextRefreshAt: null,
+            canEditTrack: false,
+            timeZone: 'UTC',
+            episodeNumber: 25,
+            exchange: false, returnShipment: false,
+            chain: [],
+            returnRequest: {
+                id: 93,
+                status: 'Обмен запрошен',
+                statusLabel: 'Обмен запрошен',
+                statusBadgeClass: 'bg-warning-subtle text-warning-emphasis',
+                reasonLabel: 'Причина',
+                reason: 'Не подошёл фасон',
+                comment: 'Ожидание решения по обмену',
+                requestedAt: '2024-02-14T12:00:00Z',
+                decisionAt: null,
+                closedAt: null,
+                reverseTrackNumber: null,
+                requiresAction: true,
+                exchangeRequested: true,
+                exchangeApproved: false,
+                canStartExchange: false,
+                canCreateExchangeParcel: false,
+                canCloseWithoutExchange: false,
+                canReopenAsReturn: false,
+                canCancelExchange: false,
+                returnReceiptConfirmed: false,
+                returnReceiptConfirmedAt: null,
+                canConfirmReceipt: false,
+                hint: 'Уточните у покупателя детали обмена.',
+                warnings: [],
+                detailsUrl: null,
+                actionPermissions: {
+                    allowConfirmReceipt: false,
+                    allowConvertToExchange: false,
+                    allowCloseRequest: false,
+                    allowCancelExchange: false,
+                    allowUpdateReverseTrack: false,
+                    allowConvertToReturn: false
+                }
+            },
+            canRegisterReturn: false,
+            lifecycle: [],
+            requiresAction: true
+        };
+
+        global.window.trackModal.render(data);
+
+        const actionCard = Array.from(document.querySelectorAll('section.card'))
+            .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
+        expect(actionCard).toBeDefined();
+
+        const reopenButton = Array.from(actionCard?.querySelectorAll('button') || [])
+            .find((btn) => btn.textContent?.trim() === 'Перевести в возврат');
+        expect(reopenButton).toBeDefined();
+        expect(reopenButton?.classList.contains('d-none')).toBe(false);
+        expect(reopenButton?.getAttribute('aria-hidden')).toBe('false');
         expect(reopenButton?.getAttribute('aria-label'))
             .toBe('Перевести обращение из обмена обратно в возврат');
     });


### PR DESCRIPTION
## Summary
- treat return action permissions as primary while falling back to derived values when missing or insufficient
- expose the "Перевести в возврат" action whenever exchange markers are present even without explicit permission flags
- extend track-modal tests to verify visibility state and fallback behavior for exchange reopen actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f003f30f3c832dac70e0459fdf11e4