### PR TITLE
Enforce sequential return workflow transitions

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -1079,7 +1079,7 @@ public class OrderReturnRequestService {
     }
 
     /**
-     * Проверяет, можно ли отметить доставку обменной посылки.
+     * Проверяет, можно ли отметить доставку обменной посылки, подтверждая финальный статус в трекинге.
      */
     private boolean canMarkExchangeDelivered(OrderReturnRequest request) {
         if (request == null) {
@@ -1090,9 +1090,6 @@ public class OrderReturnRequestService {
         }
         if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_DELIVERED)) {
             return false;
-        }
-        if (hasExchangeTrack(request)) {
-            return true;
         }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDelivered)

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -330,7 +330,7 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(user);
         request.setExchangeTrackNumber(Optional.ofNullable(replacement).map(TrackParcel::getNumber).orElse(null));
         request.setExchangeTrackAssignedAt(assignedMoment);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SENT, true, user, assignedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.EXCHANGE_SENT, true, user, assignedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Создана обменная посылка {} для заявки {}",
@@ -356,7 +356,7 @@ public class OrderReturnRequestService {
         request.setClosedAt(closeMoment);
         request.setMode(ReturnRequestMode.RETURN);
         request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, closeMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.INBOUND_PICKED_UP, true, user, closeMoment);
 
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -412,7 +412,7 @@ public class OrderReturnRequestService {
         }
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
         request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.OUTBOUND_SENT, true, user, normalizedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.OUTBOUND_SENT, true, user, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Стадия OUTBOUND_SENT зафиксирована вручную для заявки {}", saved.getId());
@@ -433,7 +433,7 @@ public class OrderReturnRequestService {
         }
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
         request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_ARRIVED, true, user, normalizedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.INBOUND_ARRIVED, true, user, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Стадия INBOUND_ARRIVED зафиксирована вручную для заявки {}", saved.getId());
