### PR TITLE
Expand return request actions and expose action codes

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/ReturnRequestAvailableActionsDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ReturnRequestAvailableActionsDto.java
@@ -1,5 +1,9 @@
 package com.project.tracking_system.dto;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
  * Доступные действия с заявкой на возврат/обмен.
  *
@@ -10,6 +14,7 @@ package com.project.tracking_system.dto;
  * @param cancelExchange                  возможность отменить обмен
  * @param confirmReceipt                  доступность подтверждения возврата магазином
  * @param cancelExchangeUnavailableReason причина недоступности отмены обмена
+ * @param actionCodes                     список доступных действий в виде кодов
  */
 public record ReturnRequestAvailableActionsDto(boolean startExchange,
                                                boolean createExchangeParcel,
@@ -17,5 +22,14 @@ public record ReturnRequestAvailableActionsDto(boolean startExchange,
                                                boolean reopenAsReturn,
                                                boolean cancelExchange,
                                                boolean confirmReceipt,
-                                               String cancelExchangeUnavailableReason) {
+                                               String cancelExchangeUnavailableReason,
+                                               Set<String> actionCodes) {
+
+    public ReturnRequestAvailableActionsDto {
+        if (actionCodes == null || actionCodes.isEmpty()) {
+            actionCodes = Set.of();
+        } else {
+            actionCodes = Collections.unmodifiableSet(new LinkedHashSet<>(actionCodes));
+        }
+    }
 }

--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
@@ -12,19 +12,39 @@ import java.util.Objects;
 public enum ReturnRequestAction {
 
     /**
-     * Отмена активной заявки на возврат без запуска обмена.
+     * Переводит заявку в режим возврата (отмена обмена с сохранением обращения).
      */
-    CANCEL_RETURN("cancel", "Отменить возврат", false),
+    SET_MODE_RETURN("set_mode_return", "Перевести в возврат", true),
 
     /**
-     * Отмена одобренного обмена до отправки обменной посылки.
+     * Запускает сценарий обмена для активной заявки возврата.
+     */
+    SET_MODE_EXCHANGE("set_mode_exchange", "Перевести в обмен", false),
+
+    /**
+     * Создаёт новую обменную посылку для обменной заявки.
+     */
+    CREATE_EXCHANGE_PARCEL("create_exchange_parcel", "Создать обменную посылку", true),
+
+    /**
+     * Закрывает заявку без запуска обмена.
+     */
+    CLOSE_REQUEST("close_request", "Закрыть обращение", false),
+
+    /**
+     * Отменяет одобренный обмен.
      */
     CANCEL_EXCHANGE("cancel_exchange", "Отменить обмен", true),
 
     /**
-     * Перевод одобренного обмена обратно в возврат.
+     * Подтверждает получение возврата магазином вручную.
      */
-    CONVERT_TO_RETURN("convert", "Перевести в возврат", true);
+    CONFIRM_RECEIPT("confirm_receipt", "Подтвердить получение возврата", false),
+
+    /**
+     * Обновляет обратный трек и комментарий заявки.
+     */
+    UPDATE_DETAILS("update_details", "Обновить данные обратной отправки", false);
 
     private final String code;
     private final String displayName;

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -538,7 +539,7 @@ public class CustomerTelegramService {
                 parcelId,
                 owner,
                 customer,
-                ReturnRequestAction.CONVERT_TO_RETURN
+                ReturnRequestAction.SET_MODE_RETURN
         );
     }
 
@@ -661,16 +662,19 @@ public class CustomerTelegramService {
         String trackNumber = parcel != null ? parcel.getNumber() : null;
         String storeName = parcel != null && parcel.getStore() != null ? parcel.getStore().getName() : null;
         GlobalStatus parcelStatus = parcel != null ? parcel.getStatus() : null;
-        boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
         EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
-        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CANCEL_RETURN);
-        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.CONVERT_TO_RETURN);
+        Set<String> actionCodes = actions.stream()
+                .map(ReturnRequestAction::getCode)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        boolean canStartExchange = actions.contains(ReturnRequestAction.SET_MODE_EXCHANGE);
+        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CLOSE_REQUEST);
+        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.SET_MODE_RETURN);
         boolean canCancelExchange = actions.contains(ReturnRequestAction.CANCEL_EXCHANGE);
         String cancelExchangeReason = orderReturnRequestService
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);
         boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
