### PR TITLE
Refine reverse track form rendering

### DIFF
--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -2480,6 +2480,9 @@
             statusSection.appendChild(badgeRow);
             returnCard.body.appendChild(statusSection);
 
+            // Получаем разрешения, чтобы использовать единый источник прав при решении, нужна ли форма обновления трека.
+            const permissions = resolveReturnRequestPermissions(returnRequest);
+
             const actionsContainer = document.createElement('div');
             actionsContainer.className = 'd-flex flex-column gap-3 mt-3';
             actionsContainer.dataset.returnActionsContainer = 'true';
@@ -2487,12 +2490,13 @@
 
             let reverseFormController = null;
 
-            const canEditReverseTrack = Boolean(
+            // Форма должна существовать всегда, когда бэкенд разрешает редактирование обратного трека.
+            const canAttachReverseTrackForm = Boolean(
                 returnRequest?.id !== undefined
                 && data?.id !== undefined
-                && (!returnRequest?.reverseTrackNumber || returnRequest?.requiresAction)
+                && permissions.allowUpdateReverseTrack
             );
-            if (canEditReverseTrack) {
+            if (canAttachReverseTrackForm) {
                 const reverseFormElement = createReverseTrackForm(data.id, returnRequest);
                 reverseFormElement.classList.add('border', 'border-light', 'rounded-3', 'p-3', 'bg-body-tertiary');
                 reverseFormController = createReverseFormController(reverseFormElement);


### PR DESCRIPTION
## Summary
- create a reusable controller for the reverse track form and ensure its visibility state stays in sync with aria attributes
- move reverse track form creation into the return card so actions reuse a single instance
- simplify the return actions section to render only buttons and hints while delegating form toggling to the shared controller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f033ade1b4832da770bb84775b3168