### PR TITLE
Align ReturnRequestCommandType with ReturnRequestAction codes

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
@@ -1,76 +1,126 @@
 package com.project.tracking_system.controller;
 
-import java.util.Arrays;
+import com.project.tracking_system.entity.ReturnRequestAction;
+
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
- * Перечисление доступных команд управления заявками на возврат.
+ * Перечисление, описывающее команды, которые может инициировать клиентский интерфейс
+ * для управления жизненным циклом заявки на возврат или обмен.
  */
 enum ReturnRequestCommandType {
 
-    /** Перевести заявку в режим возврата. */
-    SET_MODE_RETURN("SET_MODE_RETURN"),
+    /**
+     * Активирует классический сценарий возврата и отключает привязанный обмен.
+     */
+    SET_MODE_RETURN(ReturnRequestAction.SET_MODE_RETURN),
 
-    /** Перевести заявку в режим обмена. */
-    SET_MODE_EXCHANGE("SET_MODE_EXCHANGE"),
+    /**
+     * Переводит заявку в режим обмена и запускает соответствующий бизнес-процесс.
+     */
+    SET_MODE_EXCHANGE(ReturnRequestAction.SET_MODE_EXCHANGE),
 
-    /** Зарегистрировать вручную обменную посылку. */
-    REGISTER_EXCHANGE_PARCEL("REGISTER_EXCHANGE_PARCEL"),
+    /**
+     * Привязывает к заявке обменную посылку, зарегистрированную вручную оператором.
+     */
+    REGISTER_EXCHANGE_PARCEL(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL),
 
-    /** Отметить отправку обменной посылки. */
-    MARK_EXCHANGE_SENT("MARK_EXCHANGE_SENT"),
+    /**
+     * Подтверждает передачу обменной посылки службе доставки со склада магазина.
+     */
+    MARK_EXCHANGE_SENT(ReturnRequestAction.MARK_EXCHANGE_SENT),
 
-    /** Отметить доставку обменной посылки покупателю. */
-    MARK_EXCHANGE_DELIVERED("MARK_EXCHANGE_DELIVERED"),
+    /**
+     * Фиксирует успешную доставку обменной посылки покупателю.
+     */
+    MARK_EXCHANGE_DELIVERED(ReturnRequestAction.MARK_EXCHANGE_DELIVERED),
 
-    /** Обновить обратный трек или комментарий заявки. */
-    UPDATE_REVERSE_TRACK("UPDATE_REVERSE_TRACK"),
+    /**
+     * Обновляет обратный трек и комментарии в заявке для информирования клиента.
+     */
+    UPDATE_REVERSE_TRACK(ReturnRequestAction.UPDATE_REVERSE_TRACK),
 
-    /** Отметить отправку возврата покупателем. */
-    MARK_OUTBOUND_SENT("MARK_OUTBOUND_SENT"),
+    /**
+     * Подтверждает отправку возвратной посылки покупателем и старт отслеживания.
+     */
+    MARK_OUTBOUND_SENT(ReturnRequestAction.MARK_OUTBOUND_SENT),
 
-    /** Отметить прибытие возврата в пункт назначения. */
-    MARK_INBOUND_ARRIVED("MARK_INBOUND_ARRIVED"),
+    /**
+     * Фиксирует прибытие возврата на пункт приёма магазина для дальнейшей обработки.
+     */
+    MARK_INBOUND_ARRIVED(ReturnRequestAction.MARK_INBOUND_ARRIVED),
 
-    /** Отметить приём возврата магазином. */
-    MARK_INBOUND_PICKED_UP("MARK_INBOUND_PICKED_UP"),
+    /**
+     * Регистрирует вручную факт приёма возврата сотрудником магазина.
+     */
+    MARK_INBOUND_PICKED_UP(ReturnRequestAction.MARK_INBOUND_PICKED_UP),
 
-    /** Закрыть заявку. */
-    CLOSE_REQUEST("CLOSE_REQUEST");
+    /**
+     * Закрывает заявку после завершения всех обязательных этапов.
+     */
+    CLOSE_REQUEST(ReturnRequestAction.CLOSE_REQUEST);
 
+    private static final Map<String, ReturnRequestCommandType> CODE_INDEX;
     private static final Map<String, ReturnRequestCommandType> LEGACY_CODES;
 
+    private final ReturnRequestAction action;
     private final String code;
 
-    ReturnRequestCommandType(String code) {
-        this.code = code;
+    ReturnRequestCommandType(ReturnRequestAction action) {
+        this.action = action;
+        this.code = action.getCode();
     }
 
     /**
-     * Восстанавливает тип команды по строковому коду без учёта регистра.
+     * Возвращает строковый код команды, совпадающий с кодом {@link ReturnRequestAction}.
      *
-     * @param code код команды из запроса
+     * @return текстовый код для сериализации команды
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * Возвращает исходное действие, на основе которого построена команда.
+     *
+     * @return действие возвратной заявки
+     */
+    public ReturnRequestAction getAction() {
+        return action;
+    }
+
+    /**
+     * Восстанавливает тип команды по строковому коду без учёта регистра и с поддержкой легаси-значений.
+     *
+     * @param code код команды из внешнего интерфейса
      * @return найденный тип или {@code null}, если код неизвестен
      */
     public static ReturnRequestCommandType fromCode(String code) {
         if (code == null) {
             return null;
         }
-        return Arrays.stream(values())
-                .filter(item -> item.code.equalsIgnoreCase(code))
-                .findFirst()
-                .orElseGet(() -> {
-                    ReturnRequestCommandType legacy = LEGACY_CODES.get(code);
-                    if (legacy != null) {
-                        return legacy;
-                    }
-                    return LEGACY_CODES.get(code != null ? code.toUpperCase() : null);
-                });
+        String normalized = code.toUpperCase(Locale.ROOT);
+        ReturnRequestCommandType type = CODE_INDEX.get(normalized);
+        if (type != null) {
+            return type;
+        }
+        ReturnRequestCommandType legacy = LEGACY_CODES.get(code);
+        if (legacy != null) {
+            return legacy;
+        }
+        return LEGACY_CODES.get(normalized);
     }
 
     static {
+        Map<String, ReturnRequestCommandType> codeIndex = new HashMap<>();
+        for (ReturnRequestCommandType type : values()) {
+            codeIndex.put(type.code.toUpperCase(Locale.ROOT), type);
+        }
+        CODE_INDEX = Collections.unmodifiableMap(codeIndex);
+
         Map<String, ReturnRequestCommandType> legacy = new HashMap<>();
         legacy.put("START_EXCHANGE", SET_MODE_EXCHANGE);
         legacy.put("CREATE_EXCHANGE_PARCEL", REGISTER_EXCHANGE_PARCEL);


### PR DESCRIPTION
## Summary
- align return request command types with the ReturnRequestAction enum to reuse the same codes
- add Russian documentation for the refreshed command scenarios and expose the underlying action
- keep case-insensitive lookup while indexing codes and legacy aliases for backward compatibility

## Testing
- ./mvnw -q -DskipTests compile *(fails: missing .mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_69089396ef68832db6d2afd7a8d70f54