### PR TITLE
Introduce return request workflow state machine

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -22,6 +22,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -660,12 +661,11 @@ public class CustomerTelegramService {
         String trackNumber = parcel != null ? parcel.getNumber() : null;
         String storeName = parcel != null && parcel.getStore() != null ? parcel.getStore().getName() : null;
         GlobalStatus parcelStatus = parcel != null ? parcel.getStatus() : null;
-        OrderReturnRequestStatus status = request.getStatus();
-
         boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
-        boolean canCloseWithoutExchange = status == OrderReturnRequestStatus.REGISTERED;
-        boolean canReopenAsReturn = orderReturnRequestService.canReopenAsReturn(request);
-        boolean canCancelExchange = orderReturnRequestService.canCancelExchange(request);
+        EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
+        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CANCEL_RETURN);
+        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.CONVERT_TO_RETURN);
+        boolean canCancelExchange = actions.contains(ReturnRequestAction.CANCEL_EXCHANGE);
         String cancelExchangeReason = orderReturnRequestService
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,6 +51,7 @@ public class OrderReturnRequestService {
     private final OrderEpisodeLifecycleService episodeLifecycleService;
     private final OrderExchangeService orderExchangeService;
     private final TrackViewCacheInvalidator trackViewCacheInvalidator;
+    private final ReturnRequestWorkflow returnRequestWorkflow;
 
     /**
      * Обновляет трек обратной отправки и комментарий активной заявки.
@@ -179,12 +181,14 @@ public class OrderReturnRequestService {
         request.setExchangeRequested(exchangeRequested);
         request.setStore(parcel.getStore());
         request.setResponsibleManager(user);
-        request.setMode(exchangeRequested ? ReturnRequestMode.EXCHANGE : ReturnRequestMode.RETURN);
+        ReturnRequestMode mode = exchangeRequested ? ReturnRequestMode.EXCHANGE : ReturnRequestMode.RETURN;
+        request.setMode(mode);
         request.setManualTrackOverride(normalizedReverse != null && !normalizedReverse.isBlank());
         request.setExchangeTrackNumber(null);
         request.setExchangeTrackAssignedAt(null);
         ZonedDateTime stageMoment = normalizedRequestedAt != null ? normalizedRequestedAt : request.getCreatedAt();
-        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        ReturnRequestStage initialStage = returnRequestWorkflow.initialStage(mode);
+        request.setStage(initialStage);
         request.setStageStartedAt(stageMoment);
         request.setStageUpdatedAt(stageMoment);
         request.setManualStageOverride(false);
@@ -233,13 +237,7 @@ public class OrderReturnRequestService {
         request.setDecisionAt(decisionMoment);
         request.setMode(ReturnRequestMode.EXCHANGE);
         request.setResponsibleManager(user);
-        if (request.getStage() != ReturnRequestStage.EXCHANGE_SHIPMENT) {
-            request.setStage(ReturnRequestStage.EXCHANGE_SHIPMENT);
-            request.setStageStartedAt(decisionMoment);
-        }
-        request.setStageUpdatedAt(decisionMoment);
-        request.setManualStageOverride(true);
-        request.snapshotHistory(true, user, decisionMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, user, decisionMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -275,15 +273,9 @@ public class OrderReturnRequestService {
                 .map(TrackParcel::getTimestamp)
                 .orElse(now);
         request.setResponsibleManager(user);
-        request.setManualStageOverride(true);
         request.setExchangeTrackNumber(Optional.ofNullable(replacement).map(TrackParcel::getNumber).orElse(null));
         request.setExchangeTrackAssignedAt(assignedMoment);
-        if (request.getStage() != ReturnRequestStage.EXCHANGE_SHIPMENT) {
-            request.setStage(ReturnRequestStage.EXCHANGE_SHIPMENT);
-            request.setStageStartedAt(assignedMoment);
-        }
-        request.setStageUpdatedAt(assignedMoment);
-        request.snapshotHistory(true, user, assignedMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, user, assignedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Создана обменная посылка {} для заявки {}",
@@ -309,13 +301,7 @@ public class OrderReturnRequestService {
         request.setClosedAt(closeMoment);
         request.setMode(ReturnRequestMode.RETURN);
         request.setResponsibleManager(user);
-        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
-            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
-            request.setStageStartedAt(closeMoment);
-        }
-        request.setStageUpdatedAt(closeMoment);
-        request.setManualStageOverride(true);
-        request.snapshotHistory(true, user, closeMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, user, closeMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -382,13 +368,7 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(user);
         request.setExchangeTrackNumber(null);
         request.setExchangeTrackAssignedAt(null);
-        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
-            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
-            request.setStageStartedAt(cancelMoment);
-        }
-        request.setStageUpdatedAt(cancelMoment);
-        request.setManualStageOverride(true);
-        request.snapshotHistory(true, user, cancelMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, user, cancelMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -425,13 +405,7 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(user);
         request.setExchangeTrackNumber(null);
         request.setExchangeTrackAssignedAt(null);
-        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
-            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
-            request.setStageStartedAt(reopenMoment);
-        }
-        request.setStageUpdatedAt(reopenMoment);
-        request.setManualStageOverride(true);
-        request.snapshotHistory(true, user, reopenMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, user, reopenMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -509,6 +483,14 @@ public class OrderReturnRequestService {
         }
         OrderEpisode episode = request.getEpisode();
         Long episodeId = episode != null ? episode.getId() : null;
+        ReturnRequestStage currentStage = request.getStage() != null
+                ? request.getStage()
+                : ReturnRequestStage.CUSTOMER_RETURN;
+        ReturnRequestStage normalizedStage = returnRequestWorkflow
+                .adjustStageForMode(ReturnRequestMode.EXCHANGE, currentStage);
+        if (!returnRequestWorkflow.canTransition(ReturnRequestMode.EXCHANGE, normalizedStage, ReturnRequestStage.EXCHANGE_SHIPMENT)) {
+            return false;
+        }
         if (episodeId == null) {
             return true;
         }
@@ -632,6 +614,19 @@ public class OrderReturnRequestService {
     }
 
     /**
+     * Возвращает перечень действий, доступных пользователю для текущей заявки.
+     *
+     * @param request заявка на возврат/обмен
+     * @return множество доступных действий
+     */
+    @Transactional(readOnly = true)
+    public EnumSet<ReturnRequestAction> resolveAvailableActions(OrderReturnRequest request) {
+        EnumSet<ReturnRequestAction> actions = returnRequestWorkflow.resolveBaseActions(request);
+        actions.removeIf(action -> !isActionAllowed(action, request));
+        return actions;
+    }
+
+    /**
      * Определяет, считается ли обменная посылка отправленной.
      *
      * @param parcel обменная посылка
@@ -645,6 +640,20 @@ public class OrderReturnRequestService {
         GlobalStatus status = parcel.getStatus();
         boolean finalStatus = status != null && status.isFinal();
         return hasTrack || finalStatus;
+    }
+
+    /**
+     * Проверяет, разрешено ли действие для конкретной заявки с учётом всех ограничений.
+     */
+    private boolean isActionAllowed(ReturnRequestAction action, OrderReturnRequest request) {
+        if (action == null || request == null) {
+            return false;
+        }
+        return switch (action) {
+            case CANCEL_RETURN -> request.getStatus() == OrderReturnRequestStatus.REGISTERED;
+            case CANCEL_EXCHANGE -> canCancelExchange(request);
+            case CONVERT_TO_RETURN -> canReopenAsReturn(request);
+        };
     }
 
     /**
@@ -748,13 +757,7 @@ public class OrderReturnRequestService {
         request.setReturnReceiptConfirmed(true);
         request.setReturnReceiptConfirmedAt(now);
         request.setResponsibleManager(actor);
-        request.setManualStageOverride(true);
-        if (request.getStage() != ReturnRequestStage.MERCHANT_ACCEPT_RETURN) {
-            request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
-            request.setStageStartedAt(now);
-        }
-        request.setStageUpdatedAt(now);
-        request.snapshotHistory(true, actor, now);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, actor, now);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
 
 /**
  * Преобразует заявки на возврат в DTO для вкладки «Требуют действия».
@@ -52,13 +53,14 @@ public class ReturnRequestActionMapper {
         OrderReturnRequestStatus status = request.getStatus();
 
         boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
-        boolean canCloseWithoutExchange = status == OrderReturnRequestStatus.REGISTERED;
+        EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
+        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CANCEL_RETURN);
         String cancelExchangeReason = orderReturnRequestService
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);
         boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
-        boolean canReopenAsReturn = orderReturnRequestService.canReopenAsReturn(request);
-        boolean canCancelExchange = orderReturnRequestService.canCancelExchange(request);
+        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.CONVERT_TO_RETURN);
+        boolean canCancelExchange = actions.contains(ReturnRequestAction.CANCEL_EXCHANGE);
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
         ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -1,0 +1,200 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
+import com.project.tracking_system.entity.User;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Управляет допустимыми переходами стадий и вычислением действий для заявок возврата/обмена.
+ * <p>
+ * Класс концентрирует правила, чтобы сервисы могли переиспользовать единую таблицу переходов
+ * и соблюсти принцип единой ответственности.
+ * </p>
+ */
+@Component
+public class ReturnRequestWorkflow {
+
+    private final Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> transitionTable;
+
+    /**
+     * Создаёт workflow с таблицей допустимых переходов.
+     */
+    public ReturnRequestWorkflow() {
+        this.transitionTable = buildTransitionTable();
+    }
+
+    /**
+     * Переводит заявку на новую стадию, проверяя допустимость перехода.
+     *
+     * @param request          заявка, чья стадия изменяется
+     * @param targetStage      стадия назначения
+     * @param manualTransition признак ручного действия менеджера
+     * @param actor            пользователь, выполнивший действие
+     * @param moment           момент фиксации события (UTC)
+     */
+    public void transitionToStage(OrderReturnRequest request,
+                                  ReturnRequestStage targetStage,
+                                  boolean manualTransition,
+                                  User actor,
+                                  ZonedDateTime moment) {
+        if (request == null || targetStage == null) {
+            return;
+        }
+        ZonedDateTime effectiveMoment = moment != null ? moment : ZonedDateTime.now(ZoneOffset.UTC);
+        ReturnRequestMode mode = safeMode(request.getMode());
+        ReturnRequestStage currentStage = safeStage(request.getStage());
+        ReturnRequestStage effectiveCurrent = adjustStageForMode(mode, currentStage);
+        if (!canTransition(mode, effectiveCurrent, targetStage)) {
+            throw new IllegalStateException(String.format(
+                    "Недопустимый переход стадии %s→%s для режима %s",
+                    effectiveCurrent, targetStage, mode
+            ));
+        }
+        boolean stageChanged = !Objects.equals(request.getStage(), targetStage);
+        if (stageChanged) {
+            request.setStage(targetStage);
+            request.setStageStartedAt(effectiveMoment);
+        }
+        request.setStageUpdatedAt(effectiveMoment);
+        if (manualTransition) {
+            request.setManualStageOverride(true);
+        }
+        request.snapshotHistory(manualTransition, actor, effectiveMoment);
+    }
+
+    /**
+     * Определяет, допустим ли переход между стадиями в заданном режиме.
+     *
+     * @param mode        режим обработки заявки
+     * @param fromStage   исходная стадия
+     * @param targetStage целевая стадия
+     * @return {@code true}, если переход разрешён
+     */
+    public boolean canTransition(ReturnRequestMode mode,
+                                 ReturnRequestStage fromStage,
+                                 ReturnRequestStage targetStage) {
+        if (mode == null || fromStage == null || targetStage == null) {
+            return false;
+        }
+        if (Objects.equals(fromStage, targetStage)) {
+            return true;
+        }
+        Map<ReturnRequestStage, Set<ReturnRequestStage>> modeTransitions = transitionTable.get(mode);
+        if (modeTransitions == null) {
+            return false;
+        }
+        Set<ReturnRequestStage> allowedTargets = modeTransitions.get(fromStage);
+        if (allowedTargets == null || allowedTargets.isEmpty()) {
+            return allowedStages(mode).contains(targetStage);
+        }
+        return allowedTargets.contains(targetStage);
+    }
+
+    /**
+     * Возвращает начальную стадию для режима.
+     */
+    public ReturnRequestStage initialStage(ReturnRequestMode mode) {
+        if (mode == ReturnRequestMode.EXCHANGE) {
+            return ReturnRequestStage.CUSTOMER_RETURN;
+        }
+        return ReturnRequestStage.CUSTOMER_RETURN;
+    }
+
+    /**
+     * Нормализует стадию под целевой режим, чтобы переходы были валидны.
+     *
+     * @param mode   целевой режим заявки
+     * @param stage  текущая стадия
+     * @return стадия, допустимая для режима
+     */
+    public ReturnRequestStage adjustStageForMode(ReturnRequestMode mode, ReturnRequestStage stage) {
+        ReturnRequestStage safeStage = stage != null ? stage : initialStage(mode);
+        if (safeStage.supportsMode(mode)) {
+            return safeStage;
+        }
+        if (mode == ReturnRequestMode.RETURN) {
+            return ReturnRequestStage.MERCHANT_ACCEPT_RETURN;
+        }
+        return ReturnRequestStage.CUSTOMER_RETURN;
+    }
+
+    /**
+     * Вычисляет базовый набор действий, доступных по текущему состоянию заявки.
+     *
+     * @param request заявка на возврат/обмен
+     * @return множество потенциально доступных действий
+     */
+    public EnumSet<ReturnRequestAction> resolveBaseActions(OrderReturnRequest request) {
+        if (request == null) {
+            return EnumSet.noneOf(ReturnRequestAction.class);
+        }
+        OrderReturnRequestStatus status = request.getStatus();
+        ReturnRequestStage stage = safeStage(request.getStage());
+        EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
+        if (status == OrderReturnRequestStatus.REGISTERED) {
+            actions.add(ReturnRequestAction.CANCEL_RETURN);
+        }
+        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED
+                && stage != ReturnRequestStage.EXCHANGE_DELIVERY) {
+            actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
+            actions.add(ReturnRequestAction.CONVERT_TO_RETURN);
+        }
+        return actions;
+    }
+
+    private Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> buildTransitionTable() {
+        Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> table = new EnumMap<>(ReturnRequestMode.class);
+
+        Map<ReturnRequestStage, Set<ReturnRequestStage>> returnTransitions = new EnumMap<>(ReturnRequestStage.class);
+        returnTransitions.put(ReturnRequestStage.CUSTOMER_RETURN, EnumSet.of(ReturnRequestStage.MERCHANT_ACCEPT_RETURN));
+        returnTransitions.put(ReturnRequestStage.MERCHANT_ACCEPT_RETURN, EnumSet.of(ReturnRequestStage.MERCHANT_ACCEPT_RETURN));
+        table.put(ReturnRequestMode.RETURN, returnTransitions);
+
+        Map<ReturnRequestStage, Set<ReturnRequestStage>> exchangeTransitions = new EnumMap<>(ReturnRequestStage.class);
+        exchangeTransitions.put(ReturnRequestStage.CUSTOMER_RETURN, EnumSet.of(
+                ReturnRequestStage.MERCHANT_ACCEPT_RETURN,
+                ReturnRequestStage.EXCHANGE_SHIPMENT
+        ));
+        exchangeTransitions.put(ReturnRequestStage.MERCHANT_ACCEPT_RETURN, EnumSet.of(ReturnRequestStage.EXCHANGE_SHIPMENT));
+        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_SHIPMENT, EnumSet.of(
+                ReturnRequestStage.EXCHANGE_DELIVERY,
+                ReturnRequestStage.MERCHANT_ACCEPT_RETURN
+        ));
+        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_DELIVERY, EnumSet.of(ReturnRequestStage.EXCHANGE_DELIVERY));
+        table.put(ReturnRequestMode.EXCHANGE, exchangeTransitions);
+
+        return table;
+    }
+
+    private Set<ReturnRequestStage> allowedStages(ReturnRequestMode mode) {
+        EnumSet<ReturnRequestStage> allowed = EnumSet.noneOf(ReturnRequestStage.class);
+        for (ReturnRequestStage stage : ReturnRequestStage.values()) {
+            if (stage.supportsMode(mode)) {
+                allowed.add(stage);
+            }
+        }
+        return Collections.unmodifiableSet(allowed);
+    }
+
+    private ReturnRequestMode safeMode(ReturnRequestMode mode) {
+        return mode != null ? mode : ReturnRequestMode.RETURN;
+    }
+
+    private ReturnRequestStage safeStage(ReturnRequestStage stage) {
+        return stage != null ? stage : ReturnRequestStage.CUSTOMER_RETURN;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -14,6 +14,7 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderEpisode;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.PostalServiceType;
@@ -36,6 +37,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -476,9 +478,10 @@ public class TrackViewService {
      */
     private OrderReturnRequestDto mapReturnRequest(OrderReturnRequest request, ZoneId userZone) {
         boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
-        boolean canCloseWithoutExchange = request.getStatus() == OrderReturnRequestStatus.REGISTERED;
-        boolean canReopenAsReturn = orderReturnRequestService.canReopenAsReturn(request);
-        boolean canCancelExchange = orderReturnRequestService.canCancelExchange(request);
+        EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
+        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CANCEL_RETURN);
+        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.CONVERT_TO_RETURN);
+        boolean canCancelExchange = actions.contains(ReturnRequestAction.CANCEL_EXCHANGE);
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
         boolean canCreateExchangeParcel = orderReturnRequestService.canCreateExchangeParcel(request);
         String requestedAt = formatNullableTimestamp(request.getRequestedAt(), userZone);

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -20,6 +20,7 @@ import com.project.tracking_system.service.order.OrderReturnRequestService;
 import com.project.tracking_system.service.telegram.FullNameValidator;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import org.springframework.security.access.AccessDeniedException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -69,6 +71,12 @@ class CustomerTelegramServiceTest {
 
     @InjectMocks
     private CustomerTelegramService customerTelegramService;
+
+    @BeforeEach
+    void initDefaultActions() {
+        when(orderReturnRequestService.resolveAvailableActions(any()))
+                .thenReturn(EnumSet.noneOf(ReturnRequestAction.class));
+    }
 
     /**
      * Убеждаемся, что при подтверждении существующего ФИО источник обновляется до USER_CONFIRMED.

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.security.access.AccessDeniedException;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -67,11 +68,13 @@ class OrderReturnRequestServiceTest {
     private OrderReturnRequestService service;
 
     private User user;
+    private ReturnRequestWorkflow workflow;
 
     @BeforeEach
     void setUp() {
+        workflow = new ReturnRequestWorkflow();
         service = new OrderReturnRequestService(repository, actionRequestRepository, trackParcelService,
-                episodeLifecycleService, orderExchangeService, trackViewCacheInvalidator);
+                episodeLifecycleService, orderExchangeService, trackViewCacheInvalidator, workflow);
         user = new User();
         user.setId(5L);
     }
@@ -753,6 +756,39 @@ class OrderReturnRequestServiceTest {
         verify(repository, never()).save(any());
         verify(orderExchangeService, never()).cancelExchangeParcel(any(), any());
         verify(episodeLifecycleService, never()).decrementExchangeCount(any());
+    }
+
+    @Test
+    void resolveAvailableActions_ReturnsCancelForRegisteredRequest() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        request.setMode(ReturnRequestMode.RETURN);
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(ReturnRequestAction.CANCEL_RETURN);
+        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.CONVERT_TO_RETURN);
+    }
+
+    @Test
+    void resolveAvailableActions_ExcludesExchangeActionsWhenShipmentDispatched() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+
+        TrackParcel replacement = new TrackParcel();
+        replacement.setNumber("TRK123");
+        replacement.setStatus(GlobalStatus.IN_TRANSIT);
+
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(replacement));
+        when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
+                .thenThrow(new IllegalStateException("Отмена недоступна"));
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.CONVERT_TO_RETURN);
     }
 
     private OrderReturnRequest buildExchangeRequest(Long id, TrackParcel parcel) {

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -1,0 +1,67 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
+import com.project.tracking_system.entity.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Тесты таблицы переходов стадий заявок на возврат/обмен.
+ */
+class ReturnRequestWorkflowTest {
+
+    private final ReturnRequestWorkflow workflow = new ReturnRequestWorkflow();
+
+    @Test
+    void transitionToStage_AllowsExchangeShipmentFromMerchantStage() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        User manager = new User();
+        manager.setId(42L);
+        ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
+
+        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, manager, moment);
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        assertThat(request.getStageStartedAt()).isEqualTo(moment);
+        assertThat(request.getStageUpdatedAt()).isEqualTo(moment);
+        assertThat(request.isManualStageOverride()).isTrue();
+        assertThat(request.getHistoryEntries()).hasSize(1);
+    }
+
+    @Test
+    void transitionToStage_AllowsDirectExchangeLaunchFromCustomerStage() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
+
+        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, null, moment);
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        assertThat(request.getHistoryEntries()).hasSize(1);
+    }
+
+    @Test
+    void transitionToStage_ThrowsWhenTargetNotAllowedForMode() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+
+        assertThatThrownBy(() -> workflow.transitionToStage(
+                request,
+                ReturnRequestStage.EXCHANGE_DELIVERY,
+                true,
+                null,
+                ZonedDateTime.now(ZoneOffset.UTC)
+        )).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
@@ -13,6 +13,7 @@ import com.project.tracking_system.service.admin.ApplicationSettingsService;
 import com.project.tracking_system.service.order.OrderEpisodeLifecycleService;
 import com.project.tracking_system.service.order.OrderExchangeService;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.order.ReturnRequestWorkflow;
 import com.project.tracking_system.service.user.UserService;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackStatusEventService;
