### PR TITLE
Refactor return request mode switching workflow

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnRequestCommandType.java
@@ -24,6 +24,11 @@ enum ReturnRequestCommandType {
     SET_MODE_EXCHANGE(ReturnRequestAction.SET_MODE_EXCHANGE),
 
     /**
+     * Отменяет ранее запущенный обмен и возвращает заявку к сценарию возврата.
+     */
+    CANCEL_EXCHANGE(ReturnRequestAction.CANCEL_EXCHANGE),
+
+    /**
      * Привязывает к заявке обменную посылку, зарегистрированную вручную оператором.
      */
     REGISTER_EXCHANGE_PARCEL(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL),
@@ -124,7 +129,7 @@ enum ReturnRequestCommandType {
         Map<String, ReturnRequestCommandType> legacy = new HashMap<>();
         legacy.put("START_EXCHANGE", SET_MODE_EXCHANGE);
         legacy.put("CREATE_EXCHANGE_PARCEL", REGISTER_EXCHANGE_PARCEL);
-        legacy.put("CANCEL_EXCHANGE", CLOSE_REQUEST);
+        legacy.put("CANCEL_EXCHANGE", CANCEL_EXCHANGE);
         legacy.put("REOPEN_RETURN", SET_MODE_RETURN);
         legacy.put("CONFIRM_RECEIPT", MARK_INBOUND_PICKED_UP);
         legacy.put("UPDATE_DETAILS", UPDATE_REVERSE_TRACK);

--- a/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
+++ b/src/main/java/com/project/tracking_system/entity/ReturnRequestAction.java
@@ -46,6 +46,11 @@ public enum ReturnRequestAction {
     REGISTER_EXCHANGE_PARCEL("REGISTER_EXCHANGE_PARCEL", "Зарегистрировать обменную посылку", true),
 
     /**
+     * Отменяет запущенный обмен без удаления заявки.
+     */
+    CANCEL_EXCHANGE("CANCEL_EXCHANGE", "Отменить обмен", true),
+
+    /**
      * Отмечает отправку обменной посылки со склада магазина.
      */
     MARK_EXCHANGE_SENT("MARK_EXCHANGE_SENT", "Отметить отправку обмена", true),
@@ -82,7 +87,7 @@ public enum ReturnRequestAction {
         legacyMap.put("START_EXCHANGE", SET_MODE_EXCHANGE);
         legacyMap.put("CREATE_EXCHANGE_PARCEL", REGISTER_EXCHANGE_PARCEL);
         legacyMap.put("MARK_EXCHANGE_REGISTERED", SET_MODE_EXCHANGE);
-        legacyMap.put("CANCEL_EXCHANGE", CLOSE_REQUEST);
+        legacyMap.put("CANCEL_EXCHANGE", CANCEL_EXCHANGE);
         legacyMap.put("REOPEN_RETURN", SET_MODE_RETURN);
         legacyMap.put("CONFIRM_RECEIPT", MARK_INBOUND_PICKED_UP);
         legacyMap.put("UPDATE_DETAILS", UPDATE_REVERSE_TRACK);

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -475,7 +475,12 @@ public class CustomerTelegramService {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        return orderReturnRequestService.cancelExchange(requestId, parcelId, owner);
+        orderReturnRequestService.switchMode(requestId,
+                parcelId,
+                owner,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
+        return orderReturnRequestService.closeWithoutExchange(requestId, parcelId, owner);
     }
 
     /**
@@ -488,7 +493,11 @@ public class CustomerTelegramService {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        return orderReturnRequestService.reopenAsReturn(requestId, parcelId, owner);
+        return orderReturnRequestService.switchMode(requestId,
+                parcelId,
+                owner,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -54,6 +54,22 @@ public class OrderReturnRequestService {
     private final ReturnRequestWorkflow returnRequestWorkflow;
 
     /**
+     * Типовые причины переключения режима заявки.
+     * <p>
+     * Значения помогают фиксировать контекст действия в логах и поддерживать единый интерфейс
+     * при работе из разных каналов (админ-панель, Telegram, автоматические сценарии).
+     * </p>
+     */
+    public enum ModeSwitchTrigger {
+        /** Ручное решение менеджера из административного интерфейса. */
+        MANUAL_DECISION,
+        /** Отмена обмена с последующим закрытием обращения. */
+        EXCHANGE_CANCELLATION,
+        /** Инициатива покупателя из Telegram или другого внешнего канала. */
+        CUSTOMER_REQUEST
+    }
+
+    /**
      * Обновляет трек обратной отправки и комментарий активной заявки.
      * <p>
      * Метод убеждается, что заявка принадлежит пользователю и находится в активном статусе,
@@ -217,32 +233,54 @@ public class OrderReturnRequestService {
      */
     @Transactional
     public OrderReturnRequest approveExchange(Long requestId, Long parcelId, User user) {
+        return switchMode(requestId, parcelId, user, ReturnRequestMode.EXCHANGE, ModeSwitchTrigger.MANUAL_DECISION);
+    }
+
+    /**
+     * Переключает режим обработки заявки на возврат или обмен.
+     * <p>
+     * Метод реализует единый шаблон перехода между режимами: проверяет допустимость операции
+     * согласно матрице состояний, нормализует стадию через {@link ReturnRequestWorkflow}
+     * и выполняет побочные действия с обменными посылками через профильные сервисы.
+     * </p>
+     *
+     * @param requestId   идентификатор заявки
+     * @param parcelId    идентификатор посылки
+     * @param user        менеджер, инициировавший действие
+     * @param targetMode  целевой режим обработки
+     * @param trigger     причина переключения (используется в логировании)
+     * @return обновлённая заявка после сохранения
+     */
+    @Transactional
+    public OrderReturnRequest switchMode(Long requestId,
+                                         Long parcelId,
+                                         User user,
+                                         ReturnRequestMode targetMode,
+                                         ModeSwitchTrigger trigger) {
+        if (targetMode == null) {
+            throw new IllegalArgumentException("Не указан целевой режим заявки");
+        }
+        ModeSwitchTrigger effectiveTrigger = trigger != null ? trigger : ModeSwitchTrigger.MANUAL_DECISION;
         OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
-
-        if (request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
-            throw new IllegalStateException("Заявка уже обработана");
-        }
-
-        Long episodeId = Optional.ofNullable(request.getEpisode())
-                .map(OrderEpisode::getId)
-                .orElse(null);
-        if (episodeId != null && returnRequestRepository.existsByEpisode_IdAndStatus(episodeId,
-                OrderReturnRequestStatus.EXCHANGE_APPROVED)) {
-            throw new IllegalStateException("В эпизоде уже запущен обмен");
-        }
-
-        ZonedDateTime decisionMoment = ZonedDateTime.now(ZoneOffset.UTC);
-        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
-        request.setDecisionBy(user);
-        request.setDecisionAt(decisionMoment);
-        request.setMode(ReturnRequestMode.EXCHANGE);
-        request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, user, decisionMoment);
-
-        OrderReturnRequest saved = returnRequestRepository.save(request);
+        OrderReturnRequest updated = switch (targetMode) {
+            case EXCHANGE -> applyExchangeMode(request, user);
+            case RETURN -> applyReturnMode(request, user, effectiveTrigger);
+        };
+        OrderReturnRequest saved = returnRequestRepository.save(updated);
         evictTrackDetailsCache(saved);
-        log.info("Одобрен обмен по заявке {} без автоматического создания обменной посылки", saved.getId());
+        log.info("Заявка {} переведена в режим {} по причине {}", saved.getId(), targetMode, effectiveTrigger);
         return saved;
+    }
+
+    /**
+     * Перегрузка переключения режима без указания причины (используется для совместимости вызовов).
+     */
+    @Transactional
+    public OrderReturnRequest switchMode(Long requestId,
+                                         Long parcelId,
+                                         User user,
+                                         ReturnRequestMode targetMode) {
+        return switchMode(requestId, parcelId, user, targetMode, ModeSwitchTrigger.MANUAL_DECISION);
     }
 
     /**
@@ -482,73 +520,6 @@ public class OrderReturnRequestService {
      * Отменяет обмен по активной заявке пользователя.
      */
     @Transactional
-    public OrderReturnRequest cancelExchange(Long requestId, Long parcelId, User user) {
-        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
-        if (request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            throw new IllegalStateException("Обмен ещё не запущен или заявка уже закрыта");
-        }
-        TrackParcel replacement;
-        try {
-            replacement = orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request)
-                    .orElse(null);
-        } catch (IllegalStateException ex) {
-            log.warn("Нельзя отменить обмен по заявке {}: {}", request.getId(), ex.getMessage());
-            throw ex;
-        }
-        ZonedDateTime cancelMoment = ZonedDateTime.now(ZoneOffset.UTC);
-        request.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
-        request.setClosedBy(user);
-        request.setClosedAt(cancelMoment);
-        request.setMode(ReturnRequestMode.RETURN);
-        request.setResponsibleManager(user);
-        request.setExchangeTrackNumber(null);
-        request.setExchangeTrackAssignedAt(null);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, cancelMoment);
-        orderExchangeService.cancelExchangeParcel(request, replacement);
-        episodeLifecycleService.decrementExchangeCount(request.getEpisode());
-        OrderReturnRequest saved = returnRequestRepository.save(request);
-        evictTrackDetailsCache(saved);
-        log.info("Обмен по заявке {} отменён пользователем", saved.getId());
-        return saved;
-    }
-
-    /**
-     * Переводит одобренный обмен обратно в статус возврата без удаления заявки.
-     */
-    @Transactional
-    public OrderReturnRequest reopenAsReturn(Long requestId, Long parcelId, User user) {
-        OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
-        if (request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            throw new IllegalStateException("Заявка не находится в статусе обмена");
-        }
-        TrackParcel replacement;
-        try {
-            replacement = orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request)
-                    .orElse(null);
-        } catch (IllegalStateException ex) {
-            log.warn("Нельзя перевести обмен по заявке {} в возврат: {}", request.getId(), ex.getMessage());
-            throw ex;
-        }
-        ZonedDateTime reopenMoment = ZonedDateTime.now(ZoneOffset.UTC);
-        request.setStatus(OrderReturnRequestStatus.REGISTERED);
-        request.setDecisionBy(null);
-        request.setDecisionAt(null);
-        request.setClosedBy(null);
-        request.setClosedAt(null);
-        request.setExchangeRequested(false);
-        request.setMode(ReturnRequestMode.RETURN);
-        request.setResponsibleManager(user);
-        request.setExchangeTrackNumber(null);
-        request.setExchangeTrackAssignedAt(null);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, reopenMoment);
-        orderExchangeService.cancelExchangeParcel(request, replacement);
-        episodeLifecycleService.decrementExchangeCount(request.getEpisode());
-        OrderReturnRequest saved = returnRequestRepository.save(request);
-        evictTrackDetailsCache(saved);
-        log.info("Заявка {} переведена из обмена в возврат", saved.getId());
-        return saved;
-    }
-
     /**
      * Регистрирует запрос покупателя магазину по активной заявке обмена.
      * <p>
@@ -631,6 +602,26 @@ public class OrderReturnRequestService {
         }
         return !returnRequestRepository.existsByEpisode_IdAndStatus(episodeId,
                 OrderReturnRequestStatus.EXCHANGE_APPROVED);
+    }
+
+    /**
+     * Проверяет, можно ли вернуть обменную заявку в режим возврата без закрытия обращения.
+     */
+    private boolean canSwitchToReturnMode(OrderReturnRequest request) {
+        if (request == null || request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            return false;
+        }
+        if (isExchangeShipmentDispatched(request)) {
+            return false;
+        }
+        return getExchangeCancellationBlockReason(request).isEmpty();
+    }
+
+    /**
+     * Проверяет, доступна ли отмена обмена с последующим закрытием заявки.
+     */
+    private boolean canCancelExchangeAction(OrderReturnRequest request) {
+        return canSwitchToReturnMode(request);
     }
 
     /**
@@ -762,6 +753,114 @@ public class OrderReturnRequestService {
     }
 
     /**
+     * Применяет правила перевода заявки в режим обмена.
+     */
+    private OrderReturnRequest applyExchangeMode(OrderReturnRequest request, User actor) {
+        if (request == null) {
+            throw new IllegalArgumentException("Не найдена заявка для переключения режима");
+        }
+        if (request.getStatus() == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            request.setMode(ReturnRequestMode.EXCHANGE);
+            return request;
+        }
+        if (request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            throw new IllegalStateException("Перевод в обмен доступен только для активной заявки");
+        }
+        Long episodeId = Optional.ofNullable(request.getEpisode())
+                .map(OrderEpisode::getId)
+                .orElse(null);
+        if (episodeId != null && returnRequestRepository.existsByEpisode_IdAndStatus(episodeId,
+                OrderReturnRequestStatus.EXCHANGE_APPROVED)) {
+            throw new IllegalStateException("В эпизоде уже запущен обмен");
+        }
+        ZonedDateTime decisionMoment = ZonedDateTime.now(ZoneOffset.UTC);
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setDecisionBy(actor);
+        request.setDecisionAt(decisionMoment);
+        request.setClosedBy(null);
+        request.setClosedAt(null);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setResponsibleManager(actor);
+        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, actor, decisionMoment);
+        return request;
+    }
+
+    /**
+     * Применяет правила перевода заявки в режим возврата.
+     */
+    private OrderReturnRequest applyReturnMode(OrderReturnRequest request,
+                                               User actor,
+                                               ModeSwitchTrigger trigger) {
+        if (request == null) {
+            throw new IllegalArgumentException("Не найдена заявка для переключения режима");
+        }
+        OrderReturnRequestStatus status = request.getStatus();
+        if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
+            request.setMode(ReturnRequestMode.RETURN);
+            return request;
+        }
+        if (status == OrderReturnRequestStatus.REGISTERED) {
+            request.setMode(ReturnRequestMode.RETURN);
+            request.setResponsibleManager(actor);
+            ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
+            ReturnRequestStage normalized = returnRequestWorkflow.adjustStageForMode(
+                    ReturnRequestMode.RETURN,
+                    Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW)
+            );
+            returnRequestWorkflow.transitionToStage(request, normalized, true, actor, moment);
+            return request;
+        }
+        if (status != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            throw new IllegalStateException("Заявка не находится в режиме обмена");
+        }
+        ensureExchangeCancellationPossible(request, trigger);
+        TrackParcel replacement;
+        try {
+            replacement = orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request)
+                    .orElse(null);
+        } catch (IllegalStateException ex) {
+            log.warn("Нельзя перевести обмен по заявке {} в возврат: {}", request.getId(), ex.getMessage());
+            throw ex;
+        }
+        ZonedDateTime reopenMoment = ZonedDateTime.now(ZoneOffset.UTC);
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setDecisionBy(null);
+        request.setDecisionAt(null);
+        request.setClosedBy(null);
+        request.setClosedAt(null);
+        request.setExchangeRequested(false);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setResponsibleManager(actor);
+        request.setExchangeTrackNumber(null);
+        request.setExchangeTrackAssignedAt(null);
+        ReturnRequestStage normalized = returnRequestWorkflow.adjustStageForMode(
+                ReturnRequestMode.RETURN,
+                Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW)
+        );
+        returnRequestWorkflow.transitionToStage(request, normalized, true, actor, reopenMoment);
+        orderExchangeService.cancelExchangeParcel(request, replacement);
+        episodeLifecycleService.decrementExchangeCount(request.getEpisode());
+        return request;
+    }
+
+    /**
+     * Убеждается, что отмена обмена разрешена матрицей переходов и состоянием посылок.
+     */
+    private void ensureExchangeCancellationPossible(OrderReturnRequest request, ModeSwitchTrigger trigger) {
+        if (request == null) {
+            return;
+        }
+        log.debug("Проверка возможности отмены обмена по заявке {} (триггер {})",
+                request.getId(), trigger);
+        if (isExchangeShipmentDispatched(request)) {
+            throw new IllegalStateException("Отмена обмена недоступна: обменная посылка уже отправлена или доставлена");
+        }
+        getExchangeCancellationBlockReason(request).ifPresent(reason -> {
+            throw new IllegalStateException(reason);
+        });
+    }
+
+    /**
      * Определяет, считается ли обменная посылка отправленной.
      *
      * @param parcel обменная посылка
@@ -797,7 +896,8 @@ public class OrderReturnRequestService {
         }
         return switch (action) {
             case SET_MODE_EXCHANGE -> canStartExchange(request);
-            case SET_MODE_RETURN -> canReopenAsReturn(request);
+            case SET_MODE_RETURN -> canSwitchToReturnMode(request);
+            case CANCEL_EXCHANGE -> canCancelExchangeAction(request);
             case REGISTER_EXCHANGE_PARCEL -> canRegisterExchangeParcel(request);
             case CLOSE_REQUEST -> canCloseRequest(request);
             case UPDATE_REVERSE_TRACK -> canUpdateDetails(request);
@@ -817,13 +917,7 @@ public class OrderReturnRequestService {
             return false;
         }
         OrderReturnRequestStatus status = request.getStatus();
-        if (status == OrderReturnRequestStatus.REGISTERED) {
-            return true;
-        }
-        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            return canCancelExchange(request);
-        }
-        return false;
+        return status == OrderReturnRequestStatus.REGISTERED;
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -8,6 +8,7 @@ import com.project.tracking_system.dto.RequestDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.ReturnCommandLog;
+import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.ReturnCommandLogRepository;
@@ -271,8 +272,11 @@ public class ReturnRequestCommandService {
      */
     private Map<ReturnRequestCommandType, ReturnRequestCommandHandler> createHandlers(OrderReturnRequestService service) {
         EnumMap<ReturnRequestCommandType, ReturnRequestCommandHandler> handlers = new EnumMap<>(ReturnRequestCommandType.class);
-        handlers.put(ReturnRequestCommandType.SET_MODE_EXCHANGE, simpleHandler(service::approveExchange));
-        handlers.put(ReturnRequestCommandType.SET_MODE_RETURN, simpleHandler(service::reopenAsReturn));
+        handlers.put(ReturnRequestCommandType.SET_MODE_EXCHANGE,
+                modeSwitchHandler(ReturnRequestMode.EXCHANGE, OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION));
+        handlers.put(ReturnRequestCommandType.SET_MODE_RETURN,
+                modeSwitchHandler(ReturnRequestMode.RETURN, OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION));
+        handlers.put(ReturnRequestCommandType.CANCEL_EXCHANGE, this::handleCancelExchange);
         handlers.put(ReturnRequestCommandType.CLOSE_REQUEST, this::handleCloseRequest);
         handlers.put(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL,
                 exchangeHandler(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL, service::registerExchangeParcel));
@@ -316,11 +320,27 @@ public class ReturnRequestCommandService {
             case REGISTERED -> orderReturnRequestService.closeWithoutExchange(context.requestId(),
                     context.parcelId(),
                     context.user());
-            case EXCHANGE_APPROVED -> orderReturnRequestService.cancelExchange(context.requestId(),
-                    context.parcelId(),
-                    context.user());
+            case EXCHANGE_APPROVED -> throw new IllegalStateException("Для обменных заявок используйте отмену обмена");
             case CLOSED_NO_EXCHANGE -> throw new IllegalStateException("Заявка уже закрыта");
         };
+    }
+
+    /**
+     * Обрабатывает отмену обмена с последующим закрытием заявки.
+     */
+    private OrderReturnRequest handleCancelExchange(CommandContext context, ReturnRequestCommandPayload payload) {
+        orderReturnRequestService.switchMode(
+                context.requestId(),
+                context.parcelId(),
+                context.user(),
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION
+        );
+        return orderReturnRequestService.closeWithoutExchange(
+                context.requestId(),
+                context.parcelId(),
+                context.user()
+        );
     }
 
     /**
@@ -370,6 +390,20 @@ public class ReturnRequestCommandService {
                     + " передана с неподдерживаемой структурой данных");
         }
         return payloadType.cast(payload);
+    }
+
+    /**
+     * Формирует обработчик переключения режима заявки.
+     */
+    private ReturnRequestCommandHandler modeSwitchHandler(ReturnRequestMode targetMode,
+                                                         OrderReturnRequestService.ModeSwitchTrigger trigger) {
+        return (context, payload) -> orderReturnRequestService.switchMode(
+                context.requestId(),
+                context.parcelId(),
+                context.user(),
+                targetMode,
+                trigger
+        );
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -161,8 +161,8 @@ public class ReturnRequestWorkflow {
             actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
         } else if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
             actions.add(ReturnRequestAction.SET_MODE_RETURN);
+            actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
             actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
-            actions.add(ReturnRequestAction.CLOSE_REQUEST);
             actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
         } else if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
             actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);

