### PR TITLE
Обновление цепочки стадий возврата и обмена

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequest.java
@@ -135,7 +135,7 @@ public class OrderReturnRequest {
      */
     @Enumerated(EnumType.STRING)
     @Column(name = "stage", nullable = false)
-    private ReturnRequestStage stage = ReturnRequestStage.CUSTOMER_RETURN;
+    private ReturnRequestStage stage = ReturnRequestStage.NEW;
 
     /**
      * Время начала текущего этапа обработки.
@@ -363,7 +363,7 @@ public class OrderReturnRequest {
     }
 
     public void setStage(ReturnRequestStage stage) {
-        this.stage = Objects.requireNonNullElse(stage, ReturnRequestStage.CUSTOMER_RETURN);
+        this.stage = Objects.requireNonNullElse(stage, ReturnRequestStage.NEW);
     }
 
     public ZonedDateTime getStageStartedAt() {

--- a/src/main/java/com/project/tracking_system/entity/OrderReturnRequestHistoryEntry.java
+++ b/src/main/java/com/project/tracking_system/entity/OrderReturnRequestHistoryEntry.java
@@ -40,7 +40,7 @@ public class OrderReturnRequestHistoryEntry {
      */
     @Enumerated(EnumType.STRING)
     @Column(name = "stage", nullable = false)
-    private ReturnRequestStage stage = ReturnRequestStage.CUSTOMER_RETURN;
+    private ReturnRequestStage stage = ReturnRequestStage.NEW;
 
     /**
      * Трек обратной отправки на момент фиксации события.
@@ -98,7 +98,7 @@ public class OrderReturnRequestHistoryEntry {
     }
 
     public void setStage(ReturnRequestStage stage) {
-        this.stage = Objects.requireNonNullElse(stage, ReturnRequestStage.CUSTOMER_RETURN);
+        this.stage = Objects.requireNonNullElse(stage, ReturnRequestStage.NEW);
     }
 
     public String getReverseTrackNumber() {
@@ -157,7 +157,7 @@ public class OrderReturnRequestHistoryEntry {
         OrderReturnRequestHistoryEntry entry = new OrderReturnRequestHistoryEntry();
         entry.setReturnRequest(request);
         entry.setMode(request != null ? request.getMode() : ReturnRequestMode.RETURN);
-        entry.setStage(request != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN);
+        entry.setStage(request != null ? request.getStage() : ReturnRequestStage.NEW);
         entry.setReverseTrackNumber(request != null ? request.getReverseTrackNumber() : null);
         entry.setExchangeTrackNumber(request != null ? request.getExchangeTrackNumber() : null);
         entry.setManualTransition(manualTransition);

--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestStage.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestStage.java
@@ -15,51 +15,101 @@ import java.util.Set;
 public enum ReturnRequestStage {
 
     /**
-     * Покупатель отправляет товар обратно магазину.
+     * Заявка зарегистрирована и ожидает действий покупателя.
      */
-    CUSTOMER_RETURN(
-            "CUSTOMER_RETURN",
-            "Возврат от покупателя",
+    NEW(
+            "NEW",
+            "Заявка зарегистрирована",
             "Покупатель",
-            "Покупатель оформляет заявку и отправляет посылку обратно магазину.",
+            "Заявка создана и ожидает, когда покупатель отправит товар обратно.",
             EnumSet.of(ReturnRequestMode.RETURN, ReturnRequestMode.EXCHANGE),
-            "Обратный трек"
+            null,
+            false,
+            false
     ),
 
     /**
-     * Менеджер магазина проверяет возврат и принимает решение.
+     * Покупатель передал возврат в службу доставки.
      */
-    MERCHANT_ACCEPT_RETURN(
-            "MERCHANT_ACCEPT_RETURN",
-            "Приём возврата магазином",
-            "Магазин",
-            "Менеджер проверяет возврат и принимает решение: закрыть заявку или запустить обмен.",
-            EnumSet.of(ReturnRequestMode.RETURN, ReturnRequestMode.EXCHANGE),
-            null
-    ),
-
-    /**
-     * Магазин формирует и отправляет обменную посылку.
-     */
-    EXCHANGE_SHIPMENT(
-            "EXCHANGE_SHIPMENT",
-            "Отправление обмена",
-            "Магазин",
-            "После подтверждения возврата магазин создаёт обменную посылку.",
-            EnumSet.of(ReturnRequestMode.EXCHANGE),
-            "Обменная посылка"
-    ),
-
-    /**
-     * Покупатель получает обменную посылку и цикл завершается.
-     */
-    EXCHANGE_DELIVERY(
-            "EXCHANGE_DELIVERY",
-            "Получение обмена",
+    OUTBOUND_SENT(
+            "OUTBOUND_SENT",
+            "Возврат отправлен",
             "Покупатель",
-            "Покупатель забирает новую посылку. Цикл завершается до следующей заявки.",
+            "Покупатель передал посылку оператору доставки и предоставил обратный трек.",
+            EnumSet.of(ReturnRequestMode.RETURN, ReturnRequestMode.EXCHANGE),
+            "Обратный трек",
+            false,
+            false
+    ),
+
+    /**
+     * Обратная посылка прибыла в пункт назначения магазина.
+     */
+    INBOUND_ARRIVED(
+            "INBOUND_ARRIVED",
+            "Возврат прибыл",
+            "Логистика",
+            "Обратная посылка прибыла в пункт назначения и ожидает проверки магазином.",
+            EnumSet.of(ReturnRequestMode.RETURN, ReturnRequestMode.EXCHANGE),
+            "Обратный трек",
+            false,
+            false
+    ),
+
+    /**
+     * Магазин забрал посылку и подтвердил обработку возврата.
+     */
+    INBOUND_PICKED_UP(
+            "INBOUND_PICKED_UP",
+            "Возврат обработан",
+            "Магазин",
+            "Сотрудник магазина забрал посылку и подтвердил факт возврата товара.",
+            EnumSet.of(ReturnRequestMode.RETURN, ReturnRequestMode.EXCHANGE),
+            "Обратный трек",
+            true,
+            false
+    ),
+
+    /**
+     * Магазин зарегистрировал обмен и готовит новое отправление.
+     */
+    EXCHANGE_REGISTERED(
+            "EXCHANGE_REGISTERED",
+            "Обмен зарегистрирован",
+            "Магазин",
+            "Менеджер одобрил обмен и приступил к подготовке новой посылки.",
             EnumSet.of(ReturnRequestMode.EXCHANGE),
-            "Обменная посылка"
+            "Обменная посылка",
+            false,
+            false
+    ),
+
+    /**
+     * Магазин передал обменную посылку в службу доставки.
+     */
+    EXCHANGE_SENT(
+            "EXCHANGE_SENT",
+            "Обмен отправлен",
+            "Магазин",
+            "Обменная посылка передана в доставку и движется к покупателю.",
+            EnumSet.of(ReturnRequestMode.EXCHANGE),
+            "Обменная посылка",
+            false,
+            false
+    ),
+
+    /**
+     * Покупатель получил обменную посылку.
+     */
+    EXCHANGE_DELIVERED(
+            "EXCHANGE_DELIVERED",
+            "Обмен доставлен",
+            "Покупатель",
+            "Покупатель получил обменную посылку. Цикл заявки завершён.",
+            EnumSet.of(ReturnRequestMode.EXCHANGE),
+            "Обменная посылка",
+            false,
+            true
     );
 
     private final String code;
@@ -68,19 +118,25 @@ public enum ReturnRequestStage {
     private final String description;
     private final EnumSet<ReturnRequestMode> applicableModes;
     private final String trackContextLabel;
+    private final boolean finalForReturn;
+    private final boolean finalForExchange;
 
     ReturnRequestStage(String code,
                        String title,
                        String actor,
                        String description,
                        EnumSet<ReturnRequestMode> applicableModes,
-                       String trackContextLabel) {
+                       String trackContextLabel,
+                       boolean finalForReturn,
+                       boolean finalForExchange) {
         this.code = code;
         this.title = title;
         this.actor = actor;
         this.description = description;
         this.applicableModes = EnumSet.copyOf(applicableModes);
         this.trackContextLabel = trackContextLabel;
+        this.finalForReturn = finalForReturn;
+        this.finalForExchange = finalForExchange;
     }
 
     /**
@@ -140,5 +196,32 @@ public enum ReturnRequestStage {
      */
     public String getTrackContextLabel() {
         return trackContextLabel;
+    }
+
+    /**
+     * Определяет, является ли стадия финальной для режима возврата.
+     */
+    public boolean isFinalForReturn() {
+        return finalForReturn;
+    }
+
+    /**
+     * Определяет, является ли стадия финальной для режима обмена.
+     */
+    public boolean isFinalForExchange() {
+        return finalForExchange;
+    }
+
+    /**
+     * Проверяет, финальна ли стадия для указанного режима обработки.
+     */
+    public boolean isFinalForMode(ReturnRequestMode mode) {
+        if (mode == null) {
+            return false;
+        }
+        return switch (mode) {
+            case RETURN -> finalForReturn;
+            case EXCHANGE -> finalForExchange;
+        };
     }
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -673,7 +673,7 @@ public class CustomerTelegramService {
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
 
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
-        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
+        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.NEW;
 
         ReturnRequestStateDto state = new ReturnRequestStateDto(
                 mode,

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -237,7 +237,7 @@ public class OrderReturnRequestService {
         request.setDecisionAt(decisionMoment);
         request.setMode(ReturnRequestMode.EXCHANGE);
         request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, user, decisionMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, user, decisionMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -275,7 +275,7 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(user);
         request.setExchangeTrackNumber(Optional.ofNullable(replacement).map(TrackParcel::getNumber).orElse(null));
         request.setExchangeTrackAssignedAt(assignedMoment);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, user, assignedMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SENT, true, user, assignedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Создана обменная посылка {} для заявки {}",
@@ -301,7 +301,7 @@ public class OrderReturnRequestService {
         request.setClosedAt(closeMoment);
         request.setMode(ReturnRequestMode.RETURN);
         request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, user, closeMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, closeMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -368,7 +368,7 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(user);
         request.setExchangeTrackNumber(null);
         request.setExchangeTrackAssignedAt(null);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, user, cancelMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, cancelMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -405,7 +405,7 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(user);
         request.setExchangeTrackNumber(null);
         request.setExchangeTrackAssignedAt(null);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, user, reopenMoment);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, reopenMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -485,10 +485,10 @@ public class OrderReturnRequestService {
         Long episodeId = episode != null ? episode.getId() : null;
         ReturnRequestStage currentStage = request.getStage() != null
                 ? request.getStage()
-                : ReturnRequestStage.CUSTOMER_RETURN;
+                : ReturnRequestStage.NEW;
         ReturnRequestStage normalizedStage = returnRequestWorkflow
                 .adjustStageForMode(ReturnRequestMode.EXCHANGE, currentStage);
-        if (!returnRequestWorkflow.canTransition(ReturnRequestMode.EXCHANGE, normalizedStage, ReturnRequestStage.EXCHANGE_SHIPMENT)) {
+        if (!returnRequestWorkflow.canTransition(ReturnRequestMode.EXCHANGE, normalizedStage, ReturnRequestStage.EXCHANGE_REGISTERED)) {
             return false;
         }
         if (episodeId == null) {
@@ -782,7 +782,7 @@ public class OrderReturnRequestService {
         request.setReturnReceiptConfirmed(true);
         request.setReturnReceiptConfirmedAt(now);
         request.setResponsibleManager(actor);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.MERCHANT_ACCEPT_RETURN, true, actor, now);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, actor, now);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
@@ -63,7 +63,7 @@ public class ReturnRequestActionMapper {
         boolean canCancelExchange = actions.contains(ReturnRequestAction.CANCEL_EXCHANGE);
         boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
-        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.CUSTOMER_RETURN;
+        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.NEW;
 
         ReturnRequestStateDto state = new ReturnRequestStateDto(
                 mode,

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
@@ -67,7 +67,7 @@ public class ReturnRequestMapper {
         );
 
         ReturnRequestMode mode = Optional.ofNullable(request.getMode()).orElse(ReturnRequestMode.RETURN);
-        ReturnRequestStage stage = Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.CUSTOMER_RETURN);
+        ReturnRequestStage stage = Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW);
 
         ReturnRequestStateDto state = new ReturnRequestStateDto(
                 mode,

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -108,10 +108,7 @@ public class ReturnRequestWorkflow {
      * Возвращает начальную стадию для режима.
      */
     public ReturnRequestStage initialStage(ReturnRequestMode mode) {
-        if (mode == ReturnRequestMode.EXCHANGE) {
-            return ReturnRequestStage.CUSTOMER_RETURN;
-        }
-        return ReturnRequestStage.CUSTOMER_RETURN;
+        return ReturnRequestStage.NEW;
     }
 
     /**
@@ -127,9 +124,9 @@ public class ReturnRequestWorkflow {
             return safeStage;
         }
         if (mode == ReturnRequestMode.RETURN) {
-            return ReturnRequestStage.MERCHANT_ACCEPT_RETURN;
+            return ReturnRequestStage.INBOUND_PICKED_UP;
         }
-        return ReturnRequestStage.CUSTOMER_RETURN;
+        return ReturnRequestStage.EXCHANGE_REGISTERED;
     }
 
     /**
@@ -149,7 +146,7 @@ public class ReturnRequestWorkflow {
             actions.add(ReturnRequestAction.CANCEL_RETURN);
         }
         if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED
-                && stage != ReturnRequestStage.EXCHANGE_DELIVERY) {
+                && stage != ReturnRequestStage.EXCHANGE_DELIVERED) {
             actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
             actions.add(ReturnRequestAction.CONVERT_TO_RETURN);
         }
@@ -160,21 +157,42 @@ public class ReturnRequestWorkflow {
         Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> table = new EnumMap<>(ReturnRequestMode.class);
 
         Map<ReturnRequestStage, Set<ReturnRequestStage>> returnTransitions = new EnumMap<>(ReturnRequestStage.class);
-        returnTransitions.put(ReturnRequestStage.CUSTOMER_RETURN, EnumSet.of(ReturnRequestStage.MERCHANT_ACCEPT_RETURN));
-        returnTransitions.put(ReturnRequestStage.MERCHANT_ACCEPT_RETURN, EnumSet.of(ReturnRequestStage.MERCHANT_ACCEPT_RETURN));
+        returnTransitions.put(ReturnRequestStage.NEW, EnumSet.of(
+                ReturnRequestStage.OUTBOUND_SENT,
+                ReturnRequestStage.INBOUND_ARRIVED,
+                ReturnRequestStage.INBOUND_PICKED_UP
+        ));
+        returnTransitions.put(ReturnRequestStage.OUTBOUND_SENT, EnumSet.of(
+                ReturnRequestStage.INBOUND_ARRIVED,
+                ReturnRequestStage.INBOUND_PICKED_UP
+        ));
+        returnTransitions.put(ReturnRequestStage.INBOUND_ARRIVED, EnumSet.of(ReturnRequestStage.INBOUND_PICKED_UP));
+        returnTransitions.put(ReturnRequestStage.INBOUND_PICKED_UP, EnumSet.of(ReturnRequestStage.INBOUND_PICKED_UP));
         table.put(ReturnRequestMode.RETURN, returnTransitions);
 
         Map<ReturnRequestStage, Set<ReturnRequestStage>> exchangeTransitions = new EnumMap<>(ReturnRequestStage.class);
-        exchangeTransitions.put(ReturnRequestStage.CUSTOMER_RETURN, EnumSet.of(
-                ReturnRequestStage.MERCHANT_ACCEPT_RETURN,
-                ReturnRequestStage.EXCHANGE_SHIPMENT
+        exchangeTransitions.put(ReturnRequestStage.NEW, EnumSet.of(
+                ReturnRequestStage.OUTBOUND_SENT,
+                ReturnRequestStage.INBOUND_ARRIVED,
+                ReturnRequestStage.INBOUND_PICKED_UP,
+                ReturnRequestStage.EXCHANGE_REGISTERED
         ));
-        exchangeTransitions.put(ReturnRequestStage.MERCHANT_ACCEPT_RETURN, EnumSet.of(ReturnRequestStage.EXCHANGE_SHIPMENT));
-        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_SHIPMENT, EnumSet.of(
-                ReturnRequestStage.EXCHANGE_DELIVERY,
-                ReturnRequestStage.MERCHANT_ACCEPT_RETURN
+        exchangeTransitions.put(ReturnRequestStage.OUTBOUND_SENT, EnumSet.of(
+                ReturnRequestStage.INBOUND_ARRIVED,
+                ReturnRequestStage.INBOUND_PICKED_UP,
+                ReturnRequestStage.EXCHANGE_REGISTERED
         ));
-        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_DELIVERY, EnumSet.of(ReturnRequestStage.EXCHANGE_DELIVERY));
+        exchangeTransitions.put(ReturnRequestStage.INBOUND_ARRIVED, EnumSet.of(
+                ReturnRequestStage.INBOUND_PICKED_UP,
+                ReturnRequestStage.EXCHANGE_REGISTERED
+        ));
+        exchangeTransitions.put(ReturnRequestStage.INBOUND_PICKED_UP, EnumSet.of(ReturnRequestStage.EXCHANGE_REGISTERED));
+        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_REGISTERED, EnumSet.of(
+                ReturnRequestStage.EXCHANGE_SENT,
+                ReturnRequestStage.EXCHANGE_DELIVERED
+        ));
+        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_SENT, EnumSet.of(ReturnRequestStage.EXCHANGE_DELIVERED));
+        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_DELIVERED, EnumSet.of(ReturnRequestStage.EXCHANGE_DELIVERED));
         table.put(ReturnRequestMode.EXCHANGE, exchangeTransitions);
 
         return table;
@@ -195,6 +213,6 @@ public class ReturnRequestWorkflow {
     }
 
     private ReturnRequestStage safeStage(ReturnRequestStage stage) {
-        return stage != null ? stage : ReturnRequestStage.CUSTOMER_RETURN;
+        return stage != null ? stage : ReturnRequestStage.NEW;
     }
 }

--- a/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
+++ b/src/main/java/com/project/tracking_system/service/track/TrackViewService.java
@@ -211,77 +211,149 @@ public class TrackViewService {
                                              OrderReturnRequest request,
                                              ZoneId userZone,
                                              String outboundMoment) {
-        ReturnRequestStage customerStage = ReturnRequestStage.CUSTOMER_RETURN;
-        TrackLifecycleStageState customerReturnState = hasReverseShipmentStarted(parcel, request)
-                ? TrackLifecycleStageState.COMPLETED
-                : TrackLifecycleStageState.IN_PROGRESS;
-        String customerReturnMoment = formatNullableTimestamp(request.getRequestedAt(), userZone);
-        String reverseTrackNumber = normalizeTrackNumber(request.getReverseTrackNumber());
+        ReturnRequestStage registrationStage = ReturnRequestStage.NEW;
+        TrackLifecycleStageState registrationState = TrackLifecycleStageState.COMPLETED;
+        String registrationMoment = formatNullableTimestamp(coalesceReturnRequestMoment(request), userZone);
         stages.add(new TrackLifecycleStageDto(
-                customerStage.getCode(),
-                customerStage.getTitle(),
-                customerStage.getActor(),
-                customerStage.getDescription(),
-                customerReturnState,
-                customerReturnMoment,
-                reverseTrackNumber,
-                customerStage.getTrackContextLabel()
-        ));
-
-        ReturnRequestStage merchantStage = ReturnRequestStage.MERCHANT_ACCEPT_RETURN;
-        TrackLifecycleStageState merchantProcessingState = TrackLifecycleStageState.PLANNED;
-        String merchantProcessingMoment = null;
-        boolean processed = isReturnProcessed(request, parcel);
-        if (processed) {
-            merchantProcessingState = TrackLifecycleStageState.COMPLETED;
-            merchantProcessingMoment = firstNonNull(
-                    formatNullableTimestamp(request.getReturnReceiptConfirmedAt(), userZone),
-                    formatNullableTimestamp(request.getDecisionAt(), userZone),
-                    formatNullableTimestamp(request.getClosedAt(), userZone),
-                    outboundMoment
-            );
-            if (merchantProcessingMoment == null) {
-                merchantProcessingMoment = formatNullableTimestamp(resolveStatusMoment(parcel), userZone);
-            }
-        } else if (hasReverseShipmentStarted(parcel, request)) {
-            merchantProcessingState = TrackLifecycleStageState.IN_PROGRESS;
-        }
-        stages.add(new TrackLifecycleStageDto(
-                merchantStage.getCode(),
-                merchantStage.getTitle(),
-                merchantStage.getActor(),
-                merchantStage.getDescription(),
-                merchantProcessingState,
-                merchantProcessingMoment,
+                registrationStage.getCode(),
+                registrationStage.getTitle(),
+                registrationStage.getActor(),
+                registrationStage.getDescription(),
+                registrationState,
+                registrationMoment,
                 null,
                 null
         ));
 
+        ReturnRequestStage outboundStage = ReturnRequestStage.OUTBOUND_SENT;
+        boolean reverseStarted = hasReverseShipmentStarted(parcel, request);
+        TrackLifecycleStageState outboundState = reverseStarted
+                ? TrackLifecycleStageState.COMPLETED
+                : TrackLifecycleStageState.IN_PROGRESS;
+        String reverseTrackNumber = normalizeTrackNumber(request.getReverseTrackNumber());
+        String outboundContext = reverseTrackNumber != null || outboundState != TrackLifecycleStageState.PLANNED
+                ? outboundStage.getTrackContextLabel()
+                : null;
+        stages.add(new TrackLifecycleStageDto(
+                outboundStage.getCode(),
+                outboundStage.getTitle(),
+                outboundStage.getActor(),
+                outboundStage.getDescription(),
+                outboundState,
+                outboundMoment,
+                reverseTrackNumber,
+                outboundContext
+        ));
+
+        ReturnRequestStage inboundArrivalStage = ReturnRequestStage.INBOUND_ARRIVED;
+        boolean processed = isReturnProcessed(request, parcel);
+        TrackLifecycleStageState inboundArrivalState;
+        if (!reverseStarted) {
+            inboundArrivalState = TrackLifecycleStageState.PLANNED;
+        } else if (processed) {
+            inboundArrivalState = TrackLifecycleStageState.COMPLETED;
+        } else {
+            inboundArrivalState = TrackLifecycleStageState.IN_PROGRESS;
+        }
+        String inboundArrivalMoment = formatNullableTimestamp(resolveStatusMoment(parcel), userZone);
+        if (inboundArrivalMoment == null && reverseStarted) {
+            inboundArrivalMoment = outboundMoment;
+        }
+        String inboundArrivalContext = reverseTrackNumber != null
+                || inboundArrivalState != TrackLifecycleStageState.PLANNED
+                ? inboundArrivalStage.getTrackContextLabel()
+                : null;
+        stages.add(new TrackLifecycleStageDto(
+                inboundArrivalStage.getCode(),
+                inboundArrivalStage.getTitle(),
+                inboundArrivalStage.getActor(),
+                inboundArrivalStage.getDescription(),
+                inboundArrivalState,
+                inboundArrivalMoment,
+                reverseTrackNumber,
+                inboundArrivalContext
+        ));
+
+        ReturnRequestStage pickupStage = ReturnRequestStage.INBOUND_PICKED_UP;
+        TrackLifecycleStageState pickupState;
+        if (processed) {
+            pickupState = TrackLifecycleStageState.COMPLETED;
+        } else if (reverseStarted) {
+            pickupState = TrackLifecycleStageState.IN_PROGRESS;
+        } else {
+            pickupState = TrackLifecycleStageState.PLANNED;
+        }
+        String pickupMoment = firstNonNull(
+                formatNullableTimestamp(request.getReturnReceiptConfirmedAt(), userZone),
+                formatNullableTimestamp(request.getDecisionAt(), userZone),
+                formatNullableTimestamp(request.getClosedAt(), userZone),
+                inboundArrivalMoment,
+                outboundMoment
+        );
+        if (pickupMoment == null) {
+            pickupMoment = formatNullableTimestamp(resolveStatusMoment(parcel), userZone);
+        }
+        String pickupContext = reverseTrackNumber != null
+                || pickupState != TrackLifecycleStageState.PLANNED
+                ? pickupStage.getTrackContextLabel()
+                : null;
+        stages.add(new TrackLifecycleStageDto(
+                pickupStage.getCode(),
+                pickupStage.getTitle(),
+                pickupStage.getActor(),
+                pickupStage.getDescription(),
+                pickupState,
+                pickupMoment,
+                reverseTrackNumber,
+                pickupContext
+        ));
+
         TrackParcel exchangeParcel = orderExchangeService.findLatestExchangeParcel(request).orElse(null);
         if (shouldShowExchangeStages(request, exchangeParcel)) {
-            ReturnRequestStage shipmentStage = ReturnRequestStage.EXCHANGE_SHIPMENT;
-            ReturnRequestStage deliveryStage = ReturnRequestStage.EXCHANGE_DELIVERY;
             boolean hasExchangeParcel = exchangeParcel != null;
             boolean hasExchangeTrack = hasExchangeParcel
                     && exchangeParcel.getNumber() != null
                     && !exchangeParcel.getNumber().isBlank();
             GlobalStatus exchangeStatus = hasExchangeParcel ? exchangeParcel.getStatus() : null;
             boolean exchangeFinalStatus = exchangeStatus != null && exchangeStatus.isFinal();
+            boolean exchangeApproved = request.getStatus() == OrderReturnRequestStatus.EXCHANGE_APPROVED;
 
-            TrackLifecycleStageState exchangeCreationState = TrackLifecycleStageState.PLANNED;
-            String exchangeCreationMoment = null;
-            if (hasExchangeParcel && (hasExchangeTrack || exchangeFinalStatus)) {
-                exchangeCreationState = exchangeFinalStatus
+            ReturnRequestStage registeredStage = ReturnRequestStage.EXCHANGE_REGISTERED;
+            TrackLifecycleStageState registeredState = (exchangeApproved || hasExchangeParcel)
+                    ? TrackLifecycleStageState.COMPLETED
+                    : TrackLifecycleStageState.PLANNED;
+            String registeredMoment = firstNonNull(
+                    formatNullableTimestamp(request.getDecisionAt(), userZone),
+                    hasExchangeParcel ? formatNullableTimestamp(exchangeParcel.getTimestamp(), userZone) : null
+            );
+            String registeredContext = registeredState != TrackLifecycleStageState.PLANNED
+                    ? registeredStage.getTrackContextLabel()
+                    : null;
+            stages.add(new TrackLifecycleStageDto(
+                    registeredStage.getCode(),
+                    registeredStage.getTitle(),
+                    registeredStage.getActor(),
+                    registeredStage.getDescription(),
+                    registeredState,
+                    registeredMoment,
+                    null,
+                    registeredContext
+            ));
+
+            ReturnRequestStage shipmentStage = ReturnRequestStage.EXCHANGE_SENT;
+            TrackLifecycleStageState exchangeShipmentState = TrackLifecycleStageState.PLANNED;
+            String exchangeShipmentMoment = null;
+            if (hasExchangeParcel) {
+                exchangeShipmentState = exchangeFinalStatus
                         ? TrackLifecycleStageState.COMPLETED
                         : TrackLifecycleStageState.IN_PROGRESS;
-                exchangeCreationMoment = formatNullableTimestamp(exchangeParcel.getTimestamp(), userZone);
+                exchangeShipmentMoment = formatNullableTimestamp(exchangeParcel.getTimestamp(), userZone);
             }
-
             String exchangeTrackNumber = hasExchangeTrack
                     ? normalizeTrackNumber(exchangeParcel.getNumber())
                     : null;
             String shipmentContext = exchangeTrackNumber != null
-                    || exchangeCreationState != TrackLifecycleStageState.PLANNED
+                    || exchangeShipmentState != TrackLifecycleStageState.PLANNED
                     ? shipmentStage.getTrackContextLabel()
                     : null;
             stages.add(new TrackLifecycleStageDto(
@@ -289,19 +361,20 @@ public class TrackViewService {
                     shipmentStage.getTitle(),
                     shipmentStage.getActor(),
                     shipmentStage.getDescription(),
-                    exchangeCreationState,
-                    exchangeCreationMoment,
+                    exchangeShipmentState,
+                    exchangeShipmentMoment,
                     exchangeTrackNumber,
                     shipmentContext
             ));
 
+            ReturnRequestStage deliveryStage = ReturnRequestStage.EXCHANGE_DELIVERED;
             TrackLifecycleStageState exchangeDeliveryState = TrackLifecycleStageState.PLANNED;
             String exchangeDeliveryMoment = null;
-            if (hasExchangeParcel && (hasExchangeTrack || exchangeFinalStatus)) {
+            if (hasExchangeParcel) {
                 if (exchangeFinalStatus) {
                     exchangeDeliveryState = TrackLifecycleStageState.COMPLETED;
                     exchangeDeliveryMoment = formatNullableTimestamp(resolveStatusMoment(exchangeParcel), userZone);
-                } else {
+                } else if (hasExchangeTrack) {
                     exchangeDeliveryState = TrackLifecycleStageState.IN_PROGRESS;
                     exchangeDeliveryMoment = formatNullableTimestamp(exchangeParcel.getLastUpdate(), userZone);
                 }

--- a/src/main/resources/db/migration/V32__order_return_lifecycle_metadata.sql
+++ b/src/main/resources/db/migration/V32__order_return_lifecycle_metadata.sql
@@ -16,10 +16,10 @@ SET mode = CASE
         ELSE 'RETURN'
     END,
     stage = CASE
-        WHEN r.return_receipt_confirmed THEN 'MERCHANT_ACCEPT_RETURN'
-        WHEN r.status = 'EXCHANGE_APPROVED' THEN 'EXCHANGE_SHIPMENT'
-        WHEN r.status = 'CLOSED_NO_EXCHANGE' THEN 'MERCHANT_ACCEPT_RETURN'
-        ELSE 'CUSTOMER_RETURN'
+        WHEN r.return_receipt_confirmed THEN 'INBOUND_PICKED_UP'
+        WHEN r.status = 'EXCHANGE_APPROVED' THEN 'EXCHANGE_REGISTERED'
+        WHEN r.status = 'CLOSED_NO_EXCHANGE' THEN 'INBOUND_PICKED_UP'
+        ELSE 'NEW'
     END,
     store_id = p.store_id,
     responsible_id = r.created_by,

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -110,7 +110,7 @@ class OrderReturnRequestServiceTest {
         assertThat(saved.getCreatedAt()).isNotNull();
         assertThat(saved.isExchangeRequested()).isFalse();
         assertThat(saved.getMode()).isEqualTo(ReturnRequestMode.RETURN);
-        assertThat(saved.getStage()).isEqualTo(ReturnRequestStage.CUSTOMER_RETURN);
+        assertThat(saved.getStage()).isEqualTo(ReturnRequestStage.NEW);
         assertThat(saved.getStore()).isEqualTo(parcel.getStore());
         assertThat(saved.getResponsibleManager()).isEqualTo(user);
         assertThat(saved.isManualTrackOverride()).isTrue();
@@ -160,7 +160,7 @@ class OrderReturnRequestServiceTest {
         assertThat(saved.isExchangeRequested()).isTrue();
         assertThat(saved.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
         assertThat(saved.getMode()).isEqualTo(ReturnRequestMode.EXCHANGE);
-        assertThat(saved.getStage()).isEqualTo(ReturnRequestStage.CUSTOMER_RETURN);
+        assertThat(saved.getStage()).isEqualTo(ReturnRequestStage.NEW);
         assertThat(saved.getStore()).isEqualTo(parcel.getStore());
         assertThat(saved.getHistoryEntries()).hasSize(1);
         verify(repository).save(any(OrderReturnRequest.class));
@@ -257,7 +257,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getDecisionBy()).isEqualTo(user);
         assertThat(result.getDecisionAt()).isNotNull();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.EXCHANGE);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_REGISTERED);
         assertThat(result.getResponsibleManager()).isEqualTo(user);
         assertThat(result.isManualStageOverride()).isTrue();
         verify(orderExchangeService, never()).createExchangeParcel(any());
@@ -286,6 +286,7 @@ class OrderReturnRequestServiceTest {
         assertThat(created).isEqualTo(exchange);
         assertThat(request.getResponsibleManager()).isEqualTo(user);
         assertThat(request.isManualStageOverride()).isTrue();
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SENT);
         assertThat(request.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).createExchangeParcel(request);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
@@ -330,7 +331,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getClosedBy()).isEqualTo(user);
         assertThat(result.getClosedAt()).isNotNull();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
         assertThat(result.getResponsibleManager()).isEqualTo(user);
         assertThat(result.isManualStageOverride()).isTrue();
         assertThat(result.getHistoryEntries()).isNotEmpty();
@@ -355,7 +356,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isTrue();
         assertThat(result.getReturnReceiptConfirmedAt()).isNotNull();
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
         assertThat(result.getResponsibleManager()).isEqualTo(user);
         assertThat(result.isManualStageOverride()).isTrue();
         assertThat(result.getHistoryEntries()).isNotEmpty();
@@ -417,7 +418,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.isReturnReceiptConfirmed()).isTrue();
         assertThat(result.getReturnReceiptConfirmedAt()).isNotNull();
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
@@ -444,7 +445,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getClosedBy()).isEqualTo(user);
         assertThat(result.getClosedAt()).isNotNull();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
         assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
@@ -730,7 +731,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getClosedAt()).isNull();
         assertThat(result.isExchangeRequested()).isFalse();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
         assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
@@ -762,7 +763,7 @@ class OrderReturnRequestServiceTest {
     void resolveAvailableActions_ReturnsCancelForRegisteredRequest() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
-        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        request.setStage(ReturnRequestStage.NEW);
         request.setMode(ReturnRequestMode.RETURN);
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
@@ -775,7 +776,7 @@ class OrderReturnRequestServiceTest {
     void resolveAvailableActions_ExcludesExchangeActionsWhenShipmentDispatched() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
-        request.setStage(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        request.setStage(ReturnRequestStage.EXCHANGE_SENT);
         request.setMode(ReturnRequestMode.EXCHANGE);
 
         TrackParcel replacement = new TrackParcel();

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -20,17 +20,17 @@ class ReturnRequestWorkflowTest {
     private final ReturnRequestWorkflow workflow = new ReturnRequestWorkflow();
 
     @Test
-    void transitionToStage_AllowsExchangeShipmentFromMerchantStage() {
+    void transitionToStage_AllowsExchangeRegistrationFromInboundStage() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setMode(ReturnRequestMode.EXCHANGE);
-        request.setStage(ReturnRequestStage.MERCHANT_ACCEPT_RETURN);
+        request.setStage(ReturnRequestStage.INBOUND_PICKED_UP);
         User manager = new User();
         manager.setId(42L);
         ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
 
-        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, manager, moment);
+        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, manager, moment);
 
-        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_REGISTERED);
         assertThat(request.getStageStartedAt()).isEqualTo(moment);
         assertThat(request.getStageUpdatedAt()).isEqualTo(moment);
         assertThat(request.isManualStageOverride()).isTrue();
@@ -38,15 +38,15 @@ class ReturnRequestWorkflowTest {
     }
 
     @Test
-    void transitionToStage_AllowsDirectExchangeLaunchFromCustomerStage() {
+    void transitionToStage_AllowsDirectExchangeLaunchFromNewStage() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setMode(ReturnRequestMode.EXCHANGE);
-        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        request.setStage(ReturnRequestStage.NEW);
         ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
 
-        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SHIPMENT, true, null, moment);
+        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, null, moment);
 
-        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SHIPMENT);
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_REGISTERED);
         assertThat(request.getHistoryEntries()).hasSize(1);
     }
 
@@ -54,7 +54,7 @@ class ReturnRequestWorkflowTest {
     void transitionToStage_ThrowsWhenTargetNotAllowedForMode() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setMode(ReturnRequestMode.RETURN);
-        request.setStage(ReturnRequestStage.CUSTOMER_RETURN);
+        request.setStage(ReturnRequestStage.OUTBOUND_SENT);
 
         assertThatThrownBy(() -> workflow.transitionToStage(
                 request,

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -2426,7 +2426,7 @@ class BuyerTelegramBotTest {
         String closedAt = status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE ? requestedAt : null;
         ReturnRequestStateDto state = new ReturnRequestStateDto(
                 mode,
-                ReturnRequestStage.CUSTOMER_RETURN,
+                ReturnRequestStage.NEW,
                 false,
                 false,
                 exchangeRequested,

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -290,8 +290,8 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(82L, 16L);
 
         assertThat(details.lifecycle())
-                .extracting(stage -> stage.code())
-                .contains("EXCHANGE_SHIPMENT", "EXCHANGE_DELIVERY");
+                .extracting(TrackLifecycleStageDto::code)
+                .contains("EXCHANGE_REGISTERED", "EXCHANGE_SENT", "EXCHANGE_DELIVERY");
     }
 
     @Test
@@ -315,7 +315,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(83L, 20L);
 
         TrackLifecycleStageDto shipmentStage = details.lifecycle().stream()
-                .filter(stage -> stage.code().equals("EXCHANGE_SHIPMENT"))
+                .filter(stage -> stage.code().equals("EXCHANGE_SENT"))
                 .findFirst()
                 .orElseThrow();
         TrackLifecycleStageDto deliveryStage = details.lifecycle().stream()
@@ -354,7 +354,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(84L, 19L);
 
         TrackLifecycleStageDto shipmentStage = details.lifecycle().stream()
-                .filter(stage -> stage.code().equals("EXCHANGE_SHIPMENT"))
+                .filter(stage -> stage.code().equals("EXCHANGE_SENT"))
                 .findFirst()
                 .orElseThrow();
         TrackLifecycleStageDto deliveryStage = details.lifecycle().stream()
@@ -406,7 +406,7 @@ class TrackViewServiceTest {
         assertThat(outbound.trackNumber()).isEqualTo("SHOP-TRACK");
 
         TrackLifecycleStageDto customerReturn = lifecycle.stream()
-                .filter(stage -> "CUSTOMER_RETURN".equals(stage.code()))
+                .filter(stage -> "OUTBOUND_SENT".equals(stage.code()))
                 .findFirst()
                 .orElseThrow();
         assertThat(customerReturn.trackContext()).isEqualTo("Обратный трек");
@@ -419,7 +419,7 @@ class TrackViewServiceTest {
         assertThat(exchangeDelivery.trackContext()).isEqualTo("Обменная посылка");
         assertThat(exchangeDelivery.trackNumber()).isEqualTo("EX-999");
         TrackLifecycleStageDto exchangeShipment = lifecycle.stream()
-                .filter(stage -> "EXCHANGE_SHIPMENT".equals(stage.code()))
+                .filter(stage -> "EXCHANGE_SENT".equals(stage.code()))
                 .findFirst()
                 .orElseThrow();
         assertThat(exchangeShipment.state()).isEqualTo(TrackLifecycleStageState.IN_PROGRESS);
@@ -507,8 +507,8 @@ class TrackViewServiceTest {
         assertThat(details.returnRequest().state().returnReceiptConfirmed()).isFalse();
         assertThat(details.returnRequest().timestamps().returnReceiptConfirmedAt()).isNull();
         assertThat(details.lifecycle())
-                .extracting(stage -> stage.code())
-                .contains("OUTBOUND", "CUSTOMER_RETURN", "MERCHANT_ACCEPT_RETURN");
+                .extracting(TrackLifecycleStageDto::code)
+                .contains("OUTBOUND", "NEW", "OUTBOUND_SENT", "INBOUND_PICKED_UP");
     }
 
     @Test
@@ -532,7 +532,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(82L, 16L);
 
         TrackLifecycleStageDto processingStage = details.lifecycle().stream()
-                .filter(stage -> stage.code().equals("MERCHANT_ACCEPT_RETURN"))
+                .filter(stage -> stage.code().equals("INBOUND_PICKED_UP"))
                 .findFirst()
                 .orElseThrow();
         assertThat(processingStage.state()).isEqualTo(TrackLifecycleStageState.COMPLETED);
@@ -563,7 +563,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(84L, 18L);
 
         TrackLifecycleStageDto processingStage = details.lifecycle().stream()
-                .filter(stage -> stage.code().equals("MERCHANT_ACCEPT_RETURN"))
+                .filter(stage -> stage.code().equals("INBOUND_PICKED_UP"))
                 .findFirst()
                 .orElseThrow();
         assertThat(processingStage.state()).isEqualTo(TrackLifecycleStageState.IN_PROGRESS);
@@ -592,7 +592,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(186L, 19L);
 
         TrackLifecycleStageDto processingStage = details.lifecycle().stream()
-                .filter(stage -> stage.code().equals("MERCHANT_ACCEPT_RETURN"))
+                .filter(stage -> stage.code().equals("INBOUND_PICKED_UP"))
                 .findFirst()
                 .orElseThrow();
         assertThat(processingStage.state()).isEqualTo(TrackLifecycleStageState.COMPLETED);
@@ -643,7 +643,7 @@ class TrackViewServiceTest {
         TrackDetailsDto details = service.getTrackDetails(83L, 17L);
 
         TrackLifecycleStageDto processingStage = details.lifecycle().stream()
-                .filter(stage -> stage.code().equals("MERCHANT_ACCEPT_RETURN"))
+                .filter(stage -> stage.code().equals("INBOUND_PICKED_UP"))
                 .findFirst()
                 .orElseThrow();
         assertThat(processingStage.state()).isEqualTo(TrackLifecycleStageState.COMPLETED);

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -64,7 +64,7 @@ describe('track-modal render', () => {
         if (!request || typeof request !== 'object') {
             return request;
         }
-        const stage = request.stage || request.state || 'CUSTOMER_RETURN';
+        const stage = request.stage || request.state || 'NEW';
         const stageUpper = typeof stage === 'string' ? stage.toUpperCase() : '';
         const mode = request.mode
             || (stageUpper.includes('EXCHANGE')
@@ -281,8 +281,18 @@ status: 'Зарегистрирована',
                     trackContext: 'Исходная посылка'
                 },
                 {
-                    code: 'CUSTOMER_RETURN',
-                    title: 'Возврат от покупателя',
+                    code: 'NEW',
+                    title: 'Заявка зарегистрирована',
+                    actor: 'Покупатель',
+                    description: '...',
+                    state: 'COMPLETED',
+                    occurredAt: '2024-01-05T11:30:00Z',
+                    trackNumber: null,
+                    trackContext: null
+                },
+                {
+                    code: 'OUTBOUND_SENT',
+                    title: 'Возврат отправлен',
                     actor: 'Покупатель',
                     description: '...',
                     state: 'IN_PROGRESS',
@@ -291,8 +301,18 @@ status: 'Зарегистрирована',
                     trackContext: 'Обратный трек'
                 },
                 {
-                    code: 'MERCHANT_ACCEPT_RETURN',
-                    title: 'Приём возврата магазином',
+                    code: 'INBOUND_ARRIVED',
+                    title: 'Возврат прибыл',
+                    actor: 'Логистика',
+                    description: '...',
+                    state: 'PLANNED',
+                    occurredAt: null,
+                    trackNumber: null,
+                    trackContext: null
+                },
+                {
+                    code: 'INBOUND_PICKED_UP',
+                    title: 'Возврат обработан',
                     actor: 'Магазин',
                     description: '...',
                     state: 'PLANNED',
@@ -929,8 +949,8 @@ status: 'Зарегистрирована',
                     trackContext: 'Исходная посылка'
                 },
                 {
-                    code: 'CUSTOMER_RETURN',
-                    title: 'Возврат от покупателя',
+                    code: 'OUTBOUND_SENT',
+                    title: 'Возврат отправлен',
                     actor: 'Покупатель',
                     description: '...',
                     state: 'COMPLETED',
@@ -1703,8 +1723,8 @@ status: 'Закрыта',
                     trackContext: 'Исходная посылка'
                 },
                 {
-                    code: 'CUSTOMER_RETURN',
-                    title: 'Возврат от покупателя',
+                    code: 'NEW',
+                    title: 'Заявка зарегистрирована',
                     actor: 'Покупатель',
                     description: '...',
                     state: 'PLANNED',
@@ -1713,8 +1733,28 @@ status: 'Закрыта',
                     trackContext: null
                 },
                 {
-                    code: 'MERCHANT_ACCEPT_RETURN',
-                    title: 'Приём возврата магазином',
+                    code: 'OUTBOUND_SENT',
+                    title: 'Возврат отправлен',
+                    actor: 'Покупатель',
+                    description: '...',
+                    state: 'PLANNED',
+                    occurredAt: null,
+                    trackNumber: null,
+                    trackContext: null
+                },
+                {
+                    code: 'INBOUND_ARRIVED',
+                    title: 'Возврат прибыл',
+                    actor: 'Логистика',
+                    description: '...',
+                    state: 'PLANNED',
+                    occurredAt: null,
+                    trackNumber: null,
+                    trackContext: null
+                },
+                {
+                    code: 'INBOUND_PICKED_UP',
+                    title: 'Возврат обработан',
                     actor: 'Магазин',
                     description: '...',
                     state: 'PLANNED',


### PR DESCRIPTION
## Summary
- расширены enum-стадии возврата/обмена новыми этапами NEW, OUTBOUND_SENT, INBOUND_ARRIVED, INBOUND_PICKED_UP, EXCHANGE_REGISTERED, EXCHANGE_SENT, EXCHANGE_DELIVERED с финальными признаками
- переработаны workflow-переходы и OrderReturnRequestService под новую последовательность стадий и актуализированы SQL-миграции
- обновлены TrackViewService, серверные и фронтовые тесты для отображения нового таймлайна возврата

## Testing
- `mvn -q -Dtest=ReturnRequestWorkflowTest,OrderReturnRequestServiceTest,TrackViewServiceTest test` *(провалено: недоступен артефакт bucket4j на jitpack.io)*
- `npm test -- --runTestsByPath src/test/js/track-modal.test.js` *(провалено: не найден бинарник jest в окружении)*

------
https://chatgpt.com/codex/tasks/task_e_6904ab74dcb0832dab5d1a9615838da9