### PR TITLE
feat: expand return workflow stage actions

### DIFF
--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
@@ -17,9 +17,29 @@ public enum ReturnRequestAction {
     START_EXCHANGE("start_exchange", "Запустить обмен", false),
 
     /**
+     * Фиксирует передачу возврата в доставку клиентом.
+     */
+    MARK_OUTBOUND_SENT("mark_outbound_sent", "Отметить отправку возврата", false),
+
+    /**
+     * Фиксирует прибытие возврата в пункт назначения магазина.
+     */
+    MARK_INBOUND_ARRIVED("mark_inbound_arrived", "Отметить прибытие возврата", false),
+
+    /**
+     * Фиксирует факт получения возврата магазином.
+     */
+    MARK_INBOUND_PICKED_UP("mark_inbound_picked_up", "Отметить приём возврата", false),
+
+    /**
      * Создаёт обменную посылку и фиксирует её привязку к заявке.
      */
     CREATE_EXCHANGE_PARCEL("create_exchange_parcel", "Создать обменную посылку", true),
+
+    /**
+     * Регистрирует обменную посылку без автоматического создания в системе.
+     */
+    REGISTER_EXCHANGE_PARCEL("register_exchange_parcel", "Зарегистрировать обменную посылку", true),
 
     /**
      * Отменяет обмен, возвращая заявку к обработке как классического возврата.
@@ -30,6 +50,21 @@ public enum ReturnRequestAction {
      * Переводит обмен обратно в возврат без закрытия заявки.
      */
     REOPEN_RETURN("reopen_return", "Перевести в возврат", true),
+
+    /**
+     * Отмечает, что обмен зарегистрирован и обрабатывается магазином.
+     */
+    MARK_EXCHANGE_REGISTERED("mark_exchange_registered", "Отметить регистрацию обмена", true),
+
+    /**
+     * Фиксирует отправку обменной посылки из магазина.
+     */
+    MARK_EXCHANGE_SENT("mark_exchange_sent", "Отметить отправку обмена", true),
+
+    /**
+     * Фиксирует доставку обменной посылки покупателю.
+     */
+    MARK_EXCHANGE_DELIVERED("mark_exchange_delivered", "Отметить доставку обмена", true),
 
     /**
      * Подтверждает приём возврата магазином в ручном режиме.

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -643,6 +643,17 @@ public class OrderReturnRequestService {
     }
 
     /**
+     * Проверяет, достигла ли обменная посылка финального статуса доставки.
+     */
+    private boolean isParcelDelivered(TrackParcel parcel) {
+        if (parcel == null) {
+            return false;
+        }
+        GlobalStatus status = parcel.getStatus();
+        return status == GlobalStatus.DELIVERED || status == GlobalStatus.RETURNED;
+    }
+
+    /**
      * Проверяет, разрешено ли действие для конкретной заявки с учётом всех ограничений.
      */
     private boolean isActionAllowed(ReturnRequestAction action, OrderReturnRequest request) {
@@ -657,7 +668,132 @@ public class OrderReturnRequestService {
             case CANCEL_EXCHANGE -> canCancelExchange(request);
             case CONFIRM_RECEIPT -> canConfirmReceipt(request);
             case UPDATE_DETAILS -> canUpdateDetails(request);
+            case MARK_OUTBOUND_SENT -> canMarkOutboundSent(request);
+            case MARK_INBOUND_ARRIVED -> canMarkInboundArrived(request);
+            case MARK_INBOUND_PICKED_UP -> canMarkInboundPickedUp(request);
+            case MARK_EXCHANGE_REGISTERED -> canMarkExchangeRegistered(request);
+            case REGISTER_EXCHANGE_PARCEL -> canRegisterExchangeParcel(request);
+            case MARK_EXCHANGE_SENT -> canMarkExchangeSent(request);
+            case MARK_EXCHANGE_DELIVERED -> canMarkExchangeDelivered(request);
         };
+    }
+
+    /**
+     * Проверяет, достаточно ли данных для фиксации отправки возврата пользователем.
+     */
+    private boolean canMarkOutboundSent(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            return false;
+        }
+        if (!hasReverseTrack(request)) {
+            return false;
+        }
+        return canTransitionToStage(request, ReturnRequestStage.OUTBOUND_SENT);
+    }
+
+    /**
+     * Проверяет, можно ли отметить прибытие возврата в пункт назначения.
+     */
+    private boolean canMarkInboundArrived(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            return false;
+        }
+        if (!hasReverseTrack(request)) {
+            return false;
+        }
+        return canTransitionToStage(request, ReturnRequestStage.INBOUND_ARRIVED);
+    }
+
+    /**
+     * Проверяет, можно ли подтвердить получение возврата магазином.
+     */
+    private boolean canMarkInboundPickedUp(OrderReturnRequest request) {
+        if (request == null) {
+            return false;
+        }
+        OrderReturnRequestStatus status = request.getStatus();
+        if (status != OrderReturnRequestStatus.REGISTERED && status != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            return false;
+        }
+        if (!hasReverseTrack(request)) {
+            return false;
+        }
+        return canTransitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP);
+    }
+
+    /**
+     * Проверяет, можно ли вручную отметить регистрацию обмена.
+     */
+    private boolean canMarkExchangeRegistered(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            return false;
+        }
+        return canTransitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED);
+    }
+
+    /**
+     * Проверяет, можно ли зарегистрировать обменную посылку вручную.
+     */
+    private boolean canRegisterExchangeParcel(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            return false;
+        }
+        ReturnRequestStage stage = request.getStage() != null ? request.getStage() : ReturnRequestStage.NEW;
+        if (stage != ReturnRequestStage.EXCHANGE_REGISTERED) {
+            return false;
+        }
+        return canCreateExchangeParcel(request);
+    }
+
+    /**
+     * Проверяет, можно ли отметить отправку обменной посылки.
+     */
+    private boolean canMarkExchangeSent(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            return false;
+        }
+        if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_SENT)) {
+            return false;
+        }
+        return orderExchangeService.findLatestExchangeParcel(request)
+                .map(this::isParcelDispatched)
+                .orElse(false);
+    }
+
+    /**
+     * Проверяет, можно ли отметить доставку обменной посылки.
+     */
+    private boolean canMarkExchangeDelivered(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            return false;
+        }
+        if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_DELIVERED)) {
+            return false;
+        }
+        return orderExchangeService.findLatestExchangeParcel(request)
+                .map(this::isParcelDelivered)
+                .orElse(false);
+    }
+
+    /**
+     * Проверяет, есть ли у заявки валидный обратный трек.
+     */
+    private boolean hasReverseTrack(OrderReturnRequest request) {
+        String track = request.getReverseTrackNumber();
+        return track != null && !track.isBlank();
+    }
+
+    /**
+     * Проверяет, разрешён ли переход на указанную стадию.
+     */
+    private boolean canTransitionToStage(OrderReturnRequest request, ReturnRequestStage targetStage) {
+        ReturnRequestMode mode = Optional.ofNullable(request.getMode()).orElse(ReturnRequestMode.RETURN);
+        ReturnRequestStage currentStage = Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW);
+        ReturnRequestStage normalized = returnRequestWorkflow.adjustStageForMode(mode, currentStage);
+        if (normalized == targetStage) {
+            return false;
+        }
+        return returnRequestWorkflow.canTransition(mode, normalized, targetStage);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -29,12 +29,14 @@ import org.springframework.stereotype.Component;
 public class ReturnRequestWorkflow {
 
     private final Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> transitionTable;
+    private final Map<ReturnRequestMode, Map<ReturnRequestStage, EnumSet<ReturnRequestAction>>> actionMatrix;
 
     /**
      * Создаёт workflow с таблицей допустимых переходов.
      */
     public ReturnRequestWorkflow() {
         this.transitionTable = buildTransitionTable();
+        this.actionMatrix = buildActionMatrix();
     }
 
     /**
@@ -140,23 +142,30 @@ public class ReturnRequestWorkflow {
             return EnumSet.noneOf(ReturnRequestAction.class);
         }
         OrderReturnRequestStatus status = request.getStatus();
+        ReturnRequestMode mode = safeMode(request.getMode());
         ReturnRequestStage stage = safeStage(request.getStage());
+
         EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
+        Map<ReturnRequestStage, EnumSet<ReturnRequestAction>> modeActions = actionMatrix.get(mode);
+        if (modeActions != null) {
+            EnumSet<ReturnRequestAction> stageActions = modeActions.get(stage);
+            if (stageActions != null) {
+                actions.addAll(stageActions);
+            }
+        }
+
         if (status == OrderReturnRequestStatus.REGISTERED) {
             actions.add(ReturnRequestAction.START_EXCHANGE);
             actions.add(ReturnRequestAction.CLOSE);
             actions.add(ReturnRequestAction.CONFIRM_RECEIPT);
             actions.add(ReturnRequestAction.UPDATE_DETAILS);
-        }
-        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+        } else if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
             actions.add(ReturnRequestAction.CREATE_EXCHANGE_PARCEL);
             actions.add(ReturnRequestAction.UPDATE_DETAILS);
-            if (stage != ReturnRequestStage.EXCHANGE_DELIVERED) {
-                actions.add(ReturnRequestAction.REOPEN_RETURN);
-                actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
-            }
-        }
-        if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
+            actions.add(ReturnRequestAction.REOPEN_RETURN);
+            actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
+            actions.add(ReturnRequestAction.CONFIRM_RECEIPT);
+        } else if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
             actions.add(ReturnRequestAction.CONFIRM_RECEIPT);
         }
         return actions;
@@ -205,6 +214,54 @@ public class ReturnRequestWorkflow {
         table.put(ReturnRequestMode.EXCHANGE, exchangeTransitions);
 
         return table;
+    }
+
+    private Map<ReturnRequestMode, Map<ReturnRequestStage, EnumSet<ReturnRequestAction>>> buildActionMatrix() {
+        Map<ReturnRequestMode, Map<ReturnRequestStage, EnumSet<ReturnRequestAction>>> matrix = new EnumMap<>(ReturnRequestMode.class);
+        for (ReturnRequestMode mode : ReturnRequestMode.values()) {
+            Map<ReturnRequestStage, EnumSet<ReturnRequestAction>> stageActions = new EnumMap<>(ReturnRequestStage.class);
+            Map<ReturnRequestStage, Set<ReturnRequestStage>> modeTransitions = transitionTable.get(mode);
+            if (modeTransitions != null) {
+                for (ReturnRequestStage stage : ReturnRequestStage.values()) {
+                    if (!stage.supportsMode(mode)) {
+                        continue;
+                    }
+                    Set<ReturnRequestStage> targets = modeTransitions.getOrDefault(stage, Collections.emptySet());
+                    EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
+                    for (ReturnRequestStage target : targets) {
+                        if (stage == target) {
+                            continue;
+                        }
+                        ReturnRequestAction action = mapTransitionToAction(target);
+                        if (action != null) {
+                            actions.add(action);
+                        }
+                    }
+                    if (!actions.isEmpty()) {
+                        stageActions.put(stage, actions);
+                    }
+                }
+            }
+            if (mode == ReturnRequestMode.EXCHANGE) {
+                stageActions.computeIfAbsent(ReturnRequestStage.EXCHANGE_REGISTERED,
+                        ignored -> EnumSet.noneOf(ReturnRequestAction.class))
+                        .add(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+            }
+            matrix.put(mode, stageActions);
+        }
+        return matrix;
+    }
+
+    private ReturnRequestAction mapTransitionToAction(ReturnRequestStage target) {
+        return switch (target) {
+            case OUTBOUND_SENT -> ReturnRequestAction.MARK_OUTBOUND_SENT;
+            case INBOUND_ARRIVED -> ReturnRequestAction.MARK_INBOUND_ARRIVED;
+            case INBOUND_PICKED_UP -> ReturnRequestAction.MARK_INBOUND_PICKED_UP;
+            case EXCHANGE_REGISTERED -> ReturnRequestAction.MARK_EXCHANGE_REGISTERED;
+            case EXCHANGE_SENT -> ReturnRequestAction.MARK_EXCHANGE_SENT;
+            case EXCHANGE_DELIVERED -> ReturnRequestAction.MARK_EXCHANGE_DELIVERED;
+            default -> null;
+        };
     }
 
     private Set<ReturnRequestStage> allowedStages(ReturnRequestMode mode) {

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -2133,6 +2133,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             case REOPEN_RETURN -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CONVERT_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CONVERT_CONFIRMATION;
+            default -> RETURNS_ACTIVE_CONFIRMATION_PROMPT;
         };
     }
 

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -770,6 +770,7 @@ class OrderReturnRequestServiceTest {
 
         assertThat(actions).contains(ReturnRequestAction.CLOSE, ReturnRequestAction.START_EXCHANGE);
         assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.REOPEN_RETURN);
+        assertThat(actions).doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT);
     }
 
     @Test
@@ -790,6 +791,88 @@ class OrderReturnRequestServiceTest {
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
         assertThat(actions).doesNotContain(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.REOPEN_RETURN);
+        assertThat(actions).doesNotContain(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
+    }
+
+    @Test
+    void resolveAvailableActions_IncludesReturnStageMarksWhenTrackProvided() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.NEW);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setReverseTrackNumber("BY123");
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(
+                ReturnRequestAction.MARK_OUTBOUND_SENT,
+                ReturnRequestAction.MARK_INBOUND_ARRIVED,
+                ReturnRequestAction.MARK_INBOUND_PICKED_UP
+        );
+    }
+
+    @Test
+    void resolveAvailableActions_AllowsExchangeRegistrationMark() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.INBOUND_PICKED_UP);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(ReturnRequestAction.MARK_EXCHANGE_REGISTERED);
+    }
+
+    @Test
+    void resolveAvailableActions_RegistersExchangeParcelWhenAllowed() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+        assertThat(actions).doesNotContain(ReturnRequestAction.MARK_EXCHANGE_SENT);
+    }
+
+    @Test
+    void resolveAvailableActions_ProvidesExchangeShipmentMarksWhenParcelTracked() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber("EXCH-1");
+        parcel.setStatus(GlobalStatus.IN_TRANSIT);
+
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(parcel));
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(ReturnRequestAction.MARK_EXCHANGE_SENT);
+        assertThat(actions).doesNotContain(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
+    }
+
+    @Test
+    void resolveAvailableActions_AllowsExchangeDeliveryMarkWhenParcelDelivered() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_SENT);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber("EXCH-2");
+        parcel.setStatus(GlobalStatus.DELIVERED);
+
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(parcel));
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
     }
 
     private OrderReturnRequest buildExchangeRequest(Long id, TrackParcel parcel) {

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -58,7 +58,7 @@ class ReturnRequestWorkflowTest {
 
         assertThatThrownBy(() -> workflow.transitionToStage(
                 request,
-                ReturnRequestStage.EXCHANGE_DELIVERY,
+                ReturnRequestStage.EXCHANGE_DELIVERED,
                 true,
                 null,
                 ZonedDateTime.now(ZoneOffset.UTC)


### PR DESCRIPTION
## Summary
- add stage-oriented return and exchange actions to the workflow matrix
- enforce permission checks for new stage actions in the return request service and adjust the Telegram bot confirmation switch
- extend unit tests to cover the additional actions and update workflow expectations

## Testing
- mvn -q -DskipITs test *(fails: Could not transfer artifact io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 from https://jitpack.io: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_69068bc199e8832da194834a0c480516