### PR TITLE
Refine return request action resolution

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -14,6 +14,7 @@ import com.project.tracking_system.entity.User;
 import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.repository.OrderReturnRequestActionRequestRepository;
 import com.project.tracking_system.repository.OrderReturnRequestRepository;
+import com.project.tracking_system.service.order.context.ReturnRequestActionContext;
 import com.project.tracking_system.service.track.TrackParcelService;
 import com.project.tracking_system.service.track.TrackViewCacheInvalidator;
 import lombok.RequiredArgsConstructor;
@@ -747,9 +748,41 @@ public class OrderReturnRequestService {
      */
     @Transactional(readOnly = true)
     public EnumSet<ReturnRequestAction> resolveAvailableActions(OrderReturnRequest request) {
-        EnumSet<ReturnRequestAction> actions = returnRequestWorkflow.resolveBaseActions(request);
-        actions.removeIf(action -> !isActionAllowed(action, request));
-        return actions;
+        if (request == null) {
+            return EnumSet.noneOf(ReturnRequestAction.class);
+        }
+        ReturnRequestActionContext context = buildActionContext(request);
+        return returnRequestWorkflow.resolveBaseActions(context);
+    }
+
+    /**
+     * Формирует контекст доступности действий для workflow на основании бизнес-ограничений.
+     *
+     * @param request заявка на возврат/обмен
+     * @return заполненный контекст действий
+     */
+    private ReturnRequestActionContext buildActionContext(OrderReturnRequest request) {
+        ReturnRequestMode mode = Optional.ofNullable(request.getMode()).orElse(ReturnRequestMode.RETURN);
+        ReturnRequestStage stage = Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW);
+        ReturnRequestStage normalizedStage = returnRequestWorkflow.adjustStageForMode(mode, stage);
+        ReturnRequestActionContext.Builder builder = ReturnRequestActionContext.builder(request)
+                .withMode(mode)
+                .withStage(normalizedStage)
+                .withStatus(request.getStatus());
+
+        builder.allow(ReturnRequestAction.SET_MODE_EXCHANGE, canStartExchange(request));
+        builder.allow(ReturnRequestAction.SET_MODE_RETURN, canSwitchToReturnMode(request));
+        builder.allow(ReturnRequestAction.CANCEL_EXCHANGE, canCancelExchangeAction(request));
+        builder.allow(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL, canRegisterExchangeParcel(request));
+        builder.allow(ReturnRequestAction.CLOSE_REQUEST, canCloseRequest(request));
+        builder.allow(ReturnRequestAction.UPDATE_REVERSE_TRACK, canUpdateDetails(request));
+        builder.allow(ReturnRequestAction.MARK_OUTBOUND_SENT, canMarkOutboundSent(request));
+        builder.allow(ReturnRequestAction.MARK_INBOUND_ARRIVED, canMarkInboundArrived(request));
+        builder.allow(ReturnRequestAction.MARK_INBOUND_PICKED_UP, canMarkInboundPickedUp(request));
+        builder.allow(ReturnRequestAction.MARK_EXCHANGE_SENT, canMarkExchangeSent(request));
+        builder.allow(ReturnRequestAction.MARK_EXCHANGE_DELIVERED, canMarkExchangeDelivered(request));
+
+        return builder.build();
     }
 
     /**
@@ -890,25 +923,6 @@ public class OrderReturnRequestService {
     /**
      * Проверяет, разрешено ли действие для конкретной заявки с учётом всех ограничений.
      */
