### PR TITLE
Refine return request command handling for new payload rules

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -16,7 +16,7 @@ import com.project.tracking_system.service.order.payload.ExchangeShipmentPayload
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayload;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayloadFactory;
 import com.project.tracking_system.service.order.payload.StageMarkPayload;
-import com.project.tracking_system.service.order.payload.UpdateDetailsPayload;
+import com.project.tracking_system.service.order.payload.UpdateReverseTrackPayload;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -28,9 +28,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.EnumMap;
 import java.util.HexFormat;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -52,10 +50,9 @@ public class ReturnRequestCommandService {
     private final ReturnCommandLogRepository returnCommandLogRepository;
     private final ObjectMapper objectMapper;
     private final ReturnRequestCommandPayloadFactory payloadFactory;
-    private final Map<ReturnRequestCommandType, ReturnRequestCommandHandler> commandHandlers;
 
     /**
-     * Конструирует сервис и регистрирует обработчики доступных команд.
+     * Конструирует сервис и подготавливает зависимости для обработки команд.
      */
     public ReturnRequestCommandService(OrderReturnRequestService orderReturnRequestService,
                                        ReturnRequestMapper returnRequestMapper,
@@ -67,7 +64,6 @@ public class ReturnRequestCommandService {
         this.returnCommandLogRepository = returnCommandLogRepository;
         this.objectMapper = objectMapper;
         this.payloadFactory = payloadFactory;
-        this.commandHandlers = createHandlers(orderReturnRequestService);
     }
 
     /**
@@ -129,6 +125,9 @@ public class ReturnRequestCommandService {
         if (!StringUtils.hasText(command.action())) {
             throw new IllegalArgumentException("Не указан код действия команды");
         }
+        if (requiresPayload(commandType) && command.payload() == null) {
+            throw new IllegalArgumentException("Команда " + commandType.name() + " требует объект payload с параметрами");
+        }
         if (user == null) {
             throw new IllegalArgumentException("Не указан пользователь");
         }
@@ -154,11 +153,29 @@ public class ReturnRequestCommandService {
     private OrderReturnRequest performCommand(ReturnRequestCommandType type,
                                               ReturnRequestCommandPayload payload,
                                               CommandContext context) {
-        ReturnRequestCommandHandler handler = commandHandlers.get(type);
-        if (handler == null) {
-            throw new IllegalArgumentException("Команда " + type.name() + " не поддерживается системой");
-        }
-        return handler.handle(context, payload);
+        return switch (type) {
+            case SET_MODE_EXCHANGE -> executeModeSwitch(context,
+                    ReturnRequestMode.EXCHANGE,
+                    OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION);
+            case SET_MODE_RETURN -> executeModeSwitch(context,
+                    ReturnRequestMode.RETURN,
+                    OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION);
+            case CLOSE_REQUEST -> executeCloseRequest(context);
+            case UPDATE_REVERSE_TRACK -> executeUpdateReverseTrack(context, payload);
+            case MARK_OUTBOUND_SENT -> executeStageCommand(context, payload, type,
+                    orderReturnRequestService::markOutboundSent);
+            case MARK_INBOUND_ARRIVED -> executeStageCommand(context, payload, type,
+                    orderReturnRequestService::markInboundArrived);
+            case MARK_INBOUND_PICKED_UP -> executeStageCommand(context, payload, type,
+                    orderReturnRequestService::markInboundPickedUp);
+            case REGISTER_EXCHANGE_PARCEL -> executeExchangeCommand(context, payload, type,
+                    orderReturnRequestService::registerExchangeParcel);
+            case MARK_EXCHANGE_SENT -> executeExchangeCommand(context, payload, type,
+                    orderReturnRequestService::markExchangeSent);
+            case MARK_EXCHANGE_DELIVERED -> executeExchangeCommand(context, payload, type,
+                    orderReturnRequestService::markExchangeDelivered);
+            default -> throw new IllegalArgumentException("Команда " + type.name() + " не поддерживается системой");
+        };
     }
 
     /**
@@ -268,38 +285,11 @@ public class ReturnRequestCommandService {
     }
 
     /**
-     * Формирует реестр обработчиков команд на основании сервисных методов доменного слоя.
-     */
-    private Map<ReturnRequestCommandType, ReturnRequestCommandHandler> createHandlers(OrderReturnRequestService service) {
-        EnumMap<ReturnRequestCommandType, ReturnRequestCommandHandler> handlers = new EnumMap<>(ReturnRequestCommandType.class);
-        handlers.put(ReturnRequestCommandType.SET_MODE_EXCHANGE,
-                modeSwitchHandler(ReturnRequestMode.EXCHANGE, OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION));
-        handlers.put(ReturnRequestCommandType.SET_MODE_RETURN,
-                modeSwitchHandler(ReturnRequestMode.RETURN, OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION));
-        handlers.put(ReturnRequestCommandType.CANCEL_EXCHANGE, this::handleCancelExchange);
-        handlers.put(ReturnRequestCommandType.CLOSE_REQUEST, this::handleCloseRequest);
-        handlers.put(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL,
-                exchangeHandler(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL, service::registerExchangeParcel));
-        handlers.put(ReturnRequestCommandType.MARK_EXCHANGE_SENT,
-                exchangeHandler(ReturnRequestCommandType.MARK_EXCHANGE_SENT, service::markExchangeSent));
-        handlers.put(ReturnRequestCommandType.MARK_EXCHANGE_DELIVERED,
-                stageHandler(ReturnRequestCommandType.MARK_EXCHANGE_DELIVERED, service::markExchangeDelivered));
-        handlers.put(ReturnRequestCommandType.MARK_OUTBOUND_SENT,
-                stageHandler(ReturnRequestCommandType.MARK_OUTBOUND_SENT, service::markOutboundSent));
-        handlers.put(ReturnRequestCommandType.MARK_INBOUND_ARRIVED,
-                stageHandler(ReturnRequestCommandType.MARK_INBOUND_ARRIVED, service::markInboundArrived));
-        handlers.put(ReturnRequestCommandType.MARK_INBOUND_PICKED_UP,
-                stageHandler(ReturnRequestCommandType.MARK_INBOUND_PICKED_UP, service::markInboundPickedUp));
-        handlers.put(ReturnRequestCommandType.UPDATE_REVERSE_TRACK,
-                this::handleUpdateReverseTrack);
-        return Map.copyOf(handlers);
-    }
-
-    /**
      * Обрабатывает команду обновления обратного трека и возвращает актуальную заявку.
      */
-    private OrderReturnRequest handleUpdateReverseTrack(CommandContext context, ReturnRequestCommandPayload payload) {
-        UpdateDetailsPayload updatePayload = requirePayload(payload, UpdateDetailsPayload.class,
+    private OrderReturnRequest executeUpdateReverseTrack(CommandContext context,
+                                                        ReturnRequestCommandPayload payload) {
+        UpdateReverseTrackPayload updatePayload = requirePayload(payload, UpdateReverseTrackPayload.class,
                 ReturnRequestCommandType.UPDATE_REVERSE_TRACK);
         orderReturnRequestService.updateReverseTrackAndComment(
                 context.requestId(),
@@ -314,69 +304,44 @@ public class ReturnRequestCommandService {
     /**
      * Выполняет закрытие заявки, учитывая её текущий статус.
      */
-    private OrderReturnRequest handleCloseRequest(CommandContext context, ReturnRequestCommandPayload payload) {
+    private OrderReturnRequest executeCloseRequest(CommandContext context) {
         OrderReturnRequest request = orderReturnRequestService.getOwnedRequest(context.requestId(), context.user());
         return switch (request.getStatus()) {
             case REGISTERED -> orderReturnRequestService.closeWithoutExchange(context.requestId(),
                     context.parcelId(),
                     context.user());
-            case EXCHANGE_APPROVED -> throw new IllegalStateException("Для обменных заявок используйте отмену обмена");
+            case EXCHANGE_APPROVED -> throw new IllegalStateException("Перед закрытием переведите заявку в режим возврата");
             case CLOSED_NO_EXCHANGE -> throw new IllegalStateException("Заявка уже закрыта");
         };
     }
 
     /**
-     * Обрабатывает отмену обмена с последующим закрытием заявки.
+     * Выполняет обработку стадийной команды с опциональным временем наступления.
      */
-    private OrderReturnRequest handleCancelExchange(CommandContext context, ReturnRequestCommandPayload payload) {
-        orderReturnRequestService.switchMode(
-                context.requestId(),
+    private OrderReturnRequest executeStageCommand(CommandContext context,
+                                                   ReturnRequestCommandPayload payload,
+                                                   ReturnRequestCommandType type,
+                                                   StageCommandExecutor executor) {
+        StageMarkPayload stagePayload = requirePayload(payload, StageMarkPayload.class, type);
+        return executor.execute(context.requestId(),
                 context.parcelId(),
                 context.user(),
-                ReturnRequestMode.RETURN,
-                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION
-        );
-        return orderReturnRequestService.closeWithoutExchange(
-                context.requestId(),
+                stagePayload.stageMoment());
+    }
+
+    /**
+     * Обрабатывает команду, работающую с обменной посылкой.
+     */
+    private OrderReturnRequest executeExchangeCommand(CommandContext context,
+                                                       ReturnRequestCommandPayload payload,
+                                                       ReturnRequestCommandType type,
+                                                       ExchangeShipmentExecutor executor) {
+        ExchangeShipmentPayload exchangePayload = requirePayload(payload, ExchangeShipmentPayload.class, type);
+        return executor.execute(context.requestId(),
                 context.parcelId(),
-                context.user()
-        );
-    }
-
-    /**
-     * Формирует обработчик команд без полезной нагрузки.
-     */
-    private ReturnRequestCommandHandler simpleHandler(SimpleCommandExecutor executor) {
-        return (context, payload) -> executor.execute(context.requestId(), context.parcelId(), context.user());
-    }
-
-    /**
-     * Формирует обработчик стадийных команд, требующих отметки времени.
-     */
-    private ReturnRequestCommandHandler stageHandler(ReturnRequestCommandType type,
-                                                    StageCommandExecutor executor) {
-        return (context, payload) -> {
-            StageMarkPayload stagePayload = requirePayload(payload, StageMarkPayload.class, type);
-            return executor.execute(context.requestId(),
-                    context.parcelId(),
-                    context.user(),
-                    stagePayload.stageMoment());
-        };
-    }
-
-    /**
-     * Формирует обработчик команд, работающих с обменными отправлениями.
-     */
-    private ReturnRequestCommandHandler exchangeHandler(ReturnRequestCommandType type,
-                                                        ExchangeShipmentExecutor executor) {
-        return (context, payload) -> {
-            ExchangeShipmentPayload exchangePayload = requirePayload(payload, ExchangeShipmentPayload.class, type);
-            return executor.execute(context.requestId(),
-                    context.parcelId(),
-                    context.user(),
-                    exchangePayload.exchangeTrack(),
-                    exchangePayload.stageMoment());
-        };
+                context.user(),
+                exchangePayload.exchangeTrack(),
+                exchangePayload.stageMoment());
     }
 
     /**
@@ -393,11 +358,12 @@ public class ReturnRequestCommandService {
     }
 
     /**
-     * Формирует обработчик переключения режима заявки.
+     * Выполняет переключение режима заявки.
      */
-    private ReturnRequestCommandHandler modeSwitchHandler(ReturnRequestMode targetMode,
-                                                         OrderReturnRequestService.ModeSwitchTrigger trigger) {
-        return (context, payload) -> orderReturnRequestService.switchMode(
+    private OrderReturnRequest executeModeSwitch(CommandContext context,
+                                                 ReturnRequestMode targetMode,
+                                                 OrderReturnRequestService.ModeSwitchTrigger trigger) {
+        return orderReturnRequestService.switchMode(
                 context.requestId(),
                 context.parcelId(),
                 context.user(),
@@ -407,27 +373,21 @@ public class ReturnRequestCommandService {
     }
 
     /**
+     * Определяет, требует ли команда наличия объекта payload.
+     */
+    private boolean requiresPayload(ReturnRequestCommandType type) {
+        return switch (type) {
+            case UPDATE_REVERSE_TRACK, REGISTER_EXCHANGE_PARCEL, MARK_EXCHANGE_SENT, MARK_EXCHANGE_DELIVERED -> true;
+            default -> false;
+        };
+    }
+
+    /**
      * Контекст выполняемой команды, содержащий ключевые параметры запроса.
      */
     private record CommandContext(Long requestId,
                                   Long parcelId,
                                   User user) {
-    }
-
-    /**
-     * Интерфейс обработчика конкретной команды.
-     */
-    @FunctionalInterface
-    private interface ReturnRequestCommandHandler {
-        OrderReturnRequest handle(CommandContext context, ReturnRequestCommandPayload payload);
-    }
-
-    /**
-     * Стратегия команд без дополнительных параметров.
-     */
-    @FunctionalInterface
-    private interface SimpleCommandExecutor {
-        OrderReturnRequest execute(Long requestId, Long parcelId, User user);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayload.java
@@ -14,7 +14,7 @@ import java.security.MessageDigest;
  * и обеспечения идемпотентности команд даже при вложенных структурах.
  * </p>
  */
-public sealed interface ReturnRequestCommandPayload permits EmptyPayload, UpdateDetailsPayload,
+public sealed interface ReturnRequestCommandPayload permits EmptyPayload, UpdateReverseTrackPayload,
         StageMarkPayload, ExchangeShipmentPayload {
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Component;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.EnumMap;
-import java.util.Map;
 
 /**
  * Фабрика валидации полезной нагрузки команд управления заявками.
@@ -23,33 +21,6 @@ public class ReturnRequestCommandPayloadFactory {
     private static final int MAX_TRACK_LENGTH = 64;
     private static final int MAX_COMMENT_LENGTH = 2000;
 
-    private final Map<ReturnRequestCommandType, PayloadParser> parsers;
-
-    /**
-     * Регистрирует обработчики полезной нагрузки для всех поддерживаемых команд.
-     */
-    public ReturnRequestCommandPayloadFactory() {
-        EnumMap<ReturnRequestCommandType, PayloadParser> registry = new EnumMap<>(ReturnRequestCommandType.class);
-        registry.put(ReturnRequestCommandType.SET_MODE_EXCHANGE, emptyParser(ReturnRequestCommandType.SET_MODE_EXCHANGE));
-        registry.put(ReturnRequestCommandType.SET_MODE_RETURN, emptyParser(ReturnRequestCommandType.SET_MODE_RETURN));
-        registry.put(ReturnRequestCommandType.CANCEL_EXCHANGE, emptyParser(ReturnRequestCommandType.CANCEL_EXCHANGE));
-        registry.put(ReturnRequestCommandType.CLOSE_REQUEST, emptyParser(ReturnRequestCommandType.CLOSE_REQUEST));
-        registry.put(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL,
-                exchangeParser(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL));
-        registry.put(ReturnRequestCommandType.MARK_EXCHANGE_SENT,
-                exchangeParser(ReturnRequestCommandType.MARK_EXCHANGE_SENT));
-        registry.put(ReturnRequestCommandType.MARK_EXCHANGE_DELIVERED,
-                stageParser(ReturnRequestCommandType.MARK_EXCHANGE_DELIVERED));
-        registry.put(ReturnRequestCommandType.MARK_OUTBOUND_SENT,
-                stageParser(ReturnRequestCommandType.MARK_OUTBOUND_SENT));
-        registry.put(ReturnRequestCommandType.MARK_INBOUND_ARRIVED,
-                stageParser(ReturnRequestCommandType.MARK_INBOUND_ARRIVED));
-        registry.put(ReturnRequestCommandType.MARK_INBOUND_PICKED_UP,
-                stageParser(ReturnRequestCommandType.MARK_INBOUND_PICKED_UP));
-        registry.put(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, this::parseUpdateDetails);
-        this.parsers = Map.copyOf(registry);
-    }
-
     /**
      * Валидирует и создаёт полезную нагрузку для переданной команды.
      *
@@ -58,11 +29,16 @@ public class ReturnRequestCommandPayloadFactory {
      * @return нормализованная полезная нагрузка
      */
     public ReturnRequestCommandPayload create(ReturnRequestCommandType type, JsonNode payloadNode) {
-        PayloadParser parser = parsers.get(type);
-        if (parser == null) {
-            throw new IllegalArgumentException("Команда " + type.name() + " не поддерживается системой");
-        }
-        return parser.parse(payloadNode);
+        return switch (type) {
+            case SET_MODE_EXCHANGE, SET_MODE_RETURN -> ensureEmptyPayload(type, payloadNode);
+            case CLOSE_REQUEST -> ensureEmptyPayload(type, payloadNode);
+            case MARK_OUTBOUND_SENT, MARK_INBOUND_ARRIVED, MARK_INBOUND_PICKED_UP ->
+                    parseStageMarkPayload(type, payloadNode);
+            case UPDATE_REVERSE_TRACK -> parseUpdateReverseTrack(payloadNode);
+            case REGISTER_EXCHANGE_PARCEL, MARK_EXCHANGE_SENT, MARK_EXCHANGE_DELIVERED ->
+                    parseExchangeShipmentPayload(type, payloadNode);
+            default -> throw new IllegalArgumentException("Команда " + type.name() + " не поддерживается системой");
+        };
     }
 
     /**
@@ -80,9 +56,9 @@ public class ReturnRequestCommandPayloadFactory {
     }
 
     /**
-     * Разбирает полезную нагрузку команды обновления данных заявки.
+     * Разбирает полезную нагрузку команды обновления обратного трека.
      */
-    private ReturnRequestCommandPayload parseUpdateDetails(JsonNode payloadNode) {
+    private ReturnRequestCommandPayload parseUpdateReverseTrack(JsonNode payloadNode) {
         if (payloadNode == null || payloadNode.isNull()) {
             throw new IllegalArgumentException("Команда UPDATE_REVERSE_TRACK требует объект payload с параметрами");
         }
@@ -90,23 +66,10 @@ public class ReturnRequestCommandPayloadFactory {
             throw new IllegalArgumentException("Полезная нагрузка UPDATE_REVERSE_TRACK должна быть объектом JSON");
         }
 
-        boolean hasReverseTrack = payloadNode.has("reverseTrack");
-        boolean hasComment = payloadNode.has("comment");
-        if (!hasReverseTrack && !hasComment) {
-            throw new IllegalArgumentException("Не переданы поля reverseTrack или comment для UPDATE_REVERSE_TRACK");
-        }
+        String reverseTrack = requireReverseTrack(payloadNode.get("reverseTrack"));
+        String comment = normalizeComment(payloadNode.get("comment"));
 
-        String reverseTrack = null;
-        if (hasReverseTrack) {
-            reverseTrack = normalizeTrack(payloadNode.get("reverseTrack"), "reverseTrack");
-        }
-
-        String comment = null;
-        if (hasComment) {
-            comment = normalizeComment(payloadNode.get("comment"));
-        }
-
-        return new UpdateDetailsPayload(reverseTrack, comment);
+        return new UpdateReverseTrackPayload(reverseTrack, comment);
     }
 
     /**
@@ -190,6 +153,17 @@ public class ReturnRequestCommandPayloadFactory {
     }
 
     /**
+     * Проверяет наличие обязательного обратного трека и приводит его к нормализованному виду.
+     */
+    private String requireReverseTrack(JsonNode node) {
+        String track = normalizeTrack(node, "reverseTrack");
+        if (track == null) {
+            throw new IllegalArgumentException("Поле reverseTrack обязательно для команды UPDATE_REVERSE_TRACK");
+        }
+        return track;
+    }
+
+    /**
      * Разбирает момент наступления стадии, приводя его к UTC.
      */
     private ZonedDateTime parseStageMoment(JsonNode node, ReturnRequestCommandType type) {
@@ -210,32 +184,4 @@ public class ReturnRequestCommandPayloadFactory {
         }
     }
 
-    /**
-     * Возвращает обработчик для команд без параметров.
-     */
-    private PayloadParser emptyParser(ReturnRequestCommandType type) {
-        return payloadNode -> ensureEmptyPayload(type, payloadNode);
-    }
-
-    /**
-     * Возвращает обработчик стадийных команд.
-     */
-    private PayloadParser stageParser(ReturnRequestCommandType type) {
-        return payloadNode -> parseStageMarkPayload(type, payloadNode);
-    }
-
-    /**
-     * Возвращает обработчик команд, работающих с обменной отправкой.
-     */
-    private PayloadParser exchangeParser(ReturnRequestCommandType type) {
-        return payloadNode -> parseExchangeShipmentPayload(type, payloadNode);
-    }
-
-    /**
-     * Функциональный интерфейс обработчика конкретного типа payload.
-     */
-    @FunctionalInterface
-    private interface PayloadParser {
-        ReturnRequestCommandPayload parse(JsonNode payloadNode);
-    }
 }

--- a/src/main/java/com/project/tracking_system/service/order/payload/UpdateReverseTrackPayload.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/UpdateReverseTrackPayload.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * Полезная нагрузка для команды обновления данных заявки.
+ * Полезная нагрузка для команды обновления обратного трека.
  *
- * @param reverseTrack номер обратного трека в нормализованном виде
+ * @param reverseTrack номер обратного трека в нормализованном виде (обязательный)
  * @param comment      комментарий менеджера
  */
-public record UpdateDetailsPayload(String reverseTrack,
-                                   String comment) implements ReturnRequestCommandPayload {
+public record UpdateReverseTrackPayload(String reverseTrack,
+                                        String comment) implements ReturnRequestCommandPayload {
 
     @Override
     public JsonNode toNormalizedTree(ObjectMapper objectMapper) {

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandPayloadFactoryTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandPayloadFactoryTest.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.project.tracking_system.controller.ReturnRequestCommandType;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayload;
 import com.project.tracking_system.service.order.payload.ReturnRequestCommandPayloadFactory;
-import com.project.tracking_system.service.order.payload.UpdateDetailsPayload;
+import com.project.tracking_system.service.order.payload.ExchangeShipmentPayload;
+import com.project.tracking_system.service.order.payload.UpdateReverseTrackPayload;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,27 +32,19 @@ class ReturnRequestCommandPayloadFactoryTest {
     }
 
     @Test
-    void create_whenUpdateDetailsWithoutFields_throwsException() {
-        assertThatThrownBy(() -> factory.create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK,
-                JsonNodeFactory.instance.objectNode()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("reverseTrack");
-    }
-
-    @Test
-    void create_whenUpdateDetailsHasValues_returnsNormalizedPayload() {
+    void create_whenUpdateReverseTrackHasValues_returnsNormalizedPayload() {
         var node = JsonNodeFactory.instance.objectNode()
                 .put("reverseTrack", "  ab123 ")
                 .put("comment", "  Test comment  ");
 
-        UpdateDetailsPayload payload = (UpdateDetailsPayload) factory.create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node);
+        UpdateReverseTrackPayload payload = (UpdateReverseTrackPayload) factory.create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node);
 
         assertThat(payload.reverseTrack()).isEqualTo("AB123");
         assertThat(payload.comment()).isEqualTo("Test comment");
     }
 
     @Test
-    void create_whenUpdateDetailsHasLongTrack_throwsException() {
+    void create_whenUpdateReverseTrackHasLongTrack_throwsException() {
         String longTrack = "A".repeat(70);
         var node = JsonNodeFactory.instance.objectNode()
                 .put("reverseTrack", longTrack);
@@ -62,14 +55,46 @@ class ReturnRequestCommandPayloadFactoryTest {
     }
 
     @Test
-    void create_whenUpdateDetailsClearsValues_isAccepted() {
+    void create_whenUpdateReverseTrackWithoutTrack_throwsException() {
         var node = JsonNodeFactory.instance.objectNode()
                 .putNull("reverseTrack")
-                .put("comment", " ");
+                .put("comment", "Комментарий");
 
-        UpdateDetailsPayload payload = (UpdateDetailsPayload) factory.create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node);
+        assertThatThrownBy(() -> factory.create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("reverseTrack");
+    }
 
-        assertThat(payload.reverseTrack()).isNull();
+    @Test
+    void create_whenUpdateReverseTrackWithoutComment_returnsPayloadWithNullComment() {
+        var node = JsonNodeFactory.instance.objectNode()
+                .put("reverseTrack", "rr123");
+
+        UpdateReverseTrackPayload payload = (UpdateReverseTrackPayload) factory
+                .create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node);
+
+        assertThat(payload.reverseTrack()).isEqualTo("RR123");
         assertThat(payload.comment()).isNull();
+    }
+
+    @Test
+    void create_whenExchangeCommandWithoutTrack_throwsException() {
+        var node = JsonNodeFactory.instance.objectNode();
+
+        assertThatThrownBy(() -> factory.create(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL, node))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("exchangeTrack");
+    }
+
+    @Test
+    void create_whenExchangeCommandHasTrack_returnsNormalizedPayload() {
+        var node = JsonNodeFactory.instance.objectNode()
+                .put("exchangeTrack", " xx777 ");
+
+        ExchangeShipmentPayload payload = (ExchangeShipmentPayload) factory
+                .create(ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL, node);
+
+        assertThat(payload.exchangeTrack()).isEqualTo("XX777");
+        assertThat(payload.stageMoment()).isNull();
     }
 }

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -6,7 +6,6 @@ import com.project.tracking_system.controller.ReturnRequestCommandType;
 import com.project.tracking_system.dto.CommandDto;
 import com.project.tracking_system.dto.RequestDto;
 import com.project.tracking_system.entity.OrderReturnRequest;
-import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.ReturnCommandLog;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.TrackParcel;
@@ -191,56 +190,10 @@ class ReturnRequestCommandServiceTest {
     }
 
     @Test
-    void executeCommand_whenCancelExchange_invokesSwitchAndClose() {
-        User user = buildUser();
-        OrderReturnRequest request = buildRequest(40L, 18L);
-        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
-        OrderReturnRequest switched = buildRequest(40L, 18L);
-        switched.setStatus(OrderReturnRequestStatus.REGISTERED);
-        OrderReturnRequest closed = buildRequest(40L, 18L);
-        closed.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000040", 40L, "RETURN");
-        CommandDto command = new CommandDto("cancel-1", ReturnRequestCommandType.CANCEL_EXCHANGE.name(), null);
-
-        when(orderReturnRequestService.getOwnedRequest(40L, user)).thenReturn(request);
-        when(orderReturnRequestService.switchMode(40L,
-                18L,
-                user,
-                ReturnRequestMode.RETURN,
-                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION)).thenReturn(switched);
-        when(orderReturnRequestService.closeWithoutExchange(40L, 18L, user)).thenReturn(closed);
-        when(returnRequestMapper.toDto(eq(closed), any())).thenReturn(dto);
-
-        AtomicReference<ReturnCommandLog> savedLog = new AtomicReference<>();
-        when(returnCommandLogRepository.findFirstByRequestIdAndIdempotencyKey(40L, "cancel-1"))
-                .thenAnswer(invocation -> Optional.ofNullable(savedLog.get()));
-        when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
-                .thenAnswer(invocation -> {
-                    ReturnCommandLog logEntry = invocation.getArgument(0);
-                    savedLog.set(logEntry);
-                    return logEntry;
-                });
-
-        RequestDto result = commandService.executeCommand(40L,
-                ReturnRequestCommandType.CANCEL_EXCHANGE,
-                command,
-                user,
-                ZoneOffset.UTC);
-
-        assertThat(result).isEqualTo(dto);
-        verify(orderReturnRequestService).switchMode(40L,
-                18L,
-                user,
-                ReturnRequestMode.RETURN,
-                OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION);
-        verify(orderReturnRequestService).closeWithoutExchange(40L, 18L, user);
-    }
-
-    @Test
-    void executeCommand_whenUpdateDetailsWithoutPayload_throwsBadRequest() {
+    void executeCommand_whenUpdateReverseTrackWithoutPayload_throwsBadRequest() {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(23L, 11L);
-        CommandDto command = new CommandDto("dup-4", ReturnRequestCommandType.UPDATE_REVERSE_TRACK.name(), JsonNodeFactory.instance.objectNode());
+        CommandDto command = new CommandDto("dup-4", ReturnRequestCommandType.UPDATE_REVERSE_TRACK.name(), null);
 
         when(orderReturnRequestService.getOwnedRequest(23L, user)).thenReturn(request);
 
@@ -250,9 +203,28 @@ class ReturnRequestCommandServiceTest {
                 user,
                 ZoneOffset.UTC))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("reverseTrack");
+                .hasMessageContaining("требует объект payload");
 
         verify(orderReturnRequestService, never()).updateReverseTrackAndComment(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void executeCommand_whenExchangeCommandWithoutPayload_throwsBadRequest() {
+        User user = buildUser();
+        OrderReturnRequest request = buildRequest(24L, 12L);
+        CommandDto command = new CommandDto("dup-5", ReturnRequestCommandType.MARK_EXCHANGE_SENT.name(), null);
+
+        when(orderReturnRequestService.getOwnedRequest(24L, user)).thenReturn(request);
+
+        assertThatThrownBy(() -> commandService.executeCommand(24L,
+                ReturnRequestCommandType.MARK_EXCHANGE_SENT,
+                command,
+                user,
+                ZoneOffset.UTC))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("требует объект payload");
+
+        verify(orderReturnRequestService, never()).markExchangeSent(any(), any(), any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- align `ReturnRequestCommandPayloadFactory` with the updated command taxonomy, normalizing stage, reverse track and exchange payloads
- rename and reuse the reverse-track payload record while tightening validation rules in the command service
- refresh unit tests to reflect the new required fields and exchange parcel handling

## Testing
- mvn -q -Dtest=ReturnRequestCommandPayloadFactoryTest,ReturnRequestCommandServiceTest test *(fails: dependency download blocked by 403 from jitpack.io)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ee1f27b0832d9ce3714d56128c23)