### PR TITLE
Refine return request actions and commands

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
@@ -7,35 +7,26 @@ import java.util.Arrays;
  */
 enum ReturnRequestCommandType {
 
-    /** Перевести заявку из обмена обратно в возврат. */
-    SET_MODE_RETURN("set_mode_return"),
+    /** Запустить обмен по заявке возврата. */
+    START_EXCHANGE("start_exchange"),
 
-    /** Перевести заявку в режим обмена. */
-    SET_MODE_EXCHANGE("set_mode_exchange"),
+    /** Создать обменную посылку для одобренного обмена. */
+    CREATE_EXCHANGE_PARCEL("create_exchange_parcel"),
 
-    /** Отметить исходящую отправку покупателя. */
-    MARK_OUTBOUND_SENT("mark_outbound_sent"),
+    /** Отменить запущенный обмен. */
+    CANCEL_EXCHANGE("cancel_exchange"),
 
-    /** Зафиксировать прибытие возврата в магазин. */
-    MARK_INBOUND_ARRIVED("mark_inbound_arrived"),
+    /** Перевести обмен обратно в возврат. */
+    REOPEN_RETURN("reopen_return"),
 
-    /** Подтвердить выдачу возврата сотруднику склада. */
-    MARK_INBOUND_PICKED_UP("mark_inbound_picked_up"),
+    /** Подтвердить приём возврата магазином. */
+    CONFIRM_RECEIPT("confirm_receipt"),
 
-    /** Зарегистрировать обменную посылку магазина. */
-    REGISTER_EXCHANGE_PARCEL("register_exchange_parcel"),
+    /** Обновить данные заявки (треки и комментарии). */
+    UPDATE_DETAILS("update_details"),
 
-    /** Отметить отправку обменной посылки покупателю. */
-    MARK_EXCHANGE_SENT("mark_exchange_sent"),
-
-    /** Подтвердить доставку обменной посылки. */
-    MARK_EXCHANGE_DELIVERED("mark_exchange_delivered"),
-
-    /** Обновить данные обратного трека и комментарий. */
-    UPDATE_REVERSE_TRACK("update_reverse_track"),
-
-    /** Закрыть обращение после завершения обработки. */
-    CLOSE_REQUEST("close_request");
+    /** Закрыть заявку без запуска обмена. */
+    CLOSE("close");
 
     private final String code;
 

--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
@@ -12,54 +12,39 @@ import java.util.Objects;
 public enum ReturnRequestAction {
 
     /**
-     * Переводит текущую заявку в классический возврат, если ранее был выбран обмен.
+     * Запускает процесс обмена для заявки, находящейся в статусе возврата.
      */
-    SET_MODE_RETURN("set_mode_return", "Перевести в возврат", true),
+    START_EXCHANGE("start_exchange", "Запустить обмен", false),
 
     /**
-     * Переводит заявку в режим обмена, инициируя встречную отправку магазина.
+     * Создаёт обменную посылку и фиксирует её привязку к заявке.
      */
-    SET_MODE_EXCHANGE("set_mode_exchange", "Перевести в обмен", false),
+    CREATE_EXCHANGE_PARCEL("create_exchange_parcel", "Создать обменную посылку", true),
 
     /**
-     * Помечает, что покупатель отправил исходную посылку обратно в магазин.
+     * Отменяет обмен, возвращая заявку к обработке как классического возврата.
      */
-    MARK_OUTBOUND_SENT("mark_outbound_sent", "Отметить исходящую отправку", false),
+    CANCEL_EXCHANGE("cancel_exchange", "Отменить обмен", true),
 
     /**
-     * Фиксирует прибытие исходящей посылки в точку приёма магазина.
+     * Переводит обмен обратно в возврат без закрытия заявки.
      */
-    MARK_INBOUND_ARRIVED("mark_inbound_arrived", "Отметить прибытие возврата", false),
+    REOPEN_RETURN("reopen_return", "Перевести в возврат", true),
 
     /**
-     * Подтверждает, что возврат был выдан сотруднику склада магазина.
+     * Подтверждает приём возврата магазином в ручном режиме.
      */
-    MARK_INBOUND_PICKED_UP("mark_inbound_picked_up", "Подтвердить выдачу возврата", false),
-
-    /**
-     * Регистрирует данные обменной посылки, которую магазин подготовил покупателю.
-     */
-    REGISTER_EXCHANGE_PARCEL("register_exchange_parcel", "Зарегистрировать обменную посылку", true),
-
-    /**
-     * Помечает отправку обменной посылки покупателю.
-     */
-    MARK_EXCHANGE_SENT("mark_exchange_sent", "Отправить обменную посылку", true),
-
-    /**
-     * Отмечает успешную доставку обменной посылки покупателю.
-     */
-    MARK_EXCHANGE_DELIVERED("mark_exchange_delivered", "Подтвердить доставку обмена", true),
+    CONFIRM_RECEIPT("confirm_receipt", "Подтвердить приём возврата", false),
 
     /**
      * Обновляет данные обратного трека и комментарий по заявке.
      */
-    UPDATE_REVERSE_TRACK("update_reverse_track", "Обновить обратный трек", false),
+    UPDATE_DETAILS("update_details", "Обновить данные заявки", false),
 
     /**
-     * Закрывает заявку после завершения обработки обращения.
+     * Закрывает заявку без запуска обмена.
      */
-    CLOSE_REQUEST("close_request", "Закрыть обращение", false);
+    CLOSE("close", "Закрыть обращение", false);
 
     private final String code;
     private final String displayName;

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -539,7 +539,7 @@ public class CustomerTelegramService {
                 parcelId,
                 owner,
                 customer,
-                ReturnRequestAction.SET_MODE_RETURN
+                ReturnRequestAction.REOPEN_RETURN
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -650,10 +650,10 @@ public class OrderReturnRequestService {
             return false;
         }
         return switch (action) {
-            case SET_MODE_EXCHANGE -> canStartExchange(request);
-            case SET_MODE_RETURN -> canReopenAsReturn(request);
+            case START_EXCHANGE -> canStartExchange(request);
+            case REOPEN_RETURN -> canReopenAsReturn(request);
             case CREATE_EXCHANGE_PARCEL -> canCreateExchangeParcel(request);
-            case CLOSE_REQUEST -> request.getStatus() == OrderReturnRequestStatus.REGISTERED;
+            case CLOSE -> request.getStatus() == OrderReturnRequestStatus.REGISTERED;
             case CANCEL_EXCHANGE -> canCancelExchange(request);
             case CONFIRM_RECEIPT -> canConfirmReceipt(request);
             case UPDATE_DETAILS -> canUpdateDetails(request);

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -149,7 +149,7 @@ public class ReturnRequestCommandService {
                 );
                 yield orderReturnRequestService.getOwnedRequest(requestId, user);
             }
-            case REOPEN -> orderReturnRequestService.reopenAsReturn(requestId, parcelId, user);
+            case REOPEN_RETURN -> orderReturnRequestService.reopenAsReturn(requestId, parcelId, user);
             case CANCEL_EXCHANGE -> orderReturnRequestService.cancelExchange(requestId, parcelId, user);
         };
     }

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -143,8 +143,8 @@ public class ReturnRequestWorkflow {
         ReturnRequestStage stage = safeStage(request.getStage());
         EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
         if (status == OrderReturnRequestStatus.REGISTERED) {
-            actions.add(ReturnRequestAction.SET_MODE_EXCHANGE);
-            actions.add(ReturnRequestAction.CLOSE_REQUEST);
+            actions.add(ReturnRequestAction.START_EXCHANGE);
+            actions.add(ReturnRequestAction.CLOSE);
             actions.add(ReturnRequestAction.CONFIRM_RECEIPT);
             actions.add(ReturnRequestAction.UPDATE_DETAILS);
         }
@@ -152,7 +152,7 @@ public class ReturnRequestWorkflow {
             actions.add(ReturnRequestAction.CREATE_EXCHANGE_PARCEL);
             actions.add(ReturnRequestAction.UPDATE_DETAILS);
             if (stage != ReturnRequestStage.EXCHANGE_DELIVERED) {
-                actions.add(ReturnRequestAction.SET_MODE_RETURN);
+                actions.add(ReturnRequestAction.REOPEN_RETURN);
                 actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
             }
         }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -1329,7 +1329,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         } else {
             boolean reverseTrackProvided = request.reverseTrack() != null
                     && !request.reverseTrack().isBlank();
-            if (actionCodeSet.contains(ReturnRequestAction.CLOSE_REQUEST.getCode())) {
+            if (actionCodeSet.contains(ReturnRequestAction.CLOSE.getCode())) {
                 String cancelText = reverseTrackProvided
                         ? BUTTON_RETURNS_ACTION_CANCEL_RETURN_CONFIRM
                         : BUTTON_RETURNS_ACTION_CANCEL_RETURN;
@@ -2001,7 +2001,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
         answerCallbackQuery(callbackQuery, "Требуется подтверждение");
         ChatSession session = ensureChatSession(chatId);
-        showActiveRequestConfirmation(chatId, session, detailsOptional.get(), context, ReturnRequestAction.CLOSE_REQUEST);
+        showActiveRequestConfirmation(chatId, session, detailsOptional.get(), context, ReturnRequestAction.CLOSE);
     }
 
     private void handleActiveRequestCancelExchange(Long chatId, CallbackQuery callbackQuery, String data) {
@@ -2039,7 +2039,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         ActiveRequestDetails details = detailsOptional.get();
         answerCallbackQuery(callbackQuery, "Требуется подтверждение");
         ChatSession session = ensureChatSession(chatId);
-        showActiveRequestConfirmation(chatId, session, details, context, ReturnRequestAction.SET_MODE_RETURN);
+        showActiveRequestConfirmation(chatId, session, details, context, ReturnRequestAction.REOPEN_RETURN);
     }
 
     private Optional<ActiveRequestDetails> loadActiveRequestDetails(Long chatId, RequestActionContext context) {
@@ -2126,11 +2126,11 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return RETURNS_ACTIVE_CONFIRMATION_PROMPT;
         }
         return switch (action) {
-            case CLOSE_REQUEST -> buildCancelReturnConfirmation(request);
+            case CLOSE -> buildCancelReturnConfirmation(request);
             case CANCEL_EXCHANGE -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CANCEL_EXCHANGE_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CANCEL_EXCHANGE_CONFIRMATION;
-            case SET_MODE_RETURN -> request.state().exchangeShipmentDispatched()
+            case REOPEN_RETURN -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CONVERT_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CONVERT_CONFIRMATION;
         };
@@ -2243,9 +2243,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return;
         }
         switch (action) {
-            case CLOSE_REQUEST -> executeCancelReturn(chatId, session, context);
+            case CLOSE -> executeCancelReturn(chatId, session, context);
             case CANCEL_EXCHANGE -> executeCancelExchange(chatId, session, context, requestInfo);
-            case SET_MODE_RETURN -> executeConvertToReturn(chatId, session, context, requestInfo);
+            case REOPEN_RETURN -> executeConvertToReturn(chatId, session, context, requestInfo);
             default -> finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_NOT_AVAILABLE);
         }
     }

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -556,10 +556,10 @@
             const legacyUpdateReverse = mapLegacy('allowUpdateReverseTrack');
             const canUpdateReverseTrack = this.request?.canUpdateReverseTrack;
             const confirmReceiptFlag = hasActionCode(actions, 'confirm_receipt', { allowLegacyFallback: false });
