### PR TITLE
Add REST endpoints for updated return and exchange flow

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -23,6 +23,7 @@ package com.project.tracking_system.dto;
  * @param returnReceiptConfirmed   признак ручного подтверждения возврата магазином
  * @param returnReceiptConfirmedAt дата подтверждения возврата
  * @param canConfirmReceipt        доступность кнопки подтверждения возврата
+ * @param canAcceptReverse         доступность подтверждения обратной посылки при обмене
  */
 public record OrderReturnRequestDto(Long id,
                                     String status,
@@ -43,7 +44,8 @@ public record OrderReturnRequestDto(Long id,
                                     String cancelExchangeUnavailableReason,
                                     boolean returnReceiptConfirmed,
                                     String returnReceiptConfirmedAt,
-                                    boolean canConfirmReceipt) {
+                                    boolean canConfirmReceipt,
+                                    boolean canAcceptReverse) {
 
     /**
      * Совместимый с фронтендом аксессор, чтобы не ломать проверку {@code isExchangeRequest}.

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -470,6 +470,7 @@ public class TrackViewService {
         boolean canReopenAsReturn = orderReturnRequestService.canReopenAsReturn(request);
         boolean canCancelExchange = orderReturnRequestService.canCancelExchange(request);
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
+        boolean canAcceptReverse = orderReturnRequestService.canAcceptReverse(request);
         boolean canCreateExchangeParcel = orderReturnRequestService.canCreateExchangeParcel(request);
         String requestedAt = formatNullableTimestamp(request.getRequestedAt(), userZone);
         // Подставляем дату регистрации, если пользовательское обращение отсутствует, чтобы модалка не показывала дубль.
@@ -501,7 +502,8 @@ public class TrackViewService {
                 cancelExchangeReason,
                 request.isReturnReceiptConfirmed(),
                 formatNullableTimestamp(request.getReturnReceiptConfirmedAt(), userZone),
-                canConfirmReceipt
+                canConfirmReceipt,
+                canAcceptReverse
         );
     }
 


### PR DESCRIPTION
## Summary
- add dedicated endpoints for converting return requests, launching exchanges, accepting reverse shipments, and deprecate legacy paths
- extend the return request service with launchExchange/acceptReverseShipment orchestration and reusable approval helper
- expose the new canAcceptReverse flag in return-request DTOs so the UI can toggle reverse acceptance actions

## Testing
- mvn -q -DskipTests package *(fails: jitpack.io returned 403 for io.github.bucket4j.bucket4j:bucket4j-core:4.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d643d620832dbb13c5bed920e34c