-        boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
+        boolean canConfirmReceipt = actions.contains(ReturnRequestAction.CONFIRM_RECEIPT);
 
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
         ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.NEW;
@@ -689,12 +693,13 @@ public class CustomerTelegramService {
 
         ReturnRequestAvailableActionsDto availableActions = new ReturnRequestAvailableActionsDto(
                 canStartExchange,
-                orderReturnRequestService.canCreateExchangeParcel(request),
+                actions.contains(ReturnRequestAction.CREATE_EXCHANGE_PARCEL),
                 canCloseWithoutExchange,
                 canReopenAsReturn,
                 canCancelExchange,
                 canConfirmReceipt,
-                cancelExchangeReason
+                cancelExchangeReason,
+                actionCodes
         );
 
         String requestedAt = formatRequestMoment(request.getRequestedAt());

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -650,10 +650,24 @@ public class OrderReturnRequestService {
             return false;
         }
         return switch (action) {
-            case CANCEL_RETURN -> request.getStatus() == OrderReturnRequestStatus.REGISTERED;
+            case SET_MODE_EXCHANGE -> canStartExchange(request);
+            case SET_MODE_RETURN -> canReopenAsReturn(request);
+            case CREATE_EXCHANGE_PARCEL -> canCreateExchangeParcel(request);
+            case CLOSE_REQUEST -> request.getStatus() == OrderReturnRequestStatus.REGISTERED;
             case CANCEL_EXCHANGE -> canCancelExchange(request);
-            case CONVERT_TO_RETURN -> canReopenAsReturn(request);
+            case CONFIRM_RECEIPT -> canConfirmReceipt(request);
+            case UPDATE_DETAILS -> canUpdateDetails(request);
         };
+    }
+
+    /**
+     * Проверяет, можно ли редактировать детали обратной отправки для заявки.
+     */
+    private boolean canUpdateDetails(OrderReturnRequest request) {
+        if (request == null) {
+            return false;
+        }
+        return ACTIVE_STATUSES.contains(request.getStatus());
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestActionMapper.java
@@ -7,6 +7,7 @@ import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.TrackParcel;
@@ -17,6 +18,9 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Преобразует заявки на возврат в DTO для вкладки «Требуют действия».
@@ -52,16 +56,20 @@ public class ReturnRequestActionMapper {
         GlobalStatus parcelStatus = parcel != null ? parcel.getStatus() : null;
         OrderReturnRequestStatus status = request.getStatus();
 
-        boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
         EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
-        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CANCEL_RETURN);
+        Set<String> actionCodes = actions.stream()
+                .map(ReturnRequestAction::getCode)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        boolean canStartExchange = actions.contains(ReturnRequestAction.SET_MODE_EXCHANGE);
+        boolean canCloseWithoutExchange = actions.contains(ReturnRequestAction.CLOSE_REQUEST);
         String cancelExchangeReason = orderReturnRequestService
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);
         boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
-        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.CONVERT_TO_RETURN);
+        boolean canReopenAsReturn = actions.contains(ReturnRequestAction.SET_MODE_RETURN);
         boolean canCancelExchange = actions.contains(ReturnRequestAction.CANCEL_EXCHANGE);
-        boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
+        boolean canConfirmReceipt = actions.contains(ReturnRequestAction.CONFIRM_RECEIPT);
+        boolean canCreateExchangeParcel = actions.contains(ReturnRequestAction.CREATE_EXCHANGE_PARCEL);
         ReturnRequestMode mode = request.getMode() != null ? request.getMode() : ReturnRequestMode.RETURN;
         ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.NEW;
 