-            const convertToExchangeFlag = hasActionCode(actions, 'set_mode_exchange', { allowLegacyFallback: false });
+            const convertToExchangeFlag = hasActionCode(actions, 'start_exchange', { allowLegacyFallback: false });
             const launchExchangeFlag = hasActionCode(actions, 'create_exchange_parcel', { allowLegacyFallback: false });
-            const closeFlag = hasActionCode(actions, 'close_request', { allowLegacyFallback: false });
-            const reopenFlag = hasActionCode(actions, 'set_mode_return', { allowLegacyFallback: false });
+            const closeFlag = hasActionCode(actions, 'close', { allowLegacyFallback: false });
+            const reopenFlag = hasActionCode(actions, 'reopen_return', { allowLegacyFallback: false });
             const cancelExchangeFlag = hasActionCode(actions, 'cancel_exchange', { allowLegacyFallback: false });
             const updateDetailsFlag = hasActionCode(actions, 'update_details', { allowLegacyFallback: false });
             return {
@@ -1284,10 +1284,10 @@
      * @returns {Object|null} частичный DTO строки таблицы или {@code null}
      */
     const ACTION_CODE_ALIASES = {
-        'set_mode_exchange': ['startExchange'],
+        'start_exchange': ['startExchange'],
         'create_exchange_parcel': ['createExchangeParcel'],
-        'close_request': ['closeWithoutExchange'],
-        'set_mode_return': ['reopenAsReturn'],
+        'close': ['closeWithoutExchange'],
+        'reopen_return': ['reopenAsReturn'],
         'cancel_exchange': ['cancelExchange'],
         'confirm_receipt': ['confirmReceipt'],
         'update_details': ['updateDetails']

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -161,13 +161,13 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(52L, principal)).thenReturn(request);
         when(returnRequestMapper.toAvailableActions(request))
-                .thenReturn(new AvailableActionsDto(List.of("set_mode_exchange", "close_request")));
+                .thenReturn(new AvailableActionsDto(List.of("start_exchange", "close")));
 
         mockMvc.perform(get("/api/v1/returns/52/available-actions")
                         .with(auth))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.actions[0]", equalTo("set_mode_exchange")))
-                .andExpect(jsonPath("$.actions[1]", equalTo("close_request")));
+                .andExpect(jsonPath("$.actions[0]", equalTo("start_exchange")))
+                .andExpect(jsonPath("$.actions[1]", equalTo("close")));
     }
 
     private UsernamePasswordAuthenticationToken authentication(User user) {

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -457,7 +457,7 @@ class CustomerTelegramServiceTest {
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
         when(trackParcelRepository.findById(parcelId)).thenReturn(Optional.of(parcel));
         when(orderReturnRequestService.requestMerchantAction(requestId, parcelId, owner, customer,
-                ReturnRequestAction.SET_MODE_RETURN)).thenReturn(actionRequest);
+                ReturnRequestAction.REOPEN_RETURN)).thenReturn(actionRequest);
 
         OrderReturnRequestActionRequest result = customerTelegramService.requestExchangeConversionFromTelegram(
                 chatId,
@@ -467,7 +467,7 @@ class CustomerTelegramServiceTest {
 
         assertSame(actionRequest, result, "Метод обязан возвращать запрос на перевод обмена");
         verify(orderReturnRequestService).requestMerchantAction(requestId, parcelId, owner, customer,
-                ReturnRequestAction.SET_MODE_RETURN);
+                ReturnRequestAction.REOPEN_RETURN);
     }
 
     private TrackParcel parcelWithStatus(String number, GlobalStatus status, ZonedDateTime lastUpdate) {

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -536,18 +536,18 @@ class OrderReturnRequestServiceTest {
         OrderReturnRequestActionRequest existing = new OrderReturnRequestActionRequest();
         existing.setReturnRequest(request);
         existing.setCustomer(customer);
-        existing.setAction(ReturnRequestAction.SET_MODE_RETURN);
+        existing.setAction(ReturnRequestAction.REOPEN_RETURN);
 
         when(repository.findById(701L)).thenReturn(Optional.of(request));
         when(actionRequestRepository.findFirstByReturnRequest_IdAndActionAndProcessedAtIsNull(701L,
-                ReturnRequestAction.SET_MODE_RETURN)).thenReturn(Optional.of(existing));
+                ReturnRequestAction.REOPEN_RETURN)).thenReturn(Optional.of(existing));
 
         OrderReturnRequestActionRequest result = service.requestMerchantAction(
                 701L,
                 31L,
                 user,
                 customer,
-                ReturnRequestAction.SET_MODE_RETURN
+                ReturnRequestAction.REOPEN_RETURN
         );
 
         assertThat(result).isSameAs(existing);
