### PR TITLE
feat: expand return request dto schema

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/RequestDto.java
+++ b/src/main/java/com/project/tracking_system/dto/RequestDto.java
@@ -2,29 +2,59 @@ package com.project.tracking_system.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.time.ZonedDateTime;
+
 /**
  * DTO заявки на возврат или обмен для REST-API.
  * <p>
- * Запись содержит только идентификаторы и текущие технические атрибуты,
- * необходимые для последующих запросов клиентских приложений.
+ * Структура отражает JSON Schema внешнего API: помимо идентификаторов
+ * добавлены атрибуты причины возврата, комментариев, треков и технические флаги
+ * для ручных операций. UUID заявки передаётся в текстовом виде, чтобы клиенты
+ * могли использовать его в распределённых интеграциях без потери точности.
  * </p>
  *
- * @param id            идентификатор заявки
- * @param mode          активный режим (возврат или обмен)
- * @param stage         код текущего этапа обработки
- * @param storeId       идентификатор магазина
- * @param orderId       идентификатор заказа или эпизода, к которому относится заявка
- * @param parcelId      идентификатор исходной посылки
- * @param userId        идентификатор пользователя, создавшего заявку
- * @param responsibleId идентификатор ответственного менеджера
+ * @param id                       публичный идентификатор заявки (UUID в текстовом виде)
+ * @param legacyId                 числовой идентификатор заявки внутри монолита
+ * @param mode                     активный режим (возврат или обмен)
+ * @param stage                    код текущего этапа обработки
+ * @param storeId                  идентификатор магазина
+ * @param orderId                  идентификатор заказа или эпизода, к которому относится заявка
+ * @param parcelId                 идентификатор исходной посылки
+ * @param userId                   идентификатор пользователя, создавшего заявку
+ * @param responsibleId            идентификатор ответственного менеджера
+ * @param reason                   причина возврата в нормализованном виде
+ * @param requestedAt              момент, когда пользователь запросил возврат
+ * @param comment                  дополнительный комментарий пользователя
+ * @param reverseTrackNumber       трек обратной отправки
+ * @param exchangeTrackNumber      трек обменной посылки
+ * @param manualTrackOverride      признак ручного указания треков
+ * @param manualStageOverride      признак ручного перевода между этапами
+ * @param manualInboundPick        флаг, что этап приёма возврата подтверждён вручную
+ * @param returnReceiptConfirmed   магазин подтвердил получение возврата
+ * @param exchangeTrackAssignedAt  момент, когда трек обмена был установлен
+ * @param createdAt                момент создания заявки
+ * @param updatedAt                момент последнего обновления заявки
  */
 @JsonIgnoreProperties(ignoreUnknown = false)