@@ -79,12 +87,13 @@ public class ReturnRequestActionMapper {
 
         ReturnRequestAvailableActionsDto availableActions = new ReturnRequestAvailableActionsDto(
                 canStartExchange,
-                orderReturnRequestService.canCreateExchangeParcel(request),
+                canCreateExchangeParcel,
                 canCloseWithoutExchange,
                 canReopenAsReturn,
                 canCancelExchange,
                 canConfirmReceipt,
-                cancelExchangeReason
+                cancelExchangeReason,
+                actionCodes
         );
 
         ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
@@ -17,7 +17,10 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Маппер доменной заявки на возврат в DTO для API.
@@ -116,21 +119,22 @@ public class ReturnRequestMapper {
             return null;
         }
         EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
-        boolean canStartExchange = orderReturnRequestService.canStartExchange(request);
-        boolean canCreateExchangeParcel = orderReturnRequestService.canCreateExchangeParcel(request);
-        boolean canConfirmReceipt = orderReturnRequestService.canConfirmReceipt(request);
+        Set<String> actionCodes = actions.stream()
+                .map(ReturnRequestAction::getCode)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         String cancelExchangeReason = orderReturnRequestService
                 .getExchangeCancellationBlockReason(request)
                 .orElse(null);
 
         return new ReturnRequestAvailableActionsDto(
-                canStartExchange,
-                canCreateExchangeParcel,
-                actions.contains(ReturnRequestAction.CANCEL_RETURN),
-                actions.contains(ReturnRequestAction.CONVERT_TO_RETURN),
+                actions.contains(ReturnRequestAction.SET_MODE_EXCHANGE),
+                actions.contains(ReturnRequestAction.CREATE_EXCHANGE_PARCEL),
+                actions.contains(ReturnRequestAction.CLOSE_REQUEST),
+                actions.contains(ReturnRequestAction.SET_MODE_RETURN),
                 actions.contains(ReturnRequestAction.CANCEL_EXCHANGE),
-                canConfirmReceipt,
-                cancelExchangeReason
+                actions.contains(ReturnRequestAction.CONFIRM_RECEIPT),
+                cancelExchangeReason,
+                actionCodes
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -143,12 +143,21 @@ public class ReturnRequestWorkflow {
         ReturnRequestStage stage = safeStage(request.getStage());
         EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
         if (status == OrderReturnRequestStatus.REGISTERED) {
-            actions.add(ReturnRequestAction.CANCEL_RETURN);
+            actions.add(ReturnRequestAction.SET_MODE_EXCHANGE);
+            actions.add(ReturnRequestAction.CLOSE_REQUEST);
+            actions.add(ReturnRequestAction.CONFIRM_RECEIPT);
+            actions.add(ReturnRequestAction.UPDATE_DETAILS);
         }
-        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED
-                && stage != ReturnRequestStage.EXCHANGE_DELIVERED) {
-            actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
-            actions.add(ReturnRequestAction.CONVERT_TO_RETURN);
+        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            actions.add(ReturnRequestAction.CREATE_EXCHANGE_PARCEL);
+            actions.add(ReturnRequestAction.UPDATE_DETAILS);
+            if (stage != ReturnRequestStage.EXCHANGE_DELIVERED) {
+                actions.add(ReturnRequestAction.SET_MODE_RETURN);
+                actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
+            }
+        }
+        if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
+            actions.add(ReturnRequestAction.CONFIRM_RECEIPT);
         }
         return actions;
     }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.tracking_system.dto.ActionRequiredReturnRequestDto;
 import com.project.tracking_system.dto.CustomerStatisticsDTO;
+import com.project.tracking_system.dto.ReturnRequestAvailableActionsDto;
 import com.project.tracking_system.dto.ReturnRequestUpdateResponse;
 import com.project.tracking_system.dto.TelegramParcelInfoDTO;
 import com.project.tracking_system.dto.TelegramParcelsOverviewDTO;
@@ -49,6 +50,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.Map;
 import java.util.UUID;
@@ -1298,6 +1300,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         if (requestId == null || parcelId == null) {
             return rows;
         }