@@ -479,7 +479,7 @@ public class OrderReturnRequestService {
         String normalizedTrack = normalizeExchangeTrackNumber(exchangeTrack);
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
         assignExchangeTrack(request, normalizedTrack, normalizedMoment, user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, user, normalizedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, user, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Обменная посылка зарегистрирована вручную для заявки {}", saved.getId());
@@ -505,7 +505,7 @@ public class OrderReturnRequestService {
         String normalizedTrack = normalizeExchangeTrackNumber(exchangeTrack);
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
         assignExchangeTrack(request, normalizedTrack, normalizedMoment, user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_SENT, true, user, normalizedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.EXCHANGE_SENT, true, user, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Стадия EXCHANGE_SENT зафиксирована вручную для заявки {}", saved.getId());
@@ -526,7 +526,7 @@ public class OrderReturnRequestService {
         }
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
         request.setResponsibleManager(user);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_DELIVERED, true, user, normalizedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.EXCHANGE_DELIVERED, true, user, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
         log.info("Стадия EXCHANGE_DELIVERED зафиксирована вручную для заявки {}", saved.getId());
@@ -608,7 +608,7 @@ public class OrderReturnRequestService {
         }
         ReturnRequestStage normalizedStage = returnRequestWorkflow
                 .adjustStageForMode(ReturnRequestMode.EXCHANGE, resolveStage(request));
-        if (!returnRequestWorkflow.canTransition(ReturnRequestMode.EXCHANGE, normalizedStage,
+        if (!returnRequestWorkflow.canReachStage(ReturnRequestMode.EXCHANGE, normalizedStage,
                 ReturnRequestStage.EXCHANGE_REGISTERED)) {
             return false;
         }
@@ -869,7 +869,7 @@ public class OrderReturnRequestService {
         request.setClosedAt(null);
         request.setMode(ReturnRequestMode.EXCHANGE);
         request.setResponsibleManager(actor);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, actor, decisionMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, actor, decisionMoment);
         return request;
     }
 
@@ -895,7 +895,7 @@ public class OrderReturnRequestService {
                     ReturnRequestMode.RETURN,
                     Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW)
             );
-            returnRequestWorkflow.transitionToStage(request, normalized, true, actor, moment);
+            returnRequestWorkflow.transitionSequentially(request, normalized, true, actor, moment);
             return request;
         }
         if (status != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
@@ -921,11 +921,14 @@ public class OrderReturnRequestService {
         request.setResponsibleManager(actor);
         request.setExchangeTrackNumber(null);
         request.setExchangeTrackAssignedAt(null);
-        ReturnRequestStage normalized = returnRequestWorkflow.adjustStageForMode(
+        ReturnRequestStage targetStage = returnRequestWorkflow.adjustStageForMode(
                 ReturnRequestMode.RETURN,
                 Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW)
         );
-        returnRequestWorkflow.transitionToStage(request, normalized, true, actor, reopenMoment);
+        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            targetStage = ReturnRequestStage.INBOUND_PICKED_UP;
+        }
+        returnRequestWorkflow.transitionSequentially(request, targetStage, true, actor, reopenMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         return request;
@@ -1066,15 +1069,13 @@ public class OrderReturnRequestService {
         if (resolveMode(request) != ReturnRequestMode.EXCHANGE) {
             return false;
         }
-        if (!hasExchangeTrack(request)) {
-            return false;
-        }
         if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_SENT)) {
             return false;
         }
-        return orderExchangeService.findLatestExchangeParcel(request)
-                .map(this::isParcelDispatched)
-                .orElse(true);
+        if (hasExchangeTrack(request)) {
+            return true;
+        }
+        return orderExchangeService.findLatestExchangeParcel(request).isPresent();
     }
 
     /**
@@ -1087,15 +1088,15 @@ public class OrderReturnRequestService {
         if (resolveMode(request) != ReturnRequestMode.EXCHANGE) {
             return false;
         }
-        if (!hasExchangeTrack(request)) {
-            return false;
-        }
         if (!canTransitionToStage(request, ReturnRequestStage.EXCHANGE_DELIVERED)) {
             return false;
         }
+        if (hasExchangeTrack(request)) {
+            return true;
+        }
         return orderExchangeService.findLatestExchangeParcel(request)
                 .map(this::isParcelDelivered)
-                .orElse(true);
+                .orElse(false);
     }
 
     /**
@@ -1289,7 +1290,7 @@ public class OrderReturnRequestService {
         request.setReturnReceiptConfirmed(true);
         request.setReturnReceiptConfirmedAt(normalizedMoment);
         request.setResponsibleManager(actor);
-        returnRequestWorkflow.transitionToStage(request, ReturnRequestStage.INBOUND_PICKED_UP, true, actor, normalizedMoment);
+        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.INBOUND_PICKED_UP, true, actor, normalizedMoment);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -10,12 +10,14 @@ import com.project.tracking_system.service.order.context.ReturnRequestActionCont
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 
@@ -28,6 +30,24 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ReturnRequestWorkflow {
+
+    private static final Map<ReturnRequestMode, List<ReturnRequestStage>> STAGE_SEQUENCES = Map.of(
+            ReturnRequestMode.RETURN, List.of(
+                    ReturnRequestStage.NEW,
+                    ReturnRequestStage.OUTBOUND_SENT,
+                    ReturnRequestStage.INBOUND_ARRIVED,
+                    ReturnRequestStage.INBOUND_PICKED_UP
+            ),
+            ReturnRequestMode.EXCHANGE, List.of(
+                    ReturnRequestStage.NEW,
+                    ReturnRequestStage.OUTBOUND_SENT,
+                    ReturnRequestStage.INBOUND_ARRIVED,
+                    ReturnRequestStage.INBOUND_PICKED_UP,
+                    ReturnRequestStage.EXCHANGE_REGISTERED,
+                    ReturnRequestStage.EXCHANGE_SENT,
+                    ReturnRequestStage.EXCHANGE_DELIVERED
+            )
+    );
 
     private final Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> transitionTable;
     private final Map<ReturnRequestMode, Map<ReturnRequestStage, EnumSet<ReturnRequestAction>>> actionMatrix;
@@ -82,6 +102,70 @@ public class ReturnRequestWorkflow {
     }
 
     /**
+     * Переводит заявку по цепочке соседних стадий до целевой, соблюдая матрицу переходов.
+     * <p>
+     * Метод используется сервисами, когда нужно автоматически продвинуть заявку вперёд,
+     * не нарушая ограничений: он вычисляет маршрут через допустимые стадии и вызывает
+     * {@link #transitionToStage(OrderReturnRequest, ReturnRequestStage, boolean, User, ZonedDateTime)}
+     * для каждого шага. Финальный переход помечается как ручной, если передан соответствующий флаг.
+     * </p>
+     *
+     * @param request          заявка, которую требуется обновить
+     * @param targetStage      конечная стадия цепочки
+     * @param manualTransition признак ручного инициирования конечного шага
+     * @param actor            пользователь, выполнивший действие
+     * @param moment           момент фиксации перехода
+     */
+    public void transitionSequentially(OrderReturnRequest request,
+                                        ReturnRequestStage targetStage,
+                                        boolean manualTransition,
+                                        User actor,
+                                        ZonedDateTime moment) {
+        if (request == null || targetStage == null) {
+            return;
+        }
+        ZonedDateTime effectiveMoment = moment != null ? moment : ZonedDateTime.now(ZoneOffset.UTC);
+        ReturnRequestMode mode = safeMode(request.getMode());
+        ReturnRequestStage currentStage = adjustStageForMode(mode, safeStage(request.getStage()));
+        if (Objects.equals(currentStage, targetStage)) {
+            transitionToStage(request, targetStage, manualTransition, actor, effectiveMoment);
+            return;
+        }
+        for (ReturnRequestStage nextStage : resolveSequentialPath(mode, currentStage, targetStage)) {
+            boolean finalStep = Objects.equals(nextStage, targetStage);
+            boolean manualFlag = manualTransition && finalStep;
+            transitionToStage(request, nextStage, manualFlag, actor, effectiveMoment);
+        }
+    }
+
+    /**
+     * Проверяет, достижима ли целевая стадия из текущей через последовательность соседних переходов.
+     *
+     * @param mode       режим заявки
+     * @param fromStage  исходная стадия
+     * @param targetStage целевая стадия
+     * @return {@code true}, если маршрут существует
+     */
+    public boolean canReachStage(ReturnRequestMode mode,
+                                  ReturnRequestStage fromStage,
+                                  ReturnRequestStage targetStage) {
+        if (mode == null || fromStage == null || targetStage == null) {
+            return false;
+        }
+        ReturnRequestStage normalizedFrom = adjustStageForMode(mode, fromStage);
+        ReturnRequestStage normalizedTarget = adjustStageForMode(mode, targetStage);
+        if (Objects.equals(normalizedFrom, normalizedTarget)) {
+            return true;
+        }
+        try {
+            List<ReturnRequestStage> path = resolveSequentialPath(mode, normalizedFrom, normalizedTarget);
+            return !path.isEmpty();
+        } catch (IllegalStateException ex) {
+            return false;
+        }
+    }
+
+    /**
      * Определяет, допустим ли переход между стадиями в заданном режиме.
      *
      * @param mode        режим обработки заявки
@@ -104,7 +188,7 @@ public class ReturnRequestWorkflow {
         }
         Set<ReturnRequestStage> allowedTargets = modeTransitions.get(fromStage);
         if (allowedTargets == null || allowedTargets.isEmpty()) {
-            return allowedStages(mode).contains(targetStage);
+            return false;
         }
         return allowedTargets.contains(targetStage);
     }
@@ -180,40 +264,18 @@ public class ReturnRequestWorkflow {
         Map<ReturnRequestMode, Map<ReturnRequestStage, Set<ReturnRequestStage>>> table = new EnumMap<>(ReturnRequestMode.class);
 
         Map<ReturnRequestStage, Set<ReturnRequestStage>> returnTransitions = new EnumMap<>(ReturnRequestStage.class);
-        returnTransitions.put(ReturnRequestStage.NEW, EnumSet.of(
-                ReturnRequestStage.OUTBOUND_SENT,
-                ReturnRequestStage.INBOUND_ARRIVED,
-                ReturnRequestStage.INBOUND_PICKED_UP
-        ));
-        returnTransitions.put(ReturnRequestStage.OUTBOUND_SENT, EnumSet.of(
-                ReturnRequestStage.INBOUND_ARRIVED,
-                ReturnRequestStage.INBOUND_PICKED_UP
-        ));
+        returnTransitions.put(ReturnRequestStage.NEW, EnumSet.of(ReturnRequestStage.OUTBOUND_SENT));
+        returnTransitions.put(ReturnRequestStage.OUTBOUND_SENT, EnumSet.of(ReturnRequestStage.INBOUND_ARRIVED));
         returnTransitions.put(ReturnRequestStage.INBOUND_ARRIVED, EnumSet.of(ReturnRequestStage.INBOUND_PICKED_UP));
         returnTransitions.put(ReturnRequestStage.INBOUND_PICKED_UP, EnumSet.of(ReturnRequestStage.INBOUND_PICKED_UP));
         table.put(ReturnRequestMode.RETURN, returnTransitions);
 
         Map<ReturnRequestStage, Set<ReturnRequestStage>> exchangeTransitions = new EnumMap<>(ReturnRequestStage.class);
-        exchangeTransitions.put(ReturnRequestStage.NEW, EnumSet.of(
-                ReturnRequestStage.OUTBOUND_SENT,
-                ReturnRequestStage.INBOUND_ARRIVED,
-                ReturnRequestStage.INBOUND_PICKED_UP,
-                ReturnRequestStage.EXCHANGE_REGISTERED
-        ));
-        exchangeTransitions.put(ReturnRequestStage.OUTBOUND_SENT, EnumSet.of(
-                ReturnRequestStage.INBOUND_ARRIVED,
-                ReturnRequestStage.INBOUND_PICKED_UP,
-                ReturnRequestStage.EXCHANGE_REGISTERED
-        ));
-        exchangeTransitions.put(ReturnRequestStage.INBOUND_ARRIVED, EnumSet.of(
-                ReturnRequestStage.INBOUND_PICKED_UP,
-                ReturnRequestStage.EXCHANGE_REGISTERED
-        ));
+        exchangeTransitions.put(ReturnRequestStage.NEW, EnumSet.of(ReturnRequestStage.OUTBOUND_SENT));
+        exchangeTransitions.put(ReturnRequestStage.OUTBOUND_SENT, EnumSet.of(ReturnRequestStage.INBOUND_ARRIVED));
+        exchangeTransitions.put(ReturnRequestStage.INBOUND_ARRIVED, EnumSet.of(ReturnRequestStage.INBOUND_PICKED_UP));
         exchangeTransitions.put(ReturnRequestStage.INBOUND_PICKED_UP, EnumSet.of(ReturnRequestStage.EXCHANGE_REGISTERED));
-        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_REGISTERED, EnumSet.of(
-                ReturnRequestStage.EXCHANGE_SENT,
-                ReturnRequestStage.EXCHANGE_DELIVERED
-        ));
+        exchangeTransitions.put(ReturnRequestStage.EXCHANGE_REGISTERED, EnumSet.of(ReturnRequestStage.EXCHANGE_SENT));
         exchangeTransitions.put(ReturnRequestStage.EXCHANGE_SENT, EnumSet.of(ReturnRequestStage.EXCHANGE_DELIVERED));
         exchangeTransitions.put(ReturnRequestStage.EXCHANGE_DELIVERED, EnumSet.of(ReturnRequestStage.EXCHANGE_DELIVERED));
         table.put(ReturnRequestMode.EXCHANGE, exchangeTransitions);
@@ -276,31 +338,82 @@ public class ReturnRequestWorkflow {
     private EnumSet<ReturnRequestAction> mapTransitionToActions(ReturnRequestMode mode,
                                                                 ReturnRequestStage from,
                                                                 ReturnRequestStage target) {
-        if (target == null) {
+        if (mode == null || from == null || target == null) {
             return EnumSet.noneOf(ReturnRequestAction.class);
         }
-        return switch (target) {
-            case OUTBOUND_SENT -> EnumSet.of(ReturnRequestAction.MARK_OUTBOUND_SENT);
-            case INBOUND_ARRIVED -> EnumSet.of(ReturnRequestAction.MARK_INBOUND_ARRIVED);
-            case INBOUND_PICKED_UP -> EnumSet.of(ReturnRequestAction.MARK_INBOUND_PICKED_UP);
-            case EXCHANGE_SENT -> mode == ReturnRequestMode.EXCHANGE
+        return switch (mode) {
+            case RETURN -> mapReturnTransition(from, target);
+            case EXCHANGE -> mapExchangeTransition(from, target);
+        };
+    }
+
+    /**
+     * Возвращает действия для переходов в режиме возврата согласно матрице смежных стадий.
+     */
+    private EnumSet<ReturnRequestAction> mapReturnTransition(ReturnRequestStage from, ReturnRequestStage target) {
+        return switch (from) {
+            case NEW -> target == ReturnRequestStage.OUTBOUND_SENT
+                    ? EnumSet.of(ReturnRequestAction.MARK_OUTBOUND_SENT)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            case OUTBOUND_SENT -> target == ReturnRequestStage.INBOUND_ARRIVED
+                    ? EnumSet.of(ReturnRequestAction.MARK_INBOUND_ARRIVED)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            case INBOUND_ARRIVED -> target == ReturnRequestStage.INBOUND_PICKED_UP
+                    ? EnumSet.of(ReturnRequestAction.MARK_INBOUND_PICKED_UP)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            default -> EnumSet.noneOf(ReturnRequestAction.class);
+        };
+    }
+
+    /**
+     * Возвращает действия для переходов в режиме обмена, придерживаясь соседних стадий.
+     */
+    private EnumSet<ReturnRequestAction> mapExchangeTransition(ReturnRequestStage from, ReturnRequestStage target) {
+        return switch (from) {
+            case NEW -> target == ReturnRequestStage.OUTBOUND_SENT
+                    ? EnumSet.of(ReturnRequestAction.MARK_OUTBOUND_SENT)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            case OUTBOUND_SENT -> target == ReturnRequestStage.INBOUND_ARRIVED
+                    ? EnumSet.of(ReturnRequestAction.MARK_INBOUND_ARRIVED)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            case INBOUND_ARRIVED -> target == ReturnRequestStage.INBOUND_PICKED_UP
+                    ? EnumSet.of(ReturnRequestAction.MARK_INBOUND_PICKED_UP)
+                    : EnumSet.noneOf(ReturnRequestAction.class);
+            case EXCHANGE_REGISTERED -> target == ReturnRequestStage.EXCHANGE_SENT
                     ? EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_SENT)
                     : EnumSet.noneOf(ReturnRequestAction.class);
-            case EXCHANGE_DELIVERED -> mode == ReturnRequestMode.EXCHANGE
+            case EXCHANGE_SENT -> target == ReturnRequestStage.EXCHANGE_DELIVERED
                     ? EnumSet.of(ReturnRequestAction.MARK_EXCHANGE_DELIVERED)
                     : EnumSet.noneOf(ReturnRequestAction.class);
             default -> EnumSet.noneOf(ReturnRequestAction.class);
         };
     }
 
-    private Set<ReturnRequestStage> allowedStages(ReturnRequestMode mode) {
-        EnumSet<ReturnRequestStage> allowed = EnumSet.noneOf(ReturnRequestStage.class);
-        for (ReturnRequestStage stage : ReturnRequestStage.values()) {
-            if (stage.supportsMode(mode)) {
-                allowed.add(stage);
-            }
+    /**
+     * Строит список стадий, через которые нужно пройти при продвижении заявки.
+     */
+    private List<ReturnRequestStage> resolveSequentialPath(ReturnRequestMode mode,
+                                                           ReturnRequestStage from,
+                                                           ReturnRequestStage target) {
+        List<ReturnRequestStage> sequence = STAGE_SEQUENCES.get(mode);
+        if (sequence == null) {
+            throw new IllegalStateException("Не найдена последовательность стадий для режима " + mode);
         }
-        return Collections.unmodifiableSet(allowed);
+        int fromIndex = sequence.indexOf(from);
+        int targetIndex = sequence.indexOf(target);
+        if (fromIndex < 0 || targetIndex < 0 || targetIndex < fromIndex) {
+            throw new IllegalStateException(String.format(
+                    "Нельзя построить маршрут перехода %s→%s для режима %s",
+                    from,
+                    target,
+                    mode
+            ));
+        }
+        List<ReturnRequestStage> path = new ArrayList<>();
+        for (int i = fromIndex + 1; i <= targetIndex; i++) {
+            path.add(sequence.get(i));
+        }
+        return path;
     }
 
     private ReturnRequestMode safeMode(ReturnRequestMode mode) {

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -245,6 +245,7 @@ class OrderReturnRequestServiceTest {
         request.setEpisode(parcel.getEpisode());
         request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.INBOUND_PICKED_UP);
 
         when(repository.findById(500L)).thenReturn(Optional.of(request));
         when(repository.existsByEpisode_IdAndStatus(parcel.getEpisode().getId(),
@@ -273,9 +274,9 @@ class OrderReturnRequestServiceTest {
         request.setEpisode(parcel.getEpisode());
         request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
 
         when(repository.findById(701L)).thenReturn(Optional.of(request));
-        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         TrackParcel exchange = buildParcel(199L, GlobalStatus.PRE_REGISTERED);
@@ -300,6 +301,7 @@ class OrderReturnRequestServiceTest {
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
 
         TrackParcel activeReplacement = buildParcel(300L, GlobalStatus.PRE_REGISTERED);
 
@@ -481,7 +483,6 @@ class OrderReturnRequestServiceTest {
         request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
 
         when(repository.findById(1003L)).thenReturn(Optional.of(request));
-        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ZonedDateTime stageMoment = ZonedDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.ofHours(2));
@@ -526,7 +527,6 @@ class OrderReturnRequestServiceTest {
         request.setExchangeTrackNumber("EX777");
 
         when(repository.findById(1005L)).thenReturn(Optional.of(request));
-        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         ZonedDateTime stageMoment = ZonedDateTime.of(2024, 3, 1, 8, 45, 0, 0, ZoneOffset.UTC);
@@ -537,6 +537,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getStageUpdatedAt()).isEqualTo(stageMoment);
         assertThat(result.getResponsibleManager()).isEqualTo(user);
         verify(repository).save(request);
+        verify(repository).findById(1005L);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }
 
@@ -581,6 +582,7 @@ class OrderReturnRequestServiceTest {
         request.setParcel(parcel);
         request.setEpisode(parcel.getEpisode());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
 
         when(repository.findById(611L)).thenReturn(Optional.of(request));
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
@@ -734,6 +736,7 @@ class OrderReturnRequestServiceTest {
     void getExchangeCancellationBlockReason_ReturnsMessageWhenBlocked() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
         IllegalStateException cause = new IllegalStateException("Недоступно");
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
                 .thenThrow(cause);
@@ -783,9 +786,6 @@ class OrderReturnRequestServiceTest {
         User another = new User();
         another.setId(9L);
         parcel.setUser(another);
-        when(trackParcelService.findOwnedById(15L, 5L)).thenReturn(Optional.of(parcel));
-        when(repository.findByIdempotencyKey("conflict")).thenReturn(Optional.empty());
-        when(repository.findFirstByParcel_IdAndStatusIn(eq(15L), any())).thenReturn(Optional.empty());
 
         // emulate request saved earlier by other user
         OrderReturnRequest existing = new OrderReturnRequest();
@@ -948,9 +948,9 @@ class OrderReturnRequestServiceTest {
         assertThat(actions).contains(
                 ReturnRequestAction.SET_MODE_RETURN,
                 ReturnRequestAction.REGISTER_EXCHANGE_PARCEL,
-                ReturnRequestAction.MARK_EXCHANGE_SENT,
                 ReturnRequestAction.UPDATE_REVERSE_TRACK
         );
+        assertThat(actions).doesNotContain(ReturnRequestAction.MARK_EXCHANGE_SENT);
         assertThat(actions).doesNotContain(ReturnRequestAction.CLOSE_REQUEST);
     }
 
@@ -966,8 +966,6 @@ class OrderReturnRequestServiceTest {
         replacement.setStatus(GlobalStatus.IN_TRANSIT);
 
         when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(replacement));
-        when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
-                .thenThrow(new IllegalStateException("Отмена недоступна"));
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
@@ -976,7 +974,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void resolveAvailableActions_IncludesReturnStageMarksWhenTrackProvided() {
+    void resolveAvailableActions_ProvidesSequentialReturnMarks() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
         request.setStage(ReturnRequestStage.NEW);
@@ -985,11 +983,25 @@ class OrderReturnRequestServiceTest {
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
-        assertThat(actions).contains(
-                ReturnRequestAction.MARK_OUTBOUND_SENT,
-                ReturnRequestAction.MARK_INBOUND_ARRIVED,
-                ReturnRequestAction.MARK_INBOUND_PICKED_UP
-        );
+        assertThat(actions)
+                .contains(ReturnRequestAction.MARK_OUTBOUND_SENT)
+                .doesNotContain(ReturnRequestAction.MARK_INBOUND_ARRIVED, ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+
+        request.setStage(ReturnRequestStage.OUTBOUND_SENT);
+
+        actions = service.resolveAvailableActions(request);
+
+        assertThat(actions)
+                .contains(ReturnRequestAction.MARK_INBOUND_ARRIVED)
+                .doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT, ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+
+        request.setStage(ReturnRequestStage.INBOUND_ARRIVED);
+
+        actions = service.resolveAvailableActions(request);
+
+        assertThat(actions)
+                .contains(ReturnRequestAction.MARK_INBOUND_PICKED_UP)
+                .doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT, ReturnRequestAction.MARK_INBOUND_ARRIVED);
     }
 
     @Test
@@ -1011,7 +1023,6 @@ class OrderReturnRequestServiceTest {
         request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
         request.setMode(ReturnRequestMode.EXCHANGE);
 
-        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.empty());
 
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -520,7 +520,7 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
-    void markExchangeDelivered_TransitionsStageWhenTrackPresent() {
+    void markExchangeDelivered_TransitionsStageWhenParcelDelivered() {
         TrackParcel parcel = buildParcel(45L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = buildExchangeRequest(1005L, parcel);
         request.setStage(ReturnRequestStage.EXCHANGE_SENT);
@@ -528,6 +528,7 @@ class OrderReturnRequestServiceTest {
 
         when(repository.findById(1005L)).thenReturn(Optional.of(request));
         when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(parcel));
 
         ZonedDateTime stageMoment = ZonedDateTime.of(2024, 3, 1, 8, 45, 0, 0, ZoneOffset.UTC);
 
@@ -1046,6 +1047,25 @@ class OrderReturnRequestServiceTest {
         EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
 
         assertThat(actions).contains(ReturnRequestAction.MARK_EXCHANGE_SENT);
+        assertThat(actions).doesNotContain(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
+    }
+
+    @Test
+    void resolveAvailableActions_DoesNotAllowExchangeDeliveryWhenParcelInTransit() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setStage(ReturnRequestStage.EXCHANGE_SENT);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setExchangeTrackNumber("EXCH-3");
+
+        TrackParcel parcel = new TrackParcel();
+        parcel.setNumber("EXCH-3");
+        parcel.setStatus(GlobalStatus.IN_TRANSIT);
+
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(parcel));
+
+        EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
         assertThat(actions).doesNotContain(ReturnRequestAction.MARK_EXCHANGE_DELIVERED);
     }
 

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -43,16 +43,18 @@ class ReturnRequestWorkflowTest {
     }
 
     @Test
-    void transitionToStage_AllowsDirectExchangeLaunchFromNewStage() {
+    void transitionToStage_RejectsDirectExchangeLaunchFromNewStage() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setMode(ReturnRequestMode.EXCHANGE);
         request.setStage(ReturnRequestStage.NEW);
-        ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
 
-        workflow.transitionToStage(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, null, moment);
-
-        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_REGISTERED);
-        assertThat(request.getHistoryEntries()).hasSize(1);
+        assertThatThrownBy(() -> workflow.transitionToStage(
+                request,
+                ReturnRequestStage.EXCHANGE_REGISTERED,
+                true,
+                null,
+                ZonedDateTime.now(ZoneOffset.UTC)
+        )).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -92,9 +94,12 @@ class ReturnRequestWorkflowTest {
         EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(context);
 
         assertThat(actions)
-                .contains(ReturnRequestAction.SET_MODE_EXCHANGE,
+                .containsExactlyInAnyOrder(
+                        ReturnRequestAction.SET_MODE_EXCHANGE,
                         ReturnRequestAction.UPDATE_REVERSE_TRACK,
-                        ReturnRequestAction.CLOSE_REQUEST);
+                        ReturnRequestAction.CLOSE_REQUEST,
+                        ReturnRequestAction.MARK_OUTBOUND_SENT
+                );
     }
 
     @Test
@@ -117,10 +122,26 @@ class ReturnRequestWorkflowTest {
         EnumSet<ReturnRequestAction> actions = workflow.resolveBaseActions(context);
 
         assertThat(actions)
-                .contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL,
-                        ReturnRequestAction.MARK_EXCHANGE_SENT,
+                .containsExactlyInAnyOrder(
+                        ReturnRequestAction.REGISTER_EXCHANGE_PARCEL,
+                ReturnRequestAction.MARK_EXCHANGE_SENT,
                         ReturnRequestAction.SET_MODE_RETURN,
-                        ReturnRequestAction.CLOSE_REQUEST,
-                        ReturnRequestAction.UPDATE_REVERSE_TRACK);
+                        ReturnRequestAction.UPDATE_REVERSE_TRACK
+                );
+    }
+
+    @Test
+    void transitionSequentially_AdvancesReturnThroughAllStages() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setStage(ReturnRequestStage.NEW);
+        User manager = new User();
+        manager.setId(77L);
+        ZonedDateTime moment = ZonedDateTime.now(ZoneOffset.UTC);
+
+        workflow.transitionSequentially(request, ReturnRequestStage.INBOUND_PICKED_UP, true, manager, moment);
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        assertThat(request.getHistoryEntries()).hasSizeGreaterThanOrEqualTo(3);
     }
 }


### PR DESCRIPTION
## Summary
- restrict return/exchange stage transitions to neighbour-only moves in the workflow and map each move to a single action
- update return request service to drive stage progressions through the workflow helpers and align availability checks with the matrix
- refresh workflow and service tests to cover the sequential transitions and revised action lists

## Testing
- mvn -Dtest=ReturnRequestWorkflowTest,OrderReturnRequestServiceTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913af018c24832d9cea284d64bf5290)