### PR TITLE
Fix return stage fallback when converting from exchange

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -6,6 +6,7 @@ import com.project.tracking_system.entity.GlobalStatus;
 import com.project.tracking_system.entity.OrderEpisode;
 import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.OrderReturnRequestActionRequest;
+import com.project.tracking_system.entity.OrderReturnRequestHistoryEntry;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.ReturnRequestMode;
 import com.project.tracking_system.entity.ReturnRequestStage;
@@ -895,7 +896,8 @@ public class OrderReturnRequestService {
                     ReturnRequestMode.RETURN,
                     Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW)
             );
-            returnRequestWorkflow.transitionSequentially(request, normalized, true, actor, moment);
+            ReturnRequestStage targetStage = enforceReturnHistoryFloor(request, normalized);
+            returnRequestWorkflow.transitionSequentially(request, targetStage, true, actor, moment);
             return request;
         }
         if (status != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
@@ -925,13 +927,77 @@ public class OrderReturnRequestService {
                 ReturnRequestMode.RETURN,
                 Optional.ofNullable(request.getStage()).orElse(ReturnRequestStage.NEW)
         );
-        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            targetStage = ReturnRequestStage.INBOUND_PICKED_UP;
-        }
+        targetStage = enforceReturnHistoryFloor(request, targetStage);
         returnRequestWorkflow.transitionSequentially(request, targetStage, true, actor, reopenMoment);
         orderExchangeService.cancelExchangeParcel(request, replacement);
         episodeLifecycleService.decrementExchangeCount(request.getEpisode());
         return request;
+    }
+
+    /**
+     * Определяет минимальный допустимый этап для возврата, опираясь на историю.
+     * <p>
+     * Правило {@code doNotLowerBelowKnownHistory} запрещает понижать этап ниже тех,
+     * которые уже подтверждены в режиме возврата. Метод находит максимальный этап,
+     * достигнутый в истории при режиме {@link ReturnRequestMode#RETURN}, и гарантирует,
+     * что целевой этап не опустится ниже него.
+     * </p>
+     *
+     * @param request  заявка, историю которой анализируем
+     * @param candidateStage стадия, выбранная по текущим правилам переключения
+     * @return стадия, скорректированная с учётом истории
+     */
+    private ReturnRequestStage enforceReturnHistoryFloor(OrderReturnRequest request,
+                                                         ReturnRequestStage candidateStage) {
+        ReturnRequestStage effectiveCandidate = Optional.ofNullable(candidateStage)
+                .orElse(returnRequestWorkflow.initialStage(ReturnRequestMode.RETURN));
+        ReturnRequestStage historyStage = resolveHighestReturnStage(request);
+        boolean candidateBeforeHistory = returnRequestWorkflow.canReachStage(
+                ReturnRequestMode.RETURN,
+                effectiveCandidate,
+                historyStage
+        ) && !Objects.equals(effectiveCandidate, historyStage);
+        if (candidateBeforeHistory) {
+            return historyStage;
+        }
+        return effectiveCandidate;
+    }
+
+    /**
+     * Находит максимальный этап, достигнутый заявкой в режиме возврата.
+     * <p>
+     * Метод последовательно проходит историю и нормализует этапы через
+     * {@link ReturnRequestWorkflow#adjustStageForMode(ReturnRequestMode, ReturnRequestStage)}.
+     * Для сравнения используется порядок этапов, определённый матрицей переходов:
+     * если история уже содержит более поздний этап, он возвращается как опорный.
+     * </p>
+     *
+     * @param request заявка с накопленной историей
+     * @return максимальный этап возврата из истории или стартовый этап, если записей нет
+     */
+    private ReturnRequestStage resolveHighestReturnStage(OrderReturnRequest request) {
+        ReturnRequestStage floor = returnRequestWorkflow.initialStage(ReturnRequestMode.RETURN);
+        if (request == null) {
+            return floor;
+        }
+        for (OrderReturnRequestHistoryEntry entry : request.getHistoryEntries()) {
+            if (entry == null || entry.getMode() != ReturnRequestMode.RETURN) {
+                continue;
+            }
+            ReturnRequestStage historyStage = returnRequestWorkflow.adjustStageForMode(
+                    ReturnRequestMode.RETURN,
+                    entry.getStage()
+            );
+            boolean historyAfterFloor = returnRequestWorkflow.canReachStage(
+                    ReturnRequestMode.RETURN,
+                    floor,
+                    historyStage
+            ) && !Objects.equals(floor, historyStage);
+            if (historyAfterFloor) {
+                floor = historyStage;
+            }
+        }
+        return floor;
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -213,6 +213,9 @@ public class ReturnRequestWorkflow {
             return safeStage;
         }
         if (mode == ReturnRequestMode.RETURN) {
+            if (safeStage.isExchangeOnly()) {
+                return ReturnRequestStage.INBOUND_ARRIVED;
+            }
             return ReturnRequestStage.INBOUND_PICKED_UP;
         }
         return ReturnRequestStage.EXCHANGE_REGISTERED;

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -553,6 +553,8 @@ class OrderReturnRequestServiceTest {
         request.setEpisode(parcel.getEpisode());
         request.setStore(parcel.getStore());
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
 
         when(repository.findById(610L)).thenReturn(Optional.of(request));
         when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
@@ -568,7 +570,7 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getDecisionBy()).isNull();
         assertThat(result.getClosedAt()).isNull();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_ARRIVED);
         assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
