### PR TITLE
feat: enrich return request lifecycle metadata

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
@@ -1,6 +1,8 @@
 package com.project.tracking_system.dto;
 
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
 
 /**
  * DTO для отображения заявок на возврат/обмен, требующих действий пользователя.
@@ -32,6 +34,7 @@ import com.project.tracking_system.entity.OrderReturnRequestStatus;
  * @param returnReceiptConfirmedAt дата подтверждения возврата
  * @param canConfirmReceipt доступность ручного подтверждения приёма
  */
+
 public record ActionRequiredReturnRequestDto(Long requestId,
                                              Long parcelId,
                                              String trackNumber,
@@ -53,5 +56,15 @@ public record ActionRequiredReturnRequestDto(Long requestId,
                                              String cancelExchangeUnavailableReason,
                                              boolean returnReceiptConfirmed,
                                              String returnReceiptConfirmedAt,
-                                             boolean canConfirmReceipt) {
+                                             boolean canConfirmReceipt,
+                                             ReturnRequestMode mode,
+                                             ReturnRequestStage stage,
+                                             String exchangeTrackNumber,
+                                             boolean manualStageOverride,
+                                             boolean manualTrackOverride,
+                                             String stageStartedAt,
+                                             String stageUpdatedAt,
+                                             String exchangeTrackAssignedAt,
+                                             Long storeId,
+                                             Long responsibleId) {
 }

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -1,5 +1,8 @@
 package com.project.tracking_system.dto;
 
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
+
 /**
  * DTO заявки на возврат/обмен для модального окна трека.
  *
@@ -24,6 +27,7 @@ package com.project.tracking_system.dto;
  * @param returnReceiptConfirmedAt дата подтверждения возврата
  * @param canConfirmReceipt        доступность кнопки подтверждения возврата
  */
+
 public record OrderReturnRequestDto(Long id,
                                     String status,
                                     String reason,
@@ -43,7 +47,17 @@ public record OrderReturnRequestDto(Long id,
                                     String cancelExchangeUnavailableReason,
                                     boolean returnReceiptConfirmed,
                                     String returnReceiptConfirmedAt,
-                                    boolean canConfirmReceipt) {
+                                    boolean canConfirmReceipt,
+                                    ReturnRequestMode mode,
+                                    ReturnRequestStage stage,
+                                    String exchangeTrackNumber,
+                                    boolean manualStageOverride,
+                                    boolean manualTrackOverride,
+                                    String stageStartedAt,
+                                    String stageUpdatedAt,
+                                    String exchangeTrackAssignedAt,
+                                    Long storeId,
+                                    Long responsibleId) {
 
     /**
      * Совместимый с фронтендом аксессор, чтобы не ломать проверку {@code isExchangeRequest}.

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
@@ -4,13 +4,18 @@ import jakarta.persistence.*;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Заявка на возврат или обмен по конкретной посылке.
  * <p>
  * Сущность фиксирует идемпотентный ключ, автора и время создания,
  * а также результат рассмотрения: запуск обмена или закрытие без него.
+ * Дополнительно хранится режим обработки, текущий этап и история изменений,
+ * что позволяет отображать полный таймлайн действий магазина и покупателя.
  * </p>
  */
 @Entity
@@ -37,11 +42,25 @@ public class OrderReturnRequest {
     private TrackParcel parcel;
 
     /**
+     * Магазин, оформивший исходную посылку.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    /**
      * Пользователь, зарегистрировавший заявку.
      */
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "created_by", nullable = false, updatable = false)
     private User createdBy;
+
+    /**
+     * Пользователь магазина, ответственный за текущий этап обработки.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "responsible_id")
+    private User responsibleManager;
 
     /**
      * Время регистрации заявки в UTC.
@@ -74,6 +93,63 @@ public class OrderReturnRequest {
     private String reverseTrackNumber;
 
     /**
+     * Трек обменной посылки, если он присвоен вручную или при создании обмена.
+     */
+    @Column(name = "exchange_track_number", length = 64)
+    private String exchangeTrackNumber;
+
+    /**
+     * Признак, что трек обратной отправки был задан вручную менеджером.
+     */
+    @Column(name = "manual_track_override", nullable = false)
+    private boolean manualTrackOverride = false;
+
+    /**
+     * Признак, что менеджер вручную перевёл заявку на нужный этап.
+     */
+    @Column(name = "manual_stage_override", nullable = false)
+    private boolean manualStageOverride = false;
+
+    /**
+     * Время, когда трек обменной посылки был установлен.
+     */
+    @Column(name = "exchange_track_assigned_at")
+    private ZonedDateTime exchangeTrackAssignedAt;
+
+    /**
+     * Текущее состояние заявки.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OrderReturnRequestStatus status = OrderReturnRequestStatus.REGISTERED;
+
+    /**
+     * Режим обработки заявки (возврат или обмен).
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", nullable = false)
+    private ReturnRequestMode mode = ReturnRequestMode.RETURN;
+
+    /**
+     * Текущий этап жизненного цикла заявки.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "stage", nullable = false)
+    private ReturnRequestStage stage = ReturnRequestStage.CUSTOMER_RETURN;
+
+    /**
+     * Время начала текущего этапа обработки.
+     */
+    @Column(name = "stage_started_at", nullable = false)
+    private ZonedDateTime stageStartedAt = ZonedDateTime.now(ZoneOffset.UTC);
+
+    /**
+     * Время последнего обновления текущего этапа.
+     */
+    @Column(name = "stage_updated_at")
+    private ZonedDateTime stageUpdatedAt;
+
+    /**
      * Признак, что магазин подтвердил получение возврата вручную.
      * <p>
      * Флаг устанавливается сотрудником после проверки склада и исключает повторное подтверждение,
@@ -97,13 +173,6 @@ public class OrderReturnRequest {
      */
     @Column(name = "exchange_requested", nullable = false)
     private boolean exchangeRequested = false;
-
-    /**
-     * Текущее состояние заявки.
-     */
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private OrderReturnRequestStatus status = OrderReturnRequestStatus.REGISTERED;
 
     /**
      * Пользователь, одобривший запуск обмена.
@@ -141,6 +210,13 @@ public class OrderReturnRequest {
     @Column(name = "version", nullable = false)
     private long version;
 
+    /**
+     * История изменений заявки по этапам и трекам.
+     */
+    @OneToMany(mappedBy = "returnRequest", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("changedAt ASC")
+    private List<OrderReturnRequestHistoryEntry> historyEntries = new ArrayList<>();
+
     public Long getId() {
         return id;
     }
@@ -161,12 +237,34 @@ public class OrderReturnRequest {
         this.parcel = parcel;
     }
 
+    /**
+     * Возвращает магазин, по которому оформлена заявка.
+     */
+    public Store getStore() {
+        return store;
+    }
+
+    public void setStore(Store store) {
+        this.store = store;
+    }
+
     public User getCreatedBy() {
         return createdBy;
     }
 
     public void setCreatedBy(User createdBy) {
         this.createdBy = createdBy;
+    }
+
+    /**
+     * Возвращает менеджера, ответственного за текущий этап обработки.
+     */
+    public User getResponsibleManager() {
+        return responsibleManager;
+    }
+
+    public void setResponsibleManager(User responsibleManager) {
+        this.responsibleManager = responsibleManager;
     }
 
     public ZonedDateTime getCreatedAt() {
@@ -207,6 +305,81 @@ public class OrderReturnRequest {
 
     public void setReverseTrackNumber(String reverseTrackNumber) {
         this.reverseTrackNumber = reverseTrackNumber;
+    }
+
+    /**
+     * Возвращает трек обменной посылки, если он уже известен.
+     */
+    public String getExchangeTrackNumber() {
+        return exchangeTrackNumber;
+    }
+
+    public void setExchangeTrackNumber(String exchangeTrackNumber) {
+        this.exchangeTrackNumber = exchangeTrackNumber;
+    }
+
+    public boolean isManualTrackOverride() {
+        return manualTrackOverride;
+    }
+
+    public void setManualTrackOverride(boolean manualTrackOverride) {
+        this.manualTrackOverride = manualTrackOverride;
+    }
+
+    public boolean isManualStageOverride() {
+        return manualStageOverride;
+    }
+
+    public void setManualStageOverride(boolean manualStageOverride) {
+        this.manualStageOverride = manualStageOverride;
+    }
+
+    public ZonedDateTime getExchangeTrackAssignedAt() {
+        return exchangeTrackAssignedAt;
+    }
+
+    public void setExchangeTrackAssignedAt(ZonedDateTime exchangeTrackAssignedAt) {
+        this.exchangeTrackAssignedAt = exchangeTrackAssignedAt;
+    }
+
+    public OrderReturnRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrderReturnRequestStatus status) {
+        this.status = status;
+    }
+
+    public ReturnRequestMode getMode() {
+        return mode;
+    }
+
+    public void setMode(ReturnRequestMode mode) {
+        this.mode = Objects.requireNonNullElse(mode, ReturnRequestMode.RETURN);
+    }
+
+    public ReturnRequestStage getStage() {
+        return stage;
+    }
+
+    public void setStage(ReturnRequestStage stage) {
+        this.stage = Objects.requireNonNullElse(stage, ReturnRequestStage.CUSTOMER_RETURN);
+    }
+
+    public ZonedDateTime getStageStartedAt() {
+        return stageStartedAt;
+    }
+
+    public void setStageStartedAt(ZonedDateTime stageStartedAt) {
+        this.stageStartedAt = stageStartedAt;
+    }
+
+    public ZonedDateTime getStageUpdatedAt() {
+        return stageUpdatedAt;
+    }
+
+    public void setStageUpdatedAt(ZonedDateTime stageUpdatedAt) {
+        this.stageUpdatedAt = stageUpdatedAt;
     }
 
     /**
@@ -251,14 +424,6 @@ public class OrderReturnRequest {
 
     public void setExchangeRequested(boolean exchangeRequested) {
         this.exchangeRequested = exchangeRequested;
-    }
-
-    public OrderReturnRequestStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(OrderReturnRequestStatus status) {
-        this.status = status;
     }
 
     public User getDecisionBy() {
@@ -310,6 +475,13 @@ public class OrderReturnRequest {
     }
 
     /**
+     * Возвращает неизменяемую историю изменений заявки.
+     */
+    public List<OrderReturnRequestHistoryEntry> getHistoryEntries() {
+        return Collections.unmodifiableList(historyEntries);
+    }
+
+    /**
      * Проверяет, ожидает ли заявка решения.
      */
     public boolean requiresAction() {
@@ -326,8 +498,33 @@ public class OrderReturnRequest {
     /**
      * Возвращает режим обработки заявки (возврат или обмен) на основе текущих флагов.
      */
-    public ReturnRequestMode getMode() {
-        return ReturnRequestMode.from(this);
+    public ReturnRequestMode getDerivedMode() {
+        if (mode != null) {
+            return mode;
+        }
+        if (isExchangeApproved() || isExchangeRequested()) {
+            return ReturnRequestMode.EXCHANGE;
+        }
+        return ReturnRequestMode.RETURN;
+    }
+
+    /**
+     * Создаёт снимок текущего состояния заявки для истории изменений.
+     *
+     * @param manualTransition признак ручного действия менеджера
+     * @param actor             пользователь, инициировавший изменение
+     * @param moment            момент фиксации изменения
+     */
+    public void snapshotHistory(boolean manualTransition, User actor, ZonedDateTime moment) {
+        OrderReturnRequestHistoryEntry entry = OrderReturnRequestHistoryEntry.snapshotOf(this, manualTransition, actor, moment);
+        addHistoryEntry(entry);
+    }
+
+    private void addHistoryEntry(OrderReturnRequestHistoryEntry entry) {
+        if (entry == null) {
+            return;
+        }
+        entry.setReturnRequest(this);
+        historyEntries.add(entry);
     }
 }
-

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequestHistoryEntry.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequestHistoryEntry.java
@@ -1,0 +1,168 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.*;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+/**
+ * История изменений заявки на возврат/обмен.
+ * <p>
+ * Каждая запись фиксирует этап, режим и актуальные трек-номера в момент изменения.
+ * Записи используются для построения таймлайна обработки и аудита действий менеджеров.
+ * </p>
+ */
+@Entity
+@Table(name = "tb_order_return_request_history")
+public class OrderReturnRequestHistoryEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Заявка, к которой относится запись истории.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "return_request_id", nullable = false)
+    private OrderReturnRequest returnRequest;
+
+    /**
+     * Режим обработки заявки на момент изменения.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", nullable = false)
+    private ReturnRequestMode mode = ReturnRequestMode.RETURN;
+
+    /**
+     * Этап обработки заявки.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "stage", nullable = false)
+    private ReturnRequestStage stage = ReturnRequestStage.CUSTOMER_RETURN;
+
+    /**
+     * Трек обратной отправки на момент фиксации события.
+     */
+    @Column(name = "reverse_track_number", length = 64)
+    private String reverseTrackNumber;
+
+    /**
+     * Трек обменной посылки на момент фиксации события.
+     */
+    @Column(name = "exchange_track_number", length = 64)
+    private String exchangeTrackNumber;
+
+    /**
+     * Признак, что изменение выполнено вручную менеджером.
+     */
+    @Column(name = "manual_transition", nullable = false)
+    private boolean manualTransition = false;
+
+    /**
+     * Пользователь, выполнивший изменение.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "changed_by")
+    private User changedBy;
+
+    /**
+     * Время фиксации изменения.
+     */
+    @Column(name = "changed_at", nullable = false, updatable = false)
+    private ZonedDateTime changedAt = ZonedDateTime.now(ZoneOffset.UTC);
+
+    public Long getId() {
+        return id;
+    }
+
+    public OrderReturnRequest getReturnRequest() {
+        return returnRequest;
+    }
+
+    public void setReturnRequest(OrderReturnRequest returnRequest) {
+        this.returnRequest = returnRequest;
+    }
+
+    public ReturnRequestMode getMode() {
+        return mode;
+    }
+
+    public void setMode(ReturnRequestMode mode) {
+        this.mode = Objects.requireNonNullElse(mode, ReturnRequestMode.RETURN);
+    }
+
+    public ReturnRequestStage getStage() {
+        return stage;
+    }
+
+    public void setStage(ReturnRequestStage stage) {
+        this.stage = Objects.requireNonNullElse(stage, ReturnRequestStage.CUSTOMER_RETURN);
+    }
+
+    public String getReverseTrackNumber() {
+        return reverseTrackNumber;
+    }
+
+    public void setReverseTrackNumber(String reverseTrackNumber) {
+        this.reverseTrackNumber = reverseTrackNumber;
+    }
+
+    public String getExchangeTrackNumber() {
+        return exchangeTrackNumber;
+    }
+
+    public void setExchangeTrackNumber(String exchangeTrackNumber) {
+        this.exchangeTrackNumber = exchangeTrackNumber;
+    }
+
+    public boolean isManualTransition() {
+        return manualTransition;
+    }
+
+    public void setManualTransition(boolean manualTransition) {
+        this.manualTransition = manualTransition;
+    }
+
+    public User getChangedBy() {
+        return changedBy;
+    }
+
+    public void setChangedBy(User changedBy) {
+        this.changedBy = changedBy;
+    }
+
+    public ZonedDateTime getChangedAt() {
+        return changedAt;
+    }
+
+    public void setChangedAt(ZonedDateTime changedAt) {
+        this.changedAt = changedAt;
+    }
+
+    /**
+     * Создаёт запись истории на основе текущего состояния заявки.
+     *
+     * @param request          заявка, состояние которой фиксируется
+     * @param manualTransition признак, что изменение инициировано вручную
+     * @param actor            пользователь, выполнивший действие
+     * @param moment           момент фиксации события
+     * @return заполненная запись истории
+     */
+    public static OrderReturnRequestHistoryEntry snapshotOf(OrderReturnRequest request,
+                                                            boolean manualTransition,
+                                                            User actor,
+                                                            ZonedDateTime moment) {
+        OrderReturnRequestHistoryEntry entry = new OrderReturnRequestHistoryEntry();
+        entry.setReturnRequest(request);
+        entry.setMode(request != null ? request.getMode() : ReturnRequestMode.RETURN);
+        entry.setStage(request != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN);
+        entry.setReverseTrackNumber(request != null ? request.getReverseTrackNumber() : null);
+        entry.setExchangeTrackNumber(request != null ? request.getExchangeTrackNumber() : null);
+        entry.setManualTransition(manualTransition);
+        entry.setChangedBy(actor);
+        entry.setChangedAt(moment != null ? moment : ZonedDateTime.now(ZoneOffset.UTC));
+        return entry;
+    }
+}

--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestMode.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestMode.java
@@ -59,6 +59,10 @@ public enum ReturnRequestMode {
         if (request == null) {
             return RETURN;
         }
+        ReturnRequestMode stored = request.getMode();
+        if (stored != null) {
+            return stored;
+        }
         if (request.isExchangeApproved() || request.isExchangeRequested()) {
             return EXCHANGE;
         }

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -7,6 +7,8 @@ import com.project.tracking_system.entity.OrderEpisode;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestActionRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.ReturnRequestAction;
@@ -78,6 +80,12 @@ public class OrderReturnRequestService {
         String normalizedComment = normalizeComment(comment);
         request.setReverseTrackNumber(normalizedTrack);
         request.setComment(normalizedComment);
+        boolean trackProvided = normalizedTrack != null && !normalizedTrack.isBlank();
+        request.setManualTrackOverride(request.isManualTrackOverride() || trackProvided);
+        request.setResponsibleManager(user);
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        request.setStageUpdatedAt(now);
+        request.snapshotHistory(true, user, now);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -169,6 +177,18 @@ public class OrderReturnRequestService {
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
         request.setIdempotencyKey(idempotencyKey);
         request.setExchangeRequested(exchangeRequested);
+        request.setStore(parcel.getStore());
+        request.setResponsibleManager(user);
+        request.setMode(exchangeRequested ? ReturnRequestMode.EXCHANGE : ReturnRequestMode.RETURN);
+        request.setManualTrackOverride(normalizedReverse != null && !normalizedReverse.isBlank());
+        request.setExchangeTrackNumber(null);
+        request.setExchangeTrackAssignedAt(null);
+        ZonedDateTime stageMoment = normalizedRequestedAt != null ? normalizedRequestedAt : request.getCreatedAt();
+        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        request.setStageStartedAt(stageMoment);
+        request.setStageUpdatedAt(stageMoment);
+        request.setManualStageOverride(false);
+        request.snapshotHistory(false, user, stageMoment);
 
         // Автоматический запуск обмена оставляем ручным, чтобы менеджер успел проверить данные перед созданием посылки.
 
@@ -207,9 +227,19 @@ public class OrderReturnRequestService {
             throw new IllegalStateException("В эпизоде уже запущен обмен");
         }
 
+        ZonedDateTime decisionMoment = ZonedDateTime.now(ZoneOffset.UTC);
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         request.setDecisionBy(user);
-        request.setDecisionAt(ZonedDateTime.now(ZoneOffset.UTC));
+        request.setDecisionAt(decisionMoment);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setResponsibleManager(user);
+        if (request.getStage() != ReturnRequestStage.EXCHANGE_SHIPMENT) {
+            request.setStage(ReturnRequestStage.EXCHANGE_SHIPMENT);
+            request.setStageStartedAt(decisionMoment);
+        }
+        request.setStageUpdatedAt(decisionMoment);
+        request.setManualStageOverride(true);
+        request.snapshotHistory(true, user, decisionMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -240,7 +270,25 @@ public class OrderReturnRequestService {
             throw new IllegalStateException("Обменная посылка уже создана или находится в работе");
         }
         TrackParcel replacement = orderExchangeService.createExchangeParcel(request);
-        log.info("Создана обменная посылка {} для заявки {}", replacement.getId(), request.getId());
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime assignedMoment = Optional.ofNullable(replacement)
+                .map(TrackParcel::getTimestamp)
+                .orElse(now);
+        request.setResponsibleManager(user);
+        request.setManualStageOverride(true);
+        request.setExchangeTrackNumber(Optional.ofNullable(replacement).map(TrackParcel::getNumber).orElse(null));
+        request.setExchangeTrackAssignedAt(assignedMoment);
+        if (request.getStage() != ReturnRequestStage.EXCHANGE_SHIPMENT) {
+            request.setStage(ReturnRequestStage.EXCHANGE_SHIPMENT);
+            request.setStageStartedAt(assignedMoment);
+        }
+        request.setStageUpdatedAt(assignedMoment);
+        request.snapshotHistory(true, user, assignedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Создана обменная посылка {} для заявки {}",
+                Optional.ofNullable(replacement).map(TrackParcel::getId).orElse(null),
+                saved.getId());
         return replacement;
     }
 
@@ -255,9 +303,19 @@ public class OrderReturnRequestService {
             throw new IllegalStateException("Заявка уже обработана");
         }
 
+        ZonedDateTime closeMoment = ZonedDateTime.now(ZoneOffset.UTC);
         request.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         request.setClosedBy(user);
-        request.setClosedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        request.setClosedAt(closeMoment);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setResponsibleManager(user);
+        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
+            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+            request.setStageStartedAt(closeMoment);
+        }
+        request.setStageUpdatedAt(closeMoment);
+        request.setManualStageOverride(true);
+        request.snapshotHistory(true, user, closeMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -292,7 +350,7 @@ public class OrderReturnRequestService {
         if (request.isReturnReceiptConfirmed()) {
             return request;
         }
-        markReturnProcessingConfirmed(request);
+        markReturnProcessingConfirmed(request, user);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Получение возврата подтверждено вручную для заявки {}", saved.getId());
@@ -316,9 +374,21 @@ public class OrderReturnRequestService {
             log.warn("Нельзя отменить обмен по заявке {}: {}", request.getId(), ex.getMessage());
             throw ex;
         }
+        ZonedDateTime cancelMoment = ZonedDateTime.now(ZoneOffset.UTC);
         request.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         request.setClosedBy(user);
-        request.setClosedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        request.setClosedAt(cancelMoment);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setResponsibleManager(user);
+        request.setExchangeTrackNumber(null);
+        request.setExchangeTrackAssignedAt(null);
+        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
+            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+            request.setStageStartedAt(cancelMoment);
+        }
+        request.setStageUpdatedAt(cancelMoment);
+        request.setManualStageOverride(true);
+        request.snapshotHistory(true, user, cancelMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -344,12 +414,24 @@ public class OrderReturnRequestService {
             log.warn("Нельзя перевести обмен по заявке {} в возврат: {}", request.getId(), ex.getMessage());
             throw ex;
         }
+        ZonedDateTime reopenMoment = ZonedDateTime.now(ZoneOffset.UTC);
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
         request.setDecisionBy(null);
         request.setDecisionAt(null);
         request.setClosedBy(null);
         request.setClosedAt(null);
         request.setExchangeRequested(false);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setResponsibleManager(user);
+        request.setExchangeTrackNumber(null);
+        request.setExchangeTrackAssignedAt(null);
+        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
+            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+            request.setStageStartedAt(reopenMoment);
+        }
+        request.setStageUpdatedAt(reopenMoment);
+        request.setManualStageOverride(true);
+        request.snapshotHistory(true, user, reopenMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -658,12 +740,21 @@ public class OrderReturnRequestService {
      * что облегчает расширение бизнес-правил и соответствует принципу DRY.
      * </p>
      */
-    private void markReturnProcessingConfirmed(OrderReturnRequest request) {
+    private void markReturnProcessingConfirmed(OrderReturnRequest request, User actor) {
         if (request == null || request.isReturnReceiptConfirmed()) {
             return;
         }
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         request.setReturnReceiptConfirmed(true);
-        request.setReturnReceiptConfirmedAt(ZonedDateTime.now(ZoneOffset.UTC));
+        request.setReturnReceiptConfirmedAt(now);
+        request.setResponsibleManager(actor);
+        request.setManualStageOverride(true);
+        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
+            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+            request.setStageStartedAt(now);
+        }
+        request.setStageUpdatedAt(now);
+        request.snapshotHistory(true, actor, now);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
@@ -4,6 +4,8 @@ import com.project.tracking_system.dto.ActionRequiredReturnRequestDto;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.TrackParcel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -55,6 +57,13 @@ public class ReturnRequestActionMapper {
         boolean canReopenAsReturn = orderReturnRequestService.canReopenAsReturn(request);
         boolean canCancelExchange = orderReturnRequestService.canCancelExchange(request);
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
+        ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
+        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
+        String stageStartedAt = formatRequestMoment(request.getStageStartedAt(), userZone);
+        String stageUpdatedAt = formatRequestMoment(request.getStageUpdatedAt(), userZone);
+        String exchangeTrackAssignedAt = formatRequestMoment(request.getExchangeTrackAssignedAt(), userZone);
+        Long storeId = request.getStore() != null ? request.getStore().getId() : null;
+        Long responsibleId = request.getResponsibleManager() != null ? request.getResponsibleManager().getId() : null;
 
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
@@ -78,7 +87,17 @@ public class ReturnRequestActionMapper {
                 cancelExchangeReason,
                 request.isReturnReceiptConfirmed(),
                 formatRequestMoment(request.getReturnReceiptConfirmedAt(), userZone),
-                canConfirmReceipt
+                canConfirmReceipt,
+                mode,
+                stage,
+                request.getExchangeTrackNumber(),
+                request.isManualStageOverride(),
+                request.isManualTrackOverride(),
+                stageStartedAt,
+                stageUpdatedAt,
+                exchangeTrackAssignedAt,
+                storeId,
+                responsibleId
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -487,6 +487,13 @@ public class TrackViewService {
         String cancelExchangeReason = orderReturnRequestService
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);
+        ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
+        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
+        String stageStartedAt = formatNullableTimestamp(request.getStageStartedAt(), userZone);
+        String stageUpdatedAt = formatNullableTimestamp(request.getStageUpdatedAt(), userZone);
+        String exchangeTrackAssignedAt = formatNullableTimestamp(request.getExchangeTrackAssignedAt(), userZone);
+        Long storeId = request.getStore() != null ? request.getStore().getId() : null;
+        Long responsibleId = request.getResponsibleManager() != null ? request.getResponsibleManager().getId() : null;
 
         return new OrderReturnRequestDto(
                 request.getId(),
@@ -508,7 +515,17 @@ public class TrackViewService {
                 cancelExchangeReason,
                 request.isReturnReceiptConfirmed(),
                 formatNullableTimestamp(request.getReturnReceiptConfirmedAt(), userZone),
-                canConfirmReceipt
+                canConfirmReceipt,
+                mode,
+                stage,
+                request.getExchangeTrackNumber(),
+                request.isManualStageOverride(),
+                request.isManualTrackOverride(),
+                stageStartedAt,
+                stageUpdatedAt,
+                exchangeTrackAssignedAt,
+                storeId,
+                responsibleId
         );
     }
 

--- a/src/main/resources/db/migration/V32__order_return_lifecycle_metadata.sql
+++ b/src/main/resources/db/migration/V32__order_return_lifecycle_metadata.sql
@@ -16,6 +16,7 @@ SET mode = CASE
         ELSE 'RETURN'
     END,
     stage = CASE
+        WHEN r.return_receipt_confirmed THEN 'MERCHANT_ACCEPT_RETURN'
         WHEN r.status = 'EXCHANGE_APPROVED' THEN 'EXCHANGE_SHIPMENT'
         WHEN r.status = 'CLOSED_NO_EXCHANGE' THEN 'MERCHANT_ACCEPT_RETURN'
         ELSE 'CUSTOMER_RETURN'

--- a/src/main/resources/db/migration/V32__order_return_lifecycle_metadata.sql
+++ b/src/main/resources/db/migration/V32__order_return_lifecycle_metadata.sql
@@ -1,0 +1,78 @@
+ALTER TABLE tb_order_return_requests
+    ADD COLUMN mode VARCHAR(32),
+    ADD COLUMN stage VARCHAR(64),
+    ADD COLUMN store_id BIGINT,
+    ADD COLUMN responsible_id BIGINT,
+    ADD COLUMN exchange_track_number VARCHAR(64),
+    ADD COLUMN manual_stage_override BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN manual_track_override BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN stage_started_at TIMESTAMPTZ,
+    ADD COLUMN stage_updated_at TIMESTAMPTZ,
+    ADD COLUMN exchange_track_assigned_at TIMESTAMPTZ;
+
+UPDATE tb_order_return_requests r
+SET mode = CASE
+        WHEN r.exchange_requested OR r.status = 'EXCHANGE_APPROVED' THEN 'EXCHANGE'
+        ELSE 'RETURN'
+    END,
+    stage = CASE
+        WHEN r.status = 'EXCHANGE_APPROVED' THEN 'EXCHANGE_SHIPMENT'
+        WHEN r.status = 'CLOSED_NO_EXCHANGE' THEN 'MERCHANT_ACCEPT_RETURN'
+        ELSE 'CUSTOMER_RETURN'
+    END,
+    store_id = p.store_id,
+    responsible_id = r.created_by,
+    manual_track_override = r.reverse_track_number IS NOT NULL,
+    manual_stage_override = CASE WHEN r.status <> 'REGISTERED' OR r.return_receipt_confirmed THEN TRUE ELSE FALSE END,
+    stage_started_at = COALESCE(r.requested_at, r.created_at),
+    stage_updated_at = COALESCE(r.return_receipt_confirmed_at, r.decision_at, r.closed_at, r.requested_at, r.created_at),
+    exchange_track_number = NULL,
+    exchange_track_assigned_at = CASE
+        WHEN r.status = 'EXCHANGE_APPROVED' THEN COALESCE(r.decision_at, r.created_at)
+        ELSE NULL
+    END
+FROM tb_track_parcels p
+WHERE p.id = r.parcel_id;
+
+ALTER TABLE tb_order_return_requests
+    ALTER COLUMN mode SET NOT NULL,
+    ALTER COLUMN stage SET NOT NULL,
+    ALTER COLUMN store_id SET NOT NULL,
+    ALTER COLUMN stage_started_at SET NOT NULL,
+    ALTER COLUMN stage_updated_at SET NOT NULL;
+
+ALTER TABLE tb_order_return_requests
+    ADD CONSTRAINT fk_order_return_requests_store
+        FOREIGN KEY (store_id) REFERENCES tb_stores (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_order_return_requests_responsible
+        FOREIGN KEY (responsible_id) REFERENCES tb_users (id) ON DELETE SET NULL;
+
+CREATE INDEX idx_order_return_requests_mode ON tb_order_return_requests (mode);
+CREATE INDEX idx_order_return_requests_stage ON tb_order_return_requests (stage);
+CREATE INDEX idx_order_return_requests_store ON tb_order_return_requests (store_id);
+
+CREATE TABLE tb_order_return_request_history (
+    id BIGSERIAL PRIMARY KEY,
+    return_request_id BIGINT NOT NULL REFERENCES tb_order_return_requests (id) ON DELETE CASCADE,
+    mode VARCHAR(32) NOT NULL,
+    stage VARCHAR(64) NOT NULL,
+    reverse_track_number VARCHAR(64),
+    exchange_track_number VARCHAR(64),
+    manual_transition BOOLEAN NOT NULL DEFAULT FALSE,
+    changed_by BIGINT REFERENCES tb_users (id) ON DELETE SET NULL,
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+CREATE INDEX idx_return_request_history_request ON tb_order_return_request_history (return_request_id);
+CREATE INDEX idx_return_request_history_stage ON tb_order_return_request_history (stage);
+
+INSERT INTO tb_order_return_request_history (return_request_id, mode, stage, reverse_track_number, exchange_track_number, manual_transition, changed_by, changed_at)
+SELECT r.id,
+       r.mode,
+       r.stage,
+       r.reverse_track_number,
+       r.exchange_track_number,
+       FALSE,
+       r.created_by,
+       r.stage_started_at
+FROM tb_order_return_requests r;

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -6,6 +6,9 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderEpisode;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestActionRequest;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
+import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.TrackParcel;
@@ -103,15 +106,26 @@ class OrderReturnRequestServiceTest {
         assertThat(saved.getCreatedBy()).isEqualTo(user);
         assertThat(saved.getCreatedAt()).isNotNull();
         assertThat(saved.isExchangeRequested()).isFalse();
+        assertThat(saved.getMode()).isEqualTo(ReturnRequestMode.RETURN);
+        assertThat(saved.getStage()).isEqualTo(ReturnRequestStage.CUSTOMER_RETURN);
+        assertThat(saved.getStore()).isEqualTo(parcel.getStore());
+        assertThat(saved.getResponsibleManager()).isEqualTo(user);
+        assertThat(saved.isManualTrackOverride()).isTrue();
+        assertThat(saved.isManualStageOverride()).isFalse();
+        assertThat(saved.getStageStartedAt()).isEqualTo(DEFAULT_REQUESTED_AT);
+        assertThat(saved.getStageUpdatedAt()).isEqualTo(DEFAULT_REQUESTED_AT);
+        assertThat(saved.getHistoryEntries()).hasSize(1);
 
         ArgumentCaptor<OrderReturnRequest> captor = ArgumentCaptor.forClass(OrderReturnRequest.class);
         verify(repository).save(captor.capture());
-        assertThat(captor.getValue().getParcel()).isEqualTo(parcel);
-        assertThat(captor.getValue().getReason()).isEqualTo(DEFAULT_REASON);
-        assertThat(captor.getValue().getComment()).isEqualTo(DEFAULT_COMMENT);
-        assertThat(captor.getValue().getRequestedAt()).isEqualTo(DEFAULT_REQUESTED_AT);
-        assertThat(captor.getValue().getReverseTrackNumber()).isEqualTo(DEFAULT_REVERSE_TRACK);
-        assertThat(captor.getValue().isExchangeRequested()).isFalse();
+        OrderReturnRequest persisted = captor.getValue();
+        assertThat(persisted.getParcel()).isEqualTo(parcel);
+        assertThat(persisted.getReason()).isEqualTo(DEFAULT_REASON);
+        assertThat(persisted.getComment()).isEqualTo(DEFAULT_COMMENT);
+        assertThat(persisted.getRequestedAt()).isEqualTo(DEFAULT_REQUESTED_AT);
+        assertThat(persisted.getReverseTrackNumber()).isEqualTo(DEFAULT_REVERSE_TRACK);
+        assertThat(persisted.isExchangeRequested()).isFalse();
+        assertThat(persisted.getHistoryEntries()).hasSize(1);
         verifyNoInteractions(orderExchangeService);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
@@ -142,6 +156,10 @@ class OrderReturnRequestServiceTest {
 
         assertThat(saved.isExchangeRequested()).isTrue();
         assertThat(saved.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
+        assertThat(saved.getMode()).isEqualTo(ReturnRequestMode.EXCHANGE);
+        assertThat(saved.getStage()).isEqualTo(ReturnRequestStage.CUSTOMER_RETURN);
+        assertThat(saved.getStore()).isEqualTo(parcel.getStore());
+        assertThat(saved.getHistoryEntries()).hasSize(1);
         verify(repository).save(any(OrderReturnRequest.class));
         verifyNoInteractions(orderExchangeService);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
@@ -222,6 +240,7 @@ class OrderReturnRequestServiceTest {
         request.setId(500L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
 
         when(repository.findById(500L)).thenReturn(Optional.of(request));
@@ -234,8 +253,10 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         assertThat(result.getDecisionBy()).isEqualTo(user);
         assertThat(result.getDecisionAt()).isNotNull();
-        assertThat(result.isReturnReceiptConfirmed()).isFalse();
-        assertThat(result.getReturnReceiptConfirmedAt()).isNull();
+        assertThat(result.getMode()).isEqualTo(ReturnRequestMode.EXCHANGE);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        assertThat(result.getResponsibleManager()).isEqualTo(user);
+        assertThat(result.isManualStageOverride()).isTrue();
         verify(orderExchangeService, never()).createExchangeParcel(any());
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
@@ -247,10 +268,12 @@ class OrderReturnRequestServiceTest {
         request.setId(701L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
 
         when(repository.findById(701L)).thenReturn(Optional.of(request));
         when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         TrackParcel exchange = buildParcel(199L, GlobalStatus.PRE_REGISTERED);
         when(orderExchangeService.createExchangeParcel(request)).thenReturn(exchange);
@@ -258,7 +281,11 @@ class OrderReturnRequestServiceTest {
         TrackParcel created = service.createExchangeParcel(701L, 44L, user);
 
         assertThat(created).isEqualTo(exchange);
+        assertThat(request.getResponsibleManager()).isEqualTo(user);
+        assertThat(request.isManualStageOverride()).isTrue();
+        assertThat(request.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).createExchangeParcel(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
     @Test
@@ -288,6 +315,7 @@ class OrderReturnRequestServiceTest {
         request.setId(300L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
 
         when(repository.findById(300L)).thenReturn(Optional.of(request));
@@ -298,8 +326,11 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         assertThat(result.getClosedBy()).isEqualTo(user);
         assertThat(result.getClosedAt()).isNotNull();
-        assertThat(result.isReturnReceiptConfirmed()).isFalse();
-        assertThat(result.getReturnReceiptConfirmedAt()).isNull();
+        assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getResponsibleManager()).isEqualTo(user);
+        assertThat(result.isManualStageOverride()).isTrue();
+        assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
@@ -310,6 +341,7 @@ class OrderReturnRequestServiceTest {
         request.setId(901L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
 
         when(repository.findById(901L)).thenReturn(Optional.of(request));
@@ -320,6 +352,10 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isTrue();
         assertThat(result.getReturnReceiptConfirmedAt()).isNotNull();
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getResponsibleManager()).isEqualTo(user);
+        assertThat(result.isManualStageOverride()).isTrue();
+        assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
@@ -365,6 +401,7 @@ class OrderReturnRequestServiceTest {
         request.setId(904L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         request.setClosedBy(user);
         request.setClosedAt(ZonedDateTime.now(ZoneOffset.UTC).minusHours(1));
@@ -377,6 +414,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isTrue();
         assertThat(result.getReturnReceiptConfirmedAt()).isNotNull();
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
@@ -389,6 +427,7 @@ class OrderReturnRequestServiceTest {
         request.setId(610L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
 
         when(repository.findById(610L)).thenReturn(Optional.of(request));
@@ -401,8 +440,9 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         assertThat(result.getClosedBy()).isEqualTo(user);
         assertThat(result.getClosedAt()).isNotNull();
-        assertThat(result.isReturnReceiptConfirmed()).isFalse();
-        assertThat(result.getReturnReceiptConfirmedAt()).isNull();
+        assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
@@ -629,6 +669,9 @@ class OrderReturnRequestServiceTest {
         assertThat(response.reverseTrackNumber()).isEqualTo("AB123");
         assertThat(response.comment()).isEqualTo("комментарий");
         assertThat(response.requestId()).isEqualTo(801L);
+        assertThat(request.isManualTrackOverride()).isTrue();
+        assertThat(request.getHistoryEntries()).hasSize(1);
+        assertThat(request.getResponsibleManager()).isEqualTo(user);
         verify(repository).save(any(OrderReturnRequest.class));
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
@@ -661,6 +704,7 @@ class OrderReturnRequestServiceTest {
         request.setId(950L);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         request.setDecisionBy(user);
         request.setDecisionAt(ZonedDateTime.now(ZoneOffset.UTC));
@@ -682,6 +726,9 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getClosedBy()).isNull();
         assertThat(result.getClosedAt()).isNull();
         assertThat(result.isExchangeRequested()).isFalse();
+        assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
@@ -713,6 +760,7 @@ class OrderReturnRequestServiceTest {
         request.setId(id);
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         return request;
     }
@@ -726,6 +774,10 @@ class OrderReturnRequestServiceTest {
         OrderEpisode episode = new OrderEpisode();
         episode.setId(500L + id);
         parcel.setEpisode(episode);
+        Store store = new Store();
+        store.setId(900L + id);
+        store.setName("Store-" + id);
+        parcel.setStore(store);
         parcel.setUser(user);
         return parcel;
     }


### PR DESCRIPTION
## Summary
- add lifecycle metadata, manual flags, and responsible/store relations to order return requests
- persist return request history entries and expose new attributes via DTOs and mappers
- deliver migration and unit test updates covering the new lifecycle fields

## Testing
- `mvn -DskipITs test` *(fails: dependency download forbidden from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_6900f8dd25d8832da1321faaa5cf5588