--- a/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
@@ -32,6 +32,7 @@ public class ReturnRequestCommandPayloadFactory {
         EnumMap<ReturnRequestCommandType, PayloadParser> registry = new EnumMap<>(ReturnRequestCommandType.class);
         registry.put(ReturnRequestCommandType.SET_MODE_EXCHANGE, emptyParser(ReturnRequestCommandType.SET_MODE_EXCHANGE));
         registry.put(ReturnRequestCommandType.SET_MODE_RETURN, emptyParser(ReturnRequestCommandType.SET_MODE_RETURN));
+        registry.put(ReturnRequestCommandType.CANCEL_EXCHANGE, emptyParser(ReturnRequestCommandType.CANCEL_EXCHANGE));
         registry.put(ReturnRequestCommandType.CLOSE_REQUEST, emptyParser(ReturnRequestCommandType.CLOSE_REQUEST));
         registry.put(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL,
                 exchangeParser(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL));

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -1013,13 +1013,13 @@
                     }
                 },
                 {
-                    key: 'close',
-                    label: 'Закрыть обращение',
-                    ariaLabel: 'Закрыть обращение без обмена',
+                    key: 'cancelExchange',
+                    label: 'Отменить обмен',
+                    ariaLabel: 'Отменить обмен и закрыть обращение',
                     className: 'btn btn-outline-danger btn-sm',
                     enabled: Boolean(this._permissions.cancelExchange || this._permissions.close),
                     options: {
-                        successMessage: 'Обращение закрыто',
+                        successMessage: 'Обмен отменён',
                         notificationType: 'warning'
                     }
                 }