@@ -768,8 +768,8 @@ class OrderReturnRequestServiceTest {
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
-        assertThat(actions).contains(ReturnRequestAction.CLOSE_REQUEST, ReturnRequestAction.SET_MODE_EXCHANGE);
-        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.SET_MODE_RETURN);
+        assertThat(actions).contains(ReturnRequestAction.CLOSE, ReturnRequestAction.START_EXCHANGE);
+        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.REOPEN_RETURN);
     }
 
     @Test
@@ -789,7 +789,7 @@ class OrderReturnRequestServiceTest {
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
-        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.SET_MODE_RETURN);
+        assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.REOPEN_RETURN);
     }
 
     private OrderReturnRequest buildExchangeRequest(Long id, TrackParcel parcel) {

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -2441,13 +2441,13 @@ class BuyerTelegramBotTest {
         );
         List<String> actionCodes = new ArrayList<>();
         if (canStartExchange) {
-            actionCodes.add(ReturnRequestAction.SET_MODE_EXCHANGE.getCode());
+            actionCodes.add(ReturnRequestAction.START_EXCHANGE.getCode());
         }
         if (canCloseWithoutExchange) {
-            actionCodes.add(ReturnRequestAction.CLOSE_REQUEST.getCode());
+            actionCodes.add(ReturnRequestAction.CLOSE.getCode());
         }
         if (canReopenAsReturn) {
-            actionCodes.add(ReturnRequestAction.SET_MODE_RETURN.getCode());
+            actionCodes.add(ReturnRequestAction.REOPEN_RETURN.getCode());
         }
         if (canCancelExchange) {
             actionCodes.add(ReturnRequestAction.CANCEL_EXCHANGE.getCode());

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -492,7 +492,7 @@ class TrackViewServiceTest {
         when(orderReturnRequestService.canConfirmReceipt(request)).thenReturn(true);
         when(orderReturnRequestService.canCreateExchangeParcel(request)).thenReturn(false);
         when(orderReturnRequestService.resolveAvailableActions(request))
-                .thenReturn(EnumSet.of(ReturnRequestAction.CLOSE_REQUEST));
+                .thenReturn(EnumSet.of(ReturnRequestAction.CLOSE));
         when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
 
         TrackDetailsDto details = service.getTrackDetails(81L, 15L);


### PR DESCRIPTION
## Summary
- replace legacy return request actions with the new action set and update the workflow to expose the refreshed transitions
- align service logic, command handling, bots, and UI helpers with the new command identifiers and availability checks
- refresh associated unit tests and mappers so that the build reflects the renamed actions and commands

## Testing
- `mvn -q -DskipTests package` *(fails: dependency resolution blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_690687ba7650832d82cc1d3282f07f0a