### PR TITLE
Refactor return request DTO structure

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
@@ -1,40 +1,28 @@
 package com.project.tracking_system.dto;
 
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
-import com.project.tracking_system.entity.ReturnRequestMode;
-import com.project.tracking_system.entity.ReturnRequestStage;
 
 /**
  * DTO для отображения заявок на возврат/обмен, требующих действий пользователя.
  * <p>
- * Запись содержит сведения о посылке, статусе заявки и доступных действиях,
+ * Запись содержит сведения о посылке, статусе заявки и агрегированные данные о состоянии,
  * чтобы шаблон "Отправления" мог отрисовать таблицу вкладки «Требуют действия».
  * </p>
  *
- * @param requestId                 идентификатор заявки на возврат
- * @param parcelId                  идентификатор посылки, к которой относится заявка
- * @param trackNumber               трек-номер посылки или {@code null}, если он отсутствует
- * @param storeName                 название магазина, оформившего отправление
- * @param parcelStatus              человеко-читаемый статус посылки
- * @param status                    статус самой заявки
- * @param statusLabel               локализованное имя статуса
- * @param requestedAt               дата обращения пользователя в локальной зоне
- * @param createdAt                 дата регистрации заявки в системе
- * @param reason                    причина оформления возврата
- * @param comment                   дополнительный комментарий пользователя
- * @param reverseTrackNumber        трек обратной отправки, если указан
- * @param exchangeRequested         признак, что покупатель запросил обмен при регистрации
- * @param canStartExchange          признак доступности запуска обмена
- * @param canCloseWithoutExchange   признак доступности закрытия без обмена
- * @param canReopenAsReturn         признак возможности вернуть заявку из обмена в возврат
- * @param canCancelExchange         признак доступности отмены обмена
- * @param exchangeShipmentDispatched признак, что обменная посылка уже отправлена
- * @param cancelExchangeUnavailableReason сообщение о недоступности отмены обмена
- * @param returnReceiptConfirmed признак, что магазин подтвердил получение возврата
- * @param returnReceiptConfirmedAt дата подтверждения возврата
- * @param canConfirmReceipt доступность ручного подтверждения приёма
+ * @param requestId       идентификатор заявки на возврат
+ * @param parcelId        идентификатор посылки, к которой относится заявка
+ * @param trackNumber     трек-номер посылки или {@code null}, если он отсутствует
+ * @param storeName       название магазина, оформившего отправление
+ * @param parcelStatus    человеко-читаемый статус посылки
+ * @param status          статус самой заявки
+ * @param statusLabel     локализованное имя статуса
+ * @param reason          причина оформления возврата
+ * @param comment         дополнительный комментарий пользователя
+ * @param reverseTrackNumber трек обратной отправки, если указан
+ * @param state           агрегированное состояние заявки
+ * @param availableActions набор доступных действий
+ * @param timestamps      временные метки, необходимые интерфейсу
  */
