### PR TITLE
Refine return request actions and stage handling

### DIFF
--- a/src/main/java/com/project/tracking_system/dto/AvailableActionsDto.java
+++ b/src/main/java/com/project/tracking_system/dto/AvailableActionsDto.java
@@ -1,5 +1,8 @@
 package com.project.tracking_system.dto;
 
+import com.project.tracking_system.entity.ReturnRequestAction;
+
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -8,6 +11,7 @@ import java.util.List;
 public final class AvailableActionsDto {
 
     private final List<String> actions;
+    private final EnumSet<ReturnRequestAction> actionSet;
 
     /**
      * Создаёт DTO доступных действий, гарантируя неизменяемость списка.
@@ -16,6 +20,14 @@ public final class AvailableActionsDto {
      */
     public AvailableActionsDto(List<String> actions) {
         this.actions = actions == null ? List.of() : List.copyOf(actions);
+        this.actionSet = EnumSet.noneOf(ReturnRequestAction.class);
+        this.actions.stream()
+                .map(ReturnRequestAction::fromCode)
+                .forEach(action -> {
+                    if (action != null) {
+                        actionSet.add(action);
+                    }
+                });
     }
 
     /**
@@ -25,5 +37,64 @@ public final class AvailableActionsDto {
      */
     public List<String> getActions() {
         return actions;
+    }
+
+    /** Проверяет, можно ли перевести заявку в обмен. */
+    public boolean isSetModeExchange() {
+        return contains(ReturnRequestAction.SET_MODE_EXCHANGE);
+    }
+
+    /** Проверяет, можно ли вернуть заявку в режим возврата. */
+    public boolean isSetModeReturn() {
+        return contains(ReturnRequestAction.SET_MODE_RETURN);
+    }
+
+    /** Проверяет, доступна ли отмена обмена. */
+    public boolean isCancelExchange() {
+        return contains(ReturnRequestAction.CANCEL_EXCHANGE);
+    }
+
+    /** Проверяет, можно ли зарегистрировать обменную посылку. */
+    public boolean isRegisterExchangeParcel() {
+        return contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+    }
+
+    /** Проверяет, доступно ли обновление обратного трека. */
+    public boolean isUpdateReverseTrack() {
+        return contains(ReturnRequestAction.UPDATE_REVERSE_TRACK);
+    }
+
+    /** Проверяет, можно ли закрыть заявку. */
+    public boolean isCloseRequest() {
+        return contains(ReturnRequestAction.CLOSE_REQUEST);
+    }
+
+    /** Проверяет, можно ли отметить отправку возврата. */
+    public boolean isMarkOutboundSent() {
+        return contains(ReturnRequestAction.MARK_OUTBOUND_SENT);
+    }
+
+    /** Проверяет, можно ли отметить прибытие возврата. */
+    public boolean isMarkInboundArrived() {
+        return contains(ReturnRequestAction.MARK_INBOUND_ARRIVED);
+    }
+
+    /** Проверяет, можно ли отметить приём возврата. */
+    public boolean isMarkInboundPickedUp() {
+        return contains(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+    }
+
+    /** Проверяет, можно ли отметить отправку обменной посылки. */
+    public boolean isMarkExchangeSent() {
+        return contains(ReturnRequestAction.MARK_EXCHANGE_SENT);
+    }
+
+    /** Проверяет, можно ли отметить доставку обменной посылки. */
+    public boolean isMarkExchangeDelivered() {
+        return contains(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
+    }
+
+    private boolean contains(ReturnRequestAction action) {
+        return actionSet.contains(action);
     }
 }

--- a/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
+++ b/src/main/java/com/project/tracking_system/service/customer/CustomerTelegramService.java
@@ -435,13 +435,16 @@ public class CustomerTelegramService {
      * @return заявка после перевода в обмен
      */
     @Transactional
-    public OrderReturnRequest approveExchangeFromTelegram(Long chatId,
+    public OrderReturnRequest setModeExchangeFromTelegram(Long chatId,
                                                           Long parcelId,
                                                           Long requestId) {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        return orderReturnRequestService.approveExchange(requestId, parcelId, owner);
+        return orderReturnRequestService.setModeExchange(requestId,
+                parcelId,
+                owner,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
     }
 
     /**
@@ -463,7 +466,7 @@ public class CustomerTelegramService {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        return orderReturnRequestService.closeWithoutExchange(requestId, parcelId, owner);
+        return orderReturnRequestService.closeRequest(requestId, parcelId, owner);
     }
 
     /**
@@ -476,12 +479,11 @@ public class CustomerTelegramService {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        orderReturnRequestService.switchMode(requestId,
+        orderReturnRequestService.setModeReturn(requestId,
                 parcelId,
                 owner,
-                ReturnRequestMode.RETURN,
                 OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
-        return orderReturnRequestService.closeWithoutExchange(requestId, parcelId, owner);
+        return orderReturnRequestService.closeRequest(requestId, parcelId, owner);
     }
 
     /**
@@ -494,10 +496,9 @@ public class CustomerTelegramService {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        return orderReturnRequestService.switchMode(requestId,
+        return orderReturnRequestService.setModeReturn(requestId,
                 parcelId,
                 owner,
-                ReturnRequestMode.RETURN,
                 OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
     }
 
@@ -577,7 +578,7 @@ public class CustomerTelegramService {
         Customer customer = requireCustomerByChat(chatId);
         TrackParcel parcel = requireOwnedParcel(parcelId, customer.getId());
         User owner = requireParcelOwner(parcel);
-        return orderReturnRequestService.updateReverseTrackAndComment(requestId, parcelId, owner, reverseTrack, comment);
+        return orderReturnRequestService.updateReverseTrack(requestId, parcelId, owner, reverseTrack, comment);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -85,11 +85,11 @@ public class OrderReturnRequestService {
      * @return DTO с подтверждением сохранённых данных
      */
     @Transactional
-    public ReturnRequestUpdateResponse updateReverseTrackAndComment(Long requestId,
-                                                                    Long parcelId,
-                                                                    User user,
-                                                                    String reverseTrack,
-                                                                    String comment) {
+    public ReturnRequestUpdateResponse updateReverseTrack(Long requestId,
+                                                          Long parcelId,
+                                                          User user,
+                                                          String reverseTrack,
+                                                          String comment) {
         OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
         if (!ACTIVE_STATUSES.contains(request.getStatus())) {
             throw new IllegalStateException("Заявку нельзя изменить в текущем статусе");
@@ -220,21 +220,32 @@ public class OrderReturnRequestService {
     }
 
     /**
-     * Одобряет запуск обмена по заявке.
+     * Переводит заявку в режим обмена.
      * <p>
-     * Метод переводит заявку в статус обмена и фиксирует менеджера, принявшего решение.
-     * Создание обменной посылки выполняется отдельным действием через {@link #createExchangeParcel(Long, Long, User)},
-     * чтобы соблюсти SRP и дать менеджеру время на проверку данных перед оформлением отправления.
+     * Метод фиксирует решение менеджера, подготавливает заявку к созданию обменной посылки
+     * и оставляет подготовку отправления за отдельным действием {@link #createExchangeParcel(Long, Long, User)},
+     * соблюдая принцип единой ответственности.
      * </p>
      *
      * @param requestId идентификатор заявки
      * @param parcelId  идентификатор посылки
      * @param user      автор решения
-     * @return обновлённая заявка после одобрения обмена
+     * @return обновлённая заявка после переключения режима
      */
     @Transactional
-    public OrderReturnRequest approveExchange(Long requestId, Long parcelId, User user) {
-        return switchMode(requestId, parcelId, user, ReturnRequestMode.EXCHANGE, ModeSwitchTrigger.MANUAL_DECISION);
+    public OrderReturnRequest setModeExchange(Long requestId, Long parcelId, User user) {
+        return setModeExchange(requestId, parcelId, user, ModeSwitchTrigger.MANUAL_DECISION);
+    }
+
+    /**
+     * Переводит заявку в режим обмена с указанием причины переключения.
+     */
+    @Transactional
+    public OrderReturnRequest setModeExchange(Long requestId,
+                                              Long parcelId,
+                                              User user,
+                                              ModeSwitchTrigger trigger) {
+        return switchModeInternal(requestId, parcelId, user, ReturnRequestMode.EXCHANGE, trigger);
     }
 
     /**
@@ -244,20 +255,12 @@ public class OrderReturnRequestService {
      * согласно матрице состояний, нормализует стадию через {@link ReturnRequestWorkflow}
      * и выполняет побочные действия с обменными посылками через профильные сервисы.
      * </p>
-     *
-     * @param requestId   идентификатор заявки
-     * @param parcelId    идентификатор посылки
-     * @param user        менеджер, инициировавший действие
-     * @param targetMode  целевой режим обработки
-     * @param trigger     причина переключения (используется в логировании)
-     * @return обновлённая заявка после сохранения
      */
-    @Transactional
-    public OrderReturnRequest switchMode(Long requestId,
-                                         Long parcelId,
-                                         User user,
-                                         ReturnRequestMode targetMode,
-                                         ModeSwitchTrigger trigger) {
+    private OrderReturnRequest switchModeInternal(Long requestId,
+                                                  Long parcelId,
+                                                  User user,
+                                                  ReturnRequestMode targetMode,
+                                                  ModeSwitchTrigger trigger) {
         if (targetMode == null) {
             throw new IllegalArgumentException("Не указан целевой режим заявки");
         }
@@ -274,14 +277,27 @@ public class OrderReturnRequestService {
     }
 
     /**
-     * Перегрузка переключения режима без указания причины (используется для совместимости вызовов).
+     * Возвращает заявку в классический режим возврата.
+     * <p>
+     * Используется при отмене обмена или когда менеджер решил продолжать сценарий возврата.
+     * </p>
      */
     @Transactional
-    public OrderReturnRequest switchMode(Long requestId,
-                                         Long parcelId,
-                                         User user,
-                                         ReturnRequestMode targetMode) {
-        return switchMode(requestId, parcelId, user, targetMode, ModeSwitchTrigger.MANUAL_DECISION);
+    public OrderReturnRequest setModeReturn(Long requestId,
+                                            Long parcelId,
+                                            User user) {
+        return setModeReturn(requestId, parcelId, user, ModeSwitchTrigger.MANUAL_DECISION);
+    }
+
+    /**
+     * Возвращает заявку в режим возврата с кастомным триггером (например, запрос клиента).
+     */
+    @Transactional
+    public OrderReturnRequest setModeReturn(Long requestId,
+                                            Long parcelId,
+                                            User user,
+                                            ModeSwitchTrigger trigger) {
+        return switchModeInternal(requestId, parcelId, user, ReturnRequestMode.RETURN, trigger);
     }
 
     /**
@@ -324,10 +340,10 @@ public class OrderReturnRequestService {
     }
 
     /**
-     * Закрывает заявку без запуска обмена.
+     * Закрывает заявку после завершения обработки возврата без запуска обмена.
      */
     @Transactional
-    public OrderReturnRequest closeWithoutExchange(Long requestId, Long parcelId, User user) {
+    public OrderReturnRequest closeRequest(Long requestId, Long parcelId, User user) {
         OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
 
         if (request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
@@ -344,7 +360,7 @@ public class OrderReturnRequestService {
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
-        log.info("Заявка {} закрыта без обмена", saved.getId());
+        log.info("Заявка {} закрыта", saved.getId());
         return saved;
     }
 
@@ -590,7 +606,7 @@ public class OrderReturnRequestService {
      * </p>
      */
     @Transactional(readOnly = true)
-    public boolean canStartExchange(OrderReturnRequest request) {
+    public boolean canSetModeExchange(OrderReturnRequest request) {
         if (request == null || request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
             return false;
         }
@@ -612,7 +628,7 @@ public class OrderReturnRequestService {
     /**
      * Проверяет, можно ли вернуть обменную заявку в режим возврата без закрытия обращения.
      */
-    private boolean canSwitchToReturnMode(OrderReturnRequest request) {
+    private boolean canSetModeReturn(OrderReturnRequest request) {
         if (request == null) {
             return false;
         }
@@ -630,7 +646,7 @@ public class OrderReturnRequestService {
      * Проверяет, доступна ли отмена обмена с последующим закрытием заявки.
      */
     private boolean canCancelExchangeAction(OrderReturnRequest request) {
-        return canSwitchToReturnMode(request);
+        return canSetModeReturn(request);
     }
 
     /**
@@ -806,19 +822,34 @@ public class OrderReturnRequestService {
                 .withStage(normalizedStage)
                 .withStatus(request.getStatus());
 
-        builder.allow(ReturnRequestAction.SET_MODE_EXCHANGE, canStartExchange(request));
-        builder.allow(ReturnRequestAction.SET_MODE_RETURN, canSwitchToReturnMode(request));
-        builder.allow(ReturnRequestAction.CANCEL_EXCHANGE, canCancelExchangeAction(request));
-        builder.allow(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL, canRegisterExchangeParcel(request));
-        builder.allow(ReturnRequestAction.CLOSE_REQUEST, canCloseRequest(request));
-        builder.allow(ReturnRequestAction.UPDATE_REVERSE_TRACK, canUpdateReverseTrack(request));
-        builder.allow(ReturnRequestAction.MARK_OUTBOUND_SENT, canMarkOutboundSent(request));
-        builder.allow(ReturnRequestAction.MARK_INBOUND_ARRIVED, canMarkInboundArrived(request));
-        builder.allow(ReturnRequestAction.MARK_INBOUND_PICKED_UP, canMarkInboundPickedUp(request));
-        builder.allow(ReturnRequestAction.MARK_EXCHANGE_SENT, canMarkExchangeSent(request));
-        builder.allow(ReturnRequestAction.MARK_EXCHANGE_DELIVERED, canMarkExchangeDelivered(request));
+        for (ReturnRequestAction action : ReturnRequestAction.values()) {
+            builder.allow(action, isActionAllowed(request, action));
+        }
 
         return builder.build();
+    }
+
+    /**
+     * Проверяет доступность конкретного действия для заявки с учётом бизнес-ограничений.
+     */
+    private boolean isActionAllowed(OrderReturnRequest request, ReturnRequestAction action) {
+        if (request == null || action == null) {
+            return false;
+        }
+        return switch (action) {
+            case SET_MODE_EXCHANGE -> canSetModeExchange(request);
+            case SET_MODE_RETURN -> canSetModeReturn(request);
+            case CANCEL_EXCHANGE -> canCancelExchangeAction(request);
+            case REGISTER_EXCHANGE_PARCEL -> canRegisterExchangeParcel(request);
+            case CLOSE_REQUEST -> canCloseRequest(request);
+            case UPDATE_REVERSE_TRACK -> canUpdateReverseTrack(request);
+            case MARK_OUTBOUND_SENT -> canMarkOutboundSent(request);
+            case MARK_INBOUND_ARRIVED -> canMarkInboundArrived(request);
+            case MARK_INBOUND_PICKED_UP -> canMarkInboundPickedUp(request);
+            case MARK_EXCHANGE_SENT -> canMarkExchangeSent(request);
+            case MARK_EXCHANGE_DELIVERED -> canMarkExchangeDelivered(request);
+            default -> false;
+        };
     }
 
     /**
@@ -1047,12 +1078,15 @@ public class OrderReturnRequestService {
         if (resolveMode(request) != ReturnRequestMode.EXCHANGE) {
             return false;
         }
+        if (!hasExchangeTrack(request)) {
+            return false;
+        }
         if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_SENT)) {
             return false;
         }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDispatched)
-                .orElseGet(() -> hasExchangeTrack(request));
+                .orElse(true);
     }
 
     /**
@@ -1065,12 +1099,15 @@ public class OrderReturnRequestService {
         if (resolveMode(request) != ReturnRequestMode.EXCHANGE) {
             return false;
         }
+        if (!hasExchangeTrack(request)) {
+            return false;
+        }
         if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_DELIVERED)) {
             return false;
         }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDelivered)
-                .orElseGet(() -> hasExchangeTrack(request));
+                .orElse(true);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -291,7 +291,7 @@ public class ReturnRequestCommandService {
                                                         ReturnRequestCommandPayload payload) {
         UpdateReverseTrackPayload updatePayload = requirePayload(payload, UpdateReverseTrackPayload.class,
                 ReturnRequestCommandType.UPDATE_REVERSE_TRACK);
-        orderReturnRequestService.updateReverseTrackAndComment(
+        orderReturnRequestService.updateReverseTrack(
                 context.requestId(),
                 context.parcelId(),
                 context.user(),
@@ -307,7 +307,7 @@ public class ReturnRequestCommandService {
     private OrderReturnRequest executeCloseRequest(CommandContext context) {
         OrderReturnRequest request = orderReturnRequestService.getOwnedRequest(context.requestId(), context.user());
         return switch (request.getStatus()) {
-            case REGISTERED -> orderReturnRequestService.closeWithoutExchange(context.requestId(),
+            case REGISTERED -> orderReturnRequestService.closeRequest(context.requestId(),
                     context.parcelId(),
                     context.user());
             case EXCHANGE_APPROVED -> throw new IllegalStateException("Перед закрытием переведите заявку в режим возврата");
@@ -363,13 +363,20 @@ public class ReturnRequestCommandService {
     private OrderReturnRequest executeModeSwitch(CommandContext context,
                                                  ReturnRequestMode targetMode,
                                                  OrderReturnRequestService.ModeSwitchTrigger trigger) {
-        return orderReturnRequestService.switchMode(
-                context.requestId(),
-                context.parcelId(),
-                context.user(),
-                targetMode,
-                trigger
-        );
+        return switch (targetMode) {
+            case EXCHANGE -> orderReturnRequestService.setModeExchange(
+                    context.requestId(),
+                    context.parcelId(),
+                    context.user(),
+                    trigger
+            );
+            case RETURN -> orderReturnRequestService.setModeReturn(
+                    context.requestId(),
+                    context.parcelId(),
+                    context.user(),
+                    trigger
+            );
+        };
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -225,32 +225,25 @@ public class ReturnRequestWorkflow {
         Map<ReturnRequestMode, Map<ReturnRequestStage, EnumSet<ReturnRequestAction>>> matrix = new EnumMap<>(ReturnRequestMode.class);
         for (ReturnRequestMode mode : ReturnRequestMode.values()) {
             Map<ReturnRequestStage, EnumSet<ReturnRequestAction>> stageActions = new EnumMap<>(ReturnRequestStage.class);
-            Map<ReturnRequestStage, Set<ReturnRequestStage>> modeTransitions = transitionTable.get(mode);
-            if (modeTransitions != null) {
-                for (ReturnRequestStage stage : ReturnRequestStage.values()) {
-                    if (!stage.supportsMode(mode)) {
+            Map<ReturnRequestStage, Set<ReturnRequestStage>> modeTransitions = transitionTable.getOrDefault(mode, Collections.emptyMap());
+            for (ReturnRequestStage stage : ReturnRequestStage.values()) {
+                if (!stage.supportsMode(mode)) {
+                    continue;
+                }
+                Set<ReturnRequestStage> targets = modeTransitions.getOrDefault(stage, Collections.emptySet());
+                EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
+                for (ReturnRequestStage target : targets) {
+                    if (stage == target) {
                         continue;
                     }
-                    Set<ReturnRequestStage> targets = modeTransitions.getOrDefault(stage, Collections.emptySet());
-                    EnumSet<ReturnRequestAction> actions = EnumSet.noneOf(ReturnRequestAction.class);
-                    for (ReturnRequestStage target : targets) {
-                        if (stage == target) {
-                            continue;
-                        }
-                        EnumSet<ReturnRequestAction> mapped = mapTransitionToActions(mode, stage, target);
-                        if (!mapped.isEmpty()) {
-                            actions.addAll(mapped);
-                        }
-                    }
-                    if (!actions.isEmpty()) {
-                        stageActions.put(stage, actions);
+                    EnumSet<ReturnRequestAction> mapped = mapTransitionToActions(mode, stage, target);
+                    if (!mapped.isEmpty()) {
+                        actions.addAll(mapped);
                     }
                 }
-            }
-            if (mode == ReturnRequestMode.EXCHANGE) {
-                stageActions.computeIfAbsent(ReturnRequestStage.EXCHANGE_REGISTERED,
-                        ignored -> EnumSet.noneOf(ReturnRequestAction.class))
-                        .add(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+                if (!actions.isEmpty()) {
+                    stageActions.put(stage, actions);
+                }
             }
             matrix.put(mode, stageActions);
         }
@@ -267,7 +260,8 @@ public class ReturnRequestWorkflow {
         matrix.put(OrderReturnRequestStatus.EXCHANGE_APPROVED, EnumSet.of(
                 ReturnRequestAction.SET_MODE_RETURN,
                 ReturnRequestAction.CANCEL_EXCHANGE,
-                ReturnRequestAction.UPDATE_REVERSE_TRACK
+                ReturnRequestAction.UPDATE_REVERSE_TRACK,
+                ReturnRequestAction.REGISTER_EXCHANGE_PARCEL
         ));
         return matrix;
     }
@@ -290,20 +284,12 @@ public class ReturnRequestWorkflow {
             case OUTBOUND_SENT -> EnumSet.of(ReturnRequestAction.MARK_OUTBOUND_SENT);
             case INBOUND_ARRIVED -> EnumSet.of(ReturnRequestAction.MARK_INBOUND_ARRIVED);
             case INBOUND_PICKED_UP -> EnumSet.of(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
-            case EXCHANGE_REGISTERED -> mode == ReturnRequestMode.EXCHANGE
-                    ? EnumSet.of(ReturnRequestAction.SET_MODE_EXCHANGE)
+            case EXCHANGE_SENT -> mode == ReturnRequestMode.EXCHANGE
+                    ? EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_SENT)
                     : EnumSet.noneOf(ReturnRequestAction.class);
-            case EXCHANGE_SENT -> {
-                if (mode != ReturnRequestMode.EXCHANGE) {
-                    yield EnumSet.noneOf(ReturnRequestAction.class);
-                }
-                EnumSet<ReturnRequestAction> exchangeActions = EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_SENT);
-                if (from == ReturnRequestStage.EXCHANGE_REGISTERED) {
-                    exchangeActions.add(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
-                }
-                yield exchangeActions;
-            }
-            case EXCHANGE_DELIVERED -> EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
+            case EXCHANGE_DELIVERED -> mode == ReturnRequestMode.EXCHANGE
+                    ? EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_DELIVERED)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
             default -> EnumSet.noneOf(ReturnRequestAction.class);
         };
     }

--- a/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
+++ b/src/main/java/com/project/tracking_system/service/telegram/BuyerTelegramBot.java
@@ -3973,7 +3973,7 @@ public class BuyerTelegramBot implements SpringLongPollingBot, LongPollingSingle
                 resetReturnScenario(chatId, session);
                 return;
             }
-            telegramService.approveExchangeFromTelegram(chatId, parcelId, requestId);
+            telegramService.setModeExchangeFromTelegram(chatId, parcelId, requestId);
         } catch (IllegalStateException ex) {
             log.warn("⚠️ Не удалось запустить обмен по посылке {}: {}", parcelId, ex.getMessage());
             String message = ex.getMessage();

--- a/src/main/resources/templates/app/departures.html
+++ b/src/main/resources/templates/app/departures.html
@@ -308,13 +308,13 @@
                                                 </td>
                                                 <td class="text-end">
                                                     <div class="d-flex flex-column flex-lg-row gap-2 justify-content-end"
-                                                         th:with="isExchangeApproved=${request.status == T(com.project.tracking_system.entity.OrderReturnRequestStatus).EXCHANGE_APPROVED},
-                                                                  allowConfirm=${request.availableActions != null and request.availableActions.confirmReceipt},
-                                                                  allowConvertToExchange=${request.availableActions != null and request.availableActions.startExchange},
-                                                                  allowClose=${request.availableActions != null and request.availableActions.closeWithoutExchange},
-                                                                  hasReverse=${request.reverseTrackNumber != null and !#strings.isEmpty(request.reverseTrackNumber)},
-                                                                  allowConvertToReturn=${request.availableActions != null and request.availableActions.reopenAsReturn},
-                                                                  allowUpdateReverse=${isExchangeApproved and !hasReverse}">
+                                                           th:with="isExchangeApproved=${request.status == T(com.project.tracking_system.entity.OrderReturnRequestStatus).EXCHANGE_APPROVED},
+                                                                   allowConfirm=${request.availableActions != null and request.availableActions.markInboundPickedUp},
+                                                                   allowConvertToExchange=${request.availableActions != null and request.availableActions.setModeExchange},
+                                                                   allowClose=${request.availableActions != null and request.availableActions.closeRequest},
+                                                                   hasReverse=${request.reverseTrackNumber != null and !#strings.isEmpty(request.reverseTrackNumber)},
+                                                                   allowConvertToReturn=${request.availableActions != null and request.availableActions.setModeReturn},
+                                                                   allowUpdateReverse=${request.availableActions != null and request.availableActions.updateReverseTrack}">
                                                         <button type="button"
                                                                 class="btn btn-success btn-sm js-return-request-confirm-return"
                                                                 th:classappend="${allowConfirm and !isExchangeApproved} ? '' : ' d-none'"

--- a/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/customer/CustomerTelegramServiceTest.java
@@ -306,7 +306,7 @@ class CustomerTelegramServiceTest {
      * Убеждаемся, что запуск обмена через Telegram проходит проверку владельца и делегируется бизнес-сервису.
      */
     @Test
-    void approveExchangeFromTelegram_whenRequestValid_callsOrderService() {
+    void setModeExchangeFromTelegram_whenRequestValid_callsOrderService() {
         Long chatId = 909L;
         Long parcelId = 3003L;
         Long requestId = 4004L;
@@ -329,12 +329,14 @@ class CustomerTelegramServiceTest {
 
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
         when(trackParcelRepository.findById(parcelId)).thenReturn(Optional.of(parcel));
-        when(orderReturnRequestService.approveExchange(requestId, parcelId, owner)).thenReturn(approvalResult);
+        when(orderReturnRequestService.setModeExchange(requestId, parcelId, owner,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST)).thenReturn(approvalResult);
 
-        OrderReturnRequest result = customerTelegramService.approveExchangeFromTelegram(chatId, parcelId, requestId);
+        OrderReturnRequest result = customerTelegramService.setModeExchangeFromTelegram(chatId, parcelId, requestId);
 
         assertSame(approvalResult, result, "Метод должен возвращать результат обмена от OrderReturnRequestService");
-        verify(orderReturnRequestService).approveExchange(requestId, parcelId, owner);
+        verify(orderReturnRequestService).setModeExchange(requestId, parcelId, owner,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
     }
 
     @Test
@@ -359,7 +361,7 @@ class CustomerTelegramServiceTest {
 
         when(customerRepository.findByTelegramChatId(chatId)).thenReturn(Optional.of(customer));
         when(trackParcelRepository.findById(parcelId)).thenReturn(Optional.of(parcel));
-        when(orderReturnRequestService.updateReverseTrackAndComment(requestId, parcelId, owner, "track", "comment"))
+        when(orderReturnRequestService.updateReverseTrack(requestId, parcelId, owner, "track", "comment"))
                 .thenReturn(response);
 
         ReturnRequestUpdateResponse result = customerTelegramService.updateReturnRequestDetailsFromTelegram(
@@ -371,7 +373,7 @@ class CustomerTelegramServiceTest {
         );
 
         assertSame(response, result, "Ответ сервиса должен возвращаться без изменений");
-        verify(orderReturnRequestService).updateReverseTrackAndComment(requestId, parcelId, owner, "track", "comment");
+        verify(orderReturnRequestService).updateReverseTrack(requestId, parcelId, owner, "track", "comment");
     }
 
     @Test
@@ -401,7 +403,7 @@ class CustomerTelegramServiceTest {
                 "track",
                 "comment"
         ));
-        verify(orderReturnRequestService, never()).updateReverseTrackAndComment(any(), any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).updateReverseTrack(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -219,7 +219,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void approveExchange_ThrowsWhenEpisodeAlreadyHasApproved() {
+    void setModeExchange_ThrowsWhenEpisodeAlreadyHasApproved() {
         TrackParcel parcel = buildParcel(12L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(200L);
@@ -231,13 +231,13 @@ class OrderReturnRequestServiceTest {
         when(repository.existsByEpisode_IdAndStatus(parcel.getEpisode().getId(), OrderReturnRequestStatus.EXCHANGE_APPROVED))
                 .thenReturn(true);
 
-        assertThatThrownBy(() -> service.approveExchange(200L, 12L, user))
+        assertThatThrownBy(() -> service.setModeExchange(200L, 12L, user))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("уже запущен обмен");
     }
 
     @Test
-    void approveExchange_ChangesStatusWithoutCreatingParcel() {
+    void setModeExchange_ChangesStatusWithoutCreatingParcel() {
         TrackParcel parcel = buildParcel(16L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(500L);
@@ -251,7 +251,7 @@ class OrderReturnRequestServiceTest {
                 OrderReturnRequestStatus.EXCHANGE_APPROVED)).thenReturn(false);
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderReturnRequest result = service.approveExchange(500L, 16L, user);
+        OrderReturnRequest result = service.setModeExchange(500L, 16L, user);
 
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.EXCHANGE_APPROVED);
         assertThat(result.getDecisionBy()).isEqualTo(user);
@@ -313,7 +313,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void closeWithoutExchange_ChangesStatusToClosed() {
+    void closeRequest_ChangesStatusToClosed() {
         TrackParcel parcel = buildParcel(13L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(300L);
@@ -325,7 +325,7 @@ class OrderReturnRequestServiceTest {
         when(repository.findById(300L)).thenReturn(Optional.of(request));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderReturnRequest result = service.closeWithoutExchange(300L, 13L, user);
+        OrderReturnRequest result = service.closeRequest(300L, 13L, user);
 
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         assertThat(result.getClosedBy()).isEqualTo(user);
@@ -541,7 +541,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void switchMode_whenReturnFromExchange_resetsExchangeData() {
+    void setModeReturn_whenExchangeCancelled_resetsExchangeData() {
         TrackParcel parcel = buildParcel(19L, GlobalStatus.DELIVERED);
         TrackParcel replacement = new TrackParcel();
         replacement.setId(77L);
@@ -557,10 +557,9 @@ class OrderReturnRequestServiceTest {
                 .thenReturn(Optional.of(replacement));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderReturnRequest result = service.switchMode(610L,
+        OrderReturnRequest result = service.setModeReturn(610L,
                 19L,
                 user,
-                ReturnRequestMode.RETURN,
                 OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION);
 
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
@@ -575,7 +574,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void switchMode_whenReturnFromExchangeBlocked_throwsException() {
+    void setModeReturn_whenExchangeCancellationBlocked_throwsException() {
         TrackParcel parcel = buildParcel(21L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(611L);
@@ -587,10 +586,9 @@ class OrderReturnRequestServiceTest {
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
                 .thenThrow(new IllegalStateException("Отмена недоступна"));
 
-        assertThatThrownBy(() -> service.switchMode(611L,
+        assertThatThrownBy(() -> service.setModeReturn(611L,
                 21L,
                 user,
-                ReturnRequestMode.RETURN,
                 OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Отмена недоступна");
@@ -626,7 +624,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void canStartExchange_ReliesOnStageStatusAndEpisodeUniqueness() {
+    void canSetModeExchange_ReliesOnStageStatusAndEpisodeUniqueness() {
         OrderEpisode episode = new OrderEpisode();
         episode.setId(800L);
 
@@ -639,18 +637,18 @@ class OrderReturnRequestServiceTest {
         when(repository.existsByEpisode_IdAndStatus(800L, OrderReturnRequestStatus.EXCHANGE_APPROVED))
                 .thenReturn(false, false, true);
 
-        assertThat(service.canStartExchange(request)).isTrue();
+        assertThat(service.canSetModeExchange(request)).isTrue();
 
         request.setMode(ReturnRequestMode.EXCHANGE);
         request.setStage(ReturnRequestStage.NEW);
-        assertThat(service.canStartExchange(request)).isTrue();
+        assertThat(service.canSetModeExchange(request)).isTrue();
 
         request.setStage(ReturnRequestStage.EXCHANGE_DELIVERED);
-        assertThat(service.canStartExchange(request)).isFalse();
+        assertThat(service.canSetModeExchange(request)).isFalse();
 
         request.setMode(ReturnRequestMode.RETURN);
         request.setStage(ReturnRequestStage.OUTBOUND_SENT);
-        assertThat(service.canStartExchange(request)).isFalse();
+        assertThat(service.canSetModeExchange(request)).isFalse();
     }
 
     @Test
@@ -812,7 +810,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void updateReverseTrackAndComment_UpdatesFieldsForActiveRequest() {
+    void updateReverseTrack_UpdatesFieldsForActiveRequest() {
         TrackParcel parcel = buildParcel(21L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(801L);
@@ -821,7 +819,7 @@ class OrderReturnRequestServiceTest {
         when(repository.findById(801L)).thenReturn(Optional.of(request));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        ReturnRequestUpdateResponse response = service.updateReverseTrackAndComment(
+        ReturnRequestUpdateResponse response = service.updateReverseTrack(
                 801L,
                 21L,
                 user,
@@ -840,7 +838,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void updateReverseTrackAndComment_ThrowsWhenStatusInactive() {
+    void updateReverseTrack_ThrowsWhenStatusInactive() {
         TrackParcel parcel = buildParcel(22L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(901L);
@@ -848,7 +846,7 @@ class OrderReturnRequestServiceTest {
         request.setStatus(OrderReturnRequestStatus.CLOSED_NO_EXCHANGE);
         when(repository.findById(901L)).thenReturn(Optional.of(request));
 
-        assertThatThrownBy(() -> service.updateReverseTrackAndComment(
+        assertThatThrownBy(() -> service.updateReverseTrack(
                 901L,
                 22L,
                 user,
@@ -861,7 +859,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void switchMode_whenCustomerRequestsReturn_resetsExchange() {
+    void setModeReturn_whenCustomerRequestsReturn_resetsExchange() {
         TrackParcel parcel = buildParcel(23L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(950L);
@@ -881,10 +879,9 @@ class OrderReturnRequestServiceTest {
                 .thenReturn(Optional.of(replacement));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        OrderReturnRequest result = service.switchMode(950L,
+        OrderReturnRequest result = service.setModeReturn(950L,
                 23L,
                 user,
-                ReturnRequestMode.RETURN,
                 OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
 
         assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.REGISTERED);
@@ -902,7 +899,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void switchMode_whenReturnBlockedByTrack_throwsException() {
+    void setModeReturn_whenReturnBlockedByTrack_throwsException() {
         TrackParcel parcel = buildParcel(24L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(960L);
@@ -914,10 +911,9 @@ class OrderReturnRequestServiceTest {
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
                 .thenThrow(new IllegalStateException("Магазин уже указал трек"));
 
-        assertThatThrownBy(() -> service.switchMode(960L,
+        assertThatThrownBy(() -> service.setModeReturn(960L,
                 24L,
                 user,
-                ReturnRequestMode.RETURN,
                 OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Магазин уже указал трек");

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -81,10 +81,9 @@ class ReturnRequestCommandServiceTest {
         CommandDto command = new CommandDto("dup-1", ReturnRequestCommandType.SET_MODE_EXCHANGE.name(), null);
 
         when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
-        when(orderReturnRequestService.switchMode(21L,
+        when(orderReturnRequestService.setModeExchange(21L,
                 9L,
                 user,
-                ReturnRequestMode.EXCHANGE,
                 OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION)).thenReturn(updated);
         when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
 
@@ -112,10 +111,9 @@ class ReturnRequestCommandServiceTest {
 
         assertThat(first).isEqualTo(dto);
         assertThat(second).isEqualTo(dto);
-        verify(orderReturnRequestService).switchMode(21L,
+        verify(orderReturnRequestService).setModeExchange(21L,
                 9L,
                 user,
-                ReturnRequestMode.EXCHANGE,
                 OrderReturnRequestService.ModeSwitchTrigger.MANUAL_DECISION);
         verify(returnRequestMapper).toDto(eq(updated), any());
         verify(returnCommandLogRepository, atLeast(2)).saveAndFlush(any(ReturnCommandLog.class));
@@ -146,7 +144,8 @@ class ReturnRequestCommandServiceTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("уже выполнена");
 
-        verify(orderReturnRequestService, never()).switchMode(any(), any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).setModeExchange(any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).setModeReturn(any(), any(), any(), any());
         verify(returnRequestMapper, never()).toDto(any(), any());
         verify(returnCommandLogRepository, never()).saveAndFlush(any(ReturnCommandLog.class));
     }
@@ -185,7 +184,8 @@ class ReturnRequestCommandServiceTest {
                 ZoneOffset.UTC);
 
         assertThat(result.legacyId()).isEqualTo(22L);
-        verify(orderReturnRequestService, never()).switchMode(any(), any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).setModeExchange(any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).setModeReturn(any(), any(), any(), any());
         verify(returnRequestMapper, never()).toDto(any(), any());
     }
 
@@ -205,7 +205,7 @@ class ReturnRequestCommandServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("требует объект payload");
 
-        verify(orderReturnRequestService, never()).updateReverseTrackAndComment(any(), any(), any(), any(), any());
+        verify(orderReturnRequestService, never()).updateReverseTrack(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotStateIntegrationTest.java
@@ -96,7 +96,7 @@ class BuyerTelegramBotStateIntegrationTest {
         lenient().when(telegramService.getActiveReturnRequests(anyLong())).thenReturn(List.of());
         lenient().when(telegramService.registerReturnRequestFromTelegram(anyLong(), anyLong(), anyString(), anyString()))
                 .thenReturn(new OrderReturnRequest());
-        lenient().when(telegramService.approveExchangeFromTelegram(anyLong(), anyLong(), anyLong()))
+        lenient().when(telegramService.setModeExchangeFromTelegram(anyLong(), anyLong(), anyLong()))
                 .thenReturn(new OrderReturnRequest());
         lenient().when(telegramClient.execute(any(EditMessageText.class))).thenReturn(null);
         lenient().when(telegramClient.execute(any(EditMessageReplyMarkup.class))).thenReturn(null);

--- a/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
+++ b/src/test/java/com/project/tracking_system/service/telegram/BuyerTelegramBotTest.java
@@ -2128,7 +2128,7 @@ class BuyerTelegramBotTest {
         when(registered.getId()).thenReturn(555L);
         when(telegramService.registerReturnRequestFromTelegram(eq(chatId), eq(77L), anyString(), anyString()))
                 .thenReturn(registered);
-        when(telegramService.approveExchangeFromTelegram(chatId, 77L, 555L))
+        when(telegramService.setModeExchangeFromTelegram(chatId, 77L, 555L))
                 .thenReturn(registered);
 
         Update reasonCallback = mockCallbackUpdate(chatId, "returns:create:reason:defect", anchorId);
@@ -2139,7 +2139,7 @@ class BuyerTelegramBotTest {
         assertEquals("Брак", reasonCaptor.getValue(),
                 "В сервис заявок должна передаваться выбранная пользователем причина обмена");
 
-        verify(telegramService).approveExchangeFromTelegram(chatId, 77L, 555L);
+        verify(telegramService).setModeExchangeFromTelegram(chatId, 77L, 555L);
 
         ArgumentCaptor<SendMessage> messageCaptor = ArgumentCaptor.forClass(SendMessage.class);
         verify(telegramClient, atLeastOnce()).execute(messageCaptor.capture());
@@ -2622,7 +2622,7 @@ class BuyerTelegramBotTest {
                                                           String comment,
                                                           String reverseTrack,
                                                           boolean exchangeRequested,
-                                                          boolean canStartExchange,
+                                                          boolean canSetModeExchange,
                                                           boolean canCloseWithoutExchange,
                                                           boolean canReopenAsReturn,
                                                           boolean canCancelExchange,
@@ -2651,7 +2651,7 @@ class BuyerTelegramBotTest {
                 returnReceiptConfirmed
         );
         List<String> actionCodes = new ArrayList<>();
-        if (canStartExchange) {
+        if (canSetModeExchange) {
             actionCodes.add(ReturnRequestAction.SET_MODE_EXCHANGE.getCode());
         }
         if (canCloseWithoutExchange) {

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -488,7 +488,7 @@ class TrackViewServiceTest {
         when(userService.getUserZone(15L)).thenReturn(ZoneId.of("UTC"));
         when(trackStatusEventService.findEvents(81L)).thenReturn(List.of());
         when(orderReturnRequestService.findCurrentForParcel(81L)).thenReturn(Optional.of(request));
-        when(orderReturnRequestService.canStartExchange(request)).thenReturn(true);
+        when(orderReturnRequestService.canSetModeExchange(request)).thenReturn(true);
         when(orderReturnRequestService.canConfirmReceipt(request)).thenReturn(true);
         when(orderReturnRequestService.canCreateExchangeParcel(request)).thenReturn(false);
         when(orderReturnRequestService.resolveAvailableActions(request))

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -90,14 +90,21 @@ describe('track-modal render', () => {
             : Array.isArray(rawActions.actionCodes)
                 ? rawActions.actionCodes
                 : (Array.isArray(request.actionCodes) ? request.actionCodes : []);
+        const codesSet = new Set(normalizedCodes.filter(Boolean).map((code) => String(code).toUpperCase()));
+        const hasAction = (code) => codesSet.has(String(code).toUpperCase());
         const availableActions = {
             ...rawActions,
-            startExchange: Boolean(request.canStartExchange ?? rawActions.startExchange ?? (mapLegacy('allowConvertToExchange') && mapLegacy('allowLaunchExchange'))),
-            createExchangeParcel: Boolean(request.canCreateExchangeParcel ?? rawActions.createExchangeParcel ?? mapLegacy('allowLaunchExchange')),
-            closeWithoutExchange: Boolean(request.canCloseWithoutExchange ?? rawActions.closeWithoutExchange ?? mapLegacy('allowClose')),
-            reopenAsReturn: Boolean(request.canReopenAsReturn ?? rawActions.reopenAsReturn ?? mapLegacy('allowConvertToReturn')),
-            cancelExchange: Boolean(request.canCancelExchange ?? rawActions.cancelExchange ?? mapLegacy('allowClose')),
-            confirmReceipt: Boolean(request.canConfirmReceipt ?? rawActions.confirmReceipt ?? mapLegacy('allowAcceptReverse') ?? mapLegacy('allowAccept')),
+            setModeExchange: Boolean(request.canSetModeExchange ?? request.canStartExchange ?? rawActions.setModeExchange ?? rawActions.startExchange ?? (mapLegacy('allowConvertToExchange') && mapLegacy('allowLaunchExchange')) || hasAction('SET_MODE_EXCHANGE')),
+            setModeReturn: Boolean(request.canSetModeReturn ?? request.canReopenAsReturn ?? rawActions.setModeReturn ?? rawActions.reopenAsReturn ?? mapLegacy('allowConvertToReturn') || hasAction('SET_MODE_RETURN')),
+            cancelExchange: Boolean(request.canCancelExchange ?? rawActions.cancelExchange ?? mapLegacy('allowClose') || hasAction('CANCEL_EXCHANGE')),
+            registerExchangeParcel: Boolean(request.canRegisterExchangeParcel ?? rawActions.registerExchangeParcel ?? rawActions.createExchangeParcel ?? mapLegacy('allowLaunchExchange') || hasAction('REGISTER_EXCHANGE_PARCEL')),
+            closeRequest: Boolean(request.canCloseRequest ?? request.canCloseWithoutExchange ?? rawActions.closeRequest ?? rawActions.closeWithoutExchange ?? mapLegacy('allowClose') || hasAction('CLOSE_REQUEST')),
+            updateReverseTrack: Boolean(request.canUpdateReverseTrack ?? rawActions.updateReverseTrack ?? mapLegacy('allowUpdate') || hasAction('UPDATE_REVERSE_TRACK')),
+            markOutboundSent: Boolean(request.canMarkOutboundSent ?? rawActions.markOutboundSent ?? hasAction('MARK_OUTBOUND_SENT')),
+            markInboundArrived: Boolean(request.canMarkInboundArrived ?? rawActions.markInboundArrived ?? hasAction('MARK_INBOUND_ARRIVED')),
+            markInboundPickedUp: Boolean(request.canMarkInboundPickedUp ?? rawActions.markInboundPickedUp ?? rawActions.confirmReceipt ?? mapLegacy('allowAcceptReverse') ?? mapLegacy('allowAccept') || hasAction('MARK_INBOUND_PICKED_UP')),
+            markExchangeSent: Boolean(request.canMarkExchangeSent ?? rawActions.markExchangeSent ?? hasAction('MARK_EXCHANGE_SENT')),
+            markExchangeDelivered: Boolean(request.canMarkExchangeDelivered ?? rawActions.markExchangeDelivered ?? hasAction('MARK_EXCHANGE_DELIVERED')),
             actions: normalizedCodes,
             actionCodes: normalizedCodes
         };


### PR DESCRIPTION
## Summary
- expose explicit availability flags from AvailableActionsDto based on ReturnRequestAction codes
- refactor OrderReturnRequestService and ReturnRequestWorkflow to use new mode switch APIs and stage MARK_* actions, requiring exchange tracks where needed
- update command handlers, Telegram flows, templates, and tests to align with the revised action set and flags

## Testing
- `mvn -q -DskipTests package` *(fails: dependency resolution blocked by jitpack.io 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f627698c832db5db7d671fb8eba1)