@@ -230,9 +231,15 @@ class TrackViewCacheEvictionIntegrationTest {
                                                             TrackParcelService trackParcelService,
                                                             OrderEpisodeLifecycleService episodeLifecycleService,
                                                             OrderExchangeService orderExchangeService,
-                                                            TrackViewCacheInvalidator trackViewCacheInvalidator) {
+                                                            TrackViewCacheInvalidator trackViewCacheInvalidator,
+                                                            ReturnRequestWorkflow returnRequestWorkflow) {
             return new OrderReturnRequestService(repository, actionRepository, trackParcelService,
-                    episodeLifecycleService, orderExchangeService, trackViewCacheInvalidator);
+                    episodeLifecycleService, orderExchangeService, trackViewCacheInvalidator, returnRequestWorkflow);
+        }
+
+        @Bean
+        ReturnRequestWorkflow returnRequestWorkflow() {
+            return new ReturnRequestWorkflow();
         }
 
         /**

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -10,6 +10,7 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderEpisode;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.PostalServiceType;
 import com.project.tracking_system.entity.Store;
 import com.project.tracking_system.entity.TrackParcel;
@@ -30,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,8 +67,8 @@ class TrackViewServiceTest {
         when(orderReturnRequestService.findCurrentForParcel(anyLong())).thenReturn(Optional.empty());
         when(orderExchangeService.findLatestExchangeParcel(any())).thenReturn(Optional.empty());
         when(orderReturnRequestService.getExchangeCancellationBlockReason(any())).thenReturn(Optional.empty());
-        when(orderReturnRequestService.canReopenAsReturn(any())).thenReturn(false);
-        when(orderReturnRequestService.canCancelExchange(any())).thenReturn(false);
+        when(orderReturnRequestService.resolveAvailableActions(any()))
+                .thenReturn(EnumSet.noneOf(ReturnRequestAction.class));
         when(orderReturnRequestService.canConfirmReceipt(any())).thenReturn(false);
     }
 
@@ -489,6 +491,8 @@ class TrackViewServiceTest {
         when(orderReturnRequestService.canStartExchange(request)).thenReturn(true);
         when(orderReturnRequestService.canConfirmReceipt(request)).thenReturn(true);
         when(orderReturnRequestService.canCreateExchangeParcel(request)).thenReturn(false);
+        when(orderReturnRequestService.resolveAvailableActions(request))
+                .thenReturn(EnumSet.of(ReturnRequestAction.CANCEL_RETURN));
         when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
 
         TrackDetailsDto details = service.getTrackDetails(81L, 15L);


### PR DESCRIPTION
## Summary
- add a dedicated `ReturnRequestWorkflow` component to describe stage transitions and base actions for return/exchange requests
- refactor `OrderReturnRequestService` and dependent mappers/services to consume the workflow, centralize stage changes, and surface available actions
- extend unit and integration coverage with workflow-specific tests and updates to existing suites

## Testing
- mvn test *(fails: dependency resolution error from jitpack while downloading io.github.bucket4j:bucket4j-core)*

------
https://chatgpt.com/codex/tasks/task_e_69010fec7bfc832db81eec78096935e6