-public record RequestDto(Long id,
+public record RequestDto(String id,
+                         Long legacyId,
                          String mode,
                          String stage,
                          Long storeId,
                          Long orderId,
                          Long parcelId,
                          Long userId,
-                         Long responsibleId) {
+                         Long responsibleId,
+                         String reason,
+                         ZonedDateTime requestedAt,
+                         String comment,
+                         String reverseTrackNumber,
+                         String exchangeTrackNumber,
+                         boolean manualTrackOverride,
+                         boolean manualStageOverride,
+                         boolean manualInboundPick,
+                         boolean returnReceiptConfirmed,
+                         ZonedDateTime exchangeTrackAssignedAt,
+                         ZonedDateTime createdAt,
+                         ZonedDateTime updatedAt) {
 }

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -28,10 +29,10 @@ public class ReturnRequestMapper {
     private final OrderReturnRequestService orderReturnRequestService;
 
     /**
-     * Преобразует заявку в минималистичный DTO карточки возврата.
-     * Метод возвращает только идентификаторы и текущие технические поля,
-     * необходимые клиентам для дальнейших запросов (SRP: форматирование витринных
-     * данных вынесено в другие компоненты).
+     * Преобразует заявку в DTO карточки возврата согласно JSON Schema.
+     * Метод дополняет идентификаторы сведениями о причинах, комментариях и треках,
+     * сохраняя ответственность маппера за конвертацию доменной модели в формат API
+     * (принцип единой ответственности).
      *
      * @param request исходная заявка
      * @param userZone временная зона пользователя (не используется, сохранена для обратной совместимости вызовов)
@@ -60,7 +61,13 @@ public class ReturnRequestMapper {
                 .map(manager -> manager.getId())
                 .orElse(null);
 
+        String publicId = resolvePublicId(request);
+        boolean manualInboundPick = resolveManualInboundPickFlag(request, stage);
+        ZonedDateTime createdAt = request.getCreatedAt();
+        ZonedDateTime updatedAt = resolveUpdatedAt(request, createdAt);
+
         return new RequestDto(
+                publicId,
                 request.getId(),
                 mode.name(),
                 stage.getCode(),
@@ -68,8 +75,55 @@ public class ReturnRequestMapper {
                 orderId,
                 parcelId,
                 userId,
-                responsibleId
+                responsibleId,
+                request.getReason(),
+                request.getRequestedAt(),
+                request.getComment(),
+                request.getReverseTrackNumber(),
+                request.getExchangeTrackNumber(),
+                request.isManualTrackOverride(),
+                request.isManualStageOverride(),
+                manualInboundPick,
+                request.isReturnReceiptConfirmed(),
+                request.getExchangeTrackAssignedAt(),
+                createdAt,
+                updatedAt
         );
+    }
+
+    /**
+     * Возвращает публичный идентификатор заявки.
+     * <p>
+     * Если идемпотентный ключ отсутствует (старые записи), используется
+     * числовой идентификатор, чтобы не терять совместимость.
+     * </p>
+     */
+    private String resolvePublicId(OrderReturnRequest request) {
+        return Optional.ofNullable(request.getIdempotencyKey())
+                .filter(key -> !key.isBlank())
+                .orElseGet(() -> Optional.ofNullable(request.getId())
+                        .map(String::valueOf)
+                        .orElse(null));
+    }
+
+    /**
+     * Определяет флаг ручного подтверждения получения возврата.
+     * <p>
+     * Флаг активен только для стадии INBOUND_PICKED_UP и когда переход выполнен вручную,
+     * что позволяет фронтенду отличить автоматические обновления от действий оператора.
+     * </p>
+     */
+    private boolean resolveManualInboundPickFlag(OrderReturnRequest request, ReturnRequestStage stage) {
+        return request.isManualStageOverride() && stage == ReturnRequestStage.INBOUND_PICKED_UP;
+    }
+
+    /**
+     * Рассчитывает момент последнего изменения заявки с безопасным запасом.
+     */
+    private ZonedDateTime resolveUpdatedAt(OrderReturnRequest request, ZonedDateTime createdAt) {
+        return Optional.ofNullable(request.getStageUpdatedAt())
+                .orElseGet(() -> Optional.ofNullable(request.getStageStartedAt())
+                        .orElse(createdAt));
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +70,7 @@ class ReturnsControllerTest {
                 eq(false)
         )).thenReturn(request);
 
-        RequestDto responseDto = buildRequestDto(15L, "RETURN", "NEW", 17L, 7L);
+        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000015", 15L, "RETURN", "NEW", 17L, 7L);
         when(returnRequestMapper.toDto(eq(request), any())).thenReturn(responseDto);
 
         mockMvc.perform(post("/api/v1/returns")
@@ -85,7 +86,9 @@ class ReturnsControllerTest {
                                 "\"isExchange\":false" +
                                 "}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", equalTo(15)))
+                .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000015")))
+                .andExpect(jsonPath("$.legacyId", equalTo(15)))
+                .andExpect(jsonPath("$.reverseTrackNumber", equalTo("BY123")))
                 .andExpect(jsonPath("$.mode", equalTo("RETURN")));
 
         verify(orderReturnRequestService).registerReturn(
@@ -105,7 +108,7 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = authentication(principal);
 
-        RequestDto responseDto = buildRequestDto(21L, "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
+        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000021", 21L, "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
         when(returnRequestCommandService.executeCommand(eq(21L), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
@@ -114,7 +117,8 @@ class ReturnsControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"idempotencyKey\":\"cmd-1\",\"action\":\"start_exchange\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", equalTo(21)))
+                .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000021")))
+                .andExpect(jsonPath("$.legacyId", equalTo(21)))
                 .andExpect(jsonPath("$.mode", equalTo("EXCHANGE")));
         verify(returnRequestCommandService).executeCommand(eq(21L), any(), any(), eq(principal), any());
     }
@@ -124,7 +128,7 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = authentication(principal);
 
-        RequestDto responseDto = buildRequestDto(30L, "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
+        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000030", 30L, "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
         when(returnRequestCommandService.executeCommand(eq(30L), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
@@ -145,12 +149,12 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(51L, principal)).thenReturn(request);
         when(returnRequestMapper.toDto(eq(request), any()))
-                .thenReturn(buildRequestDto(51L, "RETURN", "NEW", 17L, 51L));
+                .thenReturn(buildRequestDto("00000000-0000-0000-0000-000000000051", 51L, "RETURN", "NEW", 17L, 51L));
 
         mockMvc.perform(get("/api/v1/returns/51")
                         .with(auth))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", equalTo(51)));
+                .andExpect(jsonPath("$.legacyId", equalTo(51)));
     }
 
     @Test
@@ -174,20 +178,35 @@ class ReturnsControllerTest {
         return new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities());
     }
 
-    private RequestDto buildRequestDto(Long id,
+    private RequestDto buildRequestDto(String uuid,
+                                       Long legacyId,
                                        String mode,
                                        String stage,
                                        Long storeId,
                                        Long parcelId) {
+        ZonedDateTime timestamp = ZonedDateTime.parse("2024-01-01T10:15:30Z");
         return new RequestDto(
-                id,
+                uuid,
+                legacyId,
                 mode,
                 stage,
                 storeId,
                 99L,
                 parcelId,
                 5L,
-                7L
+                7L,
+                "Причина",
+                timestamp,
+                "Комментарий",
+                "BY123",
+                "EX123",
+                false,
+                false,
+                false,
+                true,
+                timestamp,
+                timestamp,
+                timestamp
         );
     }
 

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -76,7 +76,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(21L, 9L);
         OrderReturnRequest updated = buildRequest(21L, 9L);
-        RequestDto dto = buildRequestDto(21L, "EXCHANGE");
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000021", 21L, "EXCHANGE");
         CommandDto command = new CommandDto("dup-1", "START_EXCHANGE", null);
 
         when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
@@ -148,7 +148,7 @@ class ReturnRequestCommandServiceTest {
         OrderReturnRequest request = buildRequest(22L, 10L);
         CommandDto command = new CommandDto("dup-3", "START_EXCHANGE", null);
 
-        RequestDto storedDto = buildRequestDto(22L, "EXCHANGE");
+        RequestDto storedDto = buildRequestDto("00000000-0000-0000-0000-000000000022", 22L, "EXCHANGE");
         String snapshot;
         try {
             snapshot = new ObjectMapper().writeValueAsString(storedDto);
@@ -175,7 +175,7 @@ class ReturnRequestCommandServiceTest {
                 user,
                 ZoneOffset.UTC);
 
-        assertThat(result.id()).isEqualTo(22L);
+        assertThat(result.legacyId()).isEqualTo(22L);
         verify(orderReturnRequestService, never()).approveExchange(any(), any(), any());
         verify(returnRequestMapper, never()).toDto(any(), any());
     }
@@ -204,7 +204,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(31L, 15L);
         OrderReturnRequest updated = buildRequest(31L, 15L);
-        RequestDto dto = buildRequestDto(31L, "RETURN");
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000031", 31L, "RETURN");
 
         JsonNodeFactory factory = JsonNodeFactory.instance;
         CommandDto command = new CommandDto(
@@ -245,7 +245,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(32L, 16L);
         OrderReturnRequest updated = buildRequest(32L, 16L);
-        RequestDto dto = buildRequestDto(32L, "EXCHANGE");
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000032", 32L, "EXCHANGE");
 
         JsonNodeFactory factory = JsonNodeFactory.instance;
         CommandDto command = new CommandDto(
@@ -317,16 +317,30 @@ class ReturnRequestCommandServiceTest {
         return request;
     }
 
-    private RequestDto buildRequestDto(Long id, String mode) {
+    private RequestDto buildRequestDto(String uuid, Long legacyId, String mode) {
+        ZonedDateTime timestamp = ZonedDateTime.parse("2024-01-01T10:15:30Z");
         return new RequestDto(
-                id,
+                uuid,
+                legacyId,
                 mode,
                 "NEW",
                 10L,
                 20L,
                 30L,
                 40L,
-                50L
+                50L,
+                "Причина",
+                timestamp,
+                "Комментарий",
+                "BY123",
+                "EX123",
+                false,
+                false,
+                false,
+                true,
+                timestamp,
+                timestamp,
+                timestamp
         );
     }
 }


### PR DESCRIPTION
## Summary
- align the return request DTO with the external schema by exposing UUID identifiers, track metadata, manual flags, and timestamps
- extend the return request mapper to populate the new DTO fields from OrderReturnRequest while calculating derived flags safely
- update controller and command service tests to validate the enriched response contract

## Testing
- mvn -q -DskipITs test *(fails: dependency download blocked by jitpack 403)*

------
https://chatgpt.com/codex/tasks/task_e_69079e92ef64832d837cceb5fd8d9abe