### PR TITLE
Add manual stage commands for return requests

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
@@ -13,6 +13,15 @@ enum ReturnRequestCommandType {
     /** Создать обменную посылку для одобренного обмена. */
     CREATE_EXCHANGE_PARCEL("CREATE_EXCHANGE_PARCEL"),
 
+    /** Зарегистрировать вручную обменную посылку. */
+    REGISTER_EXCHANGE_PARCEL("REGISTER_EXCHANGE_PARCEL"),
+
+    /** Отметить отправку обменной посылки. */
+    MARK_EXCHANGE_SENT("MARK_EXCHANGE_SENT"),
+
+    /** Отметить доставку обменной посылки покупателю. */
+    MARK_EXCHANGE_DELIVERED("MARK_EXCHANGE_DELIVERED"),
+
     /** Отменить запущенный обмен. */
     CANCEL_EXCHANGE("CANCEL_EXCHANGE"),
 
@@ -24,6 +33,15 @@ enum ReturnRequestCommandType {
 
     /** Обновить данные заявки (треки и комментарии). */
     UPDATE_DETAILS("UPDATE_DETAILS"),
+
+    /** Отметить отправку возврата покупателем. */
+    MARK_OUTBOUND_SENT("MARK_OUTBOUND_SENT"),
+
+    /** Отметить прибытие возврата в пункт назначения. */
+    MARK_INBOUND_ARRIVED("MARK_INBOUND_ARRIVED"),
+
+    /** Отметить приём возврата магазином. */
+    MARK_INBOUND_PICKED_UP("MARK_INBOUND_PICKED_UP"),
 
     /** Закрыть заявку без запуска обмена. */
     CLOSE("CLOSE");

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -336,10 +336,145 @@ public class OrderReturnRequestService {
         if (request.isReturnReceiptConfirmed()) {
             return request;
         }
-        markReturnProcessingConfirmed(request, user);
+        markReturnProcessingConfirmed(request, user, null);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Получение возврата подтверждено вручную для заявки {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Фиксирует вручную отправку возврата покупателем.
+     */
+    @Transactional
+    public OrderReturnRequest markOutboundSent(Long requestId,
+                                               Long parcelId,
+                                               User user,
+                                               ZonedDateTime stageMoment) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+        if (!canMarkOutboundSent(request)) {
+            throw new IllegalStateException("Стадия отправки возврата недоступна для текущего состояния заявки");
+        }
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        request.setResponsibleManager(user);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.OUTBOUND_SENT, true, user, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия OUTBOUND_SENT зафиксирована вручную для заявки {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Фиксирует вручную прибытие возврата в пункт назначения магазина.
+     */
+    @Transactional
+    public OrderReturnRequest markInboundArrived(Long requestId,
+                                                 Long parcelId,
+                                                 User user,
+                                                 ZonedDateTime stageMoment) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+        if (!canMarkInboundArrived(request)) {
+            throw new IllegalStateException("Стадия прибытия возврата недоступна для текущего состояния заявки");
+        }
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        request.setResponsibleManager(user);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_ARRIVED, true, user, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия INBOUND_ARRIVED зафиксирована вручную для заявки {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Фиксирует вручную получение возврата магазином и завершает этап обработки.
+     */
+    @Transactional
+    public OrderReturnRequest markInboundPickedUp(Long requestId,
+                                                  Long parcelId,
+                                                  User user,
+                                                  ZonedDateTime stageMoment) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+        if (!canMarkInboundPickedUp(request)) {
+            throw new IllegalStateException("Стадия приёма возврата недоступна для текущего состояния заявки");
+        }
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        markReturnProcessingConfirmed(request, user, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия INBOUND_PICKED_UP зафиксирована вручную для заявки {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Регистрирует обменную посылку без автоматического создания в системе.
+     */
+    @Transactional
+    public OrderReturnRequest registerExchangeParcel(Long requestId,
+                                                     Long parcelId,
+                                                     User user,
+                                                     String exchangeTrack,
+                                                     ZonedDateTime stageMoment) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+        if (request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            throw new IllegalStateException("Ручная регистрация доступна только для одобренного обмена");
+        }
+        if (!canRegisterExchangeParcel(request)) {
+            throw new IllegalStateException("Обменная посылка уже зарегистрирована или ожидает обработки");
+        }
+        String normalizedTrack = normalizeExchangeTrackNumber(exchangeTrack);
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        assignExchangeTrack(request, normalizedTrack, normalizedMoment, user);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, user, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Обменная посылка зарегистрирована вручную для заявки {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Фиксирует отправку обменной посылки, обновляя её трек-номер.
+     */
+    @Transactional
+    public OrderReturnRequest markExchangeSent(Long requestId,
+                                               Long parcelId,
+                                               User user,
+                                               String exchangeTrack,
+                                               ZonedDateTime stageMoment) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+        if (request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            throw new IllegalStateException("Стадия отправки обмена недоступна для текущего состояния заявки");
+        }
+        if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_SENT)) {
+            throw new IllegalStateException("Переход на стадию отправки обмена запрещён текущими правилами");
+        }
+        String normalizedTrack = normalizeExchangeTrackNumber(exchangeTrack);
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        assignExchangeTrack(request, normalizedTrack, normalizedMoment, user);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SENT, true, user, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия EXCHANGE_SENT зафиксирована вручную для заявки {}", saved.getId());
+        return saved;
+    }
+
+    /**
+     * Фиксирует вручную доставку обменной посылки.
+     */
+    @Transactional
+    public OrderReturnRequest markExchangeDelivered(Long requestId,
+                                                    Long parcelId,
+                                                    User user,
+                                                    ZonedDateTime stageMoment) {
+        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
+        if (!canMarkExchangeDelivered(request)) {
+            throw new IllegalStateException("Стадия доставки обмена недоступна для текущего состояния заявки");
+        }
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        request.setResponsibleManager(user);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_DELIVERED, true, user, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия EXCHANGE_DELIVERED зафиксирована вручную для заявки {}", saved.getId());
         return saved;
     }
 
@@ -610,7 +745,7 @@ public class OrderReturnRequestService {
         }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDispatched)
-                .orElse(false);
+                .orElseGet(() -> hasExchangeTrack(request));
     }
 
     /**
@@ -757,7 +892,7 @@ public class OrderReturnRequestService {
         }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDispatched)
-                .orElse(false);
+                .orElseGet(() -> hasExchangeTrack(request));
     }
 
     /**
@@ -772,7 +907,7 @@ public class OrderReturnRequestService {
         }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDelivered)
-                .orElse(false);
+                .orElseGet(() -> hasExchangeTrack(request));
     }
 
     /**
@@ -780,6 +915,14 @@ public class OrderReturnRequestService {
      */
     private boolean hasReverseTrack(OrderReturnRequest request) {
         String track = request.getReverseTrackNumber();
+        return track != null && !track.isBlank();
+    }
+
+    /**
+     * Проверяет, указан ли трек обменной посылки.
+     */
+    private boolean hasExchangeTrack(OrderReturnRequest request) {
+        String track = request != null ? request.getExchangeTrackNumber() : null;
         return track != null && !track.isBlank();
     }
 
@@ -924,15 +1067,17 @@ public class OrderReturnRequestService {
      * что облегчает расширение бизнес-правил и соответствует принципу DRY.
      * </p>
      */
-    private void markReturnProcessingConfirmed(OrderReturnRequest request, User actor) {
+    private void markReturnProcessingConfirmed(OrderReturnRequest request,
+                                               User actor,
+                                               ZonedDateTime stageMoment) {
         if (request == null || request.isReturnReceiptConfirmed()) {
             return;
         }
-        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
         request.setReturnReceiptConfirmed(true);
-        request.setReturnReceiptConfirmedAt(now);
+        request.setReturnReceiptConfirmedAt(normalizedMoment);
         request.setResponsibleManager(actor);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, actor, now);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, actor, normalizedMoment);
     }
 
     /**
@@ -998,6 +1143,53 @@ public class OrderReturnRequestService {
             throw new IllegalArgumentException("Трек обратной отправки не должен превышать 64 символа");
         }
         return normalized.toUpperCase();
+    }
+
+    /**
+     * Присваивает заявки трек обменной посылки и отмечает ответственного менеджера.
+     */
+    private void assignExchangeTrack(OrderReturnRequest request,
+                                     String exchangeTrack,
+                                     ZonedDateTime assignedAt,
+                                     User actor) {
+        if (request == null) {
+            return;
+        }
+        request.setExchangeTrackNumber(exchangeTrack);
+        request.setExchangeTrackAssignedAt(assignedAt);
+        request.setResponsibleManager(actor);
+    }
+
+    /**
+     * Валидирует и нормализует трек обменной посылки.
+     */
+    private String normalizeExchangeTrackNumber(String exchangeTrackNumber) {
+        if (exchangeTrackNumber == null) {
+            throw new IllegalArgumentException("Не указан трек обменной посылки");
+        }
+        String normalized = exchangeTrackNumber.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("Не указан трек обменной посылки");
+        }
+        if (normalized.length() > 64) {
+            throw new IllegalArgumentException("Трек обменной посылки не должен превышать 64 символа");
+        }
+        return normalized.toUpperCase();
+    }
+
+    /**
+     * Нормализует момент фиксации стадии и ограничивает значения будущим временем.
+     */
+    private ZonedDateTime normalizeStageMoment(ZonedDateTime stageMoment) {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        if (stageMoment == null) {
+            return now;
+        }
+        ZonedDateTime utc = stageMoment.withZoneSameInstant(ZoneOffset.UTC);
+        if (utc.isAfter(now.plusMinutes(1))) {
+            throw new IllegalArgumentException("Момент фиксации стадии не может быть в будущем");
+        }
+        return utc;
     }
 }
 

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -10,8 +10,10 @@ import com.project.tracking_system.entity.ReturnCommandLog;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.ReturnCommandLogRepository;
+import com.project.tracking_system.service.order.payload.ExchangeShipmentPayload;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayload;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayloadFactory;
+import com.project.tracking_system.service.order.payload.StageMarkPayload;
 import com.project.tracking_system.service.order.payload.UpdateDetailsPayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -120,7 +122,7 @@ public class ReturnRequestCommandService {
         MessageDigest digest = getDigest();
         digest.update(type.name().getBytes(StandardCharsets.UTF_8));
         digest.update(nullSafeBytes(command.action()));
-        payload.contributeTo(digest);
+        payload.updateDigest(digest, objectMapper);
         byte[] hash = digest.digest();
         return HexFormat.of().formatHex(hash);
     }
@@ -139,6 +141,35 @@ public class ReturnRequestCommandService {
                 orderReturnRequestService.createExchangeParcel(requestId, parcelId, user);
                 yield orderReturnRequestService.getOwnedRequest(requestId, user);
             }
+            case REGISTER_EXCHANGE_PARCEL -> {
+                ExchangeShipmentPayload exchangePayload = (ExchangeShipmentPayload) payload;
+                yield orderReturnRequestService.registerExchangeParcel(
+                        requestId,
+                        parcelId,
+                        user,
+                        exchangePayload.exchangeTrack(),
+                        exchangePayload.stageMoment()
+                );
+            }
+            case MARK_EXCHANGE_SENT -> {
+                ExchangeShipmentPayload exchangePayload = (ExchangeShipmentPayload) payload;
+                yield orderReturnRequestService.markExchangeSent(
+                        requestId,
+                        parcelId,
+                        user,
+                        exchangePayload.exchangeTrack(),
+                        exchangePayload.stageMoment()
+                );
+            }
+            case MARK_EXCHANGE_DELIVERED -> {
+                StageMarkPayload stagePayload = (StageMarkPayload) payload;
+                yield orderReturnRequestService.markExchangeDelivered(
+                        requestId,
+                        parcelId,
+                        user,
+                        stagePayload.stageMoment()
+                );
+            }
             case CLOSE -> orderReturnRequestService.closeWithoutExchange(requestId, parcelId, user);
             case CONFIRM_RECEIPT -> orderReturnRequestService.confirmReturnProcessing(requestId, parcelId, user);
             case UPDATE_DETAILS -> {
@@ -151,6 +182,33 @@ public class ReturnRequestCommandService {
                         updatePayload.comment()
                 );
                 yield orderReturnRequestService.getOwnedRequest(requestId, user);
+            }
+            case MARK_OUTBOUND_SENT -> {
+                StageMarkPayload stagePayload = (StageMarkPayload) payload;
+                yield orderReturnRequestService.markOutboundSent(
+                        requestId,
+                        parcelId,
+                        user,
+                        stagePayload.stageMoment()
+                );
+            }
+            case MARK_INBOUND_ARRIVED -> {
+                StageMarkPayload stagePayload = (StageMarkPayload) payload;
+                yield orderReturnRequestService.markInboundArrived(
+                        requestId,
+                        parcelId,
+                        user,
+                        stagePayload.stageMoment()
+                );
+            }
+            case MARK_INBOUND_PICKED_UP -> {
+                StageMarkPayload stagePayload = (StageMarkPayload) payload;
+                yield orderReturnRequestService.markInboundPickedUp(
+                        requestId,
+                        parcelId,
+                        user,
+                        stagePayload.stageMoment()
+                );
             }
             case REOPEN_RETURN -> orderReturnRequestService.reopenAsReturn(requestId, parcelId, user);
             case CANCEL_EXCHANGE -> orderReturnRequestService.cancelExchange(requestId, parcelId, user);

--- a/src/main/java/com/project/tracking_system/service/order/payload/EmptyPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/EmptyPayload.java
@@ -1,6 +1,7 @@
 package com.project.tracking_system.service.order.payload;
 
-import java.security.MessageDigest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Пустая полезная нагрузка, используемая для команд без параметров.
@@ -9,7 +10,7 @@ enum EmptyPayload implements ReturnRequestCommandPayload {
     INSTANCE;
 
     @Override
-    public void contributeTo(MessageDigest digest) {
-        // Пустой payload не влияет на хеш команды.
+    public JsonNode toNormalizedTree(ObjectMapper objectMapper) {
+        return objectMapper.createObjectNode();
     }
 }

--- a/src/main/java/com/project/tracking_system/service/order/payload/ExchangeShipmentPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ExchangeShipmentPayload.java
@@ -1,0 +1,31 @@
+package com.project.tracking_system.service.order.payload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Полезная нагрузка для команд, фиксирующих обменную отправку.
+ *
+ * @param exchangeTrack нормализованный трек обменной посылки
+ * @param stageMoment   момент фиксации стадии в UTC
+ */
+public record ExchangeShipmentPayload(String exchangeTrack,
+                                      ZonedDateTime stageMoment) implements ReturnRequestCommandPayload {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    @Override
+    public JsonNode toNormalizedTree(ObjectMapper objectMapper) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("exchangeTrack", exchangeTrack);
+        if (stageMoment != null) {
+            node.put("stageMoment", stageMoment.withZoneSameInstant(ZoneOffset.UTC).format(FORMATTER));
+        }
+        return node;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayload.java
@@ -1,23 +1,50 @@
 package com.project.tracking_system.service.order.payload;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 /**
  * Маркерный интерфейс полезной нагрузки команды управления заявкой.
  * <p>
- * Каждая реализация отвечает за сериализацию данных в хеш, чтобы обеспечить
- * идемпотентность выполнения команд с одинаковыми параметрами.
+ * Каждая реализация возвращает нормализованный JSON, который используется для расчёта хеша
+ * и обеспечения идемпотентности команд даже при вложенных структурах.
  * </p>
  */
-public sealed interface ReturnRequestCommandPayload permits EmptyPayload, UpdateDetailsPayload {
+public sealed interface ReturnRequestCommandPayload permits EmptyPayload, UpdateDetailsPayload,
+        StageMarkPayload, ExchangeShipmentPayload {
 
     /**
-     * Вносит данные полезной нагрузки в указанный MessageDigest.
+     * Возвращает нормализованное дерево JSON, содержащее параметры команды.
      *
-     * @param digest поток, в который добавляются байты параметров
+     * @param objectMapper mapper, используемый для создания узлов
+     * @return объект JSON с параметрами команды
      */
-    void contributeTo(MessageDigest digest);
+    JsonNode toNormalizedTree(ObjectMapper objectMapper);
+
+    /**
+     * Возвращает сериализованный нормализованный JSON полезной нагрузки.
+     *
+     * @param objectMapper mapper, используемый для сериализации
+     * @return массив байтов JSON-представления
+     */
+    default byte[] normalizedBytes(ObjectMapper objectMapper) {
+        try {
+            return objectMapper.writeValueAsBytes(toNormalizedTree(objectMapper));
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Не удалось сериализовать полезную нагрузку команды", ex);
+        }
+    }
+
+    /**
+     * Вносит нормализованное представление payload в digest для расчёта хеша.
+     */
+    default void updateDigest(MessageDigest digest, ObjectMapper objectMapper) {
+        digest.update(normalizedBytes(objectMapper));
+    }
 
     /**
      * Возвращает singleton пустой полезной нагрузки.

--- a/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.project.tracking_system.controller.ReturnRequestCommandType;
 import org.springframework.stereotype.Component;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+
 /**
  * Фабрика валидации полезной нагрузки команд управления заявками.
  * <p>
@@ -27,6 +31,9 @@ public class ReturnRequestCommandPayloadFactory {
     public ReturnRequestCommandPayload create(ReturnRequestCommandType type, JsonNode payloadNode) {
         return switch (type) {
             case UPDATE_DETAILS -> parseUpdateDetails(payloadNode);
+            case MARK_OUTBOUND_SENT, MARK_INBOUND_ARRIVED, MARK_INBOUND_PICKED_UP,
+                    MARK_EXCHANGE_DELIVERED -> parseStageMarkPayload(type, payloadNode);
+            case REGISTER_EXCHANGE_PARCEL, MARK_EXCHANGE_SENT -> parseExchangeShipmentPayload(type, payloadNode);
             case START_EXCHANGE, CREATE_EXCHANGE_PARCEL, CLOSE, CONFIRM_RECEIPT,
                     REOPEN_RETURN, CANCEL_EXCHANGE -> ensureEmptyPayload(type, payloadNode);
         };
@@ -77,6 +84,35 @@ public class ReturnRequestCommandPayloadFactory {
     }
 
     /**
+     * Разбирает полезную нагрузку команд, фиксирующих переход по стадии.
+     */
+    private ReturnRequestCommandPayload parseStageMarkPayload(ReturnRequestCommandType type, JsonNode payloadNode) {
+        if (payloadNode == null || payloadNode.isNull()) {
+            return new StageMarkPayload(null);
+        }
+        if (!payloadNode.isObject()) {
+            throw new IllegalArgumentException("Полезная нагрузка " + type.name() + " должна быть объектом JSON");
+        }
+        ZonedDateTime stageMoment = parseStageMoment(payloadNode.get("stageMoment"), type);
+        return new StageMarkPayload(stageMoment);
+    }
+
+    /**
+     * Разбирает payload команд регистрации и отправки обменной посылки.
+     */
+    private ReturnRequestCommandPayload parseExchangeShipmentPayload(ReturnRequestCommandType type, JsonNode payloadNode) {
+        if (payloadNode == null || payloadNode.isNull()) {
+            throw new IllegalArgumentException("Команда " + type.name() + " требует объект payload с параметрами");
+        }
+        if (!payloadNode.isObject()) {
+            throw new IllegalArgumentException("Полезная нагрузка " + type.name() + " должна быть объектом JSON");
+        }
+        String exchangeTrack = requireExchangeTrack(payloadNode.get("exchangeTrack"), type);
+        ZonedDateTime stageMoment = parseStageMoment(payloadNode.get("stageMoment"), type);
+        return new ExchangeShipmentPayload(exchangeTrack, stageMoment);
+    }
+
+    /**
      * Валидирует и нормализует строку трек-номера.
      */
     private String normalizeTrack(JsonNode node, String fieldName) {
@@ -91,7 +127,7 @@ public class ReturnRequestCommandPayloadFactory {
             return null;
         }
         if (normalized.length() > MAX_TRACK_LENGTH) {
-            throw new IllegalArgumentException("Трек обратной отправки не должен превышать 64 символа");
+            throw new IllegalArgumentException("Поле " + fieldName + " не должно превышать 64 символа");
         }
         return normalized.toUpperCase();
     }
@@ -114,5 +150,37 @@ public class ReturnRequestCommandPayloadFactory {
             throw new IllegalArgumentException("Комментарий не должен превышать 2000 символов");
         }
         return normalized;
+    }
+
+    /**
+     * Валидирует наличие и формат трека обмена.
+     */
+    private String requireExchangeTrack(JsonNode node, ReturnRequestCommandType type) {
+        String track = normalizeTrack(node, "exchangeTrack");
+        if (track == null) {
+            throw new IllegalArgumentException("Поле exchangeTrack обязательно для команды " + type.name());
+        }
+        return track;
+    }
+
+    /**
+     * Разбирает момент наступления стадии, приводя его к UTC.
+     */
+    private ZonedDateTime parseStageMoment(JsonNode node, ReturnRequestCommandType type) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (!node.isTextual()) {
+            throw new IllegalArgumentException("Поле stageMoment команды " + type.name() + " должно быть строкой");
+        }
+        String text = node.asText().trim();
+        if (text.isEmpty()) {
+            return null;
+        }
+        try {
+            return ZonedDateTime.parse(text).withZoneSameInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException("Поле stageMoment команды " + type.name() + " имеет неверный формат", ex);
+        }
     }
 }

--- a/src/main/java/com/project/tracking_system/service/order/payload/StageMarkPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/StageMarkPayload.java
@@ -1,0 +1,28 @@
+package com.project.tracking_system.service.order.payload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Полезная нагрузка с информацией о моменте наступления стадии заявки.
+ *
+ * @param stageMoment момент фиксации стадии в UTC
+ */
+public record StageMarkPayload(ZonedDateTime stageMoment) implements ReturnRequestCommandPayload {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    @Override
+    public JsonNode toNormalizedTree(ObjectMapper objectMapper) {
+        ObjectNode node = objectMapper.createObjectNode();
+        if (stageMoment != null) {
+            node.put("stageMoment", stageMoment.withZoneSameInstant(ZoneOffset.UTC).format(FORMATTER));
+        }
+        return node;
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/order/payload/UpdateDetailsPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/UpdateDetailsPayload.java
@@ -1,6 +1,8 @@
 package com.project.tracking_system.service.order.payload;
 
-import java.security.MessageDigest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Полезная нагрузка для команды обновления данных заявки.
@@ -12,8 +14,14 @@ public record UpdateDetailsPayload(String reverseTrack,
                                    String comment) implements ReturnRequestCommandPayload {
 
     @Override
-    public void contributeTo(MessageDigest digest) {
-        digest.update(nullSafeBytes(reverseTrack));
-        digest.update(nullSafeBytes(comment));
+    public JsonNode toNormalizedTree(ObjectMapper objectMapper) {
+        ObjectNode node = objectMapper.createObjectNode();
+        if (reverseTrack != null) {
+            node.put("reverseTrack", reverseTrack);
+        }
+        if (comment != null) {
+            node.put("comment", comment);
+        }
+        return node;
     }
 }

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -423,6 +423,124 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
+    void markOutboundSent_TransitionsStageAndSetsManager() {
+        TrackParcel parcel = buildParcel(41L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(1001L);
+        request.setParcel(parcel);
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.NEW);
+        request.setReverseTrackNumber("BY123");
+
+        when(repository.findById(1001L)).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime stageMoment = ZonedDateTime.of(2023, 10, 1, 10, 15, 30, 0, ZoneOffset.ofHours(3));
+
+        OrderReturnRequest result = service.markOutboundSent(1001L, 41L, user, stageMoment);
+
+        ZonedDateTime expectedUtc = stageMoment.withZoneSameInstant(ZoneOffset.UTC);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.OUTBOUND_SENT);
+        assertThat(result.getStageStartedAt()).isEqualTo(expectedUtc);
+        assertThat(result.getStageUpdatedAt()).isEqualTo(expectedUtc);
+        assertThat(result.getResponsibleManager()).isEqualTo(user);
+        assertThat(result.getHistoryEntries()).isNotEmpty();
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void markInboundPickedUp_ConfirmsReceiptAndUpdatesStage() {
+        TrackParcel parcel = buildParcel(42L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(1002L);
+        request.setParcel(parcel);
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.INBOUND_ARRIVED);
+        request.setReverseTrackNumber("BY321");
+
+        when(repository.findById(1002L)).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime stageMoment = ZonedDateTime.of(2023, 11, 5, 9, 0, 0, 0, ZoneOffset.UTC);
+
+        OrderReturnRequest result = service.markInboundPickedUp(1002L, 42L, user, stageMoment);
+
+        assertThat(result.isReturnReceiptConfirmed()).isTrue();
+        assertThat(result.getReturnReceiptConfirmedAt()).isEqualTo(stageMoment);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        assertThat(result.getResponsibleManager()).isEqualTo(user);
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void registerExchangeParcel_AssignsTrackAndKeepsStage() {
+        TrackParcel parcel = buildParcel(43L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = buildExchangeRequest(1003L, parcel);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+
+        when(repository.findById(1003L)).thenReturn(Optional.of(request));
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime stageMoment = ZonedDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.ofHours(2));
+
+        OrderReturnRequest result = service.registerExchangeParcel(1003L, 43L, user, " ex555 ", stageMoment);
+
+        ZonedDateTime expectedMoment = stageMoment.withZoneSameInstant(ZoneOffset.UTC);
+        assertThat(result.getExchangeTrackNumber()).isEqualTo("EX555");
+        assertThat(result.getExchangeTrackAssignedAt()).isEqualTo(expectedMoment);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_REGISTERED);
+        assertThat(result.isManualStageOverride()).isTrue();
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void markExchangeSent_AssignsTrackAndTransitionsStage() {
+        TrackParcel parcel = buildParcel(44L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = buildExchangeRequest(1004L, parcel);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+
+        when(repository.findById(1004L)).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime stageMoment = ZonedDateTime.of(2024, 2, 10, 15, 30, 0, 0, ZoneOffset.UTC);
+
+        OrderReturnRequest result = service.markExchangeSent(1004L, 44L, user, "ex999", stageMoment);
+
+        assertThat(result.getExchangeTrackNumber()).isEqualTo("EX999");
+        assertThat(result.getExchangeTrackAssignedAt()).isEqualTo(stageMoment);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_SENT);
+        assertThat(result.isManualStageOverride()).isTrue();
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void markExchangeDelivered_TransitionsStageWhenTrackPresent() {
+        TrackParcel parcel = buildParcel(45L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = buildExchangeRequest(1005L, parcel);
+        request.setStage(ReturnRequestStage.EXCHANGE_SENT);
+        request.setExchangeTrackNumber("EX777");
+
+        when(repository.findById(1005L)).thenReturn(Optional.of(request));
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime stageMoment = ZonedDateTime.of(2024, 3, 1, 8, 45, 0, 0, ZoneOffset.UTC);
+
+        OrderReturnRequest result = service.markExchangeDelivered(1005L, 45L, user, stageMoment);
+
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_DELIVERED);
+        assertThat(result.getStageUpdatedAt()).isEqualTo(stageMoment);
+        assertThat(result.getResponsibleManager()).isEqualTo(user);
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
     void cancelExchange_ClosesRequestWhenReplacementHasNoTrack() {
         TrackParcel parcel = buildParcel(19L, GlobalStatus.DELIVERED);
         TrackParcel replacement = new TrackParcel();

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -9,13 +9,14 @@ import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.ReturnCommandLog;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.repository.ReturnCommandLogRepository;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayload;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayloadFactory;
 import com.project.tracking_system.service.order.ReturnRequestMapper;
-import com.project.tracking_system.repository.ReturnCommandLogRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HexFormat;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,15 +56,17 @@ class ReturnRequestCommandServiceTest {
 
     private ReturnRequestCommandService commandService;
     private ReturnRequestCommandPayloadFactory payloadFactory;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
         payloadFactory = new ReturnRequestCommandPayloadFactory();
+        objectMapper = new ObjectMapper();
         commandService = new ReturnRequestCommandService(
                 orderReturnRequestService,
                 returnRequestMapper,
                 returnCommandLogRepository,
-                new ObjectMapper(),
+                objectMapper,
                 payloadFactory
         );
     }
@@ -195,13 +199,99 @@ class ReturnRequestCommandServiceTest {
         verify(orderReturnRequestService, never()).updateReverseTrackAndComment(any(), any(), any(), any(), any());
     }
 
+    @Test
+    void executeCommand_whenMarkOutboundSent_usesNormalizedStageMoment() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(31L, 15L);
+        OrderReturnRequest updated = buildRequest(31L, 15L);
+        RequestDto dto = buildRequestDto(31L, "RETURN");
+
+        JsonNodeFactory factory = JsonNodeFactory.instance;
+        CommandDto command = new CommandDto(
+                "stage-1",
+                "MARK_OUTBOUND_SENT",
+                factory.objectNode().put("stageMoment", "2023-10-01T10:15:30+03:00")
+        );
+
+        when(orderReturnRequestService.getOwnedRequest(31L, user)).thenReturn(request);
+        when(orderReturnRequestService.markOutboundSent(eq(31L), eq(15L), eq(user), any()))
+                .thenReturn(updated);
+        when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
+
+        AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
+        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(31L, "stage-1"))
+                .thenAnswer(invocation -> Optional.ofNullable(savedLog.get()));
+        when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
+                .thenAnswer(invocation -> {
+                    ReturnCommandLog logEntry = invocation.getArgument(0);
+                    savedLog.set(logEntry);
+                    return logEntry;
+                });
+
+        RequestDto result = commandService.executeCommand(31L,
+                ReturnRequestCommandType.MARK_OUTBOUND_SENT,
+                command,
+                user,
+                ZoneOffset.UTC);
+
+        assertThat(result).isEqualTo(dto);
+        ArgumentCaptor<ZonedDateTime> momentCaptor = ArgumentCaptor.forClass(ZonedDateTime.class);
+        verify(orderReturnRequestService).markOutboundSent(eq(31L), eq(15L), eq(user), momentCaptor.capture());
+        assertThat(momentCaptor.getValue()).isEqualTo(ZonedDateTime.parse("2023-10-01T07:15:30Z"));
+    }
+
+    @Test
+    void executeCommand_whenRegisterExchangeParcel_normalizesTrackAndStageMoment() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(32L, 16L);
+        OrderReturnRequest updated = buildRequest(32L, 16L);
+        RequestDto dto = buildRequestDto(32L, "EXCHANGE");
+
+        JsonNodeFactory factory = JsonNodeFactory.instance;
+        CommandDto command = new CommandDto(
+                "stage-2",
+                "REGISTER_EXCHANGE_PARCEL",
+                factory.objectNode()
+                        .put("exchangeTrack", "  ex123  ")
+                        .put("stageMoment", "2024-01-15T12:00:00+02:00")
+        );
+
+        when(orderReturnRequestService.getOwnedRequest(32L, user)).thenReturn(request);
+        when(orderReturnRequestService.registerExchangeParcel(eq(32L), eq(16L), eq(user), any(), any()))
+                .thenReturn(updated);
+        when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
+
+        AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
+        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(32L, "stage-2"))
+                .thenAnswer(invocation -> Optional.ofNullable(savedLog.get()));
+        when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
+                .thenAnswer(invocation -> {
+                    ReturnCommandLog logEntry = invocation.getArgument(0);
+                    savedLog.set(logEntry);
+                    return logEntry;
+                });
+
+        RequestDto result = commandService.executeCommand(32L,
+                ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL,
+                command,
+                user,
+                ZoneOffset.UTC);
+
+        assertThat(result).isEqualTo(dto);
+        ArgumentCaptor<String> trackCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ZonedDateTime> momentCaptor = ArgumentCaptor.forClass(ZonedDateTime.class);
+        verify(orderReturnRequestService).registerExchangeParcel(eq(32L), eq(16L), eq(user), trackCaptor.capture(), momentCaptor.capture());
+        assertThat(trackCaptor.getValue()).isEqualTo("EX123");
+        assertThat(momentCaptor.getValue()).isEqualTo(ZonedDateTime.parse("2024-01-15T10:00:00Z"));
+    }
+
     private String computePayloadHash(ReturnRequestCommandType type, CommandDto command) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             digest.update(type.name().getBytes(StandardCharsets.UTF_8));
             digest.update(nullSafeBytes(command.action()));
             ReturnRequestCommandPayload payload = payloadFactory.create(type, command.payload());
-            payload.contributeTo(digest);
+            payload.updateDigest(digest, objectMapper);
             return HexFormat.of().formatHex(digest.digest());
         } catch (NoSuchAlgorithmException ex) {
             throw new IllegalStateException(ex);


### PR DESCRIPTION
## Summary
- add new return command types for manual stage transitions and exchange handling
- normalize command payload hashing using dedicated DTOs for stage and exchange commands
- extend the order return service with manual stage operations and add unit coverage for new scenarios

## Testing
- mvn -q test *(fails: dependency download blocked by 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_69073fd7ee68832d9ec59166aa93be6d