### PR TITLE
Align return action codes with uppercase identifiers

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
@@ -8,25 +8,25 @@ import java.util.Arrays;
 enum ReturnRequestCommandType {
 
     /** Запустить обмен по заявке возврата. */
-    START_EXCHANGE("start_exchange"),
+    START_EXCHANGE("START_EXCHANGE"),
 
     /** Создать обменную посылку для одобренного обмена. */
-    CREATE_EXCHANGE_PARCEL("create_exchange_parcel"),
+    CREATE_EXCHANGE_PARCEL("CREATE_EXCHANGE_PARCEL"),
 
     /** Отменить запущенный обмен. */
-    CANCEL_EXCHANGE("cancel_exchange"),
+    CANCEL_EXCHANGE("CANCEL_EXCHANGE"),
 
     /** Перевести обмен обратно в возврат. */
-    REOPEN_RETURN("reopen_return"),
+    REOPEN_RETURN("REOPEN_RETURN"),
 
     /** Подтвердить приём возврата магазином. */
-    CONFIRM_RECEIPT("confirm_receipt"),
+    CONFIRM_RECEIPT("CONFIRM_RECEIPT"),
 
     /** Обновить данные заявки (треки и комментарии). */
-    UPDATE_DETAILS("update_details"),
+    UPDATE_DETAILS("UPDATE_DETAILS"),
 
     /** Закрыть заявку без запуска обмена. */
-    CLOSE("close");
+    CLOSE("CLOSE");
 
     private final String code;
 

--- a/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/ActionRequiredReturnRequestDto.java
@@ -54,6 +54,9 @@ public record ActionRequiredReturnRequestDto(Long requestId,
             return false;
         }
         List<String> codes = actions != null ? actions.getActions() : List.of();
-        return codes.contains(action.getCode());
+        String targetCode = action.getCode();
+        return codes.stream()
+                .filter(Objects::nonNull)
+                .anyMatch(code -> code.equals(targetCode) || code.equalsIgnoreCase(targetCode));
     }
 }