@@ -1140,6 +1140,7 @@
             convertToExchange: (options = {}) => convertReturnRequestToExchange(trackId, requestId, options),
             launchExchange: (options = {}) => createExchangeParcel(trackId, requestId, options),
             close: (options = {}) => closeReturnRequest(trackId, requestId, options),
+            cancelExchange: (options = {}) => cancelExchange(trackId, requestId, options),
             reopen: (options = {}) => reopenReturnRequest(trackId, requestId, options),
             updateReverseTrack: (options = {}) => updateReverseTrack(
                 trackId,
@@ -1288,7 +1289,9 @@
         'create_exchange_parcel': ['register_exchange_parcel'],
         'register_exchange_parcel': ['create_exchange_parcel'],
         'update_details': ['update_reverse_track'],
-        'update_reverse_track': ['update_details']
+        'update_reverse_track': ['update_details'],
+        'cancel_exchange': ['close'],
+        'close': ['cancel_exchange']
     };
 
     const STAGE_LABELS = {
@@ -1621,6 +1624,17 @@
             successMessage: options.successMessage || 'Обращение закрыто',
             notificationType: options.notificationType || 'warning',
             errorMessage: options.errorMessage || 'Не удалось закрыть обращение'
+        });
+    }
+
+    async function cancelExchange(trackId, requestId, options = {}) {
+        return await performReturnRequestAction({
+            trackId,
+            requestId,
+            command: 'cancel_exchange',
+            successMessage: options.successMessage || 'Обмен отменён',
+            notificationType: options.notificationType || 'warning',
+            errorMessage: options.errorMessage || 'Не удалось отменить обмен'
         });
     }
 
