### PR TITLE
Add idempotent return command logging

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnsController.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnsController.java
@@ -5,9 +5,9 @@ import com.project.tracking_system.dto.ReturnRequestAvailableActionsDto;
 import com.project.tracking_system.dto.ReturnRequestCommandRequest;
 import com.project.tracking_system.dto.ReturnRequestDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
-import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.order.ReturnRequestCommandService;
 import com.project.tracking_system.service.order.ReturnRequestMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +40,7 @@ public class ReturnsController {
 
     private final OrderReturnRequestService orderReturnRequestService;
     private final ReturnRequestMapper returnRequestMapper;
+    private final ReturnRequestCommandService returnRequestCommandService;
 
     /**
      * Возвращает карточку заявки на возврат.
@@ -117,35 +118,13 @@ public class ReturnsController {
                                            @RequestBody @Valid ReturnRequestCommandRequest command,
                                            @AuthenticationPrincipal User user) {
         ensureAuthenticated(user);
-        OrderReturnRequest request = loadOwnedRequest(id, user);
         ReturnRequestCommandType commandType = ReturnRequestCommandType.fromCode(command.command());
         if (commandType == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Неизвестная команда управления заявкой");
         }
-        Long parcelId = resolveParcelId(request);
         ZoneId userZone = resolveUserZone(user);
         try {
-            return switch (commandType) {
-                case START_EXCHANGE -> map(orderReturnRequestService.approveExchange(id, parcelId, user), userZone);
-                case CREATE_EXCHANGE_PARCEL -> {
-                    orderReturnRequestService.createExchangeParcel(id, parcelId, user);
-                    yield map(orderReturnRequestService.getOwnedRequest(id, user), userZone);
-                }
-                case CLOSE -> map(orderReturnRequestService.closeWithoutExchange(id, parcelId, user), userZone);
-                case CONFIRM_RECEIPT -> map(orderReturnRequestService.confirmReturnProcessing(id, parcelId, user), userZone);
-                case UPDATE_DETAILS -> {
-                    orderReturnRequestService.updateReverseTrackAndComment(
-                            id,
-                            parcelId,
-                            user,
-                            command.reverseTrackNumber(),
-                            command.comment()
-                    );
-                    yield map(orderReturnRequestService.getOwnedRequest(id, user), userZone);
-                }
-                case REOPEN -> map(orderReturnRequestService.reopenAsReturn(id, parcelId, user), userZone);
-                case CANCEL_EXCHANGE -> map(orderReturnRequestService.cancelExchange(id, parcelId, user), userZone);
-            };
+            return returnRequestCommandService.executeCommand(id, commandType, command, user, userZone);
         } catch (AccessDeniedException ex) {
             throw ex;
         } catch (IllegalArgumentException ex) {
@@ -184,17 +163,6 @@ public class ReturnsController {
      */
     private ReturnRequestDto map(OrderReturnRequest request, ZoneId userZone) {
         return returnRequestMapper.toDto(request, userZone);
-    }
-
-    /**
-     * Определяет идентификатор посылки, связанной с заявкой.
-     */
-    private Long resolveParcelId(OrderReturnRequest request) {
-        TrackParcel parcel = request.getParcel();
-        if (parcel == null || parcel.getId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Заявка не привязана к посылке");
-        }
-        return parcel.getId();
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/dto/ReturnRequestCommandRequest.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRequestCommandRequest.java
@@ -5,11 +5,13 @@ import jakarta.validation.constraints.NotBlank;
 /**
  * Запрос на выполнение команды с заявкой возврата/обмена.
  *
+ * @param idempotencyKey     ключ идемпотентности для защиты от повторов
  * @param command            строковый код команды
  * @param reverseTrackNumber новый обратный трек (для команд обновления деталей)
  * @param comment            дополнительный комментарий
  */
-public record ReturnRequestCommandRequest(@NotBlank String command,
+public record ReturnRequestCommandRequest(@NotBlank String idempotencyKey,
+                                          @NotBlank String command,
                                           String reverseTrackNumber,
                                           String comment) {
 }

--- a/src/main/java/com/project/tracking_system/entity/ReturnCommandLog.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnCommandLog.java
@@ -57,9 +57,12 @@ public class ReturnCommandLog {
 
     /**
      * Снимок ответа клиенту после выполнения команды.
+     * <p>
+     * Поле остаётся пустым, пока команда выполняется, и заполняется после успешного завершения.
+     * </p>
      */
     @Lob
-    @Column(name = "response_snapshot", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "response_snapshot", columnDefinition = "TEXT")
     private String responseSnapshot;
 
     /**

--- a/src/main/java/com/project/tracking_system/entity/ReturnCommandLog.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnCommandLog.java
@@ -1,0 +1,126 @@
+package com.project.tracking_system.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * Журнал выполнения команд по заявкам возвратов.
+ * <p>
+ * Сущность хранит ключ идемпотентности, тип действия и хеш полезной нагрузки,
+ * что позволяет выявлять повторные и конфликтующие команды. Снимок ответа
+ * сохраняется в виде JSON, чтобы повторные вызовы возвращали идентичный
+ * результат независимо от последующих изменений заявки.
+ * </p>
+ */
+@Entity
+@Table(name = "tb_return_command_logs",
+        uniqueConstraints = @UniqueConstraint(name = "ux_return_command_log_key",
+                columnNames = {"request_id", "idempotency_key"}))
+public class ReturnCommandLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * Идентификатор заявки, к которой относится команда.
+     */
+    @Column(name = "request_id", nullable = false)
+    private Long requestId;
+
+    /**
+     * Ключ идемпотентности, предоставленный клиентом.
+     */
+    @Column(name = "idempotency_key", nullable = false, length = 255)
+    private String idempotencyKey;
+
+    /**
+     * Код выполненной команды.
+     */
+    @Column(name = "action", nullable = false, length = 100)
+    private String action;
+
+    /**
+     * Хеш полезной нагрузки, используемый для обнаружения конфликтов.
+     */
+    @Column(name = "payload_hash", nullable = false, length = 64)
+    private String payloadHash;
+
+    /**
+     * Снимок ответа клиенту после выполнения команды.
+     */
+    @Lob
+    @Column(name = "response_snapshot", nullable = false, columnDefinition = "TEXT")
+    private String responseSnapshot;
+
+    /**
+     * Момент записи выполнения команды.
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt = ZonedDateTime.now(ZoneOffset.UTC);
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(Long requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getPayloadHash() {
+        return payloadHash;
+    }
+
+    public void setPayloadHash(String payloadHash) {
+        this.payloadHash = payloadHash;
+    }
+
+    public String getResponseSnapshot() {
+        return responseSnapshot;
+    }
+
+    public void setResponseSnapshot(String responseSnapshot) {
+        this.responseSnapshot = responseSnapshot;
+    }
+
+    public ZonedDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/project/tracking_system/repository/ReturnCommandLogRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/ReturnCommandLogRepository.java
@@ -1,0 +1,21 @@
+package com.project.tracking_system.repository;
+
+import com.project.tracking_system.entity.ReturnCommandLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Репозиторий журнала выполнения команд возвратов.
+ */
+public interface ReturnCommandLogRepository extends JpaRepository<ReturnCommandLog, Long> {
+
+    /**
+     * Находит запись журнала по идентификатору заявки и ключу идемпотентности.
+     *
+     * @param requestId       идентификатор заявки
+     * @param idempotencyKey  ключ идемпотентности
+     * @return найденная запись или {@link Optional#empty()}, если команда не выполнялась
+     */
+    Optional<ReturnCommandLog> findFirstByRequestIdAndIdempotencyKey(Long requestId, String idempotencyKey);
+}

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -12,6 +12,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.ReturnCommandLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -67,19 +68,14 @@ public class ReturnRequestCommandService {
         String normalizedKey = command.idempotencyKey().trim();
         String payloadHash = computePayloadHash(commandType, command);
 
-        Optional<ReturnCommandLog> existingLog = returnCommandLogRepository
-                .findFirstByRequestIdAndIdempotencyKey(requestId, normalizedKey);
-        if (existingLog.isPresent()) {
-            ReturnCommandLog logEntry = existingLog.get();
-            if (!payloadHash.equals(logEntry.getPayloadHash())) {
-                throw new IllegalStateException("Команда с таким ключом уже выполнена с другими данными");
-            }
+        ReturnCommandLog logEntry = reserveLogEntry(requestId, normalizedKey, commandType, payloadHash);
+        if (logEntry.getResponseSnapshot() != null) {
             return restoreResponse(logEntry);
         }
 
         OrderReturnRequest updated = performCommand(commandType, command, user, requestId, parcelId);
         ReturnRequestDto response = returnRequestMapper.toDto(updated, userZone);
-        persistLogEntry(requestId, normalizedKey, commandType, payloadHash, response);
+        completeLogEntry(logEntry, response);
         return response;
     }
 
@@ -152,21 +148,56 @@ public class ReturnRequestCommandService {
     }
 
     /**
-     * Создаёт и сохраняет запись журнала о выполненной команде.
+     * Завершает запись журнала, добавляя снимок ответа после успешного выполнения команды.
      */
-    private void persistLogEntry(Long requestId,
-                                 String idempotencyKey,
-                                 ReturnRequestCommandType type,
-                                 String payloadHash,
-                                 ReturnRequestDto response) {
+    private void completeLogEntry(ReturnCommandLog logEntry, ReturnRequestDto response) {
+        logEntry.setResponseSnapshot(serializeResponse(response));
+        returnCommandLogRepository.saveAndFlush(logEntry);
+        log.info("Зафиксировано выполнение команды {} по заявке {}", logEntry.getAction(), logEntry.getRequestId());
+    }
+
+    /**
+     * Резервирует запись журнала под выполняемую команду или возвращает существующий результат.
+     */
+    private ReturnCommandLog reserveLogEntry(Long requestId,
+                                             String idempotencyKey,
+                                             ReturnRequestCommandType type,
+                                             String payloadHash) {
+        Optional<ReturnCommandLog> existingLog = returnCommandLogRepository
+                .findFirstByRequestIdAndIdempotencyKey(requestId, idempotencyKey);
+        if (existingLog.isPresent()) {
+            ReturnCommandLog logEntry = existingLog.get();
+            validatePayloadMatches(payloadHash, logEntry);
+            return logEntry;
+        }
+
         ReturnCommandLog logEntry = new ReturnCommandLog();
         logEntry.setRequestId(requestId);
         logEntry.setIdempotencyKey(idempotencyKey);
         logEntry.setAction(type.name());
         logEntry.setPayloadHash(payloadHash);
-        logEntry.setResponseSnapshot(serializeResponse(response));
-        returnCommandLogRepository.save(logEntry);
-        log.info("Зафиксировано выполнение команды {} по заявке {}", type, requestId);
+
+        try {
+            return returnCommandLogRepository.saveAndFlush(logEntry);
+        } catch (DataIntegrityViolationException ex) {
+            ReturnCommandLog concurrentLog = returnCommandLogRepository
+                    .findFirstByRequestIdAndIdempotencyKey(requestId, idempotencyKey)
+                    .orElseThrow(() -> ex);
+            validatePayloadMatches(payloadHash, concurrentLog);
+            if (concurrentLog.getResponseSnapshot() == null) {
+                throw new IllegalStateException("Команда с таким ключом уже выполняется, повторите позже", ex);
+            }
+            return concurrentLog;
+        }
+    }
+
+    /**
+     * Проверяет соответствие хеша полезной нагрузки ранее выполненной команде.
+     */
+    private void validatePayloadMatches(String payloadHash, ReturnCommandLog logEntry) {
+        if (!payloadHash.equals(logEntry.getPayloadHash())) {
+            throw new IllegalStateException("Команда с таким ключом уже выполнена с другими данными");
+        }
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -1,0 +1,224 @@
+package com.project.tracking_system.service.order;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.tracking_system.controller.ReturnRequestCommandType;
+import com.project.tracking_system.dto.ReturnRequestCommandRequest;
+import com.project.tracking_system.dto.ReturnRequestDto;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.ReturnCommandLog;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.ReturnCommandLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.ZoneId;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * Сервис идемпотентного выполнения команд по заявкам возврата.
+ * <p>
+ * Компонент инкапсулирует проверку повторов, вычисление хеша полезной нагрузки
+ * и фиксацию результата в журнале. Это позволяет централизовать все правила
+ * идемпотентности и не дублировать их в REST-контроллере или других слоях.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReturnRequestCommandService {
+
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    private final OrderReturnRequestService orderReturnRequestService;
+    private final ReturnRequestMapper returnRequestMapper;
+    private final ReturnCommandLogRepository returnCommandLogRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Выполняет команду с учётом идемпотентности и возвращает DTO заявки.
+     *
+     * @param requestId идентификатор заявки
+     * @param commandType тип выполняемой команды
+     * @param command данные запроса, включая ключ идемпотентности
+     * @param user текущий пользователь
+     * @param userZone временная зона пользователя для форматирования дат
+     * @return DTO заявки после выполнения команды или сохранённый ранее результат
+     */
+    @Transactional
+    public ReturnRequestDto executeCommand(Long requestId,
+                                           ReturnRequestCommandType commandType,
+                                           ReturnRequestCommandRequest command,
+                                           User user,
+                                           ZoneId userZone) {
+        validateArguments(requestId, commandType, command, user);
+
+        OrderReturnRequest context = orderReturnRequestService.getOwnedRequest(requestId, user);
+        Long parcelId = resolveParcelId(context);
+
+        String normalizedKey = command.idempotencyKey().trim();
+        String payloadHash = computePayloadHash(commandType, command);
+
+        Optional<ReturnCommandLog> existingLog = returnCommandLogRepository
+                .findFirstByRequestIdAndIdempotencyKey(requestId, normalizedKey);
+        if (existingLog.isPresent()) {
+            ReturnCommandLog logEntry = existingLog.get();
+            if (!payloadHash.equals(logEntry.getPayloadHash())) {
+                throw new IllegalStateException("Команда с таким ключом уже выполнена с другими данными");
+            }
+            return restoreResponse(logEntry);
+        }
+
+        OrderReturnRequest updated = performCommand(commandType, command, user, requestId, parcelId);
+        ReturnRequestDto response = returnRequestMapper.toDto(updated, userZone);
+        persistLogEntry(requestId, normalizedKey, commandType, payloadHash, response);
+        return response;
+    }
+
+    /**
+     * Проверяет корректность входных параметров запроса.
+     */
+    private void validateArguments(Long requestId,
+                                   ReturnRequestCommandType commandType,
+                                   ReturnRequestCommandRequest command,
+                                   User user) {
+        if (requestId == null) {
+            throw new IllegalArgumentException("Не указан идентификатор заявки");
+        }
+        if (commandType == null) {
+            throw new IllegalArgumentException("Неизвестная команда управления заявкой");
+        }
+        if (command == null) {
+            throw new IllegalArgumentException("Не передано тело команды");
+        }
+        if (!StringUtils.hasText(command.idempotencyKey())) {
+            throw new IllegalArgumentException("Не указан идемпотентный ключ команды");
+        }
+        if (user == null) {
+            throw new IllegalArgumentException("Не указан пользователь");
+        }
+    }
+
+    /**
+     * Вычисляет хеш полезной нагрузки команды.
+     */
+    private String computePayloadHash(ReturnRequestCommandType type, ReturnRequestCommandRequest command) {
+        MessageDigest digest = getDigest();
+        digest.update(type.name().getBytes(StandardCharsets.UTF_8));
+        digest.update(nullSafeBytes(command.command()));
+        digest.update(nullSafeBytes(command.reverseTrackNumber()));
+        digest.update(nullSafeBytes(command.comment()));
+        byte[] hash = digest.digest();
+        return HexFormat.of().formatHex(hash);
+    }
+
+    /**
+     * Выполняет бизнес-логику команды через соответствующий сервис.
+     */
+    private OrderReturnRequest performCommand(ReturnRequestCommandType type,
+                                              ReturnRequestCommandRequest command,
+                                              User user,
+                                              Long requestId,
+                                              Long parcelId) {
+        return switch (type) {
+            case START_EXCHANGE -> orderReturnRequestService.approveExchange(requestId, parcelId, user);
+            case CREATE_EXCHANGE_PARCEL -> {
+                orderReturnRequestService.createExchangeParcel(requestId, parcelId, user);
+                yield orderReturnRequestService.getOwnedRequest(requestId, user);
+            }
+            case CLOSE -> orderReturnRequestService.closeWithoutExchange(requestId, parcelId, user);
+            case CONFIRM_RECEIPT -> orderReturnRequestService.confirmReturnProcessing(requestId, parcelId, user);
+            case UPDATE_DETAILS -> {
+                orderReturnRequestService.updateReverseTrackAndComment(
+                        requestId,
+                        parcelId,
+                        user,
+                        command.reverseTrackNumber(),
+                        command.comment()
+                );
+                yield orderReturnRequestService.getOwnedRequest(requestId, user);
+            }
+            case REOPEN -> orderReturnRequestService.reopenAsReturn(requestId, parcelId, user);
+            case CANCEL_EXCHANGE -> orderReturnRequestService.cancelExchange(requestId, parcelId, user);
+        };
+    }
+
+    /**
+     * Создаёт и сохраняет запись журнала о выполненной команде.
+     */
+    private void persistLogEntry(Long requestId,
+                                 String idempotencyKey,
+                                 ReturnRequestCommandType type,
+                                 String payloadHash,
+                                 ReturnRequestDto response) {
+        ReturnCommandLog logEntry = new ReturnCommandLog();
+        logEntry.setRequestId(requestId);
+        logEntry.setIdempotencyKey(idempotencyKey);
+        logEntry.setAction(type.name());
+        logEntry.setPayloadHash(payloadHash);
+        logEntry.setResponseSnapshot(serializeResponse(response));
+        returnCommandLogRepository.save(logEntry);
+        log.info("Зафиксировано выполнение команды {} по заявке {}", type, requestId);
+    }
+
+    /**
+     * Восстанавливает DTO ответа из сохранённого снимка.
+     */
+    private ReturnRequestDto restoreResponse(ReturnCommandLog logEntry) {
+        try {
+            return objectMapper.readValue(logEntry.getResponseSnapshot(), ReturnRequestDto.class);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Не удалось восстановить ответ из журнала команд", ex);
+        }
+    }
+
+    /**
+     * Сериализует DTO ответа в JSON для хранения в журнале.
+     */
+    private String serializeResponse(ReturnRequestDto response) {
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Не удалось сериализовать ответ команды", ex);
+        }
+    }
+
+    /**
+     * Возвращает массив байт строки или пустой массив, если строка пуста.
+     */
+    private byte[] nullSafeBytes(String value) {
+        return value != null ? value.getBytes(StandardCharsets.UTF_8) : new byte[0];
+    }
+
+    /**
+     * Возвращает digest для вычисления хеша.
+     */
+    private MessageDigest getDigest() {
+        try {
+            return MessageDigest.getInstance(HASH_ALGORITHM);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("Алгоритм SHA-256 недоступен", ex);
+        }
+    }
+
+    /**
+     * Извлекает идентификатор посылки из заявки с проверкой наличия.
+     */
+    private Long resolveParcelId(OrderReturnRequest request) {
+        TrackParcel parcel = Optional.ofNullable(request)
+                .map(OrderReturnRequest::getParcel)
+                .orElse(null);
+        if (parcel == null || parcel.getId() == null) {
+            throw new IllegalArgumentException("Заявка не привязана к посылке");
+        }
+        return parcel.getId();
+    }
+}

--- a/src/main/resources/db/migration/V33__return_command_logs.sql
+++ b/src/main/resources/db/migration/V33__return_command_logs.sql
@@ -1,0 +1,14 @@
+CREATE TABLE tb_return_command_logs (
+    id BIGSERIAL PRIMARY KEY,
+    request_id BIGINT NOT NULL REFERENCES tb_order_return_requests (id) ON DELETE CASCADE,
+    idempotency_key VARCHAR(255) NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    payload_hash VARCHAR(64) NOT NULL,
+    response_snapshot TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+ALTER TABLE tb_return_command_logs
+    ADD CONSTRAINT ux_return_command_log_key UNIQUE (request_id, idempotency_key);
+
+CREATE INDEX idx_return_command_logs_request ON tb_return_command_logs (request_id);

--- a/src/main/resources/db/migration/V34__allow_null_response_snapshot.sql
+++ b/src/main/resources/db/migration/V34__allow_null_response_snapshot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_return_command_logs
+    ALTER COLUMN response_snapshot DROP NOT NULL;

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.order.ReturnRequestCommandService;
 import com.project.tracking_system.service.order.ReturnRequestMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +49,9 @@ class ReturnsControllerTest {
 
     @MockBean
     private ReturnRequestMapper returnRequestMapper;
+
+    @MockBean
+    private ReturnRequestCommandService returnRequestCommandService;
 
     @Test
     void registerReturn_returnsMappedDto() throws Exception {
@@ -114,31 +118,20 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = authentication(principal);
 
-        TrackParcel parcel = new TrackParcel();
-        parcel.setId(9L);
-        OrderReturnRequest initial = new OrderReturnRequest();
-        initial.setId(21L);
-        initial.setParcel(parcel);
-
-        OrderReturnRequest updated = new OrderReturnRequest();
-        updated.setId(21L);
-        updated.setParcel(parcel);
-
-        when(orderReturnRequestService.getOwnedRequest(21L, principal))
-                .thenReturn(initial);
-        when(orderReturnRequestService.approveExchange(21L, 9L, principal)).thenReturn(updated);
-        when(returnRequestMapper.toDto(eq(updated), any()))
-                .thenReturn(new ReturnRequestDto(21L, "EXCHANGE", null, null, null, false, null, null, null, null, null));
+        ReturnRequestDto responseDto = new ReturnRequestDto(21L, "EXCHANGE", null, null, null, false, null, null, null, null, null);
+        when(returnRequestCommandService.executeCommand(eq(21L), any(), any(), eq(principal), any()))
+                .thenReturn(responseDto);
 
         mockMvc.perform(post("/api/v1/returns/21/commands")
                         .with(auth)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"command\":\"start_exchange\"}"))
+                        .content("{" +
+                                "\"idempotencyKey\":\"cmd-1\"," +
+                                "\"command\":\"start_exchange\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo(21)))
                 .andExpect(jsonPath("$.status", equalTo("EXCHANGE")));
-
-        verify(orderReturnRequestService).approveExchange(21L, 9L, principal);
+        verify(returnRequestCommandService).executeCommand(eq(21L), any(), any(), eq(principal), any());
     }
 
     @Test
@@ -146,29 +139,21 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = authentication(principal);
 
-        TrackParcel parcel = new TrackParcel();
-        parcel.setId(11L);
-        OrderReturnRequest initial = new OrderReturnRequest();
-        initial.setId(30L);
-        initial.setParcel(parcel);
-
-        when(orderReturnRequestService.getOwnedRequest(30L, principal))
-                .thenReturn(initial)
-                .thenReturn(initial);
-        when(returnRequestMapper.toDto(eq(initial), any()))
-                .thenReturn(new ReturnRequestDto(30L, "REGISTERED", null, "Комментарий", "BY000", false, null, null, null, null, null));
+        ReturnRequestDto responseDto = new ReturnRequestDto(30L, "REGISTERED", null, "Комментарий", "BY000", false, null, null, null, null, null);
+        when(returnRequestCommandService.executeCommand(eq(30L), any(), any(), eq(principal), any()))
+                .thenReturn(responseDto);
 
         mockMvc.perform(post("/api/v1/returns/30/commands")
                         .with(auth)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{" +
+                                "\"idempotencyKey\":\"cmd-2\"," +
                                 "\"command\":\"update_details\"," +
                                 "\"reverseTrackNumber\":\"BY000\"," +
                                 "\"comment\":\"Комментарий\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.reverseTrackNumber", equalTo("BY000")));
-
-        verify(orderReturnRequestService).updateReverseTrackAndComment(30L, 11L, principal, "BY000", "Комментарий");
+        verify(returnRequestCommandService).executeCommand(eq(30L), any(), any(), eq(principal), any());
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -1,0 +1,142 @@
+package com.project.tracking_system.service.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.tracking_system.controller.ReturnRequestCommandType;
+import com.project.tracking_system.dto.ReturnRequestCommandRequest;
+import com.project.tracking_system.dto.ReturnRequestDto;
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.ReturnCommandLog;
+import com.project.tracking_system.entity.TrackParcel;
+import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.ReturnCommandLogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Тесты сервиса идемпотентного выполнения команд возврата.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReturnRequestCommandServiceTest {
+
+    @Mock
+    private OrderReturnRequestService orderReturnRequestService;
+
+    @Mock
+    private ReturnRequestMapper returnRequestMapper;
+
+    @Mock
+    private ReturnCommandLogRepository returnCommandLogRepository;
+
+    private ReturnRequestCommandService commandService;
+
+    @BeforeEach
+    void setUp() {
+        commandService = new ReturnRequestCommandService(
+                orderReturnRequestService,
+                returnRequestMapper,
+                returnCommandLogRepository,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void executeCommand_whenRepeated_returnsStoredSnapshot() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(21L, 9L);
+        OrderReturnRequest updated = buildRequest(21L, 9L);
+        ReturnRequestDto dto = new ReturnRequestDto(21L, "EXCHANGE", null, null, null, false, null, null, null, null, null);
+        ReturnRequestCommandRequest command = new ReturnRequestCommandRequest("dup-1", "start_exchange", null, null);
+
+        when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
+        when(orderReturnRequestService.approveExchange(21L, 9L, user)).thenReturn(updated);
+        when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
+
+        AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
+        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(21L, "dup-1"))
+                .thenAnswer(invocation -> Optional.ofNullable(savedLog.get()));
+        when(returnCommandLogRepository.save(any(ReturnCommandLog.class)))
+                .thenAnswer(invocation -> {
+                    ReturnCommandLog logEntry = invocation.getArgument(0);
+                    logEntry.setId(1L);
+                    savedLog.set(logEntry);
+                    return logEntry;
+                });
+
+        ReturnRequestDto first = commandService.executeCommand(21L,
+                ReturnRequestCommandType.START_EXCHANGE,
+                command,
+                user,
+                ZoneOffset.UTC);
+        ReturnRequestDto second = commandService.executeCommand(21L,
+                ReturnRequestCommandType.START_EXCHANGE,
+                command,
+                user,
+                ZoneOffset.UTC);
+
+        assertThat(first).isEqualTo(dto);
+        assertThat(second).isEqualTo(dto);
+        verify(orderReturnRequestService).approveExchange(21L, 9L, user);
+        verify(returnRequestMapper).toDto(eq(updated), any());
+        verify(returnCommandLogRepository).save(any(ReturnCommandLog.class));
+    }
+
+    @Test
+    void executeCommand_whenPayloadDiffers_throwsConflict() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(21L, 9L);
+        when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
+
+        ReturnCommandLog existing = new ReturnCommandLog();
+        existing.setRequestId(21L);
+        existing.setIdempotencyKey("dup-2");
+        existing.setPayloadHash("conflict");
+        existing.setResponseSnapshot("{}");
+
+        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(21L, "dup-2"))
+                .thenReturn(Optional.of(existing));
+
+        ReturnRequestCommandRequest command = new ReturnRequestCommandRequest("dup-2", "start_exchange", null, null);
+
+        assertThatThrownBy(() -> commandService.executeCommand(21L,
+                ReturnRequestCommandType.START_EXCHANGE,
+                command,
+                user,
+                ZoneOffset.UTC))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("уже выполнена");
+
+        verify(orderReturnRequestService, never()).approveExchange(21L, 9L, user);
+        verify(returnRequestMapper, never()).toDto(any(), any());
+        verify(returnCommandLogRepository, never()).save(any(ReturnCommandLog.class));
+    }
+
+    private User buildUser() {
+        User user = new User();
+        user.setId(5L);
+        return user;
+    }
+
+    private OrderReturnRequest buildRequest(Long requestId, Long parcelId) {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(requestId);
+        TrackParcel parcel = new TrackParcel();
+        parcel.setId(parcelId);
+        request.setParcel(parcel);
+        return request;
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -8,14 +8,20 @@ import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.ReturnCommandLog;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.mapper.ReturnRequestMapper;
 import com.project.tracking_system.repository.ReturnCommandLogRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.ZoneOffset;
+import java.util.HexFormat;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,7 +76,7 @@ class ReturnRequestCommandServiceTest {
         AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
         when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(21L, "dup-1"))
                 .thenAnswer(invocation -> Optional.ofNullable(savedLog.get()));
-        when(returnCommandLogRepository.save(any(ReturnCommandLog.class)))
+        when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
                 .thenAnswer(invocation -> {
                     ReturnCommandLog logEntry = invocation.getArgument(0);
                     logEntry.setId(1L);
@@ -92,7 +99,7 @@ class ReturnRequestCommandServiceTest {
         assertThat(second).isEqualTo(dto);
         verify(orderReturnRequestService).approveExchange(21L, 9L, user);
         verify(returnRequestMapper).toDto(eq(updated), any());
-        verify(returnCommandLogRepository).save(any(ReturnCommandLog.class));
+        verify(returnCommandLogRepository, atLeast(2)).saveAndFlush(any(ReturnCommandLog.class));
     }
 
     @Test
@@ -122,7 +129,62 @@ class ReturnRequestCommandServiceTest {
 
         verify(orderReturnRequestService, never()).approveExchange(21L, 9L, user);
         verify(returnRequestMapper, never()).toDto(any(), any());
-        verify(returnCommandLogRepository, never()).save(any(ReturnCommandLog.class));
+        verify(returnCommandLogRepository, never()).saveAndFlush(any(ReturnCommandLog.class));
+    }
+
+    @Test
+    void executeCommand_whenConcurrentReservation_returnsStoredSnapshot() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(22L, 10L);
+        ReturnRequestCommandRequest command = new ReturnRequestCommandRequest("dup-3", "start_exchange", null, null);
+
+        ReturnRequestDto storedDto = new ReturnRequestDto(22L, "EXCHANGE", null, null, null, false, null, null, null, null, null);
+        String snapshot;
+        try {
+            snapshot = new ObjectMapper().writeValueAsString(storedDto);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+
+        when(orderReturnRequestService.getOwnedRequest(22L, user)).thenReturn(request);
+        ReturnCommandLog completed = new ReturnCommandLog();
+        completed.setRequestId(22L);
+        completed.setIdempotencyKey("dup-3");
+        completed.setPayloadHash(computePayloadHash(ReturnRequestCommandType.START_EXCHANGE, command));
+        completed.setResponseSnapshot(snapshot);
+
+        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(22L, "dup-3"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(completed));
+        when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        ReturnRequestDto result = commandService.executeCommand(22L,
+                ReturnRequestCommandType.START_EXCHANGE,
+                command,
+                user,
+                ZoneOffset.UTC);
+
+        assertThat(result.id()).isEqualTo(22L);
+        verify(orderReturnRequestService, never()).approveExchange(any(), any(), any());
+        verify(returnRequestMapper, never()).toDto(any(), any());
+    }
+
+    private String computePayloadHash(ReturnRequestCommandType type, ReturnRequestCommandRequest command) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(type.name().getBytes(StandardCharsets.UTF_8));
+            digest.update(nullSafeBytes(command.command()));
+            digest.update(nullSafeBytes(command.reverseTrackNumber()));
+            digest.update(nullSafeBytes(command.comment()));
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private byte[] nullSafeBytes(String value) {
+        return value != null ? value.getBytes(StandardCharsets.UTF_8) : new byte[0];
     }
 
     private User buildUser() {


### PR DESCRIPTION
## Summary
- add a persistent return command log with Flyway migration and repository
- introduce an idempotent command execution service and update the REST controller/DTO to use it
- cover the new logic with controller and service tests for repeated and conflicting commands

## Testing
- mvn -q test *(fails: 403 Forbidden while downloading io.github.bucket4j artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6903b7097c0c832d8d3c5c1571a25cc4