-
 public record ActionRequiredReturnRequestDto(Long requestId,
                                              Long parcelId,
                                              String trackNumber,
@@ -42,29 +30,10 @@ public record ActionRequiredReturnRequestDto(Long requestId,
                                              String parcelStatus,
                                              OrderReturnRequestStatus status,
                                              String statusLabel,
-                                             String requestedAt,
-                                             String createdAt,
                                              String reason,
                                              String comment,
                                              String reverseTrackNumber,
-                                             boolean exchangeRequested,
-                                             boolean canStartExchange,
-                                             boolean canCloseWithoutExchange,
-                                             boolean canReopenAsReturn,
-                                             boolean canCancelExchange,
-                                             boolean exchangeShipmentDispatched,
-                                             String cancelExchangeUnavailableReason,
-                                             boolean returnReceiptConfirmed,
-                                             String returnReceiptConfirmedAt,
-                                             boolean canConfirmReceipt,
-                                             ReturnRequestMode mode,
-                                             ReturnRequestStage stage,
-                                             String exchangeTrackNumber,
-                                             boolean manualStageOverride,
-                                             boolean manualTrackOverride,
-                                             String stageStartedAt,
-                                             String stageUpdatedAt,
-                                             String exchangeTrackAssignedAt,
-                                             Long storeId,
-                                             Long responsibleId) {
+                                             ReturnRequestStateDto state,
+                                             ReturnRequestAvailableActionsDto availableActions,
+                                             ReturnRequestTimestampsDto timestamps) {
 }

--- a/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/OrderReturnRequestDto.java
@@ -1,69 +1,38 @@
 package com.project.tracking_system.dto;
 
-import com.project.tracking_system.entity.ReturnRequestMode;
-import com.project.tracking_system.entity.ReturnRequestStage;
-
 /**
  * DTO заявки на возврат/обмен для модального окна трека.
  *
- * @param id                       идентификатор заявки
- * @param status                   человеко-читаемый статус
- * @param reason                   причина оформления возврата
- * @param comment                  дополнительный комментарий пользователя
- * @param requestedAt              дата, указанная пользователем при обращении (или дата регистрации при её отсутствии)
- * @param decisionAt               дата принятия решения об обмене
- * @param closedAt                 дата закрытия без обмена
- * @param reverseTrackNumber       трек обратной отправки, если указан
- * @param requiresAction           признак, что заявка ожидает действий
- * @param exchangeApproved         признак, что обмен уже запущен
- * @param exchangeRequested        признак, что обмен был запрошен при регистрации
- * @param canStartExchange         доступность кнопки запуска обмена
- * @param canCreateExchangeParcel  доступность создания обменной посылки
- * @param canCloseWithoutExchange  доступность закрытия без обмена
- * @param canReopenAsReturn        доступность перевода обмена обратно в возврат
- * @param canCancelExchange        доступность отмены обмена
- * @param cancelExchangeUnavailableReason сообщение для пользователя, если отмена обмена недоступна
- * @param returnReceiptConfirmed   признак ручного подтверждения возврата магазином
- * @param returnReceiptConfirmedAt дата подтверждения возврата
- * @param canConfirmReceipt        доступность кнопки подтверждения возврата
+ * @param id               идентификатор заявки
+ * @param status           человеко-читаемый статус
+ * @param reason           причина оформления возврата
+ * @param comment          дополнительный комментарий пользователя
+ * @param reverseTrackNumber трек обратной отправки, если указан
+ * @param requiresAction   признак, что заявка ожидает действий
+ * @param state            агрегированное состояние заявки (режим, этап, флаги)
+ * @param availableActions доступные действия для пользователя
+ * @param timestamps       набор временных меток жизненного цикла
+ * @param storeId          идентификатор магазина, обработавшего заявку
+ * @param responsibleId    идентификатор ответственного менеджера
  */
-
 public record OrderReturnRequestDto(Long id,
                                     String status,
                                     String reason,
                                     String comment,
-                                    String requestedAt,
-                                    String decisionAt,
-                                    String closedAt,
                                     String reverseTrackNumber,
                                     boolean requiresAction,
-                                    boolean exchangeApproved,
-                                    boolean exchangeRequested,
-                                    boolean canStartExchange,
-                                    boolean canCreateExchangeParcel,
-                                    boolean canCloseWithoutExchange,
-                                    boolean canReopenAsReturn,
-                                    boolean canCancelExchange,
-                                    String cancelExchangeUnavailableReason,
-                                    boolean returnReceiptConfirmed,
-                                    String returnReceiptConfirmedAt,
-                                    boolean canConfirmReceipt,
-                                    ReturnRequestMode mode,
-                                    ReturnRequestStage stage,
-                                    String exchangeTrackNumber,
-                                    boolean manualStageOverride,
-                                    boolean manualTrackOverride,
-                                    String stageStartedAt,
-                                    String stageUpdatedAt,
-                                    String exchangeTrackAssignedAt,
+                                    ReturnRequestStateDto state,
+                                    ReturnRequestAvailableActionsDto availableActions,
+                                    ReturnRequestTimestampsDto timestamps,
                                     Long storeId,
                                     Long responsibleId) {
 
     /**
      * Совместимый с фронтендом аксессор, чтобы не ломать проверку {@code isExchangeRequest}.
+     *
+     * @return {@code true}, если заявка оформлена как обмен
      */
     public boolean isExchangeRequest() {
-        return exchangeRequested;
+        return state != null && state.exchangeRequested();
     }
 }
-

--- a/src/main/java/com/project/tracking_system/dto/ReturnRequestAvailableActionsDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRequestAvailableActionsDto.java
@@ -1,0 +1,21 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Доступные действия с заявкой на возврат/обмен.
+ *
+ * @param startExchange                   признак доступности перевода в обмен
+ * @param createExchangeParcel            возможность сформировать обменную посылку
+ * @param closeWithoutExchange            доступность закрытия без обмена
+ * @param reopenAsReturn                  доступность перевода обмена обратно в возврат
+ * @param cancelExchange                  возможность отменить обмен
+ * @param confirmReceipt                  доступность подтверждения возврата магазином
+ * @param cancelExchangeUnavailableReason причина недоступности отмены обмена
+ */
+public record ReturnRequestAvailableActionsDto(boolean startExchange,
+                                               boolean createExchangeParcel,
+                                               boolean closeWithoutExchange,
+                                               boolean reopenAsReturn,
+                                               boolean cancelExchange,
+                                               boolean confirmReceipt,
+                                               String cancelExchangeUnavailableReason) {
+}

--- a/src/main/java/com/project/tracking_system/dto/ReturnRequestStateDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRequestStateDto.java
@@ -1,0 +1,28 @@
+package com.project.tracking_system.dto;
+
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
+
+/**
+ * Текущее состояние заявки на возврат/обмен.
+ *
+ * @param mode                    режим обработки заявки
+ * @param stage                   актуальный этап обработки
+ * @param manualStageOverride     признак ручного выбора этапа
+ * @param manualTrackOverride     признак ручного выбора трека обмена
+ * @param exchangeRequested       заявка оформлена как обмен
+ * @param exchangeApproved        обмен запущен
+ * @param exchangeShipmentDispatched обменная посылка уже отправлена
+ * @param exchangeTrackNumber     трек обменной посылки
+ * @param returnReceiptConfirmed  магазин подтвердил получение возврата
+ */
+public record ReturnRequestStateDto(ReturnRequestMode mode,
+                                    ReturnRequestStage stage,
+                                    boolean manualStageOverride,
+                                    boolean manualTrackOverride,
+                                    boolean exchangeRequested,
+                                    boolean exchangeApproved,
+                                    boolean exchangeShipmentDispatched,
+                                    String exchangeTrackNumber,
+                                    boolean returnReceiptConfirmed) {
+}

--- a/src/main/java/com/project/tracking_system/dto/ReturnRequestTimestampsDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRequestTimestampsDto.java
@@ -1,0 +1,23 @@
+package com.project.tracking_system.dto;
+
+/**
+ * Временные метки жизненного цикла заявки.
+ *
+ * @param requestedAt             дата обращения пользователя
+ * @param createdAt               дата регистрации заявки
+ * @param decisionAt              дата принятия решения об обмене
+ * @param closedAt                дата закрытия без обмена
+ * @param stageStartedAt          дата начала текущего этапа
+ * @param stageUpdatedAt          дата последнего обновления этапа
+ * @param exchangeTrackAssignedAt дата назначения трека обмена
+ * @param returnReceiptConfirmedAt дата подтверждения возврата магазином
+ */
+public record ReturnRequestTimestampsDto(String requestedAt,
+                                         String createdAt,
+                                         String decisionAt,
+                                         String closedAt,
+                                         String stageStartedAt,
+                                         String stageUpdatedAt,
+                                         String exchangeTrackAssignedAt,
+                                         String returnReceiptConfirmedAt) {
+}

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -1,6 +1,9 @@
 package com.project.tracking_system.service.customer;
 
 import com.project.tracking_system.dto.ActionRequiredReturnRequestDto;
+import com.project.tracking_system.dto.ReturnRequestAvailableActionsDto;
+import com.project.tracking_system.dto.ReturnRequestStateDto;
+import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.dto.TelegramParcelInfoDTO;
 import com.project.tracking_system.dto.TelegramParcelsOverviewDTO;
 import com.project.tracking_system.dto.TelegramReturnRequestInfoDTO;
@@ -669,6 +672,47 @@ public class CustomerTelegramService {
         boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
 
+        ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
+        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
+
+        ReturnRequestStateDto state = new ReturnRequestStateDto(
+                mode,
+                stage,
+                request.isManualStageOverride(),
+                request.isManualTrackOverride(),
+                request.isExchangeRequested(),
+                request.isExchangeApproved(),
+                exchangeShipmentDispatched,
+                request.getExchangeTrackNumber(),
+                request.isReturnReceiptConfirmed()
+        );
+
+        ReturnRequestAvailableActionsDto availableActions = new ReturnRequestAvailableActionsDto(
+                canStartExchange,
+                orderReturnRequestService.canCreateExchangeParcel(request),
+                canCloseWithoutExchange,
+                canReopenAsReturn,
+                canCancelExchange,
+                canConfirmReceipt,
+                cancelExchangeReason
+        );
+
+        String requestedAt = formatRequestMoment(request.getRequestedAt());
+        if (requestedAt == null) {
+            requestedAt = formatRequestMoment(request.getCreatedAt());
+        }
+
+        ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(
+                requestedAt,
+                formatRequestMoment(request.getCreatedAt()),
+                formatRequestMoment(request.getDecisionAt()),
+                formatRequestMoment(request.getClosedAt()),
+                formatRequestMoment(request.getStageStartedAt()),
+                formatRequestMoment(request.getStageUpdatedAt()),
+                formatRequestMoment(request.getExchangeTrackAssignedAt()),
+                formatRequestMoment(request.getReturnReceiptConfirmedAt())
+        );
+
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
                 parcelId,
@@ -677,21 +721,12 @@ public class CustomerTelegramService {
                 parcelStatus != null ? parcelStatus.getDescription() : null,
                 status,
                 status != null ? status.getDisplayName() : null,
-                formatRequestMoment(request.getRequestedAt()),
-                formatRequestMoment(request.getCreatedAt()),
                 request.getReason(),
                 request.getComment(),
                 request.getReverseTrackNumber(),
-                request.isExchangeRequested(),
-                canStartExchange,
-                canCloseWithoutExchange,
-                canReopenAsReturn,
-                canCancelExchange,
-                exchangeShipmentDispatched,
-                cancelExchangeReason,
-                request.isReturnReceiptConfirmed(),
-                formatRequestMoment(request.getReturnReceiptConfirmedAt()),
-                canConfirmReceipt
+                state,
+                availableActions,
+                timestamps
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
@@ -1,6 +1,9 @@
 package com.project.tracking_system.service.order;
 
 import com.project.tracking_system.dto.ActionRequiredReturnRequestDto;
+import com.project.tracking_system.dto.ReturnRequestAvailableActionsDto;
+import com.project.tracking_system.dto.ReturnRequestStateDto;
+import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
@@ -59,11 +62,39 @@ public class ReturnRequestActionMapper {
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
         ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
-        String stageStartedAt = formatRequestMoment(request.getStageStartedAt(), userZone);
-        String stageUpdatedAt = formatRequestMoment(request.getStageUpdatedAt(), userZone);
-        String exchangeTrackAssignedAt = formatRequestMoment(request.getExchangeTrackAssignedAt(), userZone);
-        Long storeId = request.getStore() != null ? request.getStore().getId() : null;
-        Long responsibleId = request.getResponsibleManager() != null ? request.getResponsibleManager().getId() : null;
+
+        ReturnRequestStateDto state = new ReturnRequestStateDto(
+                mode,
+                stage,
+                request.isManualStageOverride(),
+                request.isManualTrackOverride(),
+                request.isExchangeRequested(),
+                request.isExchangeApproved(),
+                exchangeShipmentDispatched,
+                request.getExchangeTrackNumber(),
+                request.isReturnReceiptConfirmed()
+        );
+
+        ReturnRequestAvailableActionsDto availableActions = new ReturnRequestAvailableActionsDto(
+                canStartExchange,
+                orderReturnRequestService.canCreateExchangeParcel(request),
+                canCloseWithoutExchange,
+                canReopenAsReturn,
+                canCancelExchange,
+                canConfirmReceipt,
+                cancelExchangeReason
+        );
+
+        ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(
+                formatRequestMoment(request.getRequestedAt(), userZone),
+                formatRequestMoment(request.getCreatedAt(), userZone),
+                formatRequestMoment(request.getDecisionAt(), userZone),
+                formatRequestMoment(request.getClosedAt(), userZone),
+                formatRequestMoment(request.getStageStartedAt(), userZone),
+                formatRequestMoment(request.getStageUpdatedAt(), userZone),
+                formatRequestMoment(request.getExchangeTrackAssignedAt(), userZone),
+                formatRequestMoment(request.getReturnReceiptConfirmedAt(), userZone)
+        );
 
         return new ActionRequiredReturnRequestDto(
                 request.getId(),
@@ -73,31 +104,12 @@ public class ReturnRequestActionMapper {
                 parcelStatus != null ? parcelStatus.getDescription() : null,
                 status,
                 status != null ? status.getDisplayName() : null,
-                formatRequestMoment(request.getRequestedAt(), userZone),
-                formatRequestMoment(request.getCreatedAt(), userZone),
                 request.getReason(),
                 request.getComment(),
                 request.getReverseTrackNumber(),
-                request.isExchangeRequested(),
-                canStartExchange,
-                canCloseWithoutExchange,
-                canReopenAsReturn,
-                canCancelExchange,
-                exchangeShipmentDispatched,
-                cancelExchangeReason,
-                request.isReturnReceiptConfirmed(),
-                formatRequestMoment(request.getReturnReceiptConfirmedAt(), userZone),
-                canConfirmReceipt,
-                mode,
-                stage,
-                request.getExchangeTrackNumber(),
-                request.isManualStageOverride(),
-                request.isManualTrackOverride(),
-                stageStartedAt,
-                stageUpdatedAt,
-                exchangeTrackAssignedAt,
-                storeId,
-                responsibleId
+                state,
+                availableActions,
+                timestamps
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1214,7 +1214,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return "возврат";
         }
         if (request.status() == OrderReturnRequestStatus.EXCHANGE_APPROVED
-                || request.exchangeRequested()) {
+                || request.state().exchangeRequested()) {
             return "обмен";
         }
         return "возврат";
@@ -1224,7 +1224,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         String track = escapeMarkdown(formatTrackNumber(request.trackNumber()));
         String store = escapeMarkdown(resolveStoreLabel(request.storeName()));
         String status = escapeMarkdown(safeRequestStatus(request.statusLabel()));
-        String date = escapeMarkdown(safeOrDash(request.requestedAt()));
+        String date = escapeMarkdown(safeOrDash(request.timestamps().requestedAt()));
         String reason = escapeMarkdown(request.reason() == null ? PARCEL_RETURN_REASON_UNKNOWN : request.reason());
         String commentValue = request.comment();
         String comment = escapeMarkdown(commentValue == null || commentValue.isBlank()
@@ -1234,7 +1234,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 ? PARCEL_RETURN_NO_TRACK
                 : request.reverseTrackNumber());
         String details = String.format(RETURNS_ACTIVE_DETAILS_TEMPLATE, track, store, status, date, reason, comment, reverse);
-        String cancelReason = request.cancelExchangeUnavailableReason();
+        String cancelReason = request.availableActions().cancelExchangeUnavailableReason();
         if (cancelReason != null && !cancelReason.isBlank()
                 && request.status() == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
             details = details + System.lineSeparator()
@@ -1307,9 +1307,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 .callbackData(CALLBACK_RETURNS_ACTIVE_COMMENT_PREFIX + requestId + ':' + parcelId)
                 .build()));
         if (request.status() == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            boolean cancellationBlocked = request.cancelExchangeUnavailableReason() != null
-                    && !request.cancelExchangeUnavailableReason().isBlank();
-            boolean exchangeDispatched = request.exchangeShipmentDispatched();
+            boolean cancellationBlocked = request.availableActions().cancelExchangeUnavailableReason() != null
+                    && !request.availableActions().cancelExchangeUnavailableReason().isBlank();
+            boolean exchangeDispatched = request.state().exchangeShipmentDispatched();
             if (!cancellationBlocked) {
                 String cancelText = exchangeDispatched
                         ? BUTTON_RETURNS_ACTION_CANCEL_EXCHANGE_REQUEST
@@ -2125,10 +2125,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
         return switch (action) {
             case CANCEL_RETURN -> buildCancelReturnConfirmation(request);
-            case CANCEL_EXCHANGE -> request.exchangeShipmentDispatched()
+            case CANCEL_EXCHANGE -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CANCEL_EXCHANGE_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CANCEL_EXCHANGE_CONFIRMATION;
-            case CONVERT_TO_RETURN -> request.exchangeShipmentDispatched()
+            case CONVERT_TO_RETURN -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CONVERT_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CONVERT_CONFIRMATION;
         };

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -1,6 +1,9 @@
 package com.project.tracking_system.service.track;
 
 import com.project.tracking_system.dto.OrderReturnRequestDto;
+import com.project.tracking_system.dto.ReturnRequestAvailableActionsDto;
+import com.project.tracking_system.dto.ReturnRequestStateDto;
+import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.dto.TrackChainItemDto;
 import com.project.tracking_system.dto.TrackDetailsDto;
 import com.project.tracking_system.dto.TrackLifecycleStageDto;
@@ -489,9 +492,39 @@ public class TrackViewService {
                 .orElse(null);
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
         ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
-        String stageStartedAt = formatNullableTimestamp(request.getStageStartedAt(), userZone);
-        String stageUpdatedAt = formatNullableTimestamp(request.getStageUpdatedAt(), userZone);
-        String exchangeTrackAssignedAt = formatNullableTimestamp(request.getExchangeTrackAssignedAt(), userZone);
+        ReturnRequestStateDto state = new ReturnRequestStateDto(
+                mode,
+                stage,
+                request.isManualStageOverride(),
+                request.isManualTrackOverride(),
+                request.isExchangeRequested(),
+                request.isExchangeApproved(),
+                orderReturnRequestService.isExchangeShipmentDispatched(request),
+                request.getExchangeTrackNumber(),
+                request.isReturnReceiptConfirmed()
+        );
+
+        ReturnRequestAvailableActionsDto availableActions = new ReturnRequestAvailableActionsDto(
+                canStartExchange,
+                canCreateExchangeParcel,
+                canCloseWithoutExchange,
+                canReopenAsReturn,
+                canCancelExchange,
+                canConfirmReceipt,
+                cancelExchangeReason
+        );
+
+        ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(
+                requestedAt,
+                formatNullableTimestamp(request.getCreatedAt(), userZone),
+                formatNullableTimestamp(request.getDecisionAt(), userZone),
+                formatNullableTimestamp(request.getClosedAt(), userZone),
+                formatNullableTimestamp(request.getStageStartedAt(), userZone),
+                formatNullableTimestamp(request.getStageUpdatedAt(), userZone),
+                formatNullableTimestamp(request.getExchangeTrackAssignedAt(), userZone),
+                formatNullableTimestamp(request.getReturnReceiptConfirmedAt(), userZone)
+        );
+
         Long storeId = request.getStore() != null ? request.getStore().getId() : null;
         Long responsibleId = request.getResponsibleManager() != null ? request.getResponsibleManager().getId() : null;
 
@@ -500,30 +533,11 @@ public class TrackViewService {
                 request.getStatus().getDisplayName(),
                 request.getReason(),
                 request.getComment(),
-                requestedAt,
-                formatNullableTimestamp(request.getDecisionAt(), userZone),
-                formatNullableTimestamp(request.getClosedAt(), userZone),
                 request.getReverseTrackNumber(),
                 request.requiresAction(),
-                request.isExchangeApproved(),
-                request.isExchangeRequested(),
-                canStartExchange,
-                canCreateExchangeParcel,
-                canCloseWithoutExchange,
-                canReopenAsReturn,
-                canCancelExchange,
-                cancelExchangeReason,
-                request.isReturnReceiptConfirmed(),
-                formatNullableTimestamp(request.getReturnReceiptConfirmedAt(), userZone),
-                canConfirmReceipt,
-                mode,
-                stage,
-                request.getExchangeTrackNumber(),
-                request.isManualStageOverride(),
-                request.isManualTrackOverride(),
-                stageStartedAt,
-                stageUpdatedAt,
-                exchangeTrackAssignedAt,
+                state,
+                availableActions,
+                timestamps,
                 storeId,
                 responsibleId
         );

--- a/src/main/resources/static/js/return-requests.js
+++ b/src/main/resources/static/js/return-requests.js
@@ -106,14 +106,16 @@
 
         const derivePermissions = (item) => {
             const statusValue = typeof item?.status === 'string' ? item.status.toUpperCase() : '';
-            const exchangeStatus = statusValue === 'EXCHANGE_APPROVED';
+            const state = item?.state || {};
+            const actions = item?.availableActions || {};
+            const exchangeStatus = statusValue === 'EXCHANGE_APPROVED' || Boolean(state.exchangeApproved);
             const reverseMissing = !item?.reverseTrackNumber;
             return {
-                allowConfirmReceipt: Boolean(item?.canConfirmReceipt),
-                allowConvertToExchange: Boolean(item?.canStartExchange),
-                allowCloseRequest: Boolean(item?.canCloseWithoutExchange),
+                allowConfirmReceipt: Boolean(actions.confirmReceipt),
+                allowConvertToExchange: Boolean(actions.startExchange),
+                allowCloseRequest: Boolean(actions.closeWithoutExchange),
                 allowUpdateReverseTrack: exchangeStatus && reverseMissing,
-                allowConvertToReturn: Boolean(item?.canReopenAsReturn)
+                allowConvertToReturn: Boolean(actions.reopenAsReturn)
             };
         };
 

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -44,7 +44,8 @@
             if (request.requiresAction) {
                 return true;
             }
-            if (!request.closedAt) {
+            const timestamps = request.timestamps || {};
+            if (!timestamps.closedAt) {
                 return true;
             }
         }
@@ -457,6 +458,9 @@
         constructor(details, options = {}) {
             this.details = details || null;
             this.request = details?.returnRequest || null;
+            this.state = this.request?.state || {};
+            this.timestamps = this.request?.timestamps || {};
+            this.availableActions = this.request?.availableActions || {};
             this.trackId = details?.id ?? null;
             this.exchangeParcel = details?.exchangeParcel || null;
             this._formatDateTime = typeof options.formatDateTime === 'function'
@@ -537,25 +541,26 @@
          */
         _resolvePermissions() {
             const legacy = this.request?.actionPermissions || {};
+            const actions = this.availableActions || {};
             const mapLegacy = (key) => Boolean(legacy?.[key]);
             const legacyUpdateReverse = mapLegacy('allowUpdateReverseTrack');
             const canUpdateReverseTrack = this.request?.canUpdateReverseTrack;
             return {
-                confirmReceipt: this.request?.canConfirmReceipt
+                confirmReceipt: actions.confirmReceipt
                     ?? mapLegacy('allowAcceptReverse')
                     ?? mapLegacy('allowAccept'),
-                convertToExchange: this.request?.canStartExchange
+                convertToExchange: actions.startExchange
                     ?? mapLegacy('allowConvertToExchange')
                     ?? mapLegacy('allowLaunchExchange'),
-                launchExchange: this.request?.canCreateExchangeParcel
+                launchExchange: actions.createExchangeParcel
                     ?? mapLegacy('allowLaunchExchange'),
-                close: this.request?.canCloseWithoutExchange ?? mapLegacy('allowClose'),
-                reopen: this.request?.canReopenAsReturn ?? mapLegacy('allowConvertToReturn'),
+                close: actions.closeWithoutExchange ?? mapLegacy('allowClose'),
+                reopen: actions.reopenAsReturn ?? mapLegacy('allowConvertToReturn'),
                 updateReverseTrack: legacyUpdateReverse
                     || (canUpdateReverseTrack === undefined
-                        ? !this.request?.closedAt
+                        ? !this.timestamps.closedAt
                         : Boolean(canUpdateReverseTrack)),
-                cancelExchange: this.request?.canCancelExchange ?? mapLegacy('allowClose')
+                cancelExchange: actions.cancelExchange ?? mapLegacy('allowClose')
             };
         }
 
@@ -564,10 +569,10 @@
          * @returns {string} режим карточки
          */
         _determineMode() {
-            const state = String(this.request?.state || '').toUpperCase();
-            if (this.request?.exchangeApproved
-                || this.request?.exchangeRequested
-                || state.includes('EXCHANGE')
+            const modeValue = String(this.state.mode || '').toUpperCase();
+            if (this.state.exchangeApproved
+                || this.state.exchangeRequested
+                || modeValue.includes('EXCHANGE')
                 || this._permissions.launchExchange) {
                 return RETURN_REQUEST_MODES.EXCHANGE;
             }
@@ -603,9 +608,9 @@
                 typeBadgeClass
             ));
 
-            const stateHint = String(this.request?.state || '').toUpperCase();
+            const stateHint = String(this.state.stage || '').toUpperCase();
             const showRegisteredBadge = this._mode === RETURN_REQUEST_MODES.EXCHANGE
-                && (!this.request?.exchangeApproved || stateHint.includes('REGISTERED'));
+                && (!this.state.exchangeApproved || stateHint.includes('REGISTERED'));
             if (showRegisteredBadge) {
                 badgeContainer.appendChild(this._createBadge(
                     'Обмен зарегистрирован',
@@ -693,16 +698,18 @@
 
             appendDefinitionItem(list, 'Тип обращения', this._mode === RETURN_REQUEST_MODES.EXCHANGE ? 'Обмен' : 'Возврат');
             appendDefinitionItem(list, 'Идентификатор обращения', String(this.request?.id ?? '—'));
-            appendDefinitionItem(list, 'Текущий статус', this.request?.statusLabel || this.request?.status || '—');
+            appendDefinitionItem(list, 'Текущий статус', this.request?.status || '—');
             appendDefinitionItem(list, 'Причина обращения', this.request?.reason || '—');
             appendDefinitionItem(list, 'Комментарий', this.request?.comment || '—');
-            appendDefinitionItem(list, 'Зарегистрировано', this._formatValue(this.request?.requestedAt));
-            appendDefinitionItem(list, 'Обновлено', this._formatValue(this.request?.updatedAt));
-            appendDefinitionItem(list, 'Закрыто', this._formatValue(this.request?.closedAt));
+            const registeredAt = this.timestamps.requestedAt || this.timestamps.createdAt || null;
+            appendDefinitionItem(list, 'Зарегистрировано', this._formatValue(registeredAt));
+            const updatedAt = this.timestamps.stageUpdatedAt || this.timestamps.exchangeTrackAssignedAt || null;
+            appendDefinitionItem(list, 'Обновлено', this._formatValue(updatedAt));
+            appendDefinitionItem(list, 'Закрыто', this._formatValue(this.timestamps.closedAt));
 
-            const receiptConfirmed = Boolean(this.request?.returnReceiptConfirmed);
-            const receiptDate = this.request?.returnReceiptConfirmedAt
-                ? this._formatValue(this.request.returnReceiptConfirmedAt)
+            const receiptConfirmed = Boolean(this.state.returnReceiptConfirmed);
+            const receiptDate = this.timestamps.returnReceiptConfirmedAt
+                ? this._formatValue(this.timestamps.returnReceiptConfirmedAt)
                 : null;
             const receiptValue = receiptConfirmed
                 ? (receiptDate ? `Подтверждено ${receiptDate}` : 'Подтверждено')
@@ -715,8 +722,11 @@
 
             const showExchangeFields = this._mode === RETURN_REQUEST_MODES.EXCHANGE;
             if (showExchangeFields) {
-                appendDefinitionItem(list, 'Статус обмена', this.request?.exchangeStatusLabel || this.request?.exchangeStatus || '—');
-                appendDefinitionItem(list, 'Дата согласования обмена', this._formatValue(this.request?.exchangeApprovedAt));
+                const exchangeStatus = this.state.exchangeApproved
+                    ? 'Обмен запущен'
+                    : (this.state.exchangeRequested ? 'Запрос на обмен' : 'Ожидает запуска');
+                appendDefinitionItem(list, 'Статус обмена', exchangeStatus);
+                appendDefinitionItem(list, 'Дата согласования обмена', this._formatValue(this.timestamps.decisionAt));
             }
 
             return list;
@@ -849,12 +859,12 @@
          * @returns {HTMLElement|null} блок уведомления или {@code null}
          */
         _buildNotice() {
-            if (!this.request?.cancelExchangeUnavailableReason) {
+            if (!this.availableActions.cancelExchangeUnavailableReason) {
                 return null;
             }
             const notice = document.createElement('div');
             notice.className = 'alert alert-warning mb-0';
-            notice.textContent = this.request.cancelExchangeUnavailableReason;
+            notice.textContent = this.availableActions.cancelExchangeUnavailableReason;
             notice.setAttribute('role', 'status');
             return notice;
         }
@@ -991,7 +1001,7 @@
                         successMessage: 'Обращение закрыто',
                         notificationType: 'warning'
                     },
-                    disabledReason: this.request?.cancelExchangeUnavailableReason || null
+                    disabledReason: this.availableActions.cancelExchangeUnavailableReason || null
                 }
             ];
         }
@@ -1251,6 +1261,9 @@
         if (request.id === undefined) {
             return null;
         }
+        const state = request.state || {};
+        const actions = request.availableActions || {};
+        const timestamps = request.timestamps || {};
         const summary = {
             parcelId: details.id,
             requestId: request.id,
@@ -1260,18 +1273,20 @@
             reason: request.reason || null,
             comment: request.comment || null,
             reverseTrackNumber: request.reverseTrackNumber || null,
-            exchangeRequested: Boolean(request.exchangeRequested),
-            canStartExchange: Boolean(request.canStartExchange),
-            canCloseWithoutExchange: Boolean(request.canCloseWithoutExchange),
-            canReopenAsReturn: Boolean(request.canReopenAsReturn),
-            canCancelExchange: Boolean(request.canCancelExchange),
-            cancelExchangeUnavailableReason: request.cancelExchangeUnavailableReason || null,
-            returnReceiptConfirmed: Boolean(request.returnReceiptConfirmed),
-            returnReceiptConfirmedAt: request.returnReceiptConfirmedAt || null,
-            canConfirmReceipt: Boolean(request.canConfirmReceipt)
+            exchangeRequested: Boolean(state.exchangeRequested),
+            canStartExchange: Boolean(actions.startExchange),
+            canCloseWithoutExchange: Boolean(actions.closeWithoutExchange),
+            canReopenAsReturn: Boolean(actions.reopenAsReturn),
+            canCancelExchange: Boolean(actions.cancelExchange),
+            cancelExchangeUnavailableReason: actions.cancelExchangeUnavailableReason || null,
+            returnReceiptConfirmed: Boolean(state.returnReceiptConfirmed),
+            returnReceiptConfirmedAt: timestamps.returnReceiptConfirmedAt || null,
+            canConfirmReceipt: Boolean(actions.confirmReceipt)
         };
-        if (request.requestedAt) {
-            summary.requestedAt = request.requestedAt;
+        if (timestamps.requestedAt) {
+            summary.requestedAt = timestamps.requestedAt;
+        } else if (timestamps.createdAt) {
+            summary.requestedAt = timestamps.createdAt;
         }
         return summary;
     }

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -288,9 +288,9 @@
                                                         <span class="fw-semibold" data-return-status-label
                                                               th:text="${request.statusLabel != null ? request.statusLabel : 'Статус не определён'}"></span>
                                                         <span class="text-muted small" data-return-requested
-                                                              th:text="${request.requestedAt != null ? 'Обращение: ' + request.requestedAt : 'Обращение: —'}"></span>
+                                                              th:text="${request.timestamps != null and request.timestamps.requestedAt != null ? 'Обращение: ' + request.timestamps.requestedAt : 'Обращение: —'}"></span>
                                                         <span class="text-muted small" data-return-created
-                                                              th:text="${request.createdAt != null ? 'Регистрация: ' + request.createdAt : 'Регистрация: —'}"></span>
+                                                              th:text="${request.timestamps != null and request.timestamps.createdAt != null ? 'Регистрация: ' + request.timestamps.createdAt : 'Регистрация: —'}"></span>
                                                     </div>
                                                 </td>
                                                 <td class="text-start">
@@ -302,18 +302,18 @@
                                                       <span class="text-muted small" data-return-reverse
                                                             th:text="${request.reverseTrackNumber != null ? 'Обратный трек: ' + request.reverseTrackNumber : 'Обратный трек: —'}"></span>
                                                       <span class="text-muted small" data-return-confirmation
-                                                            th:classappend="${request.returnReceiptConfirmed} ? ' text-success' : ''"
-                                                            th:text="${request.returnReceiptConfirmed ? 'Получение подтверждено: ' + (request.returnReceiptConfirmedAt != null ? request.returnReceiptConfirmedAt : '—') : 'Получение ещё не подтверждено'}"></span>
+                                                            th:classappend="${request.state != null and request.state.returnReceiptConfirmed} ? ' text-success' : ''"
+                                                            th:text="${request.state != null and request.state.returnReceiptConfirmed ? 'Получение подтверждено: ' + (request.timestamps != null && request.timestamps.returnReceiptConfirmedAt != null ? request.timestamps.returnReceiptConfirmedAt : '—') : 'Получение ещё не подтверждено'}"></span>
                                                     </div>
                                                 </td>
                                                 <td class="text-end">
                                                     <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end"
                                                          th:with="isExchangeApproved=${request.status == T(com.project.tracking_system.entity.OrderReturnRequestStatus).EXCHANGE_APPROVED},
-                                                                  allowConfirm=${request.canConfirmReceipt},
-                                                                  allowConvertToExchange=${request.canStartExchange},
-                                                                  allowClose=${request.canCloseWithoutExchange},
+                                                                  allowConfirm=${request.availableActions != null and request.availableActions.confirmReceipt},
+                                                                  allowConvertToExchange=${request.availableActions != null and request.availableActions.startExchange},
+                                                                  allowClose=${request.availableActions != null and request.availableActions.closeWithoutExchange},
                                                                   hasReverse=${request.reverseTrackNumber != null and !#strings.isEmpty(request.reverseTrackNumber)},
-                                                                  allowConvertToReturn=${request.canReopenAsReturn},
+                                                                  allowConvertToReturn=${request.availableActions != null and request.availableActions.reopenAsReturn},
                                                                   allowUpdateReverse=${isExchangeApproved and !hasReverse}">
                                                         <button type="button"
                                                                 class="btn btn-success btn-sm js-return-request-confirm-return"

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.project.tracking_system.dto.ActionRequiredReturnRequestDto;
+import com.project.tracking_system.dto.ReturnRequestAvailableActionsDto;
+import com.project.tracking_system.dto.ReturnRequestStateDto;
+import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.dto.ReturnRequestUpdateResponse;
 import com.project.tracking_system.dto.TelegramParcelInfoDTO;
 import com.project.tracking_system.dto.TelegramParcelsOverviewDTO;
@@ -13,6 +16,8 @@ import com.project.tracking_system.entity.BuyerBotScreen;
 import com.project.tracking_system.entity.BuyerChatState;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.NameSource;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderReturnRequest;
@@ -569,7 +574,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto requestDto = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto requestDto = buildActionDto(
                 1L,
                 2L,
                 "TRK-001",
@@ -714,7 +719,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto requestDto = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto requestDto = buildActionDto(
                 11L,
                 22L,
                 "TRK-RESET",
@@ -803,7 +808,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto exchangeRequest = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto exchangeRequest = buildActionDto(
                 5L,
                 8L,
                 "EX-TRK",
@@ -853,7 +858,7 @@ class BuyerTelegramBotTest {
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
         String warning = "Отмена обмена недоступна: магазин уже указал трек обменной посылки.";
-        ActionRequiredReturnRequestDto exchangeRequest = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto exchangeRequest = buildActionDto(
                 6L,
                 9L,
                 "EX-TRK-2",
@@ -914,7 +919,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto exchangeRequest = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto exchangeRequest = buildActionDto(
                 7L,
                 10L,
                 "EX-READY",
@@ -972,7 +977,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto request = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto request = buildActionDto(
                 100L,
                 200L,
                 "TRK-500",
@@ -1040,7 +1045,7 @@ class BuyerTelegramBotTest {
         customer.setId(200L);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto dispatchedExchange = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto dispatchedExchange = buildActionDto(
                 300L,
                 400L,
                 "TRK-EX",
@@ -1099,7 +1104,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto request = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto request = buildActionDto(
                 101L,
                 201L,
                 "TRK-501",
@@ -1155,7 +1160,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto request = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto request = buildActionDto(
                 102L,
                 202L,
                 "TRK-502",
@@ -1211,7 +1216,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto exchange = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto exchange = buildActionDto(
                 103L,
                 203L,
                 "TRK-503",
@@ -1276,7 +1281,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto requestDto = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto requestDto = buildActionDto(
                 1L,
                 2L,
                 "TRK",
@@ -1329,7 +1334,7 @@ class BuyerTelegramBotTest {
         Customer customer = new Customer();
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
-        ActionRequiredReturnRequestDto requestDto = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto requestDto = buildActionDto(
                 3L,
                 2L,
                 "P-1",
@@ -1415,7 +1420,7 @@ class BuyerTelegramBotTest {
         customer.setTelegramChatId(chatId);
         when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
 
-        ActionRequiredReturnRequestDto requestDto = new ActionRequiredReturnRequestDto(
+        ActionRequiredReturnRequestDto requestDto = buildActionDto(
                 7L,
                 9L,
                 "TRACK-ERR",
@@ -2386,6 +2391,84 @@ class BuyerTelegramBotTest {
                 .map(EditMessageText::getText)
                 .filter(Objects::nonNull)
                 .anyMatch(text -> text.contains(title));
+    }
+
+    /**
+     * Формирует DTO заявки с новым контрактом на основе параметров старого конструктора.
+     * Метод упрощает поддержку тестов после рефакторинга DTO, сводя маппинг к единой точке.
+     */
+    private ActionRequiredReturnRequestDto buildActionDto(Long requestId,
+                                                          Long parcelId,
+                                                          String trackNumber,
+                                                          String storeName,
+                                                          String parcelStatus,
+                                                          OrderReturnRequestStatus status,
+                                                          String statusLabel,
+                                                          String requestedAt,
+                                                          String createdAt,
+                                                          String reason,
+                                                          String comment,
+                                                          String reverseTrackNumber,
+                                                          boolean exchangeRequested,
+                                                          boolean canStartExchange,
+                                                          boolean canCloseWithoutExchange,
+                                                          boolean canReopenAsReturn,
+                                                          boolean canCancelExchange,
+                                                          boolean exchangeShipmentDispatched,
+                                                          String cancelExchangeUnavailableReason,
+                                                          boolean returnReceiptConfirmed,
+                                                          String returnReceiptConfirmedAt,
+                                                          boolean canConfirmReceipt) {
+        ReturnRequestMode mode = exchangeRequested || status == OrderReturnRequestStatus.EXCHANGE_APPROVED
+                ? ReturnRequestMode.EXCHANGE
+                : ReturnRequestMode.RETURN;
+        String decisionAt = status == OrderReturnRequestStatus.EXCHANGE_APPROVED ? requestedAt : null;
+        String closedAt = status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE ? requestedAt : null;
+        ReturnRequestStateDto state = new ReturnRequestStateDto(
+                mode,
+                ReturnRequestStage.CUSTOMER_RETURN,
+                false,
+                false,
+                exchangeRequested,
+                status == OrderReturnRequestStatus.EXCHANGE_APPROVED,
+                exchangeShipmentDispatched,
+                null,
+                returnReceiptConfirmed
+        );
+        ReturnRequestAvailableActionsDto actions = new ReturnRequestAvailableActionsDto(
+                canStartExchange,
+                false,
+                canCloseWithoutExchange,
+                canReopenAsReturn,
+                canCancelExchange,
+                canConfirmReceipt,
+                cancelExchangeUnavailableReason
+        );
+        ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(
+                requestedAt,
+                createdAt,
+                decisionAt,
+                closedAt,
+                null,
+                null,
+                null,
+                returnReceiptConfirmedAt
+        );
+        return buildActionDto(
+                requestId,
+                parcelId,
+                trackNumber,
+                storeName,
+                parcelStatus,
+                status,
+                statusLabel,
+                reason,
+                comment,
+                reverseTrackNumber,
+                state,
+                actions,
+                timestamps
+        );
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
@@ -120,7 +120,7 @@ class TrackViewCacheEvictionIntegrationTest {
         assertThat(initialDetails.returnRequest()).isNotNull();
         assertThat(initialDetails.returnRequest().status())
                 .isEqualTo(OrderReturnRequestStatus.REGISTERED.getDisplayName());
-        assertThat(initialDetails.returnRequest().exchangeApproved()).isFalse();
+        assertThat(initialDetails.returnRequest().state().exchangeApproved()).isFalse();
 
         orderReturnRequestService.approveExchange(request.getId(), parcelId, owner);
 
@@ -129,7 +129,7 @@ class TrackViewCacheEvictionIntegrationTest {
         assertThat(refreshedDetails.returnRequest()).isNotNull();
         assertThat(refreshedDetails.returnRequest().status())
                 .isEqualTo(OrderReturnRequestStatus.EXCHANGE_APPROVED.getDisplayName());
-        assertThat(refreshedDetails.returnRequest().exchangeApproved()).isTrue();
+        assertThat(refreshedDetails.returnRequest().state().exchangeApproved()).isTrue();
 
         verify(orderReturnRequestRepository, times(2)).findFirstByParcel_IdAndStatusIn(eq(parcelId), anyCollection());
     }

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -497,11 +497,11 @@ class TrackViewServiceTest {
         assertThat(details.requiresAction()).isTrue();
         assertThat(details.returnRequest()).isNotNull();
         assertThat(details.returnRequest().requiresAction()).isTrue();
-        assertThat(details.returnRequest().canStartExchange()).isTrue();
-        assertThat(details.returnRequest().canCreateExchangeParcel()).isFalse();
-        assertThat(details.returnRequest().canConfirmReceipt()).isTrue();
-        assertThat(details.returnRequest().returnReceiptConfirmed()).isFalse();
-        assertThat(details.returnRequest().returnReceiptConfirmedAt()).isNull();
+        assertThat(details.returnRequest().availableActions().startExchange()).isTrue();
+        assertThat(details.returnRequest().availableActions().createExchangeParcel()).isFalse();
+        assertThat(details.returnRequest().availableActions().confirmReceipt()).isTrue();
+        assertThat(details.returnRequest().state().returnReceiptConfirmed()).isFalse();
+        assertThat(details.returnRequest().timestamps().returnReceiptConfirmedAt()).isNull();
         assertThat(details.lifecycle())
                 .extracting(stage -> stage.code())
                 .contains("OUTBOUND", "CUSTOMER_RETURN", "MERCHANT_ACCEPT_RETURN");
@@ -617,7 +617,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(83L, 17L);
 
         assertThat(details.returnRequest()).isNotNull();
-        assertThat(details.returnRequest().canCreateExchangeParcel()).isTrue();
+        assertThat(details.returnRequest().availableActions().createExchangeParcel()).isTrue();
     }
 
     @Test

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -39,6 +39,88 @@ describe('track-modal render', () => {
         };
     }
 
+    /**
+     * Преобразует тестовые данные старого формата в новую структуру, ожидаемую модулем.
+     * @param {Object} details исходные данные теста
+     * @returns {Object} нормализованный объект
+     */
+    function normalizeDetails(details) {
+        if (!details || typeof details !== 'object') {
+            return details;
+        }
+        const normalized = { ...details };
+        if ('returnRequest' in normalized) {
+            normalized.returnRequest = normalizeReturnRequest(normalized.returnRequest);
+        }
+        return normalized;
+    }
+
+    /**
+     * Обогащает заявку вложенными объектами (state/actions/timestamps) при отсутствии новых полей.
+     * @param {Object|null} request тестовая заявка
+     * @returns {Object|null} нормализованная заявка
+     */
+    function normalizeReturnRequest(request) {
+        if (!request || typeof request !== 'object') {
+            return request;
+        }
+        const stage = request.stage || request.state || 'CUSTOMER_RETURN';
+        const stageUpper = typeof stage === 'string' ? stage.toUpperCase() : '';
+        const mode = request.mode
+            || (stageUpper.includes('EXCHANGE')
+                ? 'EXCHANGE'
+                : (request.exchangeApproved || request.exchangeRequested ? 'EXCHANGE' : 'RETURN'));
+        const state = {
+            mode,
+            stage,
+            manualStageOverride: Boolean(request.manualStageOverride),
+            manualTrackOverride: Boolean(request.manualTrackOverride),
+            exchangeRequested: Boolean(request.exchangeRequested),
+            exchangeApproved: Boolean(request.exchangeApproved),
+            exchangeShipmentDispatched: Boolean(request.exchangeShipmentDispatched),
+            exchangeTrackNumber: request.exchangeTrackNumber || null,
+            returnReceiptConfirmed: Boolean(request.returnReceiptConfirmed),
+            ...request.state
+        };
+        const legacy = request.actionPermissions || {};
+        const mapLegacy = (key) => Boolean(legacy?.[key]);
+        const availableActions = {
+            startExchange: Boolean(request.canStartExchange ?? mapLegacy('allowConvertToExchange') ?? mapLegacy('allowLaunchExchange')),
+            createExchangeParcel: Boolean(request.canCreateExchangeParcel ?? mapLegacy('allowLaunchExchange')),
+            closeWithoutExchange: Boolean(request.canCloseWithoutExchange ?? mapLegacy('allowClose')),
+            reopenAsReturn: Boolean(request.canReopenAsReturn ?? mapLegacy('allowConvertToReturn')),
+            cancelExchange: Boolean(request.canCancelExchange ?? mapLegacy('allowClose')),
+            confirmReceipt: Boolean(request.canConfirmReceipt ?? mapLegacy('allowAcceptReverse') ?? mapLegacy('allowAccept')),
+            cancelExchangeUnavailableReason: request.cancelExchangeUnavailableReason || null,
+            ...request.availableActions
+        };
+        const timestamps = {
+            requestedAt: request.requestedAt || null,
+            createdAt: request.createdAt || null,
+            decisionAt: request.decisionAt || null,
+            closedAt: request.closedAt || null,
+            stageStartedAt: request.stageStartedAt || null,
+            stageUpdatedAt: request.stageUpdatedAt || null,
+            exchangeTrackAssignedAt: request.exchangeTrackAssignedAt || null,
+            returnReceiptConfirmedAt: request.returnReceiptConfirmedAt || null,
+            ...request.timestamps
+        };
+        return {
+            ...request,
+            state,
+            availableActions,
+            timestamps
+        };
+    }
+
+    /**
+     * Хелпер для рендеринга модалки с учётом нормализации данных.
+     * @param {Object} details исходные данные
+     */
+    function renderModal(details) {
+        global.window.trackModal.render(normalizeDetails(details));
+    }
+
     afterEach(() => {
         jest.clearAllMocks();
         document.body.innerHTML = '';
@@ -80,7 +162,7 @@ describe('track-modal render', () => {
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const content = global.document.getElementById('trackModalContent')
             || global.document.querySelector('.modal-body');
@@ -124,7 +206,7 @@ describe('track-modal render', () => {
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const lifecycleCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Жизненный цикл заказа');
@@ -241,7 +323,7 @@ status: 'Зарегистрирована',
             return Promise.resolve({ ok: true, headers, json: () => Promise.resolve({}) });
         });
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const buttons = document.querySelectorAll('button.track-chain__item');
         expect(buttons).toHaveLength(2);
@@ -336,7 +418,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -461,7 +543,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(initialData);
+        renderModal(initialData);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -541,7 +623,7 @@ status: 'Зарегистрирована',
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -603,7 +685,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -668,7 +750,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -733,7 +815,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -796,7 +878,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -857,7 +939,7 @@ status: 'Зарегистрирована',
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const button = document.querySelector('button.track-chain__item');
         expect(button).not.toBeNull();
@@ -957,7 +1039,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(initialData);
+        renderModal(initialData);
 
         const headers = { get: jest.fn(() => 'application/json') };
         global.fetch.mockResolvedValueOnce({
@@ -1011,7 +1093,7 @@ status: 'Зарегистрирована',
     test('confirms return receipt via API and updates table row', async () => {
         setupDom();
 
-        const payload = {
+        const payload = normalizeDetails({
             id: 14,
             number: 'BY000',
             deliveryService: 'Belpost',
@@ -1055,7 +1137,7 @@ status: 'Зарегистрирована',
             canRegisterReturn: false,
             lifecycle: [],
             requiresAction: false
-        };
+        });
 
         global.fetch.mockResolvedValueOnce({
             ok: true,
@@ -1098,7 +1180,7 @@ status: 'Зарегистрирована',
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const buttons = document.querySelectorAll('button.track-chain__item');
         expect(buttons).toHaveLength(1);
@@ -1140,7 +1222,7 @@ status: 'Зарегистрирована',
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const lifecycleCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Жизненный цикл заказа');
@@ -1223,7 +1305,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -1240,7 +1322,7 @@ status: 'Зарегистрирована',
         await Promise.resolve();
 
         expect(global.fetch).toHaveBeenCalledWith(
-            '/api/v1/tracks/12/returns/5/to-exchange',
+            '/api/v1/tracks/12/returns/5/exchange',
             expect.objectContaining({ method: 'POST' })
         );
         expect(global.notifyUser).toHaveBeenCalledWith('Заявка переведена в обмен', 'info');
@@ -1308,7 +1390,17 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
+
+        global.fetch.mockClear();
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            headers: { get: () => 'application/json' },
+            json: () => Promise.resolve({
+                details: normalizeDetails(data),
+                actionRequired: null
+            })
+        });
 
         const card = Array.from(document.querySelectorAll('section.card'))
             .find((item) => item.querySelector('h6')?.textContent === 'Обращение');
@@ -1322,7 +1414,7 @@ status: 'Зарегистрирована',
         await Promise.resolve();
 
         expect(global.fetch).toHaveBeenCalledWith(
-            '/api/v1/tracks/14/returns/6/exchange/launch',
+            '/api/v1/tracks/14/returns/6/exchange/parcel',
             expect.objectContaining({ method: 'POST' })
         );
         expect(global.notifyUser).toHaveBeenCalledWith('Обмен запущен', 'info');
@@ -1379,7 +1471,7 @@ status: 'Обмен запускается',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const card = Array.from(document.querySelectorAll('section.card'))
             .find((item) => item.querySelector('h6')?.textContent === 'Обращение');
@@ -1443,7 +1535,7 @@ status: 'Обмен запускается',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const returnCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -1501,7 +1593,7 @@ status: 'Зарегистрирована',
             requiresAction: true
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         await Promise.resolve();
 
@@ -1558,7 +1650,7 @@ status: 'Закрыта',
             requiresAction: false
         };
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         await Promise.resolve();
 
@@ -1636,7 +1728,7 @@ status: 'Закрыта',
             return Promise.resolve({ ok: true, headers, json: () => Promise.resolve({ history: [] }) });
         });
 
-        global.window.trackModal.render(data);
+        renderModal(data);
 
         const lifecycleHeading = Array.from(document.querySelectorAll('section.card h6'))
             .find((heading) => heading.textContent.includes('Жизненный цикл заказа'));


### PR DESCRIPTION
## Summary
- introduce structured return request DTO components for state, timestamps, and available actions
- update backend mappers, services, and telegram logic to populate the new structure
- adjust frontend widgets and tests to consume the new contract and reflect updated exchange endpoints

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_6901018a5cfc832d9c6af41efc934dad