-    private boolean isActionAllowed(ReturnRequestAction action, OrderReturnRequest request) {
-        if (action == null || request == null) {
-            return false;
-        }
-        return switch (action) {
-            case SET_MODE_EXCHANGE -> canStartExchange(request);
-            case SET_MODE_RETURN -> canSwitchToReturnMode(request);
-            case CANCEL_EXCHANGE -> canCancelExchangeAction(request);
-            case REGISTER_EXCHANGE_PARCEL -> canRegisterExchangeParcel(request);
-            case CLOSE_REQUEST -> canCloseRequest(request);
-            case UPDATE_REVERSE_TRACK -> canUpdateDetails(request);
-            case MARK_OUTBOUND_SENT -> canMarkOutboundSent(request);
-            case MARK_INBOUND_ARRIVED -> canMarkInboundArrived(request);
-            case MARK_INBOUND_PICKED_UP -> canMarkInboundPickedUp(request);
-            case MARK_EXCHANGE_SENT -> canMarkExchangeSent(request);
-            case MARK_EXCHANGE_DELIVERED -> canMarkExchangeDelivered(request);
-        };
-    }
-
     /**
      * Проверяет, можно ли закрыть заявку на текущем этапе.
      */

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.order.context.ReturnRequestActionContext;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -30,6 +31,7 @@ public class ReturnRequestWorkflow {
 
     private final Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> transitionTable;
     private final Map<ReturnRequestMode, Map<ReturnRequestStage, EnumSet<ReturnRequestAction>>> actionMatrix;
+    private final Map<OrderReturnRequestStatus, EnumSet<ReturnRequestAction>> statusActionMatrix;
 
     /**
      * Создаёт workflow с таблицей допустимых переходов.
@@ -37,6 +39,7 @@ public class ReturnRequestWorkflow {
     public ReturnRequestWorkflow() {
         this.transitionTable = buildTransitionTable();
         this.actionMatrix = buildActionMatrix();
+        this.statusActionMatrix = buildStatusActionMatrix();
     }
 
     /**
@@ -132,42 +135,45 @@ public class ReturnRequestWorkflow {
     }
 
     /**
-     * Вычисляет базовый набор действий, доступных по текущему состоянию заявки.
+     * Вычисляет итоговый набор действий, доступных для заявки с учётом матрицы и контекста.
+     * <p>
+     * Метод не ограничивается стадией: он объединяет базовые переходы из {@link #actionMatrix}
+     * и статусные команды из {@link #statusActionMatrix}, фильтруя их через политику доступности
+     * {@link ReturnRequestActionContext}. Благодаря этому сервисы получают уже согласованный
+     * перечень кнопок без повторной фильтрации (SRP).
+     * </p>
      *
-     * @param request заявка на возврат/обмен
-     * @return множество потенциально доступных действий
+     * @param context контекст заявки и предрасчитанные ограничения
+     * @return итоговое множество доступных действий
      */
-    public EnumSet<ReturnRequestAction> resolveBaseActions(OrderReturnRequest request) {
-        if (request == null) {
+    public EnumSet<ReturnRequestAction> resolveBaseActions(ReturnRequestActionContext context) {
+        if (context == null) {
             return EnumSet.noneOf(ReturnRequestAction.class);
         }
-        OrderReturnRequestStatus status = request.getStatus();
-        ReturnRequestMode mode = safeMode(request.getMode());
-        ReturnRequestStage stage = safeStage(request.getStage());
+        ReturnRequestMode mode = safeMode(context.mode());
+        ReturnRequestStage stage = adjustStageForMode(mode, safeStage(context.stage()));
+        OrderReturnRequestStatus status = context.status();
 
-        EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
+        EnumSet<ReturnRequestAction> resolved = EnumSet.noneOf(ReturnRequestAction.class);
+
         Map<ReturnRequestStage, EnumSet<ReturnRequestAction>> modeActions = actionMatrix.get(mode);
         if (modeActions != null) {
             EnumSet<ReturnRequestAction> stageActions = modeActions.get(stage);
             if (stageActions != null) {
-                actions.addAll(stageActions);
+                stageActions.stream()
+                        .filter(context::allows)
+                        .forEach(resolved::add);
             }
         }
 
-        if (status == OrderReturnRequestStatus.REGISTERED) {
-            actions.add(ReturnRequestAction.SET_MODE_EXCHANGE);
-            actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
-            actions.add(ReturnRequestAction.CLOSE_REQUEST);
-            actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
-        } else if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            actions.add(ReturnRequestAction.SET_MODE_RETURN);
-            actions.add(ReturnRequestAction.CANCEL_EXCHANGE);
-            actions.add(ReturnRequestAction.UPDATE_REVERSE_TRACK);
-            actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
-        } else if (status == OrderReturnRequestStatus.CLOSED_NO_EXCHANGE) {
-            actions.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+        EnumSet<ReturnRequestAction> statusActions = statusActionMatrix.get(status);
+        if (statusActions != null) {
+            statusActions.stream()
+                    .filter(context::allows)
+                    .forEach(resolved::add);
         }
-        return actions;
+
+        return resolved;
     }
 
     private Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> buildTransitionTable() {
@@ -248,6 +254,21 @@ public class ReturnRequestWorkflow {
             }
             matrix.put(mode, stageActions);
         }
+        return matrix;
+    }
+
+    private Map<OrderReturnRequestStatus, EnumSet<ReturnRequestAction>> buildStatusActionMatrix() {
+        EnumMap<OrderReturnRequestStatus, EnumSet<ReturnRequestAction>> matrix = new EnumMap<>(OrderReturnRequestStatus.class);
+        matrix.put(OrderReturnRequestStatus.REGISTERED, EnumSet.of(
+                ReturnRequestAction.SET_MODE_EXCHANGE,
+                ReturnRequestAction.UPDATE_REVERSE_TRACK,
+                ReturnRequestAction.CLOSE_REQUEST
+        ));
+        matrix.put(OrderReturnRequestStatus.EXCHANGE_APPROVED, EnumSet.of(
+                ReturnRequestAction.SET_MODE_RETURN,
+                ReturnRequestAction.CANCEL_EXCHANGE,
+                ReturnRequestAction.UPDATE_REVERSE_TRACK
+        ));
         return matrix;
     }
 

--- a/src/main/java/com/project/tracking_system/service/order/context/ReturnRequestActionContext.java
+++ b/src/main/java/com/project/tracking_system/service/order/context/ReturnRequestActionContext.java
@@ -1,0 +1,145 @@
+package com.project.tracking_system.service.order.context;
+
+import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.OrderReturnRequestStatus;
+import com.project.tracking_system.entity.ReturnRequestAction;
+import com.project.tracking_system.entity.ReturnRequestMode;
+import com.project.tracking_system.entity.ReturnRequestStage;
+
+import java.util.EnumMap;
+import java.util.Objects;
+
+/**
+ * Контекст расчёта доступных действий по заявке на возврат/обмен.
+ * <p>
+ * Объект содержит предрасчитанные ограничения по каждому действию и основные атрибуты заявки,
+ * чтобы {@code ReturnRequestWorkflow} мог сосредоточиться на матрице переходов
+ * и не зависеть от сервисов, проверяющих бизнес-правила (SRP, DIP).
+ * </p>
+ */
+public final class ReturnRequestActionContext {
+
+    private final OrderReturnRequest request;
+    private final ReturnRequestMode mode;
+    private final ReturnRequestStage stage;
+    private final OrderReturnRequestStatus status;
+    private final EnumMap<ReturnRequestAction, Boolean> availability;
+
+    private ReturnRequestActionContext(Builder builder) {
+        this.request = builder.request;
+        this.mode = builder.mode;
+        this.stage = builder.stage;
+        this.status = builder.status;
+        this.availability = new EnumMap<>(builder.availability);
+    }
+
+    /**
+     * Возвращает исходную заявку.
+     */
+    public OrderReturnRequest request() {
+        return request;
+    }
+
+    /**
+     * Возвращает режим обработки заявки.
+     */
+    public ReturnRequestMode mode() {
+        return mode;
+    }
+
+    /**
+     * Возвращает актуальную стадию заявки.
+     */
+    public ReturnRequestStage stage() {
+        return stage;
+    }
+
+    /**
+     * Возвращает статус заявки.
+     */
+    public OrderReturnRequestStatus status() {
+        return status;
+    }
+
+    /**
+     * Проверяет, разрешено ли конкретное действие согласно подготовленным правилам.
+     *
+     * @param action проверяемое действие
+     * @return {@code true}, если действие доступно
+     */
+    public boolean allows(ReturnRequestAction action) {
+        if (action == null) {
+            return false;
+        }
+        return availability.getOrDefault(action, Boolean.FALSE);
+    }
+
+    /**
+     * Создаёт билдер контекста для указанной заявки.
+     */
+    public static Builder builder(OrderReturnRequest request) {
+        return new Builder(request);
+    }
+
+    /**
+     * Билдер контекста, позволяющий поэтапно заполнить данные для workflow.
+     */
+    public static final class Builder {
+
+        private final OrderReturnRequest request;
+        private ReturnRequestMode mode;
+        private ReturnRequestStage stage;
+        private OrderReturnRequestStatus status;
+        private final EnumMap<ReturnRequestAction, Boolean> availability = new EnumMap<>(ReturnRequestAction.class);
+
+        private Builder(OrderReturnRequest request) {
+            this.request = request;
+        }
+
+        /**
+         * Устанавливает режим обработки заявки.
+         */
+        public Builder withMode(ReturnRequestMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        /**
+         * Устанавливает текущую стадию заявки.
+         */
+        public Builder withStage(ReturnRequestStage stage) {
+            this.stage = stage;
+            return this;
+        }
+
+        /**
+         * Устанавливает статус заявки.
+         */
+        public Builder withStatus(OrderReturnRequestStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        /**
+         * Фиксирует доступность конкретного действия.
+         *
+         * @param action действие, чью доступность требуется описать
+         * @param allowed {@code true}, если действие разрешено
+         */
+        public Builder allow(ReturnRequestAction action, boolean allowed) {
+            if (action != null) {
+                availability.put(action, allowed);
+            }
+            return this;
+        }
+
+        /**
+         * Создаёт неизменяемый контекст после заполнения обязательных полей.
+         */
+        public ReturnRequestActionContext build() {
+            Objects.requireNonNull(mode, "Не указан режим заявки для контекста действий");
+            Objects.requireNonNull(stage, "Не указана стадия заявки для контекста действий");
+            return new ReturnRequestActionContext(this);
+        }
+    }
+}

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -959,7 +959,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void resolveAvailableActions_AllowsExchangeRegistrationMark() {
+    void resolveAvailableActions_OmitsExchangeSwitchWhenAlreadyApproved() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         request.setStage(ReturnRequestStage.INBOUND_PICKED_UP);
@@ -967,7 +967,7 @@ class OrderReturnRequestServiceTest {
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
-        assertThat(actions).contains(ReturnRequestAction.SET_MODE_EXCHANGE);
+        assertThat(actions).doesNotContain(ReturnRequestAction.SET_MODE_EXCHANGE);
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.order.context.ReturnRequestActionContext;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZoneOffset;
@@ -76,7 +77,19 @@ class ReturnRequestWorkflowTest {
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
         request.setStage(ReturnRequestStage.NEW);
 
-        EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(request);
+        ReturnRequestActionContext context = ReturnRequestActionContext.builder(request)
+                .withMode(ReturnRequestMode.RETURN)
+                .withStage(ReturnRequestStage.NEW)
+                .withStatus(OrderReturnRequestStatus.REGISTERED)
+                .allow(ReturnRequestAction.SET_MODE_EXCHANGE, true)
+                .allow(ReturnRequestAction.UPDATE_REVERSE_TRACK, true)
+                .allow(ReturnRequestAction.CLOSE_REQUEST, true)
+                .allow(ReturnRequestAction.MARK_OUTBOUND_SENT, true)
+                .allow(ReturnRequestAction.MARK_INBOUND_ARRIVED, true)
+                .allow(ReturnRequestAction.MARK_INBOUND_PICKED_UP, true)
+                .build();
+
+        EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(context);
 
         assertThat(actions)
                 .contains(ReturnRequestAction.SET_MODE_EXCHANGE,
@@ -91,7 +104,18 @@ class ReturnRequestWorkflowTest {
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
 
-        EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(request);
+        ReturnRequestActionContext context = ReturnRequestActionContext.builder(request)
+                .withMode(ReturnRequestMode.EXCHANGE)
+                .withStage(ReturnRequestStage.EXCHANGE_REGISTERED)
+                .withStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED)
+                .allow(ReturnRequestAction.SET_MODE_RETURN, true)
+                .allow(ReturnRequestAction.CANCEL_EXCHANGE, true)
+                .allow(ReturnRequestAction.UPDATE_REVERSE_TRACK, true)
+                .allow(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL, true)
+                .allow(ReturnRequestAction.MARK_EXCHANGE_SENT, true)
+                .build();
+
+        EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(context);
 
         assertThat(actions)
                 .contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL,


### PR DESCRIPTION
## Summary
- introduce a dedicated ReturnRequestActionContext to transport per-action availability flags from the service layer
- update ReturnRequestWorkflow to combine stage and status matrices and filter actions via the new context
- rebuild OrderReturnRequestService action resolution and refresh unit tests to reflect the revised matrix

## Testing
- mvn -q test *(fails: jitpack.io responded 403 while downloading bucket4j-core and spring-boot-test)*

------
https://chatgpt.com/codex/tasks/task_e_6909447fcfbc832dbcd4557a2e6328df