### PR TITLE
Allow optional reverse track payload

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
+++ b/src/main/java/com/project/tracking_system/service/order/payload/ReturnRequestCommandPayloadFactory.java
@@ -57,17 +57,17 @@ public class ReturnRequestCommandPayloadFactory {
     }
 
     /**
-     * Разбирает полезную нагрузку команды обновления обратного трека.
+     * Разбирает полезную нагрузку команды обновления обратного трека, допуская пустой payload и отсутствие полей.
      */
     private ReturnRequestCommandPayload parseUpdateReverseTrack(JsonNode payloadNode) {
         if (payloadNode == null || payloadNode.isNull()) {
-            throw new IllegalArgumentException("Команда UPDATE_REVERSE_TRACK требует объект payload с параметрами");
+            return new UpdateReverseTrackPayload(null, null);
         }
         if (!payloadNode.isObject()) {
             throw new IllegalArgumentException("Полезная нагрузка UPDATE_REVERSE_TRACK должна быть объектом JSON");
         }
 
-        String reverseTrack = requireReverseTrack(payloadNode.get("reverseTrack"));
+        String reverseTrack = normalizeTrack(payloadNode.get("reverseTrack"), "reverseTrack");
         String comment = normalizeComment(payloadNode.get("comment"));
 
         return new UpdateReverseTrackPayload(reverseTrack, comment);
@@ -149,17 +149,6 @@ public class ReturnRequestCommandPayloadFactory {
         String track = normalizeTrack(node, "exchangeTrack");
         if (track == null) {
             throw new IllegalArgumentException("Поле exchangeTrack обязательно для команды " + type.name());
-        }
-        return track;
-    }
-
-    /**
-     * Проверяет наличие обязательного обратного трека и приводит его к нормализованному виду.
-     */
-    private String requireReverseTrack(JsonNode node) {
-        String track = normalizeTrack(node, "reverseTrack");
-        if (track == null) {
-            throw new IllegalArgumentException("Поле reverseTrack обязательно для команды UPDATE_REVERSE_TRACK");
         }
         return track;
     }

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandPayloadFactoryTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandPayloadFactoryTest.java
@@ -56,14 +56,24 @@ class ReturnRequestCommandPayloadFactoryTest {
     }
 
     @Test
-    void create_whenUpdateReverseTrackWithoutTrack_throwsException() {
-        var node = JsonNodeFactory.instance.objectNode()
-                .putNull("reverseTrack")
-                .put("comment", "Комментарий");
+    void create_whenUpdateReverseTrackPayloadMissing_returnsPayloadWithNullFields() {
+        UpdateReverseTrackPayload payload = (UpdateReverseTrackPayload) factory
+                .create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, null);
 
-        assertThatThrownBy(() -> factory.create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("reverseTrack");
+        assertThat(payload.reverseTrack()).isNull();
+        assertThat(payload.comment()).isNull();
+    }
+
+    @Test
+    void create_whenUpdateReverseTrackWithOnlyComment_returnsPayloadWithComment() {
+        var node = JsonNodeFactory.instance.objectNode()
+                .put("comment", "  Комментарий только  ");
+
+        UpdateReverseTrackPayload payload = (UpdateReverseTrackPayload) factory
+                .create(ReturnRequestCommandType.UPDATE_REVERSE_TRACK, node);
+
+        assertThat(payload.reverseTrack()).isNull();
+        assertThat(payload.comment()).isEqualTo("Комментарий только");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow the UPDATE_REVERSE_TRACK command to accept absent payloads and optional reverse track values
- cover comment-only and track-only scenarios in ReturnRequestCommandPayloadFactoryTest

## Testing
- mvn -Dtest=ReturnRequestCommandPayloadFactoryTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146b5f202c832d8c240fbfcb60cd62)