### PR TITLE
Refactor return modal state handling

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1402,11 +1402,19 @@
     const RETURN_REQUEST_STATE_ACTIONS = Object.freeze({
         [ReturnRequestState.RETURN]: Object.freeze({
             primary: [ReturnRequestAction.ACCEPT],
-            secondary: [ReturnRequestAction.TO_EXCHANGE, ReturnRequestAction.CLOSE]
+            secondary: [
+                ReturnRequestAction.TO_EXCHANGE,
+                ReturnRequestAction.UPDATE_REVERSE_TRACK,
+                ReturnRequestAction.CLOSE
+            ]
         }),
         [ReturnRequestState.EXCHANGE]: Object.freeze({
             primary: [ReturnRequestAction.LAUNCH_EXCHANGE, ReturnRequestAction.ACCEPT_REVERSE],
-            secondary: [ReturnRequestAction.TO_RETURN, ReturnRequestAction.CLOSE]
+            secondary: [
+                ReturnRequestAction.TO_RETURN,
+                ReturnRequestAction.UPDATE_REVERSE_TRACK,
+                ReturnRequestAction.CLOSE
+            ]
         })
     });
 


### PR DESCRIPTION
## Summary
- collapse return request state handling to a binary RETURN/EXCHANGE model with shared normalization helpers
- adjust modal actions to render the new fixed button sets and updated labels for return vs exchange scenarios
- ensure state transitions reuse the same store reset logic regardless of how the modal is opened

## Testing
- npm test -- --runTestsByPath src/test/js/track-modal.test.js *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f02c06422c832da32983dabb487398