### PR TITLE
Refine return workflow action mapping

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -156,13 +156,12 @@ public class ReturnRequestWorkflow {
 
         if (status == OrderReturnRequestStatus.REGISTERED) {
             actions.add(ReturnRequestAction.SET_MODE_EXCHANGE);
+            actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
             actions.add(ReturnRequestAction.CLOSE_REQUEST);
             actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
-            actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
         } else if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            actions.add(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
-            actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
             actions.add(ReturnRequestAction.SET_MODE_RETURN);
+            actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
             actions.add(ReturnRequestAction.CLOSE_REQUEST);
             actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
         } else if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
@@ -232,9 +231,9 @@ public class ReturnRequestWorkflow {
                         if (stage == target) {
                             continue;
                         }
-                        ReturnRequestAction action = mapTransitionToAction(target);
-                        if (action != null) {
-                            actions.add(action);
+                        EnumSet<ReturnRequestAction> mapped = mapTransitionToActions(mode, stage, target);
+                        if (!mapped.isEmpty()) {
+                            actions.addAll(mapped);
                         }
                     }
                     if (!actions.isEmpty()) {
@@ -252,15 +251,39 @@ public class ReturnRequestWorkflow {
         return matrix;
     }
 
-    private ReturnRequestAction mapTransitionToAction(ReturnRequestStage target) {
+    /**
+     * Подбирает действия, приводящие к целевой стадии, исходя из текущего контекста.
+     *
+     * @param mode   режим заявки, задающий доступные команды
+     * @param from   исходная стадия
+     * @param target целевая стадия перехода
+     * @return набор команд, инициирующих переход, может быть пустым
+     */
+    private EnumSet<ReturnRequestAction> mapTransitionToActions(ReturnRequestMode mode,
+                                                                ReturnRequestStage from,
+                                                                ReturnRequestStage target) {
+        if (target == null) {
+            return EnumSet.noneOf(ReturnRequestAction.class);
+        }
         return switch (target) {
-            case OUTBOUND_SENT -> ReturnRequestAction.MARK_OUTBOUND_SENT;
-            case INBOUND_ARRIVED -> ReturnRequestAction.MARK_INBOUND_ARRIVED;
-            case INBOUND_PICKED_UP -> ReturnRequestAction.MARK_INBOUND_PICKED_UP;
-            case EXCHANGE_REGISTERED -> ReturnRequestAction.SET_MODE_EXCHANGE;
-            case EXCHANGE_SENT -> ReturnRequestAction.MARK_EXCHANGE_SENT;
-            case EXCHANGE_DELIVERED -> ReturnRequestAction.MARK_EXCHANGE_DELIVERED;
-            default -> null;
+            case OUTBOUND_SENT -> EnumSet.of(ReturnRequestAction.MARK_OUTBOUND_SENT);
+            case INBOUND_ARRIVED -> EnumSet.of(ReturnRequestAction.MARK_INBOUND_ARRIVED);
+            case INBOUND_PICKED_UP -> EnumSet.of(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+            case EXCHANGE_REGISTERED -> mode == ReturnRequestMode.EXCHANGE
+                    ? EnumSet.of(ReturnRequestAction.SET_MODE_EXCHANGE)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            case EXCHANGE_SENT -> {
+                if (mode != ReturnRequestMode.EXCHANGE) {
+                    yield EnumSet.noneOf(ReturnRequestAction.class);
+                }
+                EnumSet<ReturnRequestAction> exchangeActions = EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_SENT);
+                if (from == ReturnRequestStage.EXCHANGE_REGISTERED) {
+                    exchangeActions.add(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+                }
+                yield exchangeActions;
+            }
+            case EXCHANGE_DELIVERED -> EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
+            default -> EnumSet.noneOf(ReturnRequestAction.class);
         };
     }
 

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -1,6 +1,8 @@
 package com.project.tracking_system.service.order;
 
 import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.User;
@@ -8,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+
+import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,5 +67,37 @@ class ReturnRequestWorkflowTest {
                 null,
                 ZonedDateTime.now(ZoneOffset.UTC)
         )).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void resolveBaseActions_ReturnRegisteredIncludesManagementActions() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.NEW);
+
+        EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(request);
+
+        assertThat(actions)
+                .contains(ReturnRequestAction.SET_MODE_EXCHANGE,
+                        ReturnRequestAction.UPDATE_REVERSE_TRACK,
+                        ReturnRequestAction.CLOSE_REQUEST);
+    }
+
+    @Test
+    void resolveBaseActions_ExchangeApprovedIncludesParcelActions() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+
+        EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(request);
+
+        assertThat(actions)
+                .contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL,
+                        ReturnRequestAction.MARK_EXCHANGE_SENT,
+                        ReturnRequestAction.SET_MODE_RETURN,
+                        ReturnRequestAction.CLOSE_REQUEST,
+                        ReturnRequestAction.UPDATE_REVERSE_TRACK);
     }
 }


### PR DESCRIPTION
## Summary
- обновлён ReturnRequestWorkflow для использования актуальных кодов действий и расширенной матрицы переходов
- добавлены модульные тесты, подтверждающие доступность базовых действий для возврата и обмена

## Testing
- mvn test *(fails: dependency resolution blocked by jitpack.io 403)*

------
https://chatgpt.com/codex/tasks/task_e_6908b1ff9238832da8bbb8489767da3d