@@ -871,6 +873,8 @@ class OrderReturnRequestServiceTest {
         request.setDecisionBy(user);
         request.setDecisionAt(ZonedDateTime.now(ZoneOffset.UTC));
         request.setExchangeRequested(true);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
 
         TrackParcel replacement = new TrackParcel();
         replacement.setId(81L);
@@ -892,9 +896,49 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getClosedAt()).isNull();
         assertThat(result.isExchangeRequested()).isFalse();
         assertThat(result.getMode()).isEqualTo(ReturnRequestMode.RETURN);
-        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_ARRIVED);
         assertThat(result.getHistoryEntries()).isNotEmpty();
         verify(orderExchangeService).cancelExchangeParcel(request, replacement);
+        verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void setModeReturn_preservesConfirmedReturnStageFromHistory() {
+        TrackParcel parcel = buildParcel(25L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(970L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
+        request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+
+        ZonedDateTime historyMoment = ZonedDateTime.of(2024, 1, 10, 12, 0, 0, 0, ZoneOffset.UTC);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setStage(ReturnRequestStage.NEW);
+        request.snapshotHistory(false, user, historyMoment);
+        request.setStage(ReturnRequestStage.OUTBOUND_SENT);
+        request.snapshotHistory(false, user, historyMoment.plusMinutes(5));
+        request.setStage(ReturnRequestStage.INBOUND_PICKED_UP);
+        request.snapshotHistory(true, user, historyMoment.plusMinutes(10));
+
+        request.setMode(ReturnRequestMode.EXCHANGE);
+        request.setStage(ReturnRequestStage.EXCHANGE_REGISTERED);
+
+        when(repository.findById(970L)).thenReturn(Optional.of(request));
+        when(orderExchangeService.getLatestExchangeParcelOrThrowIfTracked(request))
+                .thenReturn(Optional.empty());
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        OrderReturnRequest result = service.setModeReturn(970L,
+                25L,
+                user,
+                OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST);
+
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        verify(orderExchangeService).cancelExchangeParcel(request, null);
         verify(episodeLifecycleService).decrementExchangeCount(parcel.getEpisode());
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
     }


### PR DESCRIPTION
## Summary
- adjust the workflow fallback to return `INBOUND_ARRIVED` when normalizing exchange-only stages for return mode
- enforce the `doNotLowerBelowKnownHistory` rule when switching a request back to return mode
- cover conversion and history-preserving scenarios in the order return service tests

## Testing
- mvn -Dtest=OrderReturnRequestServiceTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913d0b406f0832d9a2bbf6fa9f54dea)