### PR TITLE
Align return action tests with new conversion flows

### DIFF
--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -3,6 +3,7 @@ package com.project.tracking_system.controller;
 import com.project.tracking_system.dto.AvailableActionsDto;
 import com.project.tracking_system.dto.RequestDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
+import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.User;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
 import com.project.tracking_system.service.order.ReturnRequestCommandService;
@@ -165,13 +166,16 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(52L, principal)).thenReturn(request);
         when(returnRequestMapper.toAvailableActions(request))
-                .thenReturn(new AvailableActionsDto(List.of("SET_MODE_EXCHANGE", "CLOSE_REQUEST")));
+                .thenReturn(new AvailableActionsDto(List.of(
+                        ReturnRequestAction.SET_MODE_EXCHANGE.getCode(),
+                        ReturnRequestAction.CLOSE_REQUEST.getCode()
+                )));
 
         mockMvc.perform(get("/api/v1/returns/52/available-actions")
                         .with(auth))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.actions[0]", equalTo("SET_MODE_EXCHANGE")))
-                .andExpect(jsonPath("$.actions[1]", equalTo("CLOSE_REQUEST")));
+                .andExpect(jsonPath("$.actions[0]", equalTo(ReturnRequestAction.SET_MODE_EXCHANGE.getCode())))
+                .andExpect(jsonPath("$.actions[1]", equalTo(ReturnRequestAction.CLOSE_REQUEST.getCode())));
     }
 
     private UsernamePasswordAuthenticationToken authentication(User user) {

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -79,7 +79,7 @@ class ReturnRequestCommandServiceTest {
         OrderReturnRequest request = buildRequest(21L, 9L);
         OrderReturnRequest updated = buildRequest(21L, 9L);
         RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000021", 21L, "EXCHANGE");
-        CommandDto command = new CommandDto("dup-1", "SET_MODE_EXCHANGE", null);
+        CommandDto command = new CommandDto("dup-1", ReturnRequestCommandType.SET_MODE_EXCHANGE.name(), null);
 
         when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
         when(orderReturnRequestService.switchMode(21L,
@@ -137,7 +137,7 @@ class ReturnRequestCommandServiceTest {
         when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(21L, "dup-2"))
                 .thenReturn(Optional.of(existing));
 
-        CommandDto command = new CommandDto("dup-2", "SET_MODE_EXCHANGE", null);
+        CommandDto command = new CommandDto("dup-2", ReturnRequestCommandType.SET_MODE_EXCHANGE.name(), null);
 
         assertThatThrownBy(() -> commandService.executeCommand(21L,
                 ReturnRequestCommandType.SET_MODE_EXCHANGE,
@@ -156,7 +156,7 @@ class ReturnRequestCommandServiceTest {
     void executeCommand_whenConcurrentReservation_returnsStoredSnapshot() {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(22L, 10L);
-        CommandDto command = new CommandDto("dup-3", "SET_MODE_EXCHANGE", null);
+        CommandDto command = new CommandDto("dup-3", ReturnRequestCommandType.SET_MODE_EXCHANGE.name(), null);
 
         RequestDto storedDto = buildRequestDto("00000000-0000-0000-0000-000000000022", 22L, "EXCHANGE");
         String snapshot;
@@ -200,7 +200,7 @@ class ReturnRequestCommandServiceTest {
         OrderReturnRequest closed = buildRequest(40L, 18L);
         closed.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000040", 40L, "RETURN");
-        CommandDto command = new CommandDto("cancel-1", "CANCEL_EXCHANGE", null);
+        CommandDto command = new CommandDto("cancel-1", ReturnRequestCommandType.CANCEL_EXCHANGE.name(), null);
 
         when(orderReturnRequestService.getOwnedRequest(40L, user)).thenReturn(request);
         when(orderReturnRequestService.switchMode(40L,
@@ -240,7 +240,7 @@ class ReturnRequestCommandServiceTest {
     void executeCommand_whenUpdateDetailsWithoutPayload_throwsBadRequest() {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(23L, 11L);
-        CommandDto command = new CommandDto("dup-4", "UPDATE_REVERSE_TRACK", JsonNodeFactory.instance.objectNode());
+        CommandDto command = new CommandDto("dup-4", ReturnRequestCommandType.UPDATE_REVERSE_TRACK.name(), JsonNodeFactory.instance.objectNode());
 
         when(orderReturnRequestService.getOwnedRequest(23L, user)).thenReturn(request);
 

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -972,6 +972,214 @@ class BuyerTelegramBotTest {
                 "При отправке обменной посылки должна отображаться кнопка запроса отмены");
         assertTrue(buttonLabels.contains("📝 Запросить возврат вместо обмена"),
                 "Пользователь должен видеть кнопку запроса перевода обмена в возврат");
+
+        InlineKeyboardButton convertButton = markup.getKeyboard().stream()
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .filter(button -> "📝 Запросить возврат вместо обмена".equals(button.getText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Клавиатура должна содержать кнопку запроса перевода обмена"));
+        assertEquals("returns:active:SET_MODE_RETURN:7:10", convertButton.getCallbackData(),
+                "Callback перевода обмена обязан использовать новый код действия SET_MODE_RETURN");
+    }
+
+    /**
+     * Проверяет, что при ожидающем обмене кнопка перевода в возврат использует новый callback с кодом действия.
+     */
+    @Test
+    void shouldRenderConvertButtonWithSetModeReturnCallback() throws Exception {
+        Long chatId = 6801L;
+        Customer customer = new Customer();
+        customer.setTelegramChatId(chatId);
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+
+        ActionRequiredReturnRequestDto exchangeRequest = buildActionDto(
+                11L,
+                22L,
+                "EX-PEND",
+                "Store",
+                "Готовится",
+                OrderReturnRequestStatus.EXCHANGE_APPROVED,
+                OrderReturnRequestStatus.EXCHANGE_APPROVED.getDisplayName(),
+                "13.11.2024",
+                "12.11.2024",
+                "Обмен",
+                "Комментарий",
+                null,
+                true,
+                false,
+                true,
+                true,
+                true,
+                false,
+                null,
+                false,
+                null,
+                false
+        );
+
+        when(telegramService.getReturnRequestsRequiringAction(chatId))
+                .thenReturn(List.of(exchangeRequest))
+                .thenReturn(List.of(exchangeRequest));
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active"));
+        clearInvocations(telegramClient);
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:select:11:22"));
+
+        ArgumentCaptor<EditMessageText> editCaptor = ArgumentCaptor.forClass(EditMessageText.class);
+        verify(telegramClient).execute(editCaptor.capture());
+
+        InlineKeyboardMarkup markup = editCaptor.getValue().getReplyMarkup();
+        assertNotNull(markup, "После выбора обменной заявки клавиатура должна быть доступна");
+
+        InlineKeyboardButton convertButton = markup.getKeyboard().stream()
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .filter(button -> "↩️ Перевести в возврат".equals(button.getText()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Должна отображаться кнопка перевода обмена в возврат"));
+        assertEquals("returns:active:SET_MODE_RETURN:11:22", convertButton.getCallbackData(),
+                "Callback перевода обязан содержать код SET_MODE_RETURN");
+    }
+
+    /**
+     * Проверяет, что подтверждение перевода обмена без отправки создаёт немедленное обновление заявки.
+     */
+    @Test
+    void shouldConvertExchangeToReturnWhenConfirmed() throws Exception {
+        Long chatId = 6802L;
+        Customer customer = new Customer();
+        customer.setTelegramChatId(chatId);
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+
+        ActionRequiredReturnRequestDto exchangeRequest = buildActionDto(
+                12L,
+                23L,
+                "EX-CONV",
+                "Store",
+                "Готовится",
+                OrderReturnRequestStatus.EXCHANGE_APPROVED,
+                OrderReturnRequestStatus.EXCHANGE_APPROVED.getDisplayName(),
+                "14.11.2024",
+                "12.11.2024",
+                "Обмен",
+                "Комментарий",
+                null,
+                true,
+                false,
+                true,
+                true,
+                true,
+                false,
+                null,
+                false,
+                null,
+                false
+        );
+
+        when(telegramService.getReturnRequestsRequiringAction(chatId))
+                .thenAnswer(invocation -> List.of(exchangeRequest));
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:select:12:23"));
+        clearInvocations(telegramClient);
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:SET_MODE_RETURN:12:23"));
+
+        ArgumentCaptor<EditMessageText> confirmCaptor = ArgumentCaptor.forClass(EditMessageText.class);
+        verify(telegramClient).execute(confirmCaptor.capture());
+        String confirmText = confirmCaptor.getValue().getText().replace("\\", "");
+        assertTrue(confirmText.contains("Перевести обмен обратно в возврат?"),
+                "Сообщение подтверждения обязано содержать новый текст вопроса");
+        assertEquals(BuyerChatState.AWAITING_ACTIVE_ACTION_CONFIRMATION, chatSessionRepository.getState(chatId),
+                "После выбора действия бот должен ожидать подтверждение");
+
+        clearInvocations(telegramClient);
+        OrderReturnRequest updated = new OrderReturnRequest();
+        when(telegramService.convertExchangeToReturnFromTelegram(chatId, 23L, 12L)).thenReturn(updated);
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:SET_MODE_RETURN:yes:12:23"));
+
+        verify(telegramService).convertExchangeToReturnFromTelegram(chatId, 23L, 12L);
+
+        ArgumentCaptor<EditMessageText> resultCaptor = ArgumentCaptor.forClass(EditMessageText.class);
+        verify(telegramClient).execute(resultCaptor.capture());
+        String resultText = resultCaptor.getValue().getText();
+        assertTrue(resultText.contains("Заявка переведена в возврат"),
+                "После успешного перевода бот обязан подтвердить изменение");
+        assertEquals(BuyerChatState.IDLE, chatSessionRepository.getState(chatId),
+                "После выполнения действия бот возвращается в состояние ожидания");
+    }
+
+    /**
+     * Проверяет, что при отправленной обменной посылке бот формирует запрос магазину на перевод обращения.
+     */
+    @Test
+    void shouldRequestExchangeConversionWhenReplacementDispatched() throws Exception {
+        Long chatId = 6803L;
+        Customer customer = new Customer();
+        customer.setTelegramChatId(chatId);
+        when(telegramService.findByChatId(chatId)).thenReturn(Optional.of(customer));
+
+        ActionRequiredReturnRequestDto exchangeRequest = buildActionDto(
+                13L,
+                24L,
+                "EX-CONV-REQ",
+                "Store",
+                "В пути",
+                OrderReturnRequestStatus.EXCHANGE_APPROVED,
+                OrderReturnRequestStatus.EXCHANGE_APPROVED.getDisplayName(),
+                "14.11.2024",
+                "12.11.2024",
+                "Обмен",
+                "Комментарий",
+                null,
+                true,
+                false,
+                true,
+                true,
+                true,
+                true,
+                null,
+                false,
+                null,
+                false
+        );
+
+        when(telegramService.getReturnRequestsRequiringAction(chatId))
+                .thenAnswer(invocation -> List.of(exchangeRequest));
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active"));
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:select:13:24"));
+        clearInvocations(telegramClient);
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:SET_MODE_RETURN:13:24"));
+
+        ArgumentCaptor<EditMessageText> confirmCaptor = ArgumentCaptor.forClass(EditMessageText.class);
+        verify(telegramClient).execute(confirmCaptor.capture());
+        String confirmText = confirmCaptor.getValue().getText().replace("\\", "");
+        assertTrue(confirmText.contains("Отправить запрос магазину на перевод обмена в возврат?"),
+                "При отправке обменной посылки вопрос подтверждения должен отражать запрос магазину");
+
+        clearInvocations(telegramClient);
+        OrderReturnRequestActionRequest actionRequest = new OrderReturnRequestActionRequest();
+        when(telegramService.requestExchangeConversionFromTelegram(chatId, 24L, 13L)).thenReturn(actionRequest);
+
+        bot.consume(mockCallbackUpdate(chatId, "returns:active:confirm:SET_MODE_RETURN:yes:13:24"));
+
+        verify(telegramService).requestExchangeConversionFromTelegram(chatId, 24L, 13L);
+        verify(telegramService, never()).convertExchangeToReturnFromTelegram(anyLong(), anyLong(), anyLong());
+
+        ArgumentCaptor<EditMessageText> resultCaptor = ArgumentCaptor.forClass(EditMessageText.class);
+        verify(telegramClient).execute(resultCaptor.capture());
+        String resultText = resultCaptor.getValue().getText().replace("\\", "");
+        assertTrue(resultText.contains("Мы передали запрос магазину на перевод обмена в возврат"),
+                "Результат операции обязан сообщать о переданном запросе магазину");
+        assertEquals(BuyerChatState.IDLE, chatSessionRepository.getState(chatId),
+                "После формирования запроса бот должен вернуться в состояние ожидания");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update the returns controller test to assert new return action codes instead of literals
- reuse `ReturnRequestCommandType` names when building command DTOs inside the command service tests
- expand buyer bot tests with checks for the `SET_MODE_RETURN` callbacks and confirmation flows for both immediate conversion and merchant requests

## Testing
- mvn -q test *(fails: io.github.bucket4j.bucket4j:bucket4j-core:pom:4.10.0 – 403 from https://jitpack.io)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cc4c5474832dbac3e7c8aa1d4bf1)