### PR TITLE
Align Telegram actions with new return request codes

### DIFF
--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -525,7 +525,7 @@ public class CustomerTelegramService {
                 parcelId,
                 owner,
                 customer,
-                ReturnRequestAction.CLOSE_REQUEST
+                ReturnRequestAction.CANCEL_EXCHANGE
         );
     }
 

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -104,9 +104,9 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     private static final String CALLBACK_RETURNS_ACTIVE_SELECT_PREFIX = "returns:active:select:";
     private static final String CALLBACK_RETURNS_ACTIVE_TRACK_PREFIX = "returns:active:track:";
     private static final String CALLBACK_RETURNS_ACTIVE_COMMENT_PREFIX = "returns:active:comment:";
-    private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX = "returns:active:CLOSE:";
+    private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_PREFIX = "returns:active:CLOSE_REQUEST:";
     private static final String CALLBACK_RETURNS_ACTIVE_CANCEL_EXCHANGE_PREFIX = "returns:active:CANCEL_EXCHANGE:";
-    private static final String CALLBACK_RETURNS_ACTIVE_CONVERT_PREFIX = "returns:active:REOPEN_RETURN:";
+    private static final String CALLBACK_RETURNS_ACTIVE_CONVERT_PREFIX = "returns:active:SET_MODE_RETURN:";
     private static final String CALLBACK_RETURNS_ACTIVE_CONFIRM_PREFIX = "returns:active:confirm:";
     private static final String CALLBACK_RETURNS_DONE = "returns:done";
     private static final String CALLBACK_SETTINGS_TOGGLE_NOTIFICATIONS = "settings:toggle_notifications";
@@ -1312,7 +1312,8 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 .build()));
         if (request.status() == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
             boolean exchangeDispatched = request.state().exchangeShipmentDispatched();
-            boolean cancelEnabled = request.hasAction(ReturnRequestAction.CLOSE_REQUEST);
+            boolean cancelEnabled = request.hasAction(ReturnRequestAction.CANCEL_EXCHANGE)
+                    || request.hasAction(ReturnRequestAction.CLOSE_REQUEST);
             if (cancelEnabled) {
                 String cancelText = exchangeDispatched
                         ? BUTTON_RETURNS_ACTION_CANCEL_EXCHANGE_REQUEST
@@ -2023,7 +2024,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         ActiveRequestDetails details = detailsOptional.get();
         answerCallbackQuery(callbackQuery, "Требуется подтверждение");
         ChatSession session = ensureChatSession(chatId);
-        showActiveRequestConfirmation(chatId, session, details, context, ReturnRequestAction.CLOSE_REQUEST);
+        showActiveRequestConfirmation(chatId, session, details, context, ReturnRequestAction.CANCEL_EXCHANGE);
     }
 
     private void handleActiveRequestConvert(Long chatId, CallbackQuery callbackQuery, String data) {
@@ -2129,7 +2130,8 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
             return RETURNS_ACTIVE_CONFIRMATION_PROMPT;
         }
         return switch (action) {
-            case CLOSE_REQUEST -> buildCloseRequestConfirmation(request);
+            case CLOSE_REQUEST -> buildCancelReturnConfirmation(request);
+            case CANCEL_EXCHANGE -> buildCancelExchangeConfirmation(request);
             case SET_MODE_RETURN -> request.state().exchangeShipmentDispatched()
                     ? RETURNS_ACTIVE_CONVERT_REQUEST_CONFIRMATION
                     : RETURNS_ACTIVE_CONVERT_CONFIRMATION;
@@ -2138,27 +2140,26 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
     }
 
     /**
-     * Формирует текст подтверждения закрытия заявки с учётом её текущего режима.
+     * Формирует текст вопроса при отмене классического возврата, учитывая наличие обратного трека.
      */
-    private String buildCloseRequestConfirmation(ActionRequiredReturnRequestDto request) {
-        if (request == null) {
-            return RETURNS_ACTIVE_CONFIRMATION_PROMPT;
-        }
-        ReturnRequestMode mode = request.state() != null ? request.state().mode() : ReturnRequestMode.RETURN;
-        if (mode == ReturnRequestMode.EXCHANGE) {
-            return request.state().exchangeShipmentDispatched()
-                    ? RETURNS_ACTIVE_CANCEL_EXCHANGE_REQUEST_CONFIRMATION
-                    : RETURNS_ACTIVE_CANCEL_EXCHANGE_CONFIRMATION;
-        }
-        return buildCancelReturnConfirmation(request);
-    }
-
     private String buildCancelReturnConfirmation(ActionRequiredReturnRequestDto request) {
         String reverse = request.reverseTrack();
         if (reverse != null && !reverse.isBlank()) {
             return String.format(RETURNS_ACTIVE_CANCEL_RETURN_CONFIRMATION_WITH_TRACK, reverse);
         }
         return RETURNS_ACTIVE_CANCEL_RETURN_CONFIRMATION;
+    }
+
+    /**
+     * Возвращает текст подтверждения отмены обмена с учётом статуса обменной посылки.
+     */
+    private String buildCancelExchangeConfirmation(ActionRequiredReturnRequestDto request) {
+        if (request == null || request.state() == null) {
+            return RETURNS_ACTIVE_CANCEL_EXCHANGE_CONFIRMATION;
+        }
+        return request.state().exchangeShipmentDispatched()
+                ? RETURNS_ACTIVE_CANCEL_EXCHANGE_REQUEST_CONFIRMATION
+                : RETURNS_ACTIVE_CANCEL_EXCHANGE_CONFIRMATION;
     }
 
     /**
@@ -2261,7 +2262,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
         }
         switch (action) {
             case CLOSE_REQUEST -> executeCancelReturn(chatId, session, context);
-            case CLOSE_REQUEST -> executeCancelExchange(chatId, session, context, requestInfo);
+            case CANCEL_EXCHANGE -> executeCancelExchange(chatId, session, context, requestInfo);
             case SET_MODE_RETURN -> executeConvertToReturn(chatId, session, context, requestInfo);
             default -> finalizeRequestUpdate(chatId, session, RETURNS_ACTIVE_ACTION_NOT_AVAILABLE);
         }

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -427,7 +427,7 @@ class CustomerTelegramServiceTest {
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
         when(trackParcelRepository.findById(parcelId)).thenReturn(Optional.of(parcel));
         when(orderReturnRequestService.requestMerchantAction(requestId, parcelId, owner, customer,
-                ReturnRequestAction.CLOSE_REQUEST)).thenReturn(actionRequest);
+                ReturnRequestAction.CANCEL_EXCHANGE)).thenReturn(actionRequest);
 
         OrderReturnRequestActionRequest result = customerTelegramService.requestExchangeCancellationFromTelegram(
                 chatId,
@@ -437,7 +437,7 @@ class CustomerTelegramServiceTest {
 
         assertSame(actionRequest, result, "Сервис должен возвращать созданный запрос к магазину");
         verify(orderReturnRequestService).requestMerchantAction(requestId, parcelId, owner, customer,
-                ReturnRequestAction.CLOSE_REQUEST);
+                ReturnRequestAction.CANCEL_EXCHANGE);
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -1015,7 +1015,7 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:100:200"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE:100:200"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE_REQUEST:100:200"));
 
         ArgumentCaptor<EditMessageText> editCaptor = ArgumentCaptor.forClass(EditMessageText.class);
         verify(telegramClient).execute(editCaptor.capture());
@@ -1140,10 +1140,10 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:101:201"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE:101:201"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE_REQUEST:101:201"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CLOSE:yes:101:201"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CLOSE_REQUEST:yes:101:201"));
 
         verify(telegramService).closeReturnRequestFromTelegram(chatId, 201L, 101L);
 
@@ -1196,10 +1196,10 @@ class BuyerTelegramBotTest {
         bot.consume(mockCallbackUpdate(chatId, "returns:active:select:102:202"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE:102:202"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:CLOSE_REQUEST:102:202"));
         clearInvocations(telegramClient);
 
-        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CLOSE:no:102:202"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:CLOSE_REQUEST:no:102:202"));
 
         verify(telegramService, never()).closeReturnRequestFromTelegram(anyLong(), anyLong(), anyLong());
 
@@ -2453,7 +2453,7 @@ class BuyerTelegramBotTest {
             actionCodes.add(ReturnRequestAction.SET_MODE_RETURN.getCode());
         }
         if (canCancelExchange) {
-            actionCodes.add(ReturnRequestAction.CLOSE_REQUEST.getCode());
+            actionCodes.add(ReturnRequestAction.CANCEL_EXCHANGE.getCode());
         }
         if (canConfirmReceipt) {
             actionCodes.add(ReturnRequestAction.MARK_INBOUND_PICKED_UP.getCode());


### PR DESCRIPTION
## Summary
- switch Telegram customer service exchange cancellation requests to the new CANCEL_EXCHANGE action
- refresh BuyerTelegramBot callbacks, keyboards, and confirmations to emit SET_MODE_RETURN/CLOSE_REQUEST style codes and handle exchange-specific confirmations
- update unit tests to expect the new callback payloads and action codes

## Testing
- mvn -Dtest=CustomerTelegramServiceTest,BuyerTelegramBotTest test *(fails: jitpack.io returns 403 for io.github.bucket4j.bucket4j:bucket4j-core:4.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_69095213ad64832d8216b087d679af3a