### PR TITLE
Align ReturnRequestCommandType with ReturnRequestAction codes

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
@@ -7,26 +7,35 @@ import java.util.Arrays;
  */
 enum ReturnRequestCommandType {
 
+    /** Перевести заявку из обмена обратно в возврат. */
+    SET_MODE_RETURN("set_mode_return"),
+
     /** Перевести заявку в режим обмена. */
-    START_EXCHANGE("start_exchange"),
+    SET_MODE_EXCHANGE("set_mode_exchange"),
 
-    /** Создать обменную посылку. */
-    CREATE_EXCHANGE_PARCEL("create_exchange_parcel"),
+    /** Отметить исходящую отправку покупателя. */
+    MARK_OUTBOUND_SENT("mark_outbound_sent"),
 
-    /** Закрыть заявку без запуска обмена. */
-    CLOSE("close"),
+    /** Зафиксировать прибытие возврата в магазин. */
+    MARK_INBOUND_ARRIVED("mark_inbound_arrived"),
 
-    /** Подтвердить получение возврата магазином. */
-    CONFIRM_RECEIPT("confirm_receipt"),
+    /** Подтвердить выдачу возврата сотруднику склада. */
+    MARK_INBOUND_PICKED_UP("mark_inbound_picked_up"),
 
-    /** Обновить данные обратной отправки и комментарий. */
-    UPDATE_DETAILS("update_details"),
+    /** Зарегистрировать обменную посылку магазина. */
+    REGISTER_EXCHANGE_PARCEL("register_exchange_parcel"),
 
-    /** Перевести обмен обратно в возврат. */
-    REOPEN("reopen"),
+    /** Отметить отправку обменной посылки покупателю. */
+    MARK_EXCHANGE_SENT("mark_exchange_sent"),
 
-    /** Отменить обмен после запуска. */
-    CANCEL_EXCHANGE("cancel_exchange");
+    /** Подтвердить доставку обменной посылки. */
+    MARK_EXCHANGE_DELIVERED("mark_exchange_delivered"),
+
+    /** Обновить данные обратного трека и комментарий. */
+    UPDATE_REVERSE_TRACK("update_reverse_track"),
+
+    /** Закрыть обращение после завершения обработки. */
+    CLOSE_REQUEST("close_request");
 
     private final String code;
 
@@ -35,7 +44,7 @@ enum ReturnRequestCommandType {
     }
 
     /**
-     * Восстанавливает тип команды по строковому коду.
+     * Восстанавливает тип команды по строковому коду без учёта регистра.
      *
      * @param code код команды из запроса
      * @return найденный тип или {@code null}, если код неизвестен


### PR DESCRIPTION
## Summary
- synchronize return request command enumeration with the updated action codes
- ensure the case-insensitive lookup documentation matches the new codes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690685501dfc832da3dbbbd8521938f6