--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
@@ -14,72 +14,72 @@ public enum ReturnRequestAction {
     /**
      * Запускает процесс обмена для заявки, находящейся в статусе возврата.
      */
-    START_EXCHANGE("start_exchange", "Запустить обмен", false),
+    START_EXCHANGE("START_EXCHANGE", "Запустить обмен", false),
 
     /**
      * Фиксирует передачу возврата в доставку клиентом.
      */
-    MARK_OUTBOUND_SENT("mark_outbound_sent", "Отметить отправку возврата", false),
+    MARK_OUTBOUND_SENT("MARK_OUTBOUND_SENT", "Отметить отправку возврата", false),
 
     /**
      * Фиксирует прибытие возврата в пункт назначения магазина.
      */
-    MARK_INBOUND_ARRIVED("mark_inbound_arrived", "Отметить прибытие возврата", false),
+    MARK_INBOUND_ARRIVED("MARK_INBOUND_ARRIVED", "Отметить прибытие возврата", false),
 
     /**
      * Фиксирует факт получения возврата магазином.
      */
-    MARK_INBOUND_PICKED_UP("mark_inbound_picked_up", "Отметить приём возврата", false),
+    MARK_INBOUND_PICKED_UP("MARK_INBOUND_PICKED_UP", "Отметить приём возврата", false),
 
     /**
      * Создаёт обменную посылку и фиксирует её привязку к заявке.
      */
-    CREATE_EXCHANGE_PARCEL("create_exchange_parcel", "Создать обменную посылку", true),
+    CREATE_EXCHANGE_PARCEL("CREATE_EXCHANGE_PARCEL", "Создать обменную посылку", true),
 
     /**
      * Регистрирует обменную посылку без автоматического создания в системе.
      */
-    REGISTER_EXCHANGE_PARCEL("register_exchange_parcel", "Зарегистрировать обменную посылку", true),
+    REGISTER_EXCHANGE_PARCEL("REGISTER_EXCHANGE_PARCEL", "Зарегистрировать обменную посылку", true),
 
     /**
      * Отменяет обмен, возвращая заявку к обработке как классического возврата.
      */
-    CANCEL_EXCHANGE("cancel_exchange", "Отменить обмен", true),
+    CANCEL_EXCHANGE("CANCEL_EXCHANGE", "Отменить обмен", true),
 
     /**
      * Переводит обмен обратно в возврат без закрытия заявки.
      */
-    REOPEN_RETURN("reopen_return", "Перевести в возврат", true),
+    REOPEN_RETURN("REOPEN_RETURN", "Перевести в возврат", true),
 
     /**
      * Отмечает, что обмен зарегистрирован и обрабатывается магазином.
      */
-    MARK_EXCHANGE_REGISTERED("mark_exchange_registered", "Отметить регистрацию обмена", true),
+    MARK_EXCHANGE_REGISTERED("MARK_EXCHANGE_REGISTERED", "Отметить регистрацию обмена", true),
 
     /**
      * Фиксирует отправку обменной посылки из магазина.
      */
-    MARK_EXCHANGE_SENT("mark_exchange_sent", "Отметить отправку обмена", true),
+    MARK_EXCHANGE_SENT("MARK_EXCHANGE_SENT", "Отметить отправку обмена", true),
 
     /**
      * Фиксирует доставку обменной посылки покупателю.
      */
-    MARK_EXCHANGE_DELIVERED("mark_exchange_delivered", "Отметить доставку обмена", true),
+    MARK_EXCHANGE_DELIVERED("MARK_EXCHANGE_DELIVERED", "Отметить доставку обмена", true),
 
     /**
      * Подтверждает приём возврата магазином в ручном режиме.
      */
-    CONFIRM_RECEIPT("confirm_receipt", "Подтвердить приём возврата", false),
+    CONFIRM_RECEIPT("CONFIRM_RECEIPT", "Подтвердить приём возврата", false),
 
     /**
      * Обновляет данные обратного трека и комментарий по заявке.
      */
-    UPDATE_DETAILS("update_details", "Обновить данные заявки", false),
+    UPDATE_DETAILS("UPDATE_DETAILS", "Обновить данные заявки", false),
 
     /**
      * Закрывает заявку без запуска обмена.
      */
-    CLOSE("close", "Закрыть обращение", false);
+    CLOSE("CLOSE", "Закрыть обращение", false);
 
     private final String code;
     private final String displayName;
@@ -123,7 +123,7 @@ public enum ReturnRequestAction {
             return null;
         }
         for (ReturnRequestAction action : values()) {
-            if (Objects.equals(action.code, code)) {
+            if (Objects.equals(action.code, code) || action.code.equalsIgnoreCase(code)) {
                 return action;
             }
         }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -104,9 +104,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     private static final String CALLBACK_RETURNS_ACTIVE_SELECT_PREFIX = "returns:active:select:";
     private static final String CALLBACK_RETURNS_ACTIVE_TRACK_PREFIX = "returns:active:track:";
     private static final String CALLBACK_RETURNS_ACTIVE_COMMENT_PREFIX = "returns:active:comment:";
-    private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX = "returns:active:cancel:";
-    private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_EXCHANGE_PREFIX = "returns:active:cancel_exchange:";
-    private static final String CALLBACK_RETURNS_ACTIVE_CONVERT_PREFIX = "returns:active:convert:";
+    private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX = "returns:active:CLOSE:";
+    private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_EXCHANGE_PREFIX = "returns:active:CANCEL_EXCHANGE:";
+    private static final String CALLBACK_RETURNS_ACTIVE_CONVERT_PREFIX = "returns:active:REOPEN_RETURN:";
     private static final String CALLBACK_RETURNS_ACTIVE_CONFIRM_PREFIX = "returns:active:confirm:";
     private static final String CALLBACK_RETURNS_DONE = "returns:done";
     private static final String CALLBACK_SETTINGS_TOGGLE_NOTIFICATIONS = "settings:toggle_notifications";
@@ -1298,7 +1298,10 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         List<String> actionCodes = Optional.ofNullable(request.actions())
                 .map(AvailableActionsDto::getActions)
                 .orElse(List.of());
-        Set<String> actionCodeSet = new HashSet<>(actionCodes);
+        Set<String> actionCodeSet = actionCodes.stream()
+                .filter(Objects::nonNull)
+                .map(String::toUpperCase)
+                .collect(Collectors.toCollection(HashSet::new));
         rows.add(new InlineKeyboardRow(InlineKeyboardButton.builder()
                 .text(BUTTON_RETURNS_ACTION_TRACK)
                 .callbackData(CALLBACK_RETURNS_ACTIVE_TRACK_PREFIX + requestId + ':' + parcelId)

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -161,13 +161,13 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(52L, principal)).thenReturn(request);
         when(returnRequestMapper.toAvailableActions(request))
-                .thenReturn(new AvailableActionsDto(List.of("start_exchange", "close")));
+                .thenReturn(new AvailableActionsDto(List.of("START_EXCHANGE", "CLOSE")));
 
         mockMvc.perform(get("/api/v1/returns/52/available-actions")
                         .with(auth))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.actions[0]", equalTo("start_exchange")))
-                .andExpect(jsonPath("$.actions[1]", equalTo("close")));
+                .andExpect(jsonPath("$.actions[0]", equalTo("START_EXCHANGE")))
+                .andExpect(jsonPath("$.actions[1]", equalTo("CLOSE")));
     }
 
     private UsernamePasswordAuthenticationToken authentication(User user) {

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -67,7 +67,7 @@ class ReturnRequestCommandServiceTest {
         OrderReturnRequest request = buildRequest(21L, 9L);
         OrderReturnRequest updated = buildRequest(21L, 9L);
         RequestDto dto = buildRequestDto(21L, "EXCHANGE");
-        CommandDto command = new CommandDto("dup-1", "start_exchange", null);
+        CommandDto command = new CommandDto("dup-1", "START_EXCHANGE", null);
 
         when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
         when(orderReturnRequestService.approveExchange(21L, 9L, user)).thenReturn(updated);
@@ -117,7 +117,7 @@ class ReturnRequestCommandServiceTest {
         when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(21L, "dup-2"))
                 .thenReturn(Optional.of(existing));
 
-        CommandDto command = new CommandDto("dup-2", "start_exchange", null);
+        CommandDto command = new CommandDto("dup-2", "START_EXCHANGE", null);
 
         assertThatThrownBy(() -> commandService.executeCommand(21L,
                 ReturnRequestCommandType.START_EXCHANGE,
@@ -136,7 +136,7 @@ class ReturnRequestCommandServiceTest {
     void executeCommand_whenConcurrentReservation_returnsStoredSnapshot() {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(22L, 10L);
-        CommandDto command = new CommandDto("dup-3", "start_exchange", null);
+        CommandDto command = new CommandDto("dup-3", "START_EXCHANGE", null);
 
         RequestDto storedDto = buildRequestDto(22L, "EXCHANGE");
         String snapshot;

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -1015,7 +1015,7 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:100:200"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:cancel:100:200"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE:100:200"));
 
         ArgumentCaptor<EditMessageText> editCaptor = ArgumentCaptor.forClass(EditMessageText.class);
         verify(telegramClient).execute(editCaptor.capture());
@@ -1083,13 +1083,13 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:300:400"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:cancel_exchange:300:400"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CANCEL_EXCHANGE:300:400"));
         clearInvocations(telegramClient);
 
         OrderReturnRequestActionRequest actionRequest = new OrderReturnRequestActionRequest();
         when(telegramService.requestExchangeCancellationFromTelegram(chatId, 400L, 300L)).thenReturn(actionRequest);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:cancel_exchange:yes:300:400"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CANCEL_EXCHANGE:yes:300:400"));
 
         verify(telegramService).requestExchangeCancellationFromTelegram(chatId, 400L, 300L);
         verify(telegramService, never()).cancelExchangeFromTelegram(anyLong(), anyLong(), anyLong());
@@ -1140,10 +1140,10 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:101:201"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:cancel:101:201"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE:101:201"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:cancel:yes:101:201"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CLOSE:yes:101:201"));
 
         verify(telegramService).closeReturnRequestFromTelegram(chatId, 201L, 101L);
 
@@ -1196,10 +1196,10 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:102:202"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:cancel:102:202"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE:102:202"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:cancel:no:102:202"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CLOSE:no:102:202"));
 
         verify(telegramService, never()).closeReturnRequestFromTelegram(anyLong(), anyLong(), anyLong());
 


### PR DESCRIPTION
## Summary
- align return request action and command codes with new uppercase identifiers
- update BuyerTelegramBot callbacks and action checks to accept uppercase codes
- adjust tests to assert the new uppercase action codes

## Testing
- mvn -q test *(fails: dependency download blocked by 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_69068e85af90832d93f76751c8316945