+        Set<String> actionCodes = Optional.ofNullable(request.availableActions())
+                .map(ReturnRequestAvailableActionsDto::actionCodes)
+                .orElse(Set.of());
         rows.add(new InlineKeyboardRow(InlineKeyboardButton.builder()
                 .text(BUTTON_RETURNS_ACTION_TRACK)
                 .callbackData(CALLBACK_RETURNS_ACTIVE_TRACK_PREFIX + requestId + ':' + parcelId)
@@ -1329,13 +1334,15 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         } else {
             boolean reverseTrackProvided = request.reverseTrackNumber() != null
                     && !request.reverseTrackNumber().isBlank();
-            String cancelText = reverseTrackProvided
-                    ? BUTTON_RETURNS_ACTION_CANCEL_RETURN_CONFIRM
-                    : BUTTON_RETURNS_ACTION_CANCEL_RETURN;
-            rows.add(new InlineKeyboardRow(InlineKeyboardButton.builder()
-                    .text(cancelText)
-                    .callbackData(CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX + requestId + ':' + parcelId)
-                    .build()));
+            if (actionCodes.contains(ReturnRequestAction.CLOSE_REQUEST.getCode())) {
+                String cancelText = reverseTrackProvided
+                        ? BUTTON_RETURNS_ACTION_CANCEL_RETURN_CONFIRM
+                        : BUTTON_RETURNS_ACTION_CANCEL_RETURN;
+                rows.add(new InlineKeyboardRow(InlineKeyboardButton.builder()
+                        .text(cancelText)
+                        .callbackData(CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX + requestId + ':' + parcelId)
+                        .build()));
+            }
         }
         return rows;
     }
@@ -1999,7 +2006,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
         answerCallbackQuery(callbackQuery, "Требуется подтверждение");
         ChatSession session = ensureChatSession(chatId);
-        showActiveRequestConfirmation(chatId, session, detailsOptional.get(), context, ReturnRequestAction.CANCEL_RETURN);
+        showActiveRequestConfirmation(chatId, session, detailsOptional.get(), context, ReturnRequestAction.CLOSE_REQUEST);
     }
 
     private void handleActiveRequestCancelExchange(Long chatId, CallbackQuery callbackQuery, String data) {
@@ -2037,7 +2044,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         ActiveRequestDetails details = detailsOptional.get();
         answerCallbackQuery(callbackQuery, "Требуется подтверждение");
         ChatSession session = ensureChatSession(chatId);
-        showActiveRequestConfirmation(chatId, session, details, context, ReturnRequestAction.CONVERT_TO_RETURN);
+        showActiveRequestConfirmation(chatId, session, details, context, ReturnRequestAction.SET_MODE_RETURN);
     }
 
     private Optional<ActiveRequestDetails> loadActiveRequestDetails(Long chatId, RequestActionContext context) {
@@ -2124,11 +2131,11 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return RETURNS_ACTIVE_CONFIRMATION_PROMPT;
         }
         return switch (action) {
-            case CANCEL_RETURN -> buildCancelReturnConfirmation(request);
+            case CLOSE_REQUEST -> buildCancelReturnConfirmation(request);
             case CANCEL_EXCHANGE -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CANCEL_EXCHANGE_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CANCEL_EXCHANGE_CONFIRMATION;
-            case CONVERT_TO_RETURN -> request.state().exchangeShipmentDispatched()
+            case SET_MODE_RETURN -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CONVERT_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CONVERT_CONFIRMATION;
         };
@@ -2241,9 +2248,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return;
         }
         switch (action) {
-            case CANCEL_RETURN -> executeCancelReturn(chatId, session, context);
+            case CLOSE_REQUEST -> executeCancelReturn(chatId, session, context);
             case CANCEL_EXCHANGE -> executeCancelExchange(chatId, session, context, requestInfo);
-            case CONVERT_TO_RETURN -> executeConvertToReturn(chatId, session, context, requestInfo);
+            case SET_MODE_RETURN -> executeConvertToReturn(chatId, session, context, requestInfo);
             default -> finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_NOT_AVAILABLE);
         }
     }

--- a/src/main/resources/db/migration/V35__rename_return_request_actions.sql
+++ b/src/main/resources/db/migration/V35__rename_return_request_actions.sql
@@ -1,0 +1,8 @@
+-- Обновляет сохранённые действия возвратов на новые имена перечисления
+UPDATE tb_return_request_action_requests
+SET action = 'CLOSE_REQUEST'
+WHERE action = 'CANCEL_RETURN';
+
+UPDATE tb_return_request_action_requests
+SET action = 'SET_MODE_RETURN'
+WHERE action = 'CONVERT_TO_RETURN';

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -545,22 +545,32 @@
             const mapLegacy = (key) => Boolean(legacy?.[key]);
             const legacyUpdateReverse = mapLegacy('allowUpdateReverseTrack');
             const canUpdateReverseTrack = this.request?.canUpdateReverseTrack;
+            const hasModernActions = Array.isArray(actions?.actionCodes);
+            const confirmReceiptFlag = hasActionCode(actions, 'confirm_receipt', { allowLegacyFallback: false });
+            const convertToExchangeFlag = hasActionCode(actions, 'set_mode_exchange', { allowLegacyFallback: false });
+            const launchExchangeFlag = hasActionCode(actions, 'create_exchange_parcel', { allowLegacyFallback: false });
+            const closeFlag = hasActionCode(actions, 'close_request', { allowLegacyFallback: false });
+            const reopenFlag = hasActionCode(actions, 'set_mode_return', { allowLegacyFallback: false });
+            const cancelExchangeFlag = hasActionCode(actions, 'cancel_exchange', { allowLegacyFallback: false });
+            const updateDetailsFlag = hasActionCode(actions, 'update_details', { allowLegacyFallback: false });
             return {
-                confirmReceipt: actions.confirmReceipt
-                    ?? mapLegacy('allowAcceptReverse')
-                    ?? mapLegacy('allowAccept'),
-                convertToExchange: actions.startExchange
-                    ?? mapLegacy('allowConvertToExchange')
-                    ?? mapLegacy('allowLaunchExchange'),
-                launchExchange: actions.createExchangeParcel
-                    ?? mapLegacy('allowLaunchExchange'),
-                close: actions.closeWithoutExchange ?? mapLegacy('allowClose'),
-                reopen: actions.reopenAsReturn ?? mapLegacy('allowConvertToReturn'),
-                updateReverseTrack: legacyUpdateReverse
+                confirmReceipt: confirmReceiptFlag
+                    || (!hasModernActions && (mapLegacy('allowAcceptReverse') || mapLegacy('allowAccept'))),
+                convertToExchange: convertToExchangeFlag
+                    || (!hasModernActions && (mapLegacy('allowConvertToExchange') || mapLegacy('allowLaunchExchange'))),
+                launchExchange: launchExchangeFlag
+                    || (!hasModernActions && mapLegacy('allowLaunchExchange')),
+                close: closeFlag
+                    || (!hasModernActions && mapLegacy('allowClose')),
+                reopen: reopenFlag
+                    || (!hasModernActions && mapLegacy('allowConvertToReturn')),
+                updateReverseTrack: updateDetailsFlag
+                    || legacyUpdateReverse
                     || (canUpdateReverseTrack === undefined
                         ? !this.timestamps.closedAt
                         : Boolean(canUpdateReverseTrack)),
-                cancelExchange: actions.cancelExchange ?? mapLegacy('allowClose')
+                cancelExchange: cancelExchangeFlag
+                    || (!hasModernActions && mapLegacy('allowClose'))
             };
         }
 
@@ -1263,6 +1273,46 @@
      * @param {Object} details DTO деталей трека
      * @returns {Object|null} частичный DTO строки таблицы или {@code null}
      */
+    const ACTION_CODE_ALIASES = {
+        'set_mode_exchange': ['startExchange'],
+        'create_exchange_parcel': ['createExchangeParcel'],
+        'close_request': ['closeWithoutExchange'],
+        'set_mode_return': ['reopenAsReturn'],
+        'cancel_exchange': ['cancelExchange'],
+        'confirm_receipt': ['confirmReceipt'],
+        'update_details': ['updateDetails']
+    };
+
+    function extractActionCodes(actions) {
+        if (!actions || typeof actions !== 'object') {
+            return [];
+        }
+        const rawCodes = Array.isArray(actions.actionCodes) ? actions.actionCodes : [];
+        return rawCodes
+            .map((code) => (typeof code === 'string' ? code.trim().toLowerCase() : ''))
+            .filter((code) => code.length > 0);
+    }
+
+    function hasActionCode(actions, code, options = {}) {
+        if (!code) {
+            return false;
+        }
+        const { allowLegacyFallback = true } = options;
+        const normalized = String(code).trim().toLowerCase();
+        const codes = extractActionCodes(actions);
+        if (codes.includes(normalized)) {
+            return true;
+        }
+        if (!allowLegacyFallback && Array.isArray(actions?.actionCodes)) {
+            return false;
+        }
+        const aliases = ACTION_CODE_ALIASES[normalized] || [];
+        if (!allowLegacyFallback) {
+            return false;
+        }
+        return aliases.some((alias) => Boolean(actions && typeof actions === 'object' && actions[alias]));
+    }
+
     function mapReturnRequestToTableSummary(details) {
         if (!details || typeof details !== 'object' || !details.returnRequest) {
             return null;
@@ -1284,14 +1334,14 @@
             comment: request.comment || null,
             reverseTrackNumber: request.reverseTrackNumber || null,
             exchangeRequested: Boolean(state.exchangeRequested),
-            canStartExchange: Boolean(actions.startExchange),
-            canCloseWithoutExchange: Boolean(actions.closeWithoutExchange),
-            canReopenAsReturn: Boolean(actions.reopenAsReturn),
-            canCancelExchange: Boolean(actions.cancelExchange),
+            canStartExchange: hasActionCode(actions, 'set_mode_exchange'),
+            canCloseWithoutExchange: hasActionCode(actions, 'close_request'),
+            canReopenAsReturn: hasActionCode(actions, 'set_mode_return'),
+            canCancelExchange: hasActionCode(actions, 'cancel_exchange'),
             cancelExchangeUnavailableReason: actions.cancelExchangeUnavailableReason || null,
             returnReceiptConfirmed: Boolean(state.returnReceiptConfirmed),
             returnReceiptConfirmedAt: timestamps.returnReceiptConfirmedAt || null,
-            canConfirmReceipt: Boolean(actions.confirmReceipt)
+            canConfirmReceipt: hasActionCode(actions, 'confirm_receipt')
         };
         if (timestamps.requestedAt) {
             summary.requestedAt = timestamps.requestedAt;
@@ -1322,14 +1372,14 @@
             comment: request.comment || null,
             reverseTrackNumber: request.reverseTrackNumber || null,
             exchangeRequested: Boolean(state.exchangeRequested),
-            canStartExchange: Boolean(actions.startExchange),
-            canCloseWithoutExchange: Boolean(actions.closeWithoutExchange),
-            canReopenAsReturn: Boolean(actions.reopenAsReturn),
-            canCancelExchange: Boolean(actions.cancelExchange),
+            canStartExchange: hasActionCode(actions, 'set_mode_exchange'),
+            canCloseWithoutExchange: hasActionCode(actions, 'close_request'),
+            canReopenAsReturn: hasActionCode(actions, 'set_mode_return'),
+            canCancelExchange: hasActionCode(actions, 'cancel_exchange'),
             cancelExchangeUnavailableReason: actions.cancelExchangeUnavailableReason || null,
             returnReceiptConfirmed: Boolean(state.returnReceiptConfirmed),
             returnReceiptConfirmedAt: timestamps.returnReceiptConfirmedAt || null,
-            canConfirmReceipt: Boolean(actions.confirmReceipt)
+            canConfirmReceipt: hasActionCode(actions, 'confirm_receipt')
         };
         if (timestamps.requestedAt) {
             summary.requestedAt = timestamps.requestedAt;

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -180,7 +181,7 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(52L, principal)).thenReturn(request);
         when(returnRequestMapper.toAvailableActions(request))
-                .thenReturn(new ReturnRequestAvailableActionsDto(true, false, true, false, false, false, null));
+                .thenReturn(new ReturnRequestAvailableActionsDto(true, false, true, false, false, false, null, Set.of()));
 
         mockMvc.perform(get("/api/v1/returns/52/available-actions")
                         .with(auth))

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -457,7 +457,7 @@ class CustomerTelegramServiceTest {
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
         when(trackParcelRepository.findById(parcelId)).thenReturn(Optional.of(parcel));
         when(orderReturnRequestService.requestMerchantAction(requestId, parcelId, owner, customer,
-                ReturnRequestAction.CONVERT_TO_RETURN)).thenReturn(actionRequest);
+                ReturnRequestAction.SET_MODE_RETURN)).thenReturn(actionRequest);
 
         OrderReturnRequestActionRequest result = customerTelegramService.requestExchangeConversionFromTelegram(
                 chatId,
@@ -467,7 +467,7 @@ class CustomerTelegramServiceTest {
 
         assertSame(actionRequest, result, "Метод обязан возвращать запрос на перевод обмена");
         verify(orderReturnRequestService).requestMerchantAction(requestId, parcelId, owner, customer,
-                ReturnRequestAction.CONVERT_TO_RETURN);
+                ReturnRequestAction.SET_MODE_RETURN);
     }
 
     private TrackParcel parcelWithStatus(String number, GlobalStatus status, ZonedDateTime lastUpdate) {

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -536,18 +536,18 @@ class OrderReturnRequestServiceTest {
         OrderReturnRequestActionRequest existing = new OrderReturnRequestActionRequest();
         existing.setReturnRequest(request);
         existing.setCustomer(customer);
-        existing.setAction(ReturnRequestAction.CONVERT_TO_RETURN);
+        existing.setAction(ReturnRequestAction.SET_MODE_RETURN);
 
         when(repository.findById(701L)).thenReturn(Optional.of(request));
         when(actionRequestRepository.findFirstByReturnRequest_IdAndActionAndProcessedAtIsNull(701L,
-                ReturnRequestAction.CONVERT_TO_RETURN)).thenReturn(Optional.of(existing));
+                ReturnRequestAction.SET_MODE_RETURN)).thenReturn(Optional.of(existing));
 
         OrderReturnRequestActionRequest result = service.requestMerchantAction(
                 701L,
                 31L,
                 user,
                 customer,
-                ReturnRequestAction.CONVERT_TO_RETURN
+                ReturnRequestAction.SET_MODE_RETURN
         );
 
         assertThat(result).isSameAs(existing);
@@ -768,8 +768,8 @@ class OrderReturnRequestServiceTest {
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
-        assertThat(actions).contains(ReturnRequestAction.CANCEL_RETURN);
-        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.CONVERT_TO_RETURN);
+        assertThat(actions).contains(ReturnRequestAction.CLOSE_REQUEST, ReturnRequestAction.SET_MODE_EXCHANGE);
+        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.SET_MODE_RETURN);
     }
 
     @Test
@@ -789,7 +789,7 @@ class OrderReturnRequestServiceTest {
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
-        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.CONVERT_TO_RETURN);
+        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.SET_MODE_RETURN);
     }
 
     private OrderReturnRequest buildExchangeRequest(Long id, TrackParcel parcel) {

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -16,6 +16,7 @@ import com.project.tracking_system.entity.BuyerBotScreen;
 import com.project.tracking_system.entity.BuyerChatState;
 import com.project.tracking_system.entity.Customer;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.NameSource;
@@ -59,9 +60,11 @@ import org.telegram.telegrambots.meta.generics.TelegramClient;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.time.ZonedDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -2435,6 +2438,22 @@ class BuyerTelegramBotTest {
                 null,
                 returnReceiptConfirmed
         );
+        Set<String> actionCodes = new LinkedHashSet<>();
+        if (canStartExchange) {
+            actionCodes.add(ReturnRequestAction.SET_MODE_EXCHANGE.getCode());
+        }
+        if (canCloseWithoutExchange) {
+            actionCodes.add(ReturnRequestAction.CLOSE_REQUEST.getCode());
+        }
+        if (canReopenAsReturn) {
+            actionCodes.add(ReturnRequestAction.SET_MODE_RETURN.getCode());
+        }
+        if (canCancelExchange) {
+            actionCodes.add(ReturnRequestAction.CANCEL_EXCHANGE.getCode());
+        }
+        if (canConfirmReceipt) {
+            actionCodes.add(ReturnRequestAction.CONFIRM_RECEIPT.getCode());
+        }
         ReturnRequestAvailableActionsDto actions = new ReturnRequestAvailableActionsDto(
                 canStartExchange,
                 false,
@@ -2442,7 +2461,8 @@ class BuyerTelegramBotTest {
                 canReopenAsReturn,
                 canCancelExchange,
                 canConfirmReceipt,
-                cancelExchangeUnavailableReason
+                cancelExchangeUnavailableReason,
+                actionCodes
         );
         ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(
                 requestedAt,

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -492,7 +492,7 @@ class TrackViewServiceTest {
         when(orderReturnRequestService.canConfirmReceipt(request)).thenReturn(true);
         when(orderReturnRequestService.canCreateExchangeParcel(request)).thenReturn(false);
         when(orderReturnRequestService.resolveAvailableActions(request))
-                .thenReturn(EnumSet.of(ReturnRequestAction.CANCEL_RETURN));
+                .thenReturn(EnumSet.of(ReturnRequestAction.CLOSE_REQUEST));
         when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
 
         TrackDetailsDto details = service.getTrackDetails(81L, 15L);

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -84,15 +84,21 @@ describe('track-modal render', () => {
         };
         const legacy = request.actionPermissions || {};
         const mapLegacy = (key) => Boolean(legacy?.[key]);
+        const rawActions = request.availableActions || {};
+        const normalizedCodes = Array.isArray(rawActions.actionCodes)
+            ? rawActions.actionCodes
+            : (Array.isArray(request.actionCodes) ? request.actionCodes : []);
         const availableActions = {
-            startExchange: Boolean(request.canStartExchange ?? mapLegacy('allowConvertToExchange') ?? mapLegacy('allowLaunchExchange')),
-            createExchangeParcel: Boolean(request.canCreateExchangeParcel ?? mapLegacy('allowLaunchExchange')),
-            closeWithoutExchange: Boolean(request.canCloseWithoutExchange ?? mapLegacy('allowClose')),
-            reopenAsReturn: Boolean(request.canReopenAsReturn ?? mapLegacy('allowConvertToReturn')),
-            cancelExchange: Boolean(request.canCancelExchange ?? mapLegacy('allowClose')),
-            confirmReceipt: Boolean(request.canConfirmReceipt ?? mapLegacy('allowAcceptReverse') ?? mapLegacy('allowAccept')),
-            cancelExchangeUnavailableReason: request.cancelExchangeUnavailableReason || null,
-            ...request.availableActions
+            ...rawActions,
+            startExchange: Boolean(request.canStartExchange ?? rawActions.startExchange ?? mapLegacy('allowConvertToExchange') ?? mapLegacy('allowLaunchExchange')),
+            createExchangeParcel: Boolean(request.canCreateExchangeParcel ?? rawActions.createExchangeParcel ?? mapLegacy('allowLaunchExchange')),
+            closeWithoutExchange: Boolean(request.canCloseWithoutExchange ?? rawActions.closeWithoutExchange ?? mapLegacy('allowClose')),
+            reopenAsReturn: Boolean(request.canReopenAsReturn ?? rawActions.reopenAsReturn ?? mapLegacy('allowConvertToReturn')),
+            cancelExchange: Boolean(request.canCancelExchange ?? rawActions.cancelExchange ?? mapLegacy('allowClose')),
+            confirmReceipt: Boolean(request.canConfirmReceipt ?? rawActions.confirmReceipt ?? mapLegacy('allowAcceptReverse') ?? mapLegacy('allowAccept')),
+            cancelExchangeUnavailableReason: (rawActions.cancelExchangeUnavailableReason
+                ?? request.cancelExchangeUnavailableReason) || null,
+            actionCodes: normalizedCodes
         };
         const timestamps = {
             requestedAt: request.requestedAt || null,


### PR DESCRIPTION
## Summary
- add full set of return request actions with stable codes and update workflow/service guards
- expose action codes in ReturnRequestAvailableActionsDto and propagate through mappers and DTO builders
- adjust Telegram bot and web client logic to rely on the new codes when rendering actions and confirmations

## Testing
- `mvn -q -DskipITs test` *(fails: dependency resolution error for bucket4j-core from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_6904fd4509dc832db0782006d68d89d4