### PR TITLE
Align action code handling with updated return request workflow

### DIFF
--- a/src/main/resources/static/js/return-requests.js
+++ b/src/main/resources/static/js/return-requests.js
@@ -2,6 +2,88 @@
     'use strict';
 
     /**
+     * Синонимы action-code для поддержки переходного периода API.
+     * Используем карту, чтобы распознавать новые и устаревшие коды действий как эквивалентные.
+     */
+    const ACTION_CODE_SYNONYMS = {
+        'mark_inbound_picked_up': ['confirm_receipt'],
+        'confirm_receipt': ['mark_inbound_picked_up'],
+        'create_exchange_parcel': ['register_exchange_parcel'],
+        'register_exchange_parcel': ['create_exchange_parcel'],
+        'update_reverse_track': ['update_details'],
+        'update_details': ['update_reverse_track']
+    };
+
+    /**
+     * Нормализует action-code к нижнему регистру и убирает пробелы.
+     * @param {string} value исходный код
+     * @returns {string} нормализованное значение или пустая строка
+     */
+    function normalizeActionCode(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return value.trim().toLowerCase();
+    }
+
+    /**
+     * Формирует множество доступных action-code из возможных источников summary.
+     * Метод инкапсулирует детали структуры DTO, соблюдая принцип SRP.
+     * @param {Object} summary агрегированная информация о заявке
+     * @returns {Set<string>} множество нормализованных кодов
+     */
+    function collectActionCodes(summary) {
+        if (!summary || typeof summary !== 'object') {
+            return new Set();
+        }
+        const sources = [];
+        if (Array.isArray(summary.actionCodes)) {
+            sources.push(summary.actionCodes);
+        }
+        if (Array.isArray(summary.actions)) {
+            sources.push(summary.actions);
+        }
+        const available = summary.availableActions;
+        if (available && typeof available === 'object') {
+            if (Array.isArray(available.actions)) {
+                sources.push(available.actions);
+            }
+            if (Array.isArray(available.actionCodes)) {
+                sources.push(available.actionCodes);
+            }
+        }
+        const flattened = sources.flatMap((list) => Array.isArray(list) ? list : []);
+        const codes = flattened
+            .map((value) => normalizeActionCode(value))
+            .filter((value) => value.length > 0);
+        return new Set(codes);
+    }
+
+    /**
+     * Проверяет, содержится ли указанный action-code или его синонимы в множестве.
+     * @param {Set<string>} codeSet множество доступных действий
+     * @param {string} code искомое действие
+     * @returns {boolean} {@code true}, если действие доступно
+     */
+    function hasActionFromSet(codeSet, code) {
+        if (!(codeSet instanceof Set) || codeSet.size === 0) {
+            return false;
+        }
+        const normalized = normalizeActionCode(code);
+        if (!normalized) {
+            return false;
+        }
+        if (codeSet.has(normalized)) {
+            return true;
+        }
+        const synonyms = ACTION_CODE_SYNONYMS[normalized] || [];
+        return synonyms
+            .map((item) => normalizeActionCode(item))
+            .filter((item) => item.length > 0)
+            .some((item) => codeSet.has(item));
+    }
+
+    /**
      * Удаляет строку заявки из таблицы по идентификаторам посылки и заявки.
      * @param {string|number} trackId идентификатор посылки
      * @param {string|number} requestId идентификатор заявки
@@ -115,11 +197,32 @@
         const permissions = summary.actionPermissions
             ? summary.actionPermissions
             : derivePermissions(summary);
-        const allowConfirmReceipt = Boolean(permissions.allowConfirmReceipt);
-        const allowConvertToExchange = Boolean(permissions.allowConvertToExchange);
-        const allowCloseRequest = Boolean(permissions.allowCloseRequest);
-        const allowUpdateReverseTrack = Boolean(permissions.allowUpdateReverseTrack);
-        const allowConvertToReturn = Boolean(permissions.allowConvertToReturn);
+        const actionCodeSet = collectActionCodes(summary);
+        const hasModernActions = actionCodeSet.size > 0;
+
+        const fallbackAllowConfirmReceipt = Boolean(permissions.allowConfirmReceipt)
+            || (summary.canConfirmReceipt !== undefined ? Boolean(summary.canConfirmReceipt) : false);
+        const fallbackAllowConvertToExchange = Boolean(permissions.allowConvertToExchange);
+        const fallbackAllowCloseRequest = Boolean(permissions.allowCloseRequest);
+        const fallbackAllowUpdateReverseTrack = Boolean(permissions.allowUpdateReverseTrack)
+            || (summary.canUpdateReverseTrack !== undefined ? Boolean(summary.canUpdateReverseTrack) : false);
+        const fallbackAllowConvertToReturn = Boolean(permissions.allowConvertToReturn);
+
+        const allowConfirmReceipt = hasModernActions
+            ? hasActionFromSet(actionCodeSet, 'mark_inbound_picked_up')
+            : fallbackAllowConfirmReceipt;
+        const allowConvertToExchange = hasModernActions
+            ? hasActionFromSet(actionCodeSet, 'start_exchange')
+            : fallbackAllowConvertToExchange;
+        const allowCloseRequest = hasModernActions
+            ? hasActionFromSet(actionCodeSet, 'close') || hasActionFromSet(actionCodeSet, 'cancel_exchange')
+            : fallbackAllowCloseRequest;
+        const allowUpdateReverseTrack = hasModernActions
+            ? hasActionFromSet(actionCodeSet, 'update_reverse_track')
+            : fallbackAllowUpdateReverseTrack;
+        const allowConvertToReturn = hasModernActions
+            ? hasActionFromSet(actionCodeSet, 'reopen_return')
+            : fallbackAllowConvertToReturn;
         const statusRaw = typeof summary.stage === 'string' ? summary.stage.toUpperCase() : '';
         const isExchangeStatus = statusRaw.includes('EXCHANGE');
 

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -555,13 +555,13 @@
             const mapLegacy = (key) => Boolean(legacy?.[key]);
             const legacyUpdateReverse = mapLegacy('allowUpdateReverseTrack');
             const canUpdateReverseTrack = this.request?.canUpdateReverseTrack;
-            const confirmReceiptFlag = hasActionCode(actions, 'confirm_receipt', { allowLegacyFallback: false });
-            const convertToExchangeFlag = hasActionCode(actions, 'start_exchange', { allowLegacyFallback: false });
-            const launchExchangeFlag = hasActionCode(actions, 'create_exchange_parcel', { allowLegacyFallback: false });
-            const closeFlag = hasActionCode(actions, 'close', { allowLegacyFallback: false });
-            const reopenFlag = hasActionCode(actions, 'reopen_return', { allowLegacyFallback: false });
-            const cancelExchangeFlag = hasActionCode(actions, 'cancel_exchange', { allowLegacyFallback: false });
-            const updateDetailsFlag = hasActionCode(actions, 'update_details', { allowLegacyFallback: false });
+            const confirmReceiptFlag = hasActionCode(actions, 'mark_inbound_picked_up');
+            const convertToExchangeFlag = hasActionCode(actions, 'start_exchange');
+            const launchExchangeFlag = hasActionCode(actions, 'create_exchange_parcel');
+            const closeFlag = hasActionCode(actions, 'close');
+            const reopenFlag = hasActionCode(actions, 'reopen_return');
+            const cancelExchangeFlag = hasActionCode(actions, 'cancel_exchange');
+            const updateDetailsFlag = hasActionCode(actions, 'update_reverse_track');
             return {
                 confirmReceipt: confirmReceiptFlag
                     || (!hasModernActions && (mapLegacy('allowAcceptReverse') || mapLegacy('allowAccept'))),
@@ -1278,19 +1278,17 @@
     }
 
     /**
-     * Преобразует DTO модального окна в формат, ожидаемый таблицей возвратов.
-     * Метод формирует только доступные поля, не нарушая инкапсуляцию ActionRequiredReturnRequestDto (ISP).
-     * @param {Object} details DTO деталей трека
-     * @returns {Object|null} частичный DTO строки таблицы или {@code null}
+     * Синонимы action-code для обратной совместимости.
+     * Карта помогает сопоставить устаревшие и новые коды действий,
+     * чтобы проверка доступности кнопок оставалась единообразной.
      */
     const ACTION_CODE_ALIASES = {
-        'start_exchange': ['startExchange'],
-        'create_exchange_parcel': ['createExchangeParcel'],
-        'close': ['closeWithoutExchange'],
-        'reopen_return': ['reopenAsReturn'],
-        'cancel_exchange': ['cancelExchange'],
-        'confirm_receipt': ['confirmReceipt'],
-        'update_details': ['updateDetails']
+        'confirm_receipt': ['mark_inbound_picked_up'],
+        'mark_inbound_picked_up': ['confirm_receipt'],
+        'create_exchange_parcel': ['register_exchange_parcel'],
+        'register_exchange_parcel': ['create_exchange_parcel'],
+        'update_details': ['update_reverse_track'],
+        'update_reverse_track': ['update_details']
     };
 
     const STAGE_LABELS = {
@@ -1333,26 +1331,44 @@
             .filter((code) => code.length > 0);
     }
 
+    /**
+     * Проверяет, присутствует ли указанный action-code в списке доступных действий.
+     * Метод поддерживает синонимы, чтобы плавно перейти на новый контракт API.
+     * @param {Object|Array<string>} actions объект или массив с кодами действий
+     * @param {string} code проверяемый код действия
+     * @param {Object} [options] дополнительные настройки проверки
+     * @param {boolean} [options.matchSynonyms=true] учитывать ли синонимы
+     * @returns {boolean} {@code true}, если действие доступно
+     */
     function hasActionCode(actions, code, options = {}) {
         if (!code) {
             return false;
         }
-        const { allowLegacyFallback = true } = options;
+        const { matchSynonyms = true } = options;
         const normalized = String(code).trim().toLowerCase();
         const codes = extractActionCodes(actions);
         if (codes.includes(normalized)) {
             return true;
         }
-        if (!allowLegacyFallback && codes.length > 0) {
+        if (!matchSynonyms) {
             return false;
         }
         const aliases = ACTION_CODE_ALIASES[normalized] || [];
-        if (!allowLegacyFallback) {
+        if (aliases.length === 0) {
             return false;
         }
-        return aliases.some((alias) => Boolean(actions && typeof actions === 'object' && actions[alias]));
+        return aliases
+            .map((alias) => String(alias || '').trim().toLowerCase())
+            .filter((alias) => alias.length > 0)
+            .some((alias) => codes.includes(alias));
     }
 
+    /**
+     * Преобразует DTO модального окна в формат, ожидаемый таблицей возвратов.
+     * Метод формирует только доступные поля, не нарушая инкапсуляцию ActionRequiredReturnRequestDto (ISP).
+     * @param {Object} details DTO деталей трека
+     * @returns {Object|null} частичный DTO строки таблицы или {@code null}
+     */
     function mapReturnRequestToTableSummary(details) {
         if (!details || typeof details !== 'object' || !details.returnRequest) {
             return null;
@@ -1393,6 +1409,13 @@
         }
         if (request.canConfirmReceipt !== undefined) {
             summary.canConfirmReceipt = request.canConfirmReceipt;
+        }
+        if (request.canUpdateReverseTrack !== undefined) {
+            summary.canUpdateReverseTrack = request.canUpdateReverseTrack;
+        }
+        const actionCodes = extractActionCodes(request.availableActions);
+        if (actionCodes.length > 0) {
+            summary.actionCodes = actionCodes;
         }
         return summary;
     }
@@ -1436,6 +1459,13 @@
         }
         if (request.canConfirmReceipt !== undefined) {
             summary.canConfirmReceipt = request.canConfirmReceipt;
+        }
+        if (request.canUpdateReverseTrack !== undefined) {
+            summary.canUpdateReverseTrack = request.canUpdateReverseTrack;
+        }
+        const actionCodes = extractActionCodes(request.availableActions);
+        if (actionCodes.length > 0) {
+            summary.actionCodes = actionCodes;
         }
         return summary;
     }


### PR DESCRIPTION
## Summary
- normalize action-code checks in the track modal to recognize new MARK_* and UPDATE_REVERSE_TRACK values
- surface available action codes in modal-derived table summaries for downstream consumers
- derive table button permissions from action-code sets while keeping legacy fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690692921644832d9ea00521d210e7ea