@@ -2806,6 +2820,7 @@
         render: renderTrackModal,
         invalidateLazySections: (trackId) => invalidateLazyDataCache(trackId),
         convertReturnRequestToExchange,
+        cancelExchange,
         closeReturnRequest,
         confirmReturnProcessing,
         reopenReturnRequest,

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -541,7 +541,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void cancelExchange_ClosesRequestWhenReplacementHasNoTrack() {
+    void switchMode_whenReturnFromExchange_resetsExchangeData() {
         TrackParcel parcel = buildParcel(19L, GlobalStatus.DELIVERED);
         TrackParcel replacement = new TrackParcel();
         replacement.setId(77L);
@@ -557,11 +557,15 @@ class OrderReturnRequestServiceTest {
                 .thenReturn(Optional.of(replacement));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderReturnRequest result = service.cancelExchange(610L, 19L, user);
+        OrderReturnRequest result = service.switchMode(610L,
+                19L,
+                user,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION);
 
-        assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
-        assertThat(result.getClosedBy()).isEqualTo(user);
-        assertThat(result.getClosedAt()).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
+        assertThat(result.getDecisionBy()).isNull();
+        assertThat(result.getClosedAt()).isNull();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
         assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
         assertThat(result.getHistoryEntries()).isNotEmpty();
@@ -571,7 +575,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void cancelExchange_ThrowsWhenTrackAlreadyAssigned() {
+    void switchMode_whenReturnFromExchangeBlocked_throwsException() {
         TrackParcel parcel = buildParcel(21L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(611L);
@@ -583,7 +587,11 @@ class OrderReturnRequestServiceTest {
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
                 .thenThrow(new IllegalStateException("Отмена недоступна"));
 
-        assertThatThrownBy(() -> service.cancelExchange(611L, 21L, user))
+        assertThatThrownBy(() -> service.switchMode(611L,
+                21L,
+                user,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Отмена недоступна");
         verify(repository, never()).save(any());
@@ -820,7 +828,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void reopenAsReturn_ResetsExchangeAndSavesRequest() {
+    void switchMode_whenCustomerRequestsReturn_resetsExchange() {
         TrackParcel parcel = buildParcel(23L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(950L);
@@ -840,7 +848,11 @@ class OrderReturnRequestServiceTest {
                 .thenReturn(Optional.of(replacement));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderReturnRequest result = service.reopenAsReturn(950L, 23L, user);
+        OrderReturnRequest result = service.switchMode(950L,
+                23L,
+                user,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
 
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
         assertThat(result.getDecisionBy()).isNull();
@@ -857,7 +869,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void reopenAsReturn_ThrowsWhenTrackAlreadyAssigned() {
+    void switchMode_whenReturnBlockedByTrack_throwsException() {
         TrackParcel parcel = buildParcel(24L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(960L);
@@ -869,7 +881,11 @@ class OrderReturnRequestServiceTest {
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
                 .thenThrow(new IllegalStateException("Магазин уже указал трек"));
 
-        assertThatThrownBy(() -> service.reopenAsReturn(960L, 24L, user))
+        assertThatThrownBy(() -> service.switchMode(960L,
+                24L,
+                user,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Магазин уже указал трек");
         verify(repository, never()).save(any());
@@ -889,6 +905,19 @@ class OrderReturnRequestServiceTest {
         assertThat(actions).contains(ReturnRequestAction.CLOSE_REQUEST, ReturnRequestAction.SET_MODE_EXCHANGE);
         assertThat(actions).doesNotContain(ReturnRequestAction.SET_MODE_RETURN);
         assertThat(actions).doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT);
+    }
+
+    @Test
+    void resolveAvailableActions_ReturnsCancelForExchangeRequest() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+        assertThat(actions).contains(ReturnRequestAction.CANCEL_EXCHANGE, ReturnRequestAction.SET_MODE_RETURN);
+        assertThat(actions).doesNotContain(ReturnRequestAction.CLOSE_REQUEST);
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -6,7 +6,9 @@ import com.project.tracking_system.controller.ReturnRequestCommandType;
 import com.project.tracking_system.dto.CommandDto;
 import com.project.tracking_system.dto.RequestDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.ReturnCommandLog;
+import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.repository.ReturnCommandLogRepository;
@@ -80,7 +82,11 @@ class ReturnRequestCommandServiceTest {
         CommandDto command = new CommandDto("dup-1", "SET_MODE_EXCHANGE", null);
 
         when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
-        when(orderReturnRequestService.approveExchange(21L, 9L, user)).thenReturn(updated);
+        when(orderReturnRequestService.switchMode(21L,
+                9L,
+                user,
+                ReturnRequestMode.EXCHANGE,
+                OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION)).thenReturn(updated);
         when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
 
         AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
@@ -107,7 +113,11 @@ class ReturnRequestCommandServiceTest {
 
         assertThat(first).isEqualTo(dto);
         assertThat(second).isEqualTo(dto);
-        verify(orderReturnRequestService).approveExchange(21L, 9L, user);
+        verify(orderReturnRequestService).switchMode(21L,
+                9L,
+                user,
+                ReturnRequestMode.EXCHANGE,
+                OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION);
         verify(returnRequestMapper).toDto(eq(updated), any());
         verify(returnCommandLogRepository, atLeast(2)).saveAndFlush(any(ReturnCommandLog.class));
     }
@@ -137,7 +147,7 @@ class ReturnRequestCommandServiceTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("уже выполнена");
 
-        verify(orderReturnRequestService, never()).approveExchange(21L, 9L, user);
+        verify(orderReturnRequestService, never()).switchMode(any(), any(), any(), any(), any());
         verify(returnRequestMapper, never()).toDto(any(), any());
         verify(returnCommandLogRepository, never()).saveAndFlush(any(ReturnCommandLog.class));
     }
@@ -176,8 +186,54 @@ class ReturnRequestCommandServiceTest {
                 ZoneOffset.UTC);
 
         assertThat(result.legacyId()).isEqualTo(22L);
-        verify(orderReturnRequestService, never()).approveExchange(any(), any(), any());
+        verify(orderReturnRequestService, never()).switchMode(any(), any(), any(), any(), any());
         verify(returnRequestMapper, never()).toDto(any(), any());
+    }
+
+    @Test
+    void executeCommand_whenCancelExchange_invokesSwitchAndClose() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(40L, 18L);
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        OrderReturnRequest switched = buildRequest(40L, 18L);
+        switched.setStatus(OrderReturnRequestStatus.REGISTERED);
+        OrderReturnRequest closed = buildRequest(40L, 18L);
+        closed.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000040", 40L, "RETURN");
+        CommandDto command = new CommandDto("cancel-1", "CANCEL_EXCHANGE", null);
+
+        when(orderReturnRequestService.getOwnedRequest(40L, user)).thenReturn(request);
+        when(orderReturnRequestService.switchMode(40L,
+                18L,
+                user,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION)).thenReturn(switched);
+        when(orderReturnRequestService.closeWithoutExchange(40L, 18L, user)).thenReturn(closed);
+        when(returnRequestMapper.toDto(eq(closed), any())).thenReturn(dto);
+
+        AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
+        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(40L, "cancel-1"))
+                .thenAnswer(invocation -> Optional.ofNullable(savedLog.get()));
+        when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
+                .thenAnswer(invocation -> {
+                    ReturnCommandLog logEntry = invocation.getArgument(0);
+                    savedLog.set(logEntry);
+                    return logEntry;
+                });
+
+        RequestDto result = commandService.executeCommand(40L,
+                ReturnRequestCommandType.CANCEL_EXCHANGE,
+                command,
+                user,
+                ZoneOffset.UTC);
+
+        assertThat(result).isEqualTo(dto);
+        verify(orderReturnRequestService).switchMode(40L,
+                18L,
+                user,
+                ReturnRequestMode.RETURN,
+                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION);
+        verify(orderReturnRequestService).closeWithoutExchange(40L, 18L, user);
     }
 
     @Test

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -390,7 +390,10 @@ status: 'Зарегистрирована',
         expect(confirmBtn?.textContent).toContain('Принять возврат');
 
         const closeButton = Array.from(document.querySelectorAll('button'))
-            .find((btn) => btn.textContent?.includes('Закрыть обращение'));
+            .find((btn) => {
+                const text = btn.textContent || '';
+                return text.includes('Отменить обмен') || text.includes('Закрыть обращение');
+            });
         expect(closeButton).toBeDefined();
     });
 
@@ -459,7 +462,8 @@ status: 'Зарегистрирована',
 
         expect(texts).toContain('Перевести в возврат');
         expect(texts).toContain('Добавить трек обратной посылки');
-        expect(texts).toContain('Закрыть обращение');
+        const hasCancelAction = texts.some((label) => label === 'Отменить обмен' || label === 'Закрыть обращение');
+        expect(hasCancelAction).toBe(true);
     });
 
     test('sends close request for exchange when cancel action triggered', async () => {
@@ -574,7 +578,10 @@ status: 'Зарегистрирована',
         const actionCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
         const closeButton = Array.from(actionCard?.querySelectorAll('button') || [])
-            .find((btn) => btn.textContent === 'Закрыть обращение');
+            .find((btn) => {
+                const text = btn.textContent || '';
+                return text === 'Отменить обмен' || text === 'Закрыть обращение';
+            });
         expect(closeButton).toBeDefined();
         closeButton?.click();
 
@@ -587,10 +594,10 @@ status: 'Зарегистрирована',
             '/api/v1/returns/81/commands',
             expect.objectContaining({
                 method: 'POST',
-                body: JSON.stringify({ command: 'close' })
+                body: JSON.stringify({ command: 'cancel_exchange' })
             })
         );
-        expect(global.notifyUser).toHaveBeenCalledWith('Обращение закрыто', 'warning');
+        expect(global.notifyUser).toHaveBeenCalledWith('Обмен отменён', 'warning');
 
         const rerenderedCard = Array.from(document.querySelectorAll('section.card'))
             .find((card) => card.querySelector('h6')?.textContent === 'Обращение');
@@ -919,7 +926,10 @@ status: 'Зарегистрирована',
         expect(confirmButton?.getAttribute('aria-hidden')).toBe('true');
 
         const closeButton = Array.from(actionCard?.querySelectorAll('button') || [])
-            .find((btn) => btn.textContent === 'Закрыть обращение');
+            .find((btn) => {
+                const text = btn.textContent || '';
+                return text === 'Отменить обмен' || text === 'Закрыть обращение';
+            });
         expect(closeButton).toBeDefined();
     });
 


### PR DESCRIPTION
## Summary
- introduce a unified switchMode API for return/exchange requests with shared validation
- expose a dedicated cancel exchange command and update command handlers plus telegram flows
- align web UI actions and tests with the new cancel exchange behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908caf47568832dbfe5e43845990a71