### PR TITLE
Align return request mapping with updated DTO

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestMapper.java
@@ -68,7 +68,6 @@ public class ReturnRequestMapper {
 
         return new RequestDto(
                 publicId,
-                request.getId(),
                 mode.name(),
                 stage.getCode(),
                 storeId,
@@ -81,11 +80,7 @@ public class ReturnRequestMapper {
                 request.getComment(),
                 request.getReverseTrackNumber(),
                 request.getExchangeTrackNumber(),
-                request.isManualTrackOverride(),
-                request.isManualStageOverride(),
                 manualInboundPick,
-                request.isReturnReceiptConfirmed(),
-                request.getExchangeTrackAssignedAt(),
                 createdAt,
                 updatedAt
         );

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -7,7 +7,9 @@ import com.project.tracking_system.entity.OrderReturnRequest;
 import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.controller.ReturnRequestCommandType;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.service.admin.AppInfoService;
 import com.project.tracking_system.service.order.OrderReturnRequestService;
+import com.project.tracking_system.service.ratelimit.Bucket4jRateLimiter;
 import com.project.tracking_system.service.order.ReturnRequestCommandService;
 import com.project.tracking_system.service.order.ReturnRequestMapper;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,12 @@ class ReturnsControllerTest {
     @MockBean
     private ReturnRequestCommandService returnRequestCommandService;
 
+    @MockBean
+    private AppInfoService appInfoService;
+
+    @MockBean
+    private Bucket4jRateLimiter bucket4jRateLimiter;
+
     @Test
     void registerReturn_returnsMappedDto() throws Exception {
         User principal = buildUser();
@@ -75,7 +83,7 @@ class ReturnsControllerTest {
                 eq(false)
         )).thenReturn(request);
 
-        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000015", 15L, "RETURN", "NEW", 17L, 7L);
+        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000015", "RETURN", "NEW", 17L, 7L);
         when(returnRequestMapper.toDto(eq(request), any())).thenReturn(responseDto);
 
         mockMvc.perform(post("/api/v1/returns")
@@ -92,8 +100,8 @@ class ReturnsControllerTest {
                                 "}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000015")))
-                .andExpect(jsonPath("$.legacyId", equalTo(15)))
-                .andExpect(jsonPath("$.reverseTrackNumber", equalTo("BY123")))
+                .andExpect(jsonPath("$.stage", equalTo("NEW")))
+                .andExpect(jsonPath("$.reverseTrack", equalTo("BY123")))
                 .andExpect(jsonPath("$.mode", equalTo("RETURN")));
 
         verify(orderReturnRequestService).registerReturn(
@@ -113,7 +121,7 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = buildAuthentication(principal);
 
-        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000021", 21L, "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
+        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000021", "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
         when(returnRequestCommandService.executeCommand(eq(21L), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
@@ -123,7 +131,6 @@ class ReturnsControllerTest {
                         .content("{\"idempotencyKey\":\"cmd-1\",\"action\":\"SET_MODE_EXCHANGE\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000021")))
-                .andExpect(jsonPath("$.legacyId", equalTo(21)))
                 .andExpect(jsonPath("$.mode", equalTo("EXCHANGE")));
         ArgumentCaptor<ReturnRequestCommandType> typeCaptor = ArgumentCaptor.forClass(ReturnRequestCommandType.class);
         ArgumentCaptor<CommandDto> commandCaptor = ArgumentCaptor.forClass(CommandDto.class);
@@ -140,7 +147,7 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = buildAuthentication(principal);
 
-        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000030", 30L, "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
+        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000030", "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
         when(returnRequestCommandService.executeCommand(eq(30L), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
@@ -168,12 +175,12 @@ class ReturnsControllerTest {
         OrderReturnRequest request = new OrderReturnRequest();
         when(orderReturnRequestService.getOwnedRequest(51L, principal)).thenReturn(request);
         when(returnRequestMapper.toDto(eq(request), any()))
-                .thenReturn(buildRequestDto("00000000-0000-0000-0000-000000000051", 51L, "RETURN", "NEW", 17L, 51L));
+                .thenReturn(buildRequestDto("00000000-0000-0000-0000-000000000051", "RETURN", "NEW", 17L, 51L));
 
         mockMvc.perform(get("/api/v1/returns/51")
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.legacyId", equalTo(51)));
+                .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000051")));
     }
 
     @Test
@@ -201,7 +208,6 @@ class ReturnsControllerTest {
     }
 
     private RequestDto buildRequestDto(String uuid,
-                                       Long legacyId,
                                        String mode,
                                        String stage,
                                        Long storeId,
@@ -209,7 +215,6 @@ class ReturnsControllerTest {
         ZonedDateTime timestamp = ZonedDateTime.parse("2024-01-01T10:15:30Z");
         return new RequestDto(
                 uuid,
-                legacyId,
                 mode,
                 stage,
                 storeId,
@@ -223,10 +228,6 @@ class ReturnsControllerTest {
                 "BY123",
                 "EX123",
                 false,
-                false,
-                false,
-                true,
-                timestamp,
                 timestamp,
                 timestamp
         );

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -1,7 +1,9 @@
 package com.project.tracking_system.service.order;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.project.tracking_system.controller.ReturnRequestCommandType;
 import com.project.tracking_system.dto.CommandDto;
 import com.project.tracking_system.dto.RequestDto;
@@ -62,7 +64,7 @@ class ReturnRequestCommandServiceTest {
     @BeforeEach
     void setUp() {
         payloadFactory = new ReturnRequestCommandPayloadFactory();
-        objectMapper = new ObjectMapper();
+        objectMapper = buildObjectMapper();
         commandService = new ReturnRequestCommandService(
                 orderReturnRequestService,
                 returnRequestMapper,
@@ -77,7 +79,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(21L, 9L);
         OrderReturnRequest updated = buildRequest(21L, 9L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000021", 21L, "EXCHANGE");
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000021", "EXCHANGE");
         CommandDto command = new CommandDto("dup-1", ReturnRequestCommandType.SET_MODE_EXCHANGE.getCode(), null);
 
         when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
@@ -156,10 +158,10 @@ class ReturnRequestCommandServiceTest {
         OrderReturnRequest request = buildRequest(22L, 10L);
         CommandDto command = new CommandDto("dup-3", ReturnRequestCommandType.SET_MODE_EXCHANGE.getCode(), null);
 
-        RequestDto storedDto = buildRequestDto("00000000-0000-0000-0000-000000000022", 22L, "EXCHANGE");
+        RequestDto storedDto = buildRequestDto("00000000-0000-0000-0000-000000000022", "EXCHANGE");
         String snapshot;
         try {
-            snapshot = new ObjectMapper().writeValueAsString(storedDto);
+            snapshot = buildObjectMapper().writeValueAsString(storedDto);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -183,7 +185,7 @@ class ReturnRequestCommandServiceTest {
                 user,
                 ZoneOffset.UTC);
 
-        assertThat(result.legacyId()).isEqualTo(22L);
+        assertThat(result.id()).isEqualTo("00000000-0000-0000-0000-000000000022");
         verify(orderReturnRequestService, never()).setModeExchange(any(), any(), any(), any());
         verify(orderReturnRequestService, never()).setModeReturn(any(), any(), any(), any());
         verify(returnRequestMapper, never()).toDto(any(), any());
@@ -232,7 +234,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(31L, 15L);
         OrderReturnRequest updated = buildRequest(31L, 15L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000031", 31L, "RETURN");
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000031", "RETURN");
 
         JsonNodeFactory factory = JsonNodeFactory.instance;
         CommandDto command = new CommandDto(
@@ -273,7 +275,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         OrderReturnRequest request = buildRequest(32L, 16L);
         OrderReturnRequest updated = buildRequest(32L, 16L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000032", 32L, "EXCHANGE");
+        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000032", "EXCHANGE");
 
         JsonNodeFactory factory = JsonNodeFactory.instance;
         CommandDto command = new CommandDto(
@@ -330,6 +332,16 @@ class ReturnRequestCommandServiceTest {
         return value != null ? value.getBytes(StandardCharsets.UTF_8) : new byte[0];
     }
 
+    /**
+     * Создаёт ObjectMapper с поддержкой JavaTime API для сериализации фикстур.
+     */
+    private ObjectMapper buildObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+
     private User buildUser() {
         User user = new User();
         user.setId(5L);
@@ -345,11 +357,10 @@ class ReturnRequestCommandServiceTest {
         return request;
     }
 
-    private RequestDto buildRequestDto(String uuid, Long legacyId, String mode) {
+    private RequestDto buildRequestDto(String uuid, String mode) {
         ZonedDateTime timestamp = ZonedDateTime.parse("2024-01-01T10:15:30Z");
         return new RequestDto(
                 uuid,
-                legacyId,
                 mode,
                 "NEW",
                 10L,
@@ -363,10 +374,6 @@ class ReturnRequestCommandServiceTest {
                 "BY123",
                 "EX123",
                 false,
-                false,
-                false,
-                true,
-                timestamp,
                 timestamp,
                 timestamp
         );

--- a/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/track/TrackViewServiceTest.java
@@ -508,10 +508,9 @@ class TrackViewServiceTest {
         assertThat(details.returnRequest()).isNotNull();
         assertThat(details.returnRequest().mode()).isEqualTo(ReturnRequestMode.EXCHANGE.name());
         assertThat(details.returnRequest().stage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP.getCode());
-        assertThat(details.returnRequest().reverseTrackNumber()).isEqualTo("REV-77");
+        assertThat(details.returnRequest().reverseTrack()).isEqualTo("REV-77");
         assertThat(details.returnRequest().comment()).isEqualTo("Комментарий клиента");
         assertThat(details.returnRequest().reason()).isEqualTo("Повреждение");
-        assertThat(details.returnRequest().returnReceiptConfirmed()).isFalse();
 
         assertThat(details.lifecycle())
                 .extracting(TrackLifecycleStageDto::code)
@@ -634,8 +633,7 @@ class TrackViewServiceTest {
         assertThat(details.returnRequest()).isNotNull();
         assertThat(details.returnRequest().mode()).isEqualTo(ReturnRequestMode.EXCHANGE.name());
         assertThat(details.returnRequest().stage()).isEqualTo(ReturnRequestStage.EXCHANGE_SENT.getCode());
-        assertThat(details.returnRequest().exchangeTrackNumber()).isEqualTo("EX-123");
-        assertThat(details.returnRequest().exchangeTrackAssignedAt()).isEqualTo(assignedAt);
+        assertThat(details.returnRequest().exchangeTrack()).isEqualTo("EX-123");
         assertThat(details.requiresAction()).isFalse();
     }
 


### PR DESCRIPTION
## Summary
- update `ReturnRequestMapper` to populate only the fields present in the new `RequestDto` schema and keep manual inbound flag timestamps
- refresh controller and service mapper tests to use the renamed DTO accessors and new constructor signature, adding missing mocks for shared infrastructure
- configure command service tests to serialize Java time values correctly and drop expectations for removed DTO properties

## Testing
- `mvn -Dtest=ReturnRequestCommandServiceTest test` *(fails: Mockito Strictness reports unnecessary stubs in existing tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691456220280832d8a52370429e8d990)