### PR TITLE
Remove legacy action code synonyms

### DIFF
--- a/src/main/resources/static/js/return-requests.js
+++ b/src/main/resources/static/js/return-requests.js
@@ -2,19 +2,6 @@
     'use strict';
 
     /**
-     * Синонимы action-code для поддержки переходного периода API.
-     * Используем карту, чтобы распознавать новые и устаревшие коды действий как эквивалентные.
-     */
-    const ACTION_CODE_SYNONYMS = {
-        'mark_inbound_picked_up': ['confirm_receipt'],
-        'confirm_receipt': ['mark_inbound_picked_up'],
-        'create_exchange_parcel': ['register_exchange_parcel'],
-        'register_exchange_parcel': ['create_exchange_parcel'],
-        'update_reverse_track': ['update_details'],
-        'update_details': ['update_reverse_track']
-    };
-
-    /**
      * Нормализует action-code к нижнему регистру и убирает пробелы.
      * @param {string} value исходный код
      * @returns {string} нормализованное значение или пустая строка
@@ -53,14 +40,23 @@
             }
         }
         const flattened = sources.flatMap((list) => Array.isArray(list) ? list : []);
+        const seen = new Set();
         const codes = flattened
             .map((value) => normalizeActionCode(value))
-            .filter((value) => value.length > 0);
+            .filter((value) => value.length > 0)
+            .filter((value) => {
+                if (seen.has(value)) {
+                    return false;
+                }
+                seen.add(value);
+                return true;
+            });
         return new Set(codes);
     }
 
     /**
-     * Проверяет, содержится ли указанный action-code или его синонимы в множестве.
+     * Проверяет, содержится ли указанный action-code в множестве доступных действий.
+     * Метод учитывает только актуальные идентификаторы, так как устаревшие коды удалены.
      * @param {Set<string>} codeSet множество доступных действий
      * @param {string} code искомое действие
      * @returns {boolean} {@code true}, если действие доступно
@@ -73,14 +69,7 @@
         if (!normalized) {
             return false;
         }
-        if (codeSet.has(normalized)) {
-            return true;
-        }
-        const synonyms = ACTION_CODE_SYNONYMS[normalized] || [];
-        return synonyms
-            .map((item) => normalizeActionCode(item))
-            .filter((item) => item.length > 0)
-            .some((item) => codeSet.has(item));
+        return codeSet.has(normalized);
     }
 
     /**
@@ -212,16 +201,16 @@
             ? hasActionFromSet(actionCodeSet, 'mark_inbound_picked_up')
             : fallbackAllowConfirmReceipt;
         const allowConvertToExchange = hasModernActions
-            ? hasActionFromSet(actionCodeSet, 'start_exchange')
+            ? hasActionFromSet(actionCodeSet, 'set_mode_exchange')
             : fallbackAllowConvertToExchange;
         const allowCloseRequest = hasModernActions
-            ? hasActionFromSet(actionCodeSet, 'close') || hasActionFromSet(actionCodeSet, 'cancel_exchange')
+            ? hasActionFromSet(actionCodeSet, 'close_request')
             : fallbackAllowCloseRequest;
         const allowUpdateReverseTrack = hasModernActions
             ? hasActionFromSet(actionCodeSet, 'update_reverse_track')
             : fallbackAllowUpdateReverseTrack;
         const allowConvertToReturn = hasModernActions
-            ? hasActionFromSet(actionCodeSet, 'reopen_return')
+            ? hasActionFromSet(actionCodeSet, 'set_mode_return')
             : fallbackAllowConvertToReturn;
         const statusRaw = typeof summary.stage === 'string' ? summary.stage.toUpperCase() : '';
         const isExchangeStatus = statusRaw.includes('EXCHANGE');

--- a/src/main/resources/static/js/track-modal.js
+++ b/src/main/resources/static/js/track-modal.js
@@ -556,10 +556,10 @@
             const legacyUpdateReverse = mapLegacy('allowUpdateReverseTrack');
             const canUpdateReverseTrack = this.request?.canUpdateReverseTrack;
             const confirmReceiptFlag = hasActionCode(actions, 'mark_inbound_picked_up');
-            const convertToExchangeFlag = hasActionCode(actions, 'start_exchange');
-            const launchExchangeFlag = hasActionCode(actions, 'create_exchange_parcel');
-            const closeFlag = hasActionCode(actions, 'close');
-            const reopenFlag = hasActionCode(actions, 'reopen_return');
+            const convertToExchangeFlag = hasActionCode(actions, 'set_mode_exchange');
+            const launchExchangeFlag = hasActionCode(actions, 'register_exchange_parcel');
+            const closeFlag = hasActionCode(actions, 'close_request');
+            const reopenFlag = hasActionCode(actions, 'set_mode_return');
             const cancelExchangeFlag = hasActionCode(actions, 'cancel_exchange');
             const updateDetailsFlag = hasActionCode(actions, 'update_reverse_track');
             return {
@@ -1279,20 +1279,18 @@
     }
 
     /**
-     * Синонимы action-code для обратной совместимости.
-     * Карта помогает сопоставить устаревшие и новые коды действий,
-     * чтобы проверка доступности кнопок оставалась единообразной.
+     * Нормализует action-code в единый формат для сравнения.
+     * Метод удовлетворяет SRP, скрывая детали приведения строки и
+     * позволяя переиспользовать преобразование в различных проверках.
+     * @param {string} value исходное значение кода
+     * @returns {string} нормализованный action-code или пустая строка
      */
-    const ACTION_CODE_ALIASES = {
-        'confirm_receipt': ['mark_inbound_picked_up'],
-        'mark_inbound_picked_up': ['confirm_receipt'],
-        'create_exchange_parcel': ['register_exchange_parcel'],
-        'register_exchange_parcel': ['create_exchange_parcel'],
-        'update_details': ['update_reverse_track'],
-        'update_reverse_track': ['update_details'],
-        'cancel_exchange': ['close'],
-        'close': ['cancel_exchange']
-    };
+    function normalizeActionCode(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return value.trim().toLowerCase();
+    }
 
     const STAGE_LABELS = {
         NEW: 'Заявка зарегистрирована',
@@ -1329,41 +1327,40 @@
             : Array.isArray(actions.actionCodes)
                 ? actions.actionCodes
                 : [];
+        const seen = new Set();
         return rawCodes
-            .map((code) => (typeof code === 'string' ? code.trim().toLowerCase() : ''))
-            .filter((code) => code.length > 0);
+            .map((code) => normalizeActionCode(code))
+            .filter((code) => code.length > 0)
+            .filter((code) => {
+                if (seen.has(code)) {
+                    return false;
+                }
+                seen.add(code);
+                return true;
+            });
     }
 
     /**
      * Проверяет, присутствует ли указанный action-code в списке доступных действий.
-     * Метод поддерживает синонимы, чтобы плавно перейти на новый контракт API.
+     * Метод принимает во внимание только актуальные идентификаторы, так как устаревшие
+     * коды удалены и больше не поддерживаются.
      * @param {Object|Array<string>} actions объект или массив с кодами действий
      * @param {string} code проверяемый код действия
-     * @param {Object} [options] дополнительные настройки проверки
-     * @param {boolean} [options.matchSynonyms=true] учитывать ли синонимы
      * @returns {boolean} {@code true}, если действие доступно
      */
-    function hasActionCode(actions, code, options = {}) {
+    function hasActionCode(actions, code) {
         if (!code) {
             return false;
         }
-        const { matchSynonyms = true } = options;
-        const normalized = String(code).trim().toLowerCase();
+        const normalized = normalizeActionCode(code);
+        if (!normalized) {
+            return false;
+        }
         const codes = extractActionCodes(actions);
-        if (codes.includes(normalized)) {
-            return true;
-        }
-        if (!matchSynonyms) {
+        if (codes.length === 0) {
             return false;
         }
-        const aliases = ACTION_CODE_ALIASES[normalized] || [];
-        if (aliases.length === 0) {
-            return false;
-        }
-        return aliases
-            .map((alias) => String(alias || '').trim().toLowerCase())
-            .filter((alias) => alias.length > 0)
-            .some((alias) => codes.includes(alias));
+        return codes.includes(normalized);
     }
 
     /**
@@ -1603,7 +1600,7 @@
         return await performReturnRequestAction({
             trackId,
             requestId,
-            command: 'start_exchange',
+            command: 'set_mode_exchange',
             successMessage: options.successMessage || 'Заявка переведена в обмен',
             notificationType: options.notificationType || 'info',
             errorMessage: options.errorMessage || 'Не удалось перевести заявку в обмен'
@@ -1620,7 +1617,7 @@
         return await performReturnRequestAction({
             trackId,
             requestId,
-            command: 'close',
+            command: 'close_request',
             successMessage: options.successMessage || 'Обращение закрыто',
             notificationType: options.notificationType || 'warning',
             errorMessage: options.errorMessage || 'Не удалось закрыть обращение'
@@ -1648,7 +1645,7 @@
         return await performReturnRequestAction({
             trackId,
             requestId,
-            command: 'confirm_receipt',
+            command: 'mark_inbound_picked_up',
             successMessage: options.successMessage || 'Возврат подтверждён',
             notificationType: options.notificationType || 'success',
             errorMessage: options.errorMessage || 'Не удалось подтвердить получение возврата'
@@ -1665,7 +1662,7 @@
         return await performReturnRequestAction({
             trackId,
             requestId,
-            command: 'create_exchange_parcel',
+            command: 'register_exchange_parcel',
             successMessage: options.successMessage || 'Обмен запущен',
             notificationType: options.notificationType || 'info',
             errorMessage: options.errorMessage || 'Не удалось создать обменную посылку'
@@ -1676,7 +1673,7 @@
         return await performReturnRequestAction({
             trackId,
             requestId,
-            command: 'reopen',
+            command: 'set_mode_return',
             successMessage: options.successMessage || 'Заявка переведена в возврат',
             notificationType: options.notificationType || 'info',
             errorMessage: options.errorMessage || 'Не удалось перевести заявку в возврат'
@@ -1695,7 +1692,7 @@
         return await performReturnRequestAction({
             trackId,
             requestId,
-            command: 'update_details',
+            command: 'update_reverse_track',
             payload: {
                 reverseTrackNumber: reverseTrack,
                 comment

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -115,7 +115,7 @@ class ReturnsControllerTest {
         mockMvc.perform(post("/api/v1/returns/21/commands")
                         .with(auth)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"idempotencyKey\":\"cmd-1\",\"action\":\"start_exchange\"}"))
+                        .content("{\"idempotencyKey\":\"cmd-1\",\"action\":\"set_mode_exchange\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000021")))
                 .andExpect(jsonPath("$.legacyId", equalTo(21)))
@@ -135,7 +135,7 @@ class ReturnsControllerTest {
         mockMvc.perform(post("/api/v1/returns/30/commands")
                         .with(auth)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"idempotencyKey\":\"cmd-2\",\"action\":\"update_details\",\"payload\":{\"reverseTrack\":\"BY000\",\"comment\":\"Комментарий\"}}"))
+                        .content("{\"idempotencyKey\":\"cmd-2\",\"action\":\"update_reverse_track\",\"payload\":{\"reverseTrack\":\"BY000\",\"comment\":\"Комментарий\"}}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.stage", equalTo("INBOUND_PICKED_UP")));
         verify(returnRequestCommandService).executeCommand(eq(30L), any(), any(), eq(principal), any());

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -1114,7 +1114,7 @@ status: 'Зарегистрирована',
             expect.objectContaining({
                 method: 'POST',
                 body: JSON.stringify({
-                    command: 'update_details',
+                    command: 'update_reverse_track',
                     reverseTrackNumber: 'RR123456789BY',
                     comment: 'Обновлённый комментарий'
                 })
@@ -1375,7 +1375,7 @@ status: 'Зарегистрирована',
             '/api/v1/returns/5/commands',
             expect.objectContaining({
                 method: 'POST',
-                body: JSON.stringify({ command: 'start_exchange' })
+                body: JSON.stringify({ command: 'set_mode_exchange' })
             })
         );
         expect(global.notifyUser).toHaveBeenCalledWith('Заявка переведена в обмен', 'info');
@@ -1471,7 +1471,7 @@ status: 'Зарегистрирована',
             '/api/v1/returns/6/commands',
             expect.objectContaining({
                 method: 'POST',
-                body: JSON.stringify({ command: 'create_exchange_parcel' })
+                body: JSON.stringify({ command: 'register_exchange_parcel' })
             })
         );
         expect(global.notifyUser).toHaveBeenCalledWith('Обмен запущен', 'info');


### PR DESCRIPTION
## Summary
- remove legacy action-code synonym lookup tables from the track modal and return request list
- rely exclusively on normalized new action-code identifiers when computing permissions

## Testing
- npm test -- track-modal *(fails: `jest` binary not available in PATH within container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b68cb3dc832dadf1ad20ffbf22ba)