### PR TITLE
Refactor return request dto schema

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/RequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/RequestDto.java
@@ -1,69 +1,30 @@
 package com.project.tracking_system.dto;
 
-import java.util.List;
-import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * DTO заявки на возврат или обмен для отображения в модальном окне и REST-API.
+ * DTO заявки на возврат или обмен для REST-API.
  * <p>
- * Запись содержит агрегированные сведения о статусе и доступных действиях, чтобы
- * фронтенд мог отрисовать карточку заявки без дополнительных запросов.
+ * Запись содержит только идентификаторы и текущие технические атрибуты,
+ * необходимые для последующих запросов клиентских приложений.
  * </p>
  *
- * @param id                        идентификатор заявки
- * @param status                    машинный код статуса
- * @param statusLabel               локализованное название статуса
- * @param reason                    причина оформления возврата
- * @param comment                   дополнительный комментарий
- * @param mode                      активный режим заявки (возврат/обмен)
- * @param stage                     текущий этап жизненного цикла
- * @param requiresAction            признак необходимости действий менеджера
- * @param reverseTrack              обратный трек, указанный покупателем или магазином
- * @param exchangeTrack             трек обменной посылки
- * @param manualInboundPick         флаг ручного подтверждения получения возврата
- * @param manualReverseTrack        флаг ручного указания обратного трека
- * @param exchangeRequested         признак, что обмен изначально запрошен покупателем
- * @param exchangeApproved          признак, что обмен был одобрен магазином
- * @param exchangeShipmentDispatched признак отправки обменной посылки
- * @param returnReceiptConfirmed    признак подтверждения возврата магазином
- * @param actions                   перечень доступных действий
- * @param timestamps                временные метки жизненного цикла
- * @param storeId                   идентификатор магазина
- * @param responsibleId             идентификатор ответственного менеджера
+ * @param id            идентификатор заявки
+ * @param mode          активный режим (возврат или обмен)
+ * @param stage         код текущего этапа обработки
+ * @param storeId       идентификатор магазина
+ * @param orderId       идентификатор заказа или эпизода, к которому относится заявка
+ * @param parcelId      идентификатор исходной посылки
+ * @param userId        идентификатор пользователя, создавшего заявку
+ * @param responsibleId идентификатор ответственного менеджера
  */
+@JsonIgnoreProperties(ignoreUnknown = false)
 public record RequestDto(Long id,
-                         String status,
-                         String statusLabel,
-                         String reason,
-                         String comment,
                          String mode,
                          String stage,
-                         boolean requiresAction,
-                         String reverseTrack,
-                         String exchangeTrack,
-                         boolean manualInboundPick,
-                         boolean manualReverseTrack,
-                         boolean exchangeRequested,
-                         boolean exchangeApproved,
-                         boolean exchangeShipmentDispatched,
-                         boolean returnReceiptConfirmed,
-                         List<AvailableActionsDto> actions,
-                         ReturnRequestTimestampsDto timestamps,
                          Long storeId,
+                         Long orderId,
+                         Long parcelId,
+                         Long userId,
                          Long responsibleId) {
-
-    public RequestDto {
-        actions = actions == null ? List.of() : List.copyOf(actions);
-        timestamps = Objects.requireNonNullElseGet(timestamps, () -> new ReturnRequestTimestampsDto(null, null, null, null, null, null, null, null));
-    }
-
-    /**
-     * Возвращает признак, что заявка является обменом для обратной совместимости фронтенда.
-     */
-    public boolean isExchangeRequest() {
-        if (exchangeRequested || exchangeApproved) {
-            return true;
-        }
-        return mode != null && mode.equalsIgnoreCase("EXCHANGE");
-    }
 }

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
@@ -2,9 +2,7 @@ package com.project.tracking_system.service.order;
 
 import com.project.tracking_system.dto.AvailableActionsDto;
 import com.project.tracking_system.dto.RequestDto;
-import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
-import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
@@ -12,9 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -23,7 +18,7 @@ import java.util.Optional;
 /**
  * Маппер доменной заявки на возврат в DTO для API.
  * <p>
- * Компонент инкапсулирует расчёт доступных действий и форматирование дат,
+ * Компонент инкапсулирует расчёт доступных действий и передачу идентификаторов,
  * чтобы контроллер и сервисы отображения оставались тонкими и следовали SRP.
  * </p>
  */
@@ -31,79 +26,49 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ReturnRequestMapper {
 
-    /** Формат ISO для сериализации временных меток. */
-    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-
     private final OrderReturnRequestService orderReturnRequestService;
 
     /**
-     * Преобразует заявку в DTO карточки возврата.
+     * Преобразует заявку в минималистичный DTO карточки возврата.
+     * Метод возвращает только идентификаторы и текущие технические поля,
+     * необходимые клиентам для дальнейших запросов (SRP: форматирование витринных
+     * данных вынесено в другие компоненты).
      *
      * @param request исходная заявка
-     * @param userZone предпочитаемый часовой пояс пользователя
+     * @param userZone временная зона пользователя (не используется, сохранена для обратной совместимости вызовов)
      * @return заполненный DTO или {@code null}, если заявка отсутствует
      */
     public RequestDto toDto(OrderReturnRequest request, ZoneId userZone) {
         if (request == null) {
             return null;
         }
-        ZoneId zone = Optional.ofNullable(userZone).orElse(ZoneOffset.UTC);
-
-        EnumSet<ReturnRequestAction> activeActions = orderReturnRequestService.resolveAvailableActions(request);
-        List<AvailableActionsDto> actions = buildAvailableActions(request, activeActions);
-
-        String requestedAt = formatNullable(request.getRequestedAt(), zone);
-        if (requestedAt == null) {
-            requestedAt = formatNullable(request.getCreatedAt(), zone);
-        }
-
-        ReturnRequestTimestampsDto timestamps = new ReturnRequestTimestampsDto(
-                requestedAt,
-                formatNullable(request.getCreatedAt(), zone),
-                formatNullable(request.getDecisionAt(), zone),
-                formatNullable(request.getClosedAt(), zone),
-                formatNullable(request.getStageStartedAt(), zone),
-                formatNullable(request.getStageUpdatedAt(), zone),
-                formatNullable(request.getExchangeTrackAssignedAt(), zone),
-                formatNullable(request.getReturnReceiptConfirmedAt(), zone)
-        );
-
         ReturnRequestMode mode = Optional.ofNullable(request.getMode()).orElse(ReturnRequestMode.RETURN);
         ReturnRequestStage stage = Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW);
 
-        OrderReturnRequestStatus status = request.getStatus();
-
         Long storeId = Optional.ofNullable(request.getStore())
                 .map(store -> store.getId())
+                .orElse(null);
+        Long orderId = Optional.ofNullable(request.getEpisode())
+                .map(episode -> episode.getId())
+                .orElse(null);
+        Long parcelId = Optional.ofNullable(request.getParcel())
+                .map(parcel -> parcel.getId())
+                .orElse(null);
+        Long userId = Optional.ofNullable(request.getCreatedBy())
+                .map(user -> user.getId())
                 .orElse(null);
         Long responsibleId = Optional.ofNullable(request.getResponsibleManager())
                 .map(manager -> manager.getId())
                 .orElse(null);
 
-        boolean manualInboundPick = request.isManualStageOverride() && stage == ReturnRequestStage.INBOUND_PICKED_UP;
-        boolean manualReverseTrack = request.isManualTrackOverride();
-        boolean exchangeShipmentDispatched = orderReturnRequestService.isExchangeShipmentDispatched(request);
-
         return new RequestDto(
                 request.getId(),
-                status != null ? status.name() : null,
-                status != null ? status.getDisplayName() : null,
-                request.getReason(),
-                request.getComment(),
                 mode.name(),
                 stage.getCode(),
-                request.requiresAction(),
-                request.getReverseTrackNumber(),
-                request.getExchangeTrackNumber(),
-                manualInboundPick,
-                manualReverseTrack,
-                request.isExchangeRequested(),
-                request.isExchangeApproved(),
-                exchangeShipmentDispatched,
-                request.isReturnReceiptConfirmed(),
-                actions,
-                timestamps,
                 storeId,
+                orderId,
+                parcelId,
+                userId,
                 responsibleId
         );
     }
@@ -120,16 +85,6 @@ public class ReturnRequestMapper {
         }
         EnumSet<ReturnRequestAction> actions = orderReturnRequestService.resolveAvailableActions(request);
         return buildAvailableActions(request, actions);
-    }
-
-    /**
-     * Форматирует дату с учётом временной зоны пользователя.
-     */
-    private String formatNullable(ZonedDateTime moment, ZoneId zone) {
-        if (moment == null) {
-            return null;
-        }
-        return ISO_FORMATTER.format(moment.withZoneSameInstant(zone));
     }
 
     /**

--- a/src/main/resources/static/js/return-requests.js
+++ b/src/main/resources/static/js/return-requests.js
@@ -104,20 +104,13 @@
             confirmationSpan.classList.toggle('text-muted', !confirmed);
         }
 
-        const derivePermissions = (item) => {
-            const statusValue = typeof item?.status === 'string' ? item.status.toUpperCase() : '';
-            const state = item?.state || {};
-            const actions = item?.availableActions || {};
-            const exchangeStatus = statusValue === 'EXCHANGE_APPROVED' || Boolean(state.exchangeApproved);
-            const reverseMissing = !item?.reverseTrackNumber;
-            return {
-                allowConfirmReceipt: Boolean(actions.confirmReceipt),
-                allowConvertToExchange: Boolean(actions.startExchange),
-                allowCloseRequest: Boolean(actions.closeWithoutExchange),
-                allowUpdateReverseTrack: exchangeStatus && reverseMissing,
-                allowConvertToReturn: Boolean(actions.reopenAsReturn)
-            };
-        };
+        const derivePermissions = () => ({
+            allowConfirmReceipt: false,
+            allowConvertToExchange: false,
+            allowCloseRequest: false,
+            allowUpdateReverseTrack: false,
+            allowConvertToReturn: false
+        });
 
         const permissions = summary.actionPermissions
             ? summary.actionPermissions
@@ -127,8 +120,8 @@
         const allowCloseRequest = Boolean(permissions.allowCloseRequest);
         const allowUpdateReverseTrack = Boolean(permissions.allowUpdateReverseTrack);
         const allowConvertToReturn = Boolean(permissions.allowConvertToReturn);
-        const statusRaw = typeof summary.status === 'string' ? summary.status.toUpperCase() : '';
-        const isExchangeStatus = statusRaw === 'EXCHANGE_APPROVED';
+        const statusRaw = typeof summary.stage === 'string' ? summary.stage.toUpperCase() : '';
+        const isExchangeStatus = statusRaw.includes('EXCHANGE');
 
         const syncButton = (button, visible, label) => {
             if (!button) {

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -602,7 +602,9 @@
 
             const statusValue = document.createElement('div');
             statusValue.className = 'fs-6 fw-semibold';
-            statusValue.textContent = this.request?.status
+            const stageLabel = resolveStageLabel(this.request?.stage);
+            statusValue.textContent = stageLabel
+                || this.request?.status
                 || this.request?.statusLabel
                 || 'Статус не определён';
             statusRow.appendChild(statusValue);
@@ -1283,6 +1285,32 @@
         'update_details': ['updateDetails']
     };
 
+    const STAGE_LABELS = {
+        NEW: 'Заявка зарегистрирована',
+        OUTBOUND_SENT: 'Возврат отправлен',
+        INBOUND_ARRIVED: 'Возврат прибыл',
+        INBOUND_PICKED_UP: 'Возврат обработан',
+        EXCHANGE_REGISTERED: 'Обмен зарегистрирован',
+        EXCHANGE_SENT: 'Обмен отправлен',
+        EXCHANGE_DELIVERED: 'Обмен доставлен'
+    };
+
+    /**
+     * Возвращает человеко-читаемый ярлык этапа.
+     * @param {string|null|undefined} stage код этапа из DTO
+     * @returns {string|null} локализованный ярлык или {@code null}
+     */
+    function resolveStageLabel(stage) {
+        if (!stage) {
+            return null;
+        }
+        const normalized = String(stage).trim().toUpperCase();
+        if (!normalized) {
+            return null;
+        }
+        return STAGE_LABELS[normalized] || normalized;
+    }
+
     function extractActionCodes(actions) {
         if (!actions || typeof actions !== 'object') {
             return [];
@@ -1321,32 +1349,23 @@
         if (request.id === undefined) {
             return null;
         }
-        const state = request.state || {};
-        const actions = request.availableActions || {};
-        const timestamps = request.timestamps || {};
+        const stageLabel = resolveStageLabel(request.stage);
         const summary = {
-            parcelId: details.id,
+            parcelId: details.id ?? request.parcelId ?? null,
             requestId: request.id,
-            trackNumber: details.number || null,
-            parcelStatus: details.systemStatus || null,
-            statusLabel: request.statusLabel || request.status || null,
-            reason: request.reason || null,
-            comment: request.comment || null,
-            reverseTrackNumber: request.reverseTrackNumber || null,
-            exchangeRequested: Boolean(state.exchangeRequested),
-            canStartExchange: hasActionCode(actions, 'set_mode_exchange'),
-            canCloseWithoutExchange: hasActionCode(actions, 'close_request'),
-            canReopenAsReturn: hasActionCode(actions, 'set_mode_return'),
-            canCancelExchange: hasActionCode(actions, 'cancel_exchange'),
-            cancelExchangeUnavailableReason: actions.cancelExchangeUnavailableReason || null,
-            returnReceiptConfirmed: Boolean(state.returnReceiptConfirmed),
-            returnReceiptConfirmedAt: timestamps.returnReceiptConfirmedAt || null,
-            canConfirmReceipt: hasActionCode(actions, 'confirm_receipt')
+            mode: request.mode || null,
+            stage: request.stage || null,
+            storeId: request.storeId ?? null,
+            orderId: request.orderId ?? null,
+            userId: request.userId ?? null,
+            responsibleId: request.responsibleId ?? null,
+            stageLabel
         };
-        if (timestamps.requestedAt) {
-            summary.requestedAt = timestamps.requestedAt;
-        } else if (timestamps.createdAt) {
-            summary.requestedAt = timestamps.createdAt;
+        if (summary.parcelId === null && request.parcelId !== undefined) {
+            summary.parcelId = request.parcelId;
+        }
+        if (stageLabel) {
+            summary.statusLabel = stageLabel;
         }
         return summary;
     }
@@ -1361,30 +1380,20 @@
         if (!request || request.id === undefined) {
             return null;
         }
-        const state = request.state || {};
-        const actions = request.availableActions || {};
-        const timestamps = request.timestamps || {};
+        const stageLabel = resolveStageLabel(request.stage);
         const summary = {
             parcelId: trackId,
             requestId: request.id,
-            statusLabel: request.status || null,
-            reason: request.reason || null,
-            comment: request.comment || null,
-            reverseTrackNumber: request.reverseTrackNumber || null,
-            exchangeRequested: Boolean(state.exchangeRequested),
-            canStartExchange: hasActionCode(actions, 'set_mode_exchange'),
-            canCloseWithoutExchange: hasActionCode(actions, 'close_request'),
-            canReopenAsReturn: hasActionCode(actions, 'set_mode_return'),
-            canCancelExchange: hasActionCode(actions, 'cancel_exchange'),
-            cancelExchangeUnavailableReason: actions.cancelExchangeUnavailableReason || null,
-            returnReceiptConfirmed: Boolean(state.returnReceiptConfirmed),
-            returnReceiptConfirmedAt: timestamps.returnReceiptConfirmedAt || null,
-            canConfirmReceipt: hasActionCode(actions, 'confirm_receipt')
+            mode: request.mode || null,
+            stage: request.stage || null,
+            storeId: request.storeId ?? null,
+            orderId: request.orderId ?? null,
+            userId: request.userId ?? null,
+            responsibleId: request.responsibleId ?? null,
+            stageLabel
         };
-        if (timestamps.requestedAt) {
-            summary.requestedAt = timestamps.requestedAt;
-        } else if (timestamps.createdAt) {
-            summary.requestedAt = timestamps.createdAt;
+        if (stageLabel) {
+            summary.statusLabel = stageLabel;
         }
         return summary;
     }

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -286,7 +286,7 @@
                                                 <td class="text-start">
                                                     <div class="d-flex flex-column">
                                                         <span class="fw-semibold" data-return-status-label
-                                                              th:text="${request.statusLabel != null ? request.statusLabel : 'Статус не определён'}"></span>
+                                                              th:text="${request.stageLabel != null ? request.stageLabel : (request.stage != null ? request.stage : 'Статус не определён')}"></span>
                                                         <span class="text-muted small" data-return-requested
                                                               th:text="${request.timestamps != null and request.timestamps.requestedAt != null ? 'Обращение: ' + request.timestamps.requestedAt : 'Обращение: —'}"></span>
                                                         <span class="text-muted small" data-return-created

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -286,7 +286,7 @@
                                                 <td class="text-start">
                                                     <div class="d-flex flex-column">
                                                         <span class="fw-semibold" data-return-status-label
-                                                              th:text="${request.stageLabel != null ? request.stageLabel : (request.stage != null ? request.stage : 'Статус не определён')}"></span>
+                                                              th:text="${request.statusLabel != null ? request.statusLabel : (request.status != null ? request.status.displayName : 'Статус не определён')}"></span>
                                                         <span class="text-muted small" data-return-requested
                                                               th:text="${request.timestamps != null and request.timestamps.requestedAt != null ? 'Обращение: ' + request.timestamps.requestedAt : 'Обращение: —'}"></span>
                                                         <span class="text-muted small" data-return-created

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -2,7 +2,6 @@ package com.project.tracking_system.controller;
 
 import com.project.tracking_system.dto.AvailableActionsDto;
 import com.project.tracking_system.dto.RequestDto;
-import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
@@ -71,14 +70,7 @@ class ReturnsControllerTest {
                 eq(false)
         )).thenReturn(request);
 
-        RequestDto responseDto = buildRequestDto(
-                15L,
-                "REGISTERED",
-                "Регистрация",
-                "Размер не подошёл",
-                "Комментарий",
-                "BY123"
-        );
+        RequestDto responseDto = buildRequestDto(15L, "RETURN", "NEW", 17L, 7L);
         when(returnRequestMapper.toDto(eq(request), any())).thenReturn(responseDto);
 
         mockMvc.perform(post("/api/v1/returns")
@@ -95,7 +87,7 @@ class ReturnsControllerTest {
                                 "}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo(15)))
-                .andExpect(jsonPath("$.reason", equalTo("Размер не подошёл")));
+                .andExpect(jsonPath("$.mode", equalTo("RETURN")));
 
         verify(orderReturnRequestService).registerReturn(
                 eq(7L),
@@ -114,7 +106,7 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = authentication(principal);
 
-        RequestDto responseDto = buildRequestDto(21L, "EXCHANGE", "Обмен", null, null, null);
+        RequestDto responseDto = buildRequestDto(21L, "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
         when(returnRequestCommandService.executeCommand(eq(21L), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
@@ -124,7 +116,7 @@ class ReturnsControllerTest {
                         .content("{\"idempotencyKey\":\"cmd-1\",\"action\":\"start_exchange\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo(21)))
-                .andExpect(jsonPath("$.status", equalTo("EXCHANGE")));
+                .andExpect(jsonPath("$.mode", equalTo("EXCHANGE")));
         verify(returnRequestCommandService).executeCommand(eq(21L), any(), any(), eq(principal), any());
     }
 
@@ -133,7 +125,7 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = authentication(principal);
 
-        RequestDto responseDto = buildRequestDto(30L, "REGISTERED", "Зарегистрирована", null, "Комментарий", "BY000");
+        RequestDto responseDto = buildRequestDto(30L, "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
         when(returnRequestCommandService.executeCommand(eq(30L), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
@@ -142,7 +134,7 @@ class ReturnsControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"idempotencyKey\":\"cmd-2\",\"action\":\"update_details\",\"payload\":{\"reverseTrack\":\"BY000\",\"comment\":\"Комментарий\"}}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.reverseTrack", equalTo("BY000")));
+                .andExpect(jsonPath("$.stage", equalTo("INBOUND_PICKED_UP")));
         verify(returnRequestCommandService).executeCommand(eq(30L), any(), any(), eq(principal), any());
     }
 
@@ -154,7 +146,7 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(51L, principal)).thenReturn(request);
         when(returnRequestMapper.toDto(eq(request), any()))
-                .thenReturn(buildRequestDto(51L, "REGISTERED", "Зарегистрирована", null, null, null));
+                .thenReturn(buildRequestDto(51L, "RETURN", "NEW", 17L, 51L));
 
         mockMvc.perform(get("/api/v1/returns/51")
                         .with(auth))
@@ -187,32 +179,19 @@ class ReturnsControllerTest {
     }
 
     private RequestDto buildRequestDto(Long id,
-                                       String status,
-                                       String statusLabel,
-                                       String reason,
-                                       String comment,
-                                       String reverseTrack) {
+                                       String mode,
+                                       String stage,
+                                       Long storeId,
+                                       Long parcelId) {
         return new RequestDto(
                 id,
-                status,
-                statusLabel,
-                reason,
-                comment,
-                "RETURN",
-                "NEW",
-                false,
-                reverseTrack,
-                null,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                List.of(),
-                new ReturnRequestTimestampsDto(null, null, null, null, null, null, null, null),
-                null,
-                null
+                mode,
+                stage,
+                storeId,
+                99L,
+                parcelId,
+                5L,
+                7L
         );
     }
 

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.tracking_system.controller.ReturnRequestCommandType;
 import com.project.tracking_system.dto.CommandDto;
 import com.project.tracking_system.dto.RequestDto;
-import com.project.tracking_system.dto.ReturnRequestTimestampsDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.ReturnCommandLog;
 import com.project.tracking_system.entity.TrackParcel;
@@ -23,7 +22,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZoneOffset;
 import java.util.HexFormat;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -207,28 +205,16 @@ class ReturnRequestCommandServiceTest {
         return request;
     }
 
-    private RequestDto buildRequestDto(Long id, String status) {
+    private RequestDto buildRequestDto(Long id, String mode) {
         return new RequestDto(
                 id,
-                status,
-                status,
-                null,
-                null,
-                "RETURN",
+                mode,
                 "NEW",
-                false,
-                null,
-                null,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                List.of(),
-                new ReturnRequestTimestampsDto(null, null, null, null, null, null, null, null),
-                null,
-                null
+                10L,
+                20L,
+                30L,
+                40L,
+                50L
         );
     }
 }

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewCacheEvictionIntegrationTest.java
@@ -5,6 +5,8 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderEpisode;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.OrderReturnRequestActionRequestRepository;
@@ -119,18 +121,18 @@ class TrackViewCacheEvictionIntegrationTest {
         TrackDetailsDto initialDetails = trackViewService.getTrackDetails(parcelId, userId);
 
         assertThat(initialDetails.returnRequest()).isNotNull();
-        assertThat(initialDetails.returnRequest().status())
-                .isEqualTo(OrderReturnRequestStatus.REGISTERED.getDisplayName());
-        assertThat(initialDetails.returnRequest().state().exchangeApproved()).isFalse();
+        assertThat(initialDetails.returnRequest().stage())
+                .isEqualTo(ReturnRequestStage.NEW.getCode());
+        assertThat(initialDetails.returnRequest().mode())
+                .isEqualTo(ReturnRequestMode.RETURN.name());
 
         orderReturnRequestService.approveExchange(request.getId(), parcelId, owner);
 
         TrackDetailsDto refreshedDetails = trackViewService.getTrackDetails(parcelId, userId);
 
         assertThat(refreshedDetails.returnRequest()).isNotNull();
-        assertThat(refreshedDetails.returnRequest().status())
-                .isEqualTo(OrderReturnRequestStatus.EXCHANGE_APPROVED.getDisplayName());
-        assertThat(refreshedDetails.returnRequest().state().exchangeApproved()).isTrue();
+        assertThat(refreshedDetails.returnRequest().mode())
+                .isEqualTo(ReturnRequestMode.EXCHANGE.name());
 
         verify(orderReturnRequestRepository, times(2)).findFirstByParcel_IdAndStatusIn(eq(parcelId), anyCollection());
     }


### PR DESCRIPTION
## Summary
- shrink `RequestDto` to the new minimal schema with identifiers only and forbid extra payload fields
- simplify the return request mapper plus related Java tests to align with the reduced DTO
- update templates and frontend utilities to rely on the new `stage`/`mode` fields and drop expectations about embedded actions

## Testing
- `mvn -q test` *(fails: jitpack dependency io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 returns HTTP 403)*
- `npm test -- --runInBand` *(fails: jest binary is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_69050e497cec832d841fce829479a8f0