### PR TITLE
Switch return request identifiers to UUID

### DIFF
--- a/src/main/java/com/project/tracking_system/controller/ReturnsController.java
+++ b/src/main/java/com/project/tracking_system/controller/ReturnsController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.UUID;
 /**
  * REST-контроллер управления заявками на возврат и обмен.
  * <p>
@@ -43,30 +44,32 @@ public class ReturnsController {
     /**
      * Возвращает карточку заявки на возврат.
      *
-     * @param id   идентификатор заявки
+     * @param rawId строковое представление UUID заявки
      * @param user текущий пользователь
      * @return DTO заявки
      */
     @GetMapping("/{id}")
-    public RequestDto getReturnRequest(@PathVariable Long id,
+    public RequestDto getReturnRequest(@PathVariable("id") String rawId,
                                         @AuthenticationPrincipal User user) {
         ensureAuthenticated(user);
-        OrderReturnRequest request = loadOwnedRequest(id, user);
+        UUID requestKey = parseRequestKey(rawId);
+        OrderReturnRequest request = loadOwnedRequest(requestKey, user);
         return returnRequestMapper.toDto(request, resolveUserZone(user));
     }
 
     /**
      * Возвращает доступные действия по заявке.
      *
-     * @param id   идентификатор заявки
+     * @param rawId строковое представление UUID заявки
      * @param user текущий пользователь
      * @return DTO с кодами доступных действий
      */
     @GetMapping("/{id}/available-actions")
-    public AvailableActionsDto getAvailableActions(@PathVariable Long id,
+    public AvailableActionsDto getAvailableActions(@PathVariable("id") String rawId,
                                                    @AuthenticationPrincipal User user) {
         ensureAuthenticated(user);
-        OrderReturnRequest request = loadOwnedRequest(id, user);
+        UUID requestKey = parseRequestKey(rawId);
+        OrderReturnRequest request = loadOwnedRequest(requestKey, user);
         return returnRequestMapper.toAvailableActions(request);
     }
 
@@ -98,13 +101,13 @@ public class ReturnsController {
     /**
      * Выполняет команду над заявкой и возвращает обновлённое состояние.
      *
-     * @param id      идентификатор заявки
+     * @param rawId   строковое представление UUID заявки
      * @param command тело запроса с кодом команды
      * @param user    текущий пользователь
      * @return обновлённый DTO заявки
      */
     @PostMapping("/{id}/commands")
-    public RequestDto executeCommand(@PathVariable Long id,
+    public RequestDto executeCommand(@PathVariable("id") String rawId,
                                       @RequestBody @Valid CommandDto command,
                                       @AuthenticationPrincipal User user) {
         ensureAuthenticated(user);
@@ -113,7 +116,8 @@ public class ReturnsController {
             throw new ValidationException("Неизвестная команда управления заявкой");
         }
         ZoneId userZone = resolveUserZone(user);
-        return returnRequestCommandService.executeCommand(id, commandType, command, user, userZone);
+        UUID requestKey = parseRequestKey(rawId);
+        return returnRequestCommandService.executeCommand(requestKey, commandType, command, user, userZone);
     }
 
     /**
@@ -128,8 +132,22 @@ public class ReturnsController {
     /**
      * Загружает заявку с проверкой принадлежности пользователю.
      */
-    private OrderReturnRequest loadOwnedRequest(Long id, User user) {
-        return orderReturnRequestService.getOwnedRequest(id, user);
+    private OrderReturnRequest loadOwnedRequest(UUID requestKey, User user) {
+        return orderReturnRequestService.getOwnedRequest(requestKey, user);
+    }
+
+    /**
+     * Преобразует строковый идентификатор заявки в UUID с валидацией.
+     */
+    private UUID parseRequestKey(String rawId) {
+        if (rawId == null || rawId.isBlank()) {
+            throw new ValidationException("Не указан идентификатор заявки");
+        }
+        try {
+            return UUID.fromString(rawId);
+        } catch (IllegalArgumentException ex) {
+            throw new ValidationException("Некорректный формат идентификатора заявки", ex);
+        }
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
@@ -104,5 +104,22 @@ public interface OrderReturnRequestRepository extends JpaRepository<OrderReturnR
             where r.id = :id
             """)
     Optional<OrderReturnRequest> findByIdWithDetails(@Param("id") Long id);
+
+    /**
+     * Возвращает заявку по идемпотентному ключу с ключевыми связями.
+     * <p>
+     * Используется REST-слоем, где требуется один запрос для загрузки заявки,
+     * связанной посылки и магазина, чтобы избежать дополнительных обращений к БД.
+     * </p>
+     */
+    @Query("""
+            select r from OrderReturnRequest r
+            join fetch r.parcel p
+            join fetch p.user
+            join fetch r.store
+            left join fetch r.responsibleManager
+            where r.idempotencyKey = :idempotencyKey
+            """)
+    Optional<OrderReturnRequest> findByIdempotencyKeyWithDetails(@Param("idempotencyKey") String idempotencyKey);
 }
 

--- a/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
+++ b/src/main/java/com/project/tracking_system/repository/OrderReturnRequestRepository.java
@@ -16,9 +16,13 @@ import java.util.Optional;
 public interface OrderReturnRequestRepository extends JpaRepository<OrderReturnRequest, Long> {
 
     /**
-     * Возвращает заявку по идемпотентному ключу.
+     * Возвращает заявку по идемпотентному ключу без учёта регистра.
      */
-    Optional<OrderReturnRequest> findByIdempotencyKey(String idempotencyKey);
+    @Query("""
+            select r from OrderReturnRequest r
+            where lower(r.idempotencyKey) = lower(:idempotencyKey)
+            """)
+    Optional<OrderReturnRequest> findByIdempotencyKey(@Param("idempotencyKey") String idempotencyKey);
 
     /**
      * Ищет активную заявку по посылке и статусам.
@@ -118,7 +122,7 @@ public interface OrderReturnRequestRepository extends JpaRepository<OrderReturnR
             join fetch p.user
             join fetch r.store
             left join fetch r.responsibleManager
-            where r.idempotencyKey = :idempotencyKey
+            where lower(r.idempotencyKey) = lower(:idempotencyKey)
             """)
     Optional<OrderReturnRequest> findByIdempotencyKeyWithDetails(@Param("idempotencyKey") String idempotencyKey);
 }

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Сервис управления заявками на возврат и обмен.
@@ -159,7 +160,7 @@ public class OrderReturnRequestService {
         ZonedDateTime normalizedRequestedAt = normalizeRequestedAt(requestedAt);
         String normalizedReverse = normalizeReverseTrackNumber(reverseTrack);
 
-        Optional<OrderReturnRequest> existingByKey = returnRequestRepository.findByIdempotencyKey(idempotencyKey);
+        Optional<OrderReturnRequest> existingByKey = findByIdempotencyKey(idempotencyKey);
         if (existingByKey.isPresent()) {
             OrderReturnRequest existing = existingByKey.get();
             ensureOwnership(existing, user.getId());
@@ -232,7 +233,7 @@ public class OrderReturnRequestService {
      * соблюдая принцип единой ответственности.
      * </p>
      *
-     * @param requestId идентификатор заявки
+     * @param requestKey UUID идентификатор заявки
      * @param parcelId  идентификатор посылки
      * @param user      автор решения
      * @return обновлённая заявка после переключения режима
@@ -378,7 +379,7 @@ public class OrderReturnRequestService {
      * отображения завершённости этапа «Приём возврата магазином».
      * </p>
      *
-     * @param requestId идентификатор заявки
+     * @param requestKey UUID идентификатор заявки
      * @param parcelId  идентификатор исходной посылки
      * @param user      менеджер, подтверждающий обработку
      * @return обновлённая заявка
@@ -1259,6 +1260,56 @@ public class OrderReturnRequestService {
     }
 
     /**
+     * Ищет заявку по строковому идемпотентному ключу с нормализацией ввода.
+     * <p>
+     * Метод обрабатывает пустые значения и удаляет лишние пробелы, чтобы
+     * клиенты могли передавать ключ без учёта регистра и форматирования.
+     * </p>
+     *
+     * @param idempotencyKey исходный ключ
+     * @return найденная заявка или {@link Optional#empty()}, если ключ некорректен или заявка отсутствует
+     */
+    @Transactional(readOnly = true)
+    public Optional<OrderReturnRequest> findByIdempotencyKey(String idempotencyKey) {
+        if (idempotencyKey == null) {
+            return Optional.empty();
+        }
+        String normalizedKey = idempotencyKey.trim();
+        if (normalizedKey.isEmpty()) {
+            return Optional.empty();
+        }
+        return returnRequestRepository.findByIdempotencyKey(normalizedKey);
+    }
+
+    /**
+     * Ищет заявку по UUID идемпотентного ключа.
+     *
+     * @param requestKey UUID ключа заявки
+     * @return найденная заявка или {@link Optional#empty()}, если ключ отсутствует
+     */
+    @Transactional(readOnly = true)
+    public Optional<OrderReturnRequest> findByIdempotencyKey(UUID requestKey) {
+        if (requestKey == null) {
+            return Optional.empty();
+        }
+        return findByIdempotencyKey(requestKey.toString());
+    }
+
+    /**
+     * Загружает заявку по UUID ключа вместе с ключевыми связями для REST-слоя.
+     *
+     * @param requestKey UUID ключа заявки
+     * @return заявка с инициализированными связями или {@link Optional#empty()}, если она не найдена
+     */
+    @Transactional(readOnly = true)
+    public Optional<OrderReturnRequest> findByIdempotencyKeyWithDetails(UUID requestKey) {
+        if (requestKey == null) {
+            return Optional.empty();
+        }
+        return returnRequestRepository.findByIdempotencyKeyWithDetails(requestKey.toString());
+    }
+
+    /**
      * Возвращает заявку пользователя, гарантируя принадлежность посылки.
      * <p>
      * Загружает связанные сущности (посылку, магазин и ответственного), чтобы контроллер
@@ -1270,14 +1321,14 @@ public class OrderReturnRequestService {
      * @return найденная заявка
      */
     @Transactional(readOnly = true)
-    public OrderReturnRequest getOwnedRequest(Long requestId, User user) {
-        if (requestId == null) {
+    public OrderReturnRequest getOwnedRequest(UUID requestKey, User user) {
+        if (requestKey == null) {
             throw new ValidationException("Не указан идентификатор заявки");
         }
         if (user == null || user.getId() == null) {
             throw new ValidationException("Не указан пользователь");
         }
-        OrderReturnRequest request = returnRequestRepository.findByIdWithDetails(requestId)
+        OrderReturnRequest request = findByIdempotencyKeyWithDetails(requestKey)
                 .orElseThrow(() -> new EntityNotFoundException("Заявка не найдена"));
         ensureOwnership(request, user.getId());
         return request;

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -32,6 +32,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -160,7 +161,11 @@ public class OrderReturnRequestService {
         ZonedDateTime normalizedRequestedAt = normalizeRequestedAt(requestedAt);
         String normalizedReverse = normalizeReverseTrackNumber(reverseTrack);
 
-        Optional<OrderReturnRequest> existingByKey = findByIdempotencyKey(idempotencyKey);
+        String canonicalKey = canonicalizeIdempotencyKey(idempotencyKey);
+        if (canonicalKey == null) {
+            throw new ValidationException("Некорректный идемпотентный ключ заявки");
+        }
+        Optional<OrderReturnRequest> existingByKey = findByIdempotencyKey(canonicalKey);
         if (existingByKey.isPresent()) {
             OrderReturnRequest existing = existingByKey.get();
             ensureOwnership(existing, user.getId());
@@ -200,7 +205,7 @@ public class OrderReturnRequestService {
         request.setComment(normalizedComment);
         request.setReverseTrackNumber(normalizedReverse);
         request.setStatus(OrderReturnRequestStatus.REGISTERED);
-        request.setIdempotencyKey(idempotencyKey);
+        request.setIdempotencyKey(canonicalKey);
         request.setExchangeRequested(exchangeRequested);
         request.setStore(parcel.getStore());
         request.setResponsibleManager(user);
@@ -1271,11 +1276,8 @@ public class OrderReturnRequestService {
      */
     @Transactional(readOnly = true)
     public Optional<OrderReturnRequest> findByIdempotencyKey(String idempotencyKey) {
-        if (idempotencyKey == null) {
-            return Optional.empty();
-        }
-        String normalizedKey = idempotencyKey.trim();
-        if (normalizedKey.isEmpty()) {
+        String normalizedKey = canonicalizeIdempotencyKey(idempotencyKey);
+        if (normalizedKey == null) {
             return Optional.empty();
         }
         return returnRequestRepository.findByIdempotencyKey(normalizedKey);
@@ -1306,7 +1308,11 @@ public class OrderReturnRequestService {
         if (requestKey == null) {
             return Optional.empty();
         }
-        return returnRequestRepository.findByIdempotencyKeyWithDetails(requestKey.toString());
+        String normalizedKey = canonicalizeIdempotencyKey(requestKey.toString());
+        if (normalizedKey == null) {
+            return Optional.empty();
+        }
+        return returnRequestRepository.findByIdempotencyKeyWithDetails(normalizedKey);
     }
 
     /**
@@ -1362,6 +1368,28 @@ public class OrderReturnRequestService {
         if (ownerId == null || !ownerId.equals(userId)) {
             throw new AccessDeniedException("Заявка принадлежит другому пользователю");
         }
+    }
+
+    /**
+     * Приводит идемпотентный ключ к каноническому виду для хранения и поиска.
+     * <p>
+     * Метод обрезает пробелы по краям и переводит значение в нижний регистр,
+     * чтобы одинаковые UUID, записанные в разных форматах, считались одной и той же заявкой.
+     * Возвращает {@code null}, если ключ не содержит символов после обрезки.
+     * </p>
+     *
+     * @param idempotencyKey исходное значение ключа
+     * @return нормализованный ключ или {@code null}, если строка пуста
+     */
+    private String canonicalizeIdempotencyKey(String idempotencyKey) {
+        if (idempotencyKey == null) {
+            return null;
+        }
+        String trimmed = idempotencyKey.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestCommandService.java
@@ -33,6 +33,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HexFormat;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Сервис идемпотентного выполнения команд по заявкам возврата.
@@ -72,7 +73,7 @@ public class ReturnRequestCommandService {
     /**
      * Выполняет команду с учётом идемпотентности и возвращает DTO заявки.
      *
-     * @param requestId идентификатор заявки
+     * @param requestKey UUID идентификатора заявки
      * @param commandType тип выполняемой команды
      * @param command данные запроса, включая ключ идемпотентности
      * @param user текущий пользователь
@@ -80,14 +81,15 @@ public class ReturnRequestCommandService {
      * @return DTO заявки после выполнения команды или сохранённый ранее результат
      */
     @Transactional
-    public RequestDto executeCommand(Long requestId,
+    public RequestDto executeCommand(UUID requestKey,
                                      ReturnRequestCommandType commandType,
                                      CommandDto command,
                                      User user,
                                      ZoneId userZone) {
-        validateArguments(requestId, commandType, command, user);
+        validateArguments(requestKey, commandType, command, user);
 
-        OrderReturnRequest context = orderReturnRequestService.getOwnedRequest(requestId, user);
+        OrderReturnRequest context = orderReturnRequestService.getOwnedRequest(requestKey, user);
+        Long requestId = requirePersistentId(context);
         Long parcelId = resolveParcelId(context);
 
         String normalizedKey = command.idempotencyKey().trim();
@@ -99,7 +101,7 @@ public class ReturnRequestCommandService {
             return restoreResponse(logEntry);
         }
 
-        CommandContext commandContext = new CommandContext(requestId, parcelId, user);
+        CommandContext commandContext = new CommandContext(requestKey, requestId, parcelId, user);
         OrderReturnRequest updated = performCommand(commandType, payload, commandContext);
         RequestDto response = returnRequestMapper.toDto(updated, userZone);
         completeLogEntry(logEntry, response);
@@ -109,11 +111,11 @@ public class ReturnRequestCommandService {
     /**
      * Проверяет корректность входных параметров запроса.
      */
-    private void validateArguments(Long requestId,
+    private void validateArguments(UUID requestKey,
                                    ReturnRequestCommandType commandType,
                                    CommandDto command,
                                    User user) {
-        if (requestId == null) {
+        if (requestKey == null) {
             throw new ValidationException("Не указан идентификатор заявки");
         }
         if (commandType == null) {
@@ -300,6 +302,22 @@ public class ReturnRequestCommandService {
     }
 
     /**
+     * Гарантирует наличие персистентного идентификатора заявки.
+     *
+     * @param request заявка, полученная из сервисного слоя
+     * @return идентификатор в базе данных
+     */
+    private Long requirePersistentId(OrderReturnRequest request) {
+        Long id = Optional.ofNullable(request)
+                .map(OrderReturnRequest::getId)
+                .orElse(null);
+        if (id == null) {
+            throw new IllegalStateException("У заявки отсутствует сохранённый идентификатор");
+        }
+        return id;
+    }
+
+    /**
      * Обрабатывает команду обновления обратного трека и возвращает актуальную заявку.
      */
     private OrderReturnRequest executeUpdateReverseTrack(CommandContext context,
@@ -313,14 +331,14 @@ public class ReturnRequestCommandService {
                 updatePayload.reverseTrack(),
                 updatePayload.comment()
         );
-        return orderReturnRequestService.getOwnedRequest(context.requestId(), context.user());
+        return orderReturnRequestService.getOwnedRequest(context.requestKey(), context.user());
     }
 
     /**
      * Выполняет закрытие заявки, учитывая её текущий статус.
      */
     private OrderReturnRequest executeCloseRequest(CommandContext context) {
-        OrderReturnRequest request = orderReturnRequestService.getOwnedRequest(context.requestId(), context.user());
+        OrderReturnRequest request = orderReturnRequestService.getOwnedRequest(context.requestKey(), context.user());
         return switch (request.getStatus()) {
             case REGISTERED -> orderReturnRequestService.closeRequest(context.requestId(),
                     context.parcelId(),
@@ -407,7 +425,8 @@ public class ReturnRequestCommandService {
     /**
      * Контекст выполняемой команды, содержащий ключевые параметры запроса.
      */
-    private record CommandContext(Long requestId,
+    private record CommandContext(UUID requestKey,
+                                  Long requestId,
                                   Long parcelId,
                                   User user) {
     }

--- a/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
+++ b/src/test/java/com/project/tracking_system/controller/ReturnsControllerTest.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -121,11 +122,12 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = buildAuthentication(principal);
 
-        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000021", "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
-        when(returnRequestCommandService.executeCommand(eq(21L), any(), any(), eq(principal), any()))
+        String requestUuid = "00000000-0000-0000-0000-000000000021";
+        RequestDto responseDto = buildRequestDto(requestUuid, "EXCHANGE", "EXCHANGE_REGISTERED", 17L, 11L);
+        when(returnRequestCommandService.executeCommand(eq(UUID.fromString(requestUuid)), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
-        mockMvc.perform(post("/api/v1/returns/21/commands")
+        mockMvc.perform(post("/api/v1/returns/" + requestUuid + "/commands")
                         .with(authentication(auth))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"idempotencyKey\":\"cmd-1\",\"action\":\"SET_MODE_EXCHANGE\"}"))
@@ -135,7 +137,7 @@ class ReturnsControllerTest {
         ArgumentCaptor<ReturnRequestCommandType> typeCaptor = ArgumentCaptor.forClass(ReturnRequestCommandType.class);
         ArgumentCaptor<CommandDto> commandCaptor = ArgumentCaptor.forClass(CommandDto.class);
 
-        verify(returnRequestCommandService).executeCommand(eq(21L), typeCaptor.capture(), commandCaptor.capture(), eq(principal), any());
+        verify(returnRequestCommandService).executeCommand(eq(UUID.fromString(requestUuid)), typeCaptor.capture(), commandCaptor.capture(), eq(principal), any());
         assertThat(typeCaptor.getValue()).isEqualTo(ReturnRequestCommandType.SET_MODE_EXCHANGE);
         assertThat(commandCaptor.getValue().action()).isEqualTo(ReturnRequestCommandType.SET_MODE_EXCHANGE.getCode());
         assertThat(commandCaptor.getValue().idempotencyKey()).isEqualTo("cmd-1");
@@ -147,11 +149,12 @@ class ReturnsControllerTest {
         User principal = buildUser();
         UsernamePasswordAuthenticationToken auth = buildAuthentication(principal);
 
-        RequestDto responseDto = buildRequestDto("00000000-0000-0000-0000-000000000030", "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
-        when(returnRequestCommandService.executeCommand(eq(30L), any(), any(), eq(principal), any()))
+        String requestUuid = "00000000-0000-0000-0000-000000000030";
+        RequestDto responseDto = buildRequestDto(requestUuid, "RETURN", "INBOUND_PICKED_UP", 17L, 30L);
+        when(returnRequestCommandService.executeCommand(eq(UUID.fromString(requestUuid)), any(), any(), eq(principal), any()))
                 .thenReturn(responseDto);
 
-        mockMvc.perform(post("/api/v1/returns/30/commands")
+        mockMvc.perform(post("/api/v1/returns/" + requestUuid + "/commands")
                         .with(authentication(auth))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"idempotencyKey\":\"cmd-2\",\"action\":\"UPDATE_REVERSE_TRACK\",\"payload\":{\"reverseTrack\":\"BY000\",\"comment\":\"Комментарий\"}}"))
@@ -160,7 +163,7 @@ class ReturnsControllerTest {
         ArgumentCaptor<ReturnRequestCommandType> typeCaptor = ArgumentCaptor.forClass(ReturnRequestCommandType.class);
         ArgumentCaptor<CommandDto> commandCaptor = ArgumentCaptor.forClass(CommandDto.class);
 
-        verify(returnRequestCommandService).executeCommand(eq(30L), typeCaptor.capture(), commandCaptor.capture(), eq(principal), any());
+        verify(returnRequestCommandService).executeCommand(eq(UUID.fromString(requestUuid)), typeCaptor.capture(), commandCaptor.capture(), eq(principal), any());
         assertThat(typeCaptor.getValue()).isEqualTo(ReturnRequestCommandType.UPDATE_REVERSE_TRACK);
         assertThat(commandCaptor.getValue().action()).isEqualTo(ReturnRequestCommandType.UPDATE_REVERSE_TRACK.getCode());
         assertThat(commandCaptor.getValue().payload().get("reverseTrack").asText()).isEqualTo("BY000");
@@ -173,11 +176,12 @@ class ReturnsControllerTest {
         UsernamePasswordAuthenticationToken auth = buildAuthentication(principal);
 
         OrderReturnRequest request = new OrderReturnRequest();
-        when(orderReturnRequestService.getOwnedRequest(51L, principal)).thenReturn(request);
+        String requestUuid = "00000000-0000-0000-0000-000000000051";
+        when(orderReturnRequestService.getOwnedRequest(UUID.fromString(requestUuid), principal)).thenReturn(request);
         when(returnRequestMapper.toDto(eq(request), any()))
-                .thenReturn(buildRequestDto("00000000-0000-0000-0000-000000000051", "RETURN", "NEW", 17L, 51L));
+                .thenReturn(buildRequestDto(requestUuid, "RETURN", "NEW", 17L, 51L));
 
-        mockMvc.perform(get("/api/v1/returns/51")
+        mockMvc.perform(get("/api/v1/returns/" + requestUuid)
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", equalTo("00000000-0000-0000-0000-000000000051")))
@@ -190,14 +194,15 @@ class ReturnsControllerTest {
         UsernamePasswordAuthenticationToken auth = buildAuthentication(principal);
 
         OrderReturnRequest request = new OrderReturnRequest();
-        when(orderReturnRequestService.getOwnedRequest(52L, principal)).thenReturn(request);
+        String requestUuid = "00000000-0000-0000-0000-000000000052";
+        when(orderReturnRequestService.getOwnedRequest(UUID.fromString(requestUuid), principal)).thenReturn(request);
         when(returnRequestMapper.toAvailableActions(request))
                 .thenReturn(new AvailableActionsDto(List.of(
                         ReturnRequestAction.SET_MODE_EXCHANGE.getCode(),
                         ReturnRequestAction.CLOSE_REQUEST.getCode()
                 )));
 
-        mockMvc.perform(get("/api/v1/returns/52/available-actions")
+        mockMvc.perform(get("/api/v1/returns/" + requestUuid + "/available-actions")
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.actions[0]", equalTo(ReturnRequestAction.SET_MODE_EXCHANGE.getCode())))

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -29,6 +29,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -129,8 +130,42 @@ class OrderReturnRequestServiceTest {
         assertThat(persisted.getReverseTrackNumber()).isEqualTo(DEFAULT_REVERSE_TRACK);
         assertThat(persisted.isExchangeRequested()).isFalse();
         assertThat(persisted.getHistoryEntries()).hasSize(1);
+        assertThat(persisted.getIdempotencyKey()).isEqualTo("key-1");
         verifyNoInteractions(orderExchangeService);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void registerReturn_NormalizesIdempotencyKeyToLowerCase() {
+        TrackParcel parcel = buildParcel(11L, GlobalStatus.DELIVERED);
+        when(trackParcelService.findOwnedById(11L, 5L)).thenReturn(Optional.of(parcel));
+        String uppercaseKey = "00000000-0000-0000-0000-00000000ABCD";
+        String canonicalKey = uppercaseKey.toLowerCase(Locale.ROOT);
+        when(repository.findByIdempotencyKey(canonicalKey)).thenReturn(Optional.empty());
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(11L), any())).thenReturn(Optional.empty());
+        when(episodeLifecycleService.ensureEpisode(parcel)).thenReturn(parcel.getEpisode());
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> {
+            OrderReturnRequest request = invocation.getArgument(0);
+            request.setId(300L);
+            return request;
+        });
+
+        OrderReturnRequest saved = service.registerReturn(
+                11L,
+                user,
+                uppercaseKey,
+                DEFAULT_REASON,
+                DEFAULT_COMMENT,
+                DEFAULT_REQUESTED_AT,
+                DEFAULT_REVERSE_TRACK,
+                NO_EXCHANGE_REQUESTED
+        );
+
+        assertThat(saved.getIdempotencyKey()).isEqualTo(canonicalKey);
+        verify(repository).findByIdempotencyKey(canonicalKey);
+        ArgumentCaptor<OrderReturnRequest> captor = ArgumentCaptor.forClass(OrderReturnRequest.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getIdempotencyKey()).isEqualTo(canonicalKey);
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestCommandServiceTest.java
@@ -32,6 +32,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HexFormat;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,12 +79,13 @@ class ReturnRequestCommandServiceTest {
     @Test
     void executeCommand_whenRepeated_returnsStoredSnapshot() {
         User user = buildUser();
-        OrderReturnRequest request = buildRequest(21L, 9L);
-        OrderReturnRequest updated = buildRequest(21L, 9L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000021", "EXCHANGE");
+        UUID requestKey = UUID.fromString("00000000-0000-0000-0000-000000000021");
+        OrderReturnRequest request = buildRequest(21L, 9L, requestKey);
+        OrderReturnRequest updated = buildRequest(21L, 9L, requestKey);
+        RequestDto dto = buildRequestDto(requestKey.toString(), "EXCHANGE");
         CommandDto command = new CommandDto("dup-1", ReturnRequestCommandType.SET_MODE_EXCHANGE.getCode(), null);
 
-        when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
+        when(orderReturnRequestService.getOwnedRequest(requestKey, user)).thenReturn(request);
         when(orderReturnRequestService.setModeExchange(21L,
                 9L,
                 user,
@@ -101,12 +103,12 @@ class ReturnRequestCommandServiceTest {
                     return logEntry;
                 });
 
-        RequestDto first = commandService.executeCommand(21L,
+        RequestDto first = commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.SET_MODE_EXCHANGE,
                 command,
                 user,
                 ZoneOffset.UTC);
-        RequestDto second = commandService.executeCommand(21L,
+        RequestDto second = commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.SET_MODE_EXCHANGE,
                 command,
                 user,
@@ -125,8 +127,9 @@ class ReturnRequestCommandServiceTest {
     @Test
     void executeCommand_whenPayloadDiffers_throwsConflict() {
         User user = buildUser();
-        OrderReturnRequest request = buildRequest(21L, 9L);
-        when(orderReturnRequestService.getOwnedRequest(21L, user)).thenReturn(request);
+        UUID requestKey = UUID.fromString("00000000-0000-0000-0000-000000000021");
+        OrderReturnRequest request = buildRequest(21L, 9L, requestKey);
+        when(orderReturnRequestService.getOwnedRequest(requestKey, user)).thenReturn(request);
 
         ReturnCommandLog existing = new ReturnCommandLog();
         existing.setRequestId(21L);
@@ -139,7 +142,7 @@ class ReturnRequestCommandServiceTest {
 
         CommandDto command = new CommandDto("dup-2", ReturnRequestCommandType.SET_MODE_EXCHANGE.getCode(), null);
 
-        assertThatThrownBy(() -> commandService.executeCommand(21L,
+        assertThatThrownBy(() -> commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.SET_MODE_EXCHANGE,
                 command,
                 user,
@@ -156,10 +159,11 @@ class ReturnRequestCommandServiceTest {
     @Test
     void executeCommand_whenConcurrentReservation_returnsStoredSnapshot() {
         User user = buildUser();
-        OrderReturnRequest request = buildRequest(22L, 10L);
+        UUID requestKey = UUID.fromString("00000000-0000-0000-0000-000000000022");
+        OrderReturnRequest request = buildRequest(22L, 10L, requestKey);
         CommandDto command = new CommandDto("dup-3", ReturnRequestCommandType.SET_MODE_EXCHANGE.getCode(), null);
 
-        RequestDto storedDto = buildRequestDto("00000000-0000-0000-0000-000000000022", "EXCHANGE");
+        RequestDto storedDto = buildRequestDto(requestKey.toString(), "EXCHANGE");
         String snapshot;
         try {
             snapshot = buildObjectMapper().writeValueAsString(storedDto);
@@ -167,7 +171,7 @@ class ReturnRequestCommandServiceTest {
             throw new RuntimeException(ex);
         }
 
-        when(orderReturnRequestService.getOwnedRequest(22L, user)).thenReturn(request);
+        when(orderReturnRequestService.getOwnedRequest(requestKey, user)).thenReturn(request);
         ReturnCommandLog completed = new ReturnCommandLog();
         completed.setRequestId(22L);
         completed.setIdempotencyKey("dup-3");
@@ -180,7 +184,7 @@ class ReturnRequestCommandServiceTest {
         when(returnCommandLogRepository.saveAndFlush(any(ReturnCommandLog.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate"));
 
-        RequestDto result = commandService.executeCommand(22L,
+        RequestDto result = commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.SET_MODE_EXCHANGE,
                 command,
                 user,
@@ -197,7 +201,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         CommandDto command = new CommandDto("dup-4", ReturnRequestCommandType.UPDATE_REVERSE_TRACK.getCode(), null);
 
-        assertThatThrownBy(() -> commandService.executeCommand(23L,
+        assertThatThrownBy(() -> commandService.executeCommand(UUID.fromString("00000000-0000-0000-0000-000000000023"),
                 ReturnRequestCommandType.UPDATE_REVERSE_TRACK,
                 command,
                 user,
@@ -213,7 +217,7 @@ class ReturnRequestCommandServiceTest {
         User user = buildUser();
         CommandDto command = new CommandDto("dup-5", ReturnRequestCommandType.MARK_EXCHANGE_SENT.getCode(), null);
 
-        assertThatThrownBy(() -> commandService.executeCommand(24L,
+        assertThatThrownBy(() -> commandService.executeCommand(UUID.fromString("00000000-0000-0000-0000-000000000024"),
                 ReturnRequestCommandType.MARK_EXCHANGE_SENT,
                 command,
                 user,
@@ -227,12 +231,13 @@ class ReturnRequestCommandServiceTest {
     @Test
     void executeCommand_whenMarkExchangeDeliveredWithoutPayload_executesWithNullMoment() {
         User user = buildUser();
-        OrderReturnRequest request = buildRequest(25L, 13L);
-        OrderReturnRequest updated = buildRequest(25L, 13L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000025", "EXCHANGE");
+        UUID requestKey = UUID.fromString("00000000-0000-0000-0000-000000000025");
+        OrderReturnRequest request = buildRequest(25L, 13L, requestKey);
+        OrderReturnRequest updated = buildRequest(25L, 13L, requestKey);
+        RequestDto dto = buildRequestDto(requestKey.toString(), "EXCHANGE");
         CommandDto command = new CommandDto("dup-6", ReturnRequestCommandType.MARK_EXCHANGE_DELIVERED.getCode(), null);
 
-        when(orderReturnRequestService.getOwnedRequest(25L, user)).thenReturn(request);
+        when(orderReturnRequestService.getOwnedRequest(requestKey, user)).thenReturn(request);
         when(orderReturnRequestService.markExchangeDelivered(eq(25L), eq(13L), eq(user), any())).thenReturn(updated);
         when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
 
@@ -246,7 +251,7 @@ class ReturnRequestCommandServiceTest {
                     return logEntry;
                 });
 
-        RequestDto result = commandService.executeCommand(25L,
+        RequestDto result = commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.MARK_EXCHANGE_DELIVERED,
                 command,
                 user,
@@ -261,9 +266,10 @@ class ReturnRequestCommandServiceTest {
     @Test
     void executeCommand_whenMarkOutboundSent_usesNormalizedStageMoment() {
         User user = buildUser();
-        OrderReturnRequest request = buildRequest(31L, 15L);
-        OrderReturnRequest updated = buildRequest(31L, 15L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000031", "RETURN");
+        UUID requestKey = UUID.fromString("00000000-0000-0000-0000-000000000031");
+        OrderReturnRequest request = buildRequest(31L, 15L, requestKey);
+        OrderReturnRequest updated = buildRequest(31L, 15L, requestKey);
+        RequestDto dto = buildRequestDto(requestKey.toString(), "RETURN");
 
         JsonNodeFactory factory = JsonNodeFactory.instance;
         CommandDto command = new CommandDto(
@@ -272,7 +278,7 @@ class ReturnRequestCommandServiceTest {
                 factory.objectNode().put("stageMoment", "2023-10-01T10:15:30+03:00")
         );
 
-        when(orderReturnRequestService.getOwnedRequest(31L, user)).thenReturn(request);
+        when(orderReturnRequestService.getOwnedRequest(requestKey, user)).thenReturn(request);
         when(orderReturnRequestService.markOutboundSent(eq(31L), eq(15L), eq(user), any()))
                 .thenReturn(updated);
         when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
@@ -287,7 +293,7 @@ class ReturnRequestCommandServiceTest {
                     return logEntry;
                 });
 
-        RequestDto result = commandService.executeCommand(31L,
+        RequestDto result = commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.MARK_OUTBOUND_SENT,
                 command,
                 user,
@@ -302,9 +308,10 @@ class ReturnRequestCommandServiceTest {
     @Test
     void executeCommand_whenRegisterExchangeParcel_normalizesTrackAndStageMoment() {
         User user = buildUser();
-        OrderReturnRequest request = buildRequest(32L, 16L);
-        OrderReturnRequest updated = buildRequest(32L, 16L);
-        RequestDto dto = buildRequestDto("00000000-0000-0000-0000-000000000032", "EXCHANGE");
+        UUID requestKey = UUID.fromString("00000000-0000-0000-0000-000000000032");
+        OrderReturnRequest request = buildRequest(32L, 16L, requestKey);
+        OrderReturnRequest updated = buildRequest(32L, 16L, requestKey);
+        RequestDto dto = buildRequestDto(requestKey.toString(), "EXCHANGE");
 
         JsonNodeFactory factory = JsonNodeFactory.instance;
         CommandDto command = new CommandDto(
@@ -315,7 +322,7 @@ class ReturnRequestCommandServiceTest {
                         .put("stageMoment", "2024-01-15T12:00:00+02:00")
         );
 
-        when(orderReturnRequestService.getOwnedRequest(32L, user)).thenReturn(request);
+        when(orderReturnRequestService.getOwnedRequest(requestKey, user)).thenReturn(request);
         when(orderReturnRequestService.registerExchangeParcel(eq(32L), eq(16L), eq(user), any(), any()))
                 .thenReturn(updated);
         when(returnRequestMapper.toDto(eq(updated), any())).thenReturn(dto);
@@ -330,7 +337,7 @@ class ReturnRequestCommandServiceTest {
                     return logEntry;
                 });
 
-        RequestDto result = commandService.executeCommand(32L,
+        RequestDto result = commandService.executeCommand(requestKey,
                 ReturnRequestCommandType.REGISTER_EXCHANGE_PARCEL,
                 command,
                 user,
@@ -377,9 +384,10 @@ class ReturnRequestCommandServiceTest {
         return user;
     }
 
-    private OrderReturnRequest buildRequest(Long requestId, Long parcelId) {
+    private OrderReturnRequest buildRequest(Long requestId, Long parcelId, UUID requestKey) {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setId(requestId);
+        request.setIdempotencyKey(requestKey != null ? requestKey.toString() : null);
         TrackParcel parcel = new TrackParcel();
         parcel.setId(parcelId);
         request.setParcel(parcel);

--- a/src/test/js/track-modal.test.js
+++ b/src/test/js/track-modal.test.js
@@ -469,7 +469,7 @@ describe('track-modal render', () => {
          * @param {Object} [options.refreshedDetails] DTO после обновления
          */
         mockSuccessfulCommandFlow(options = {}) {
-            const { requestDto = { id: 1, status: 'QUEUED' }, refreshedDetails = null } = options;
+            const { requestDto = { id: '00000000-0000-0000-0000-000000000001', status: 'QUEUED' }, refreshedDetails = null } = options;
             const headers = { get: jest.fn(() => 'application/json') };
             const trackResponse = refreshedDetails || this.details;
             if (typeof global.fetch?.mockClear === 'function') {
@@ -636,7 +636,7 @@ describe('track-modal render', () => {
                 { id: 10, number: 'RB111222333CN', exchange: false, returnShipment: false, current: false }
             ],
             returnRequest: {
-                id: 5,
+                id: '00000000-0000-0000-0000-000000000005',
                 state: 'REGISTERED_RETURN',
 status: 'Зарегистрирована',
                 statusLabel: 'Зарегистрирована',
@@ -802,7 +802,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 81,
+                id: '00000000-0000-0000-0000-000000000081',
                 state: 'EXCHANGE_LAUNCHED',
                 status: 'EXCHANGE_STARTED',
                 statusLabel: 'Обмен в работе',
@@ -873,7 +873,7 @@ status: 'Зарегистрирована',
             returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 81,
+                id: '00000000-0000-0000-0000-000000000081',
                 state: 'REGISTERED_RETURN',
                 status: 'REGISTERED',
                 statusLabel: 'Возврат',
@@ -905,7 +905,7 @@ status: 'Зарегистрирована',
             lifecycle: [],
             requiresAction: true
         };
-        const payload = { details: updatedDetails, actionRequired: { parcelId: 31, requestId: 81, requiresAction: true } };
+        const payload = { details: updatedDetails, actionRequired: { parcelId: 31, requestId: '00000000-0000-0000-0000-000000000081', requiresAction: true } };
         global.fetch.mockImplementation((url) => {
             if (String(url).includes('/close')) {
                 return Promise.resolve({ ok: true, headers, json: () => Promise.resolve(payload) });
@@ -928,7 +928,7 @@ status: 'Зарегистрирована',
             returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 81,
+                id: '00000000-0000-0000-0000-000000000081',
                 state: 'EXCHANGE_LAUNCHED',
                 status: 'EXCHANGE_STARTED',
                 statusLabel: 'Обмен в работе',
@@ -978,7 +978,7 @@ status: 'Зарегистрирована',
         await Promise.resolve();
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/81/commands'));
+        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/00000000-0000-0000-0000-000000000081/commands'));
         const requestDto = readCommandRequestDto(requestCall);
         expectValidIdempotencyKey(requestDto.idempotencyKey);
         expect(requestDto.action).toBe('CLOSE_REQUEST');
@@ -1011,7 +1011,7 @@ status: 'Зарегистрирована',
             returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 901,
+                id: '00000000-0000-0000-0000-000000000901',
                 state: 'REGISTERED_RETURN',
 status: 'Зарегистрирована',
                 statusLabel: 'Зарегистрирована',
@@ -1073,7 +1073,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 91,
+                id: '00000000-0000-0000-0000-000000000091',
                 state: 'REGISTERED_EXCHANGE',
                 status: 'REGISTERED',
                 statusLabel: 'Обмен запрошен',
@@ -1138,7 +1138,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 92,
+                id: '00000000-0000-0000-0000-000000000092',
                 state: 'REGISTERED_EXCHANGE',
                 status: 'REGISTERED',
                 statusLabel: 'Обмен согласован',
@@ -1203,7 +1203,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 93,
+                id: '00000000-0000-0000-0000-000000000093',
                 state: 'REGISTERED_EXCHANGE',
                 status: 'REGISTERED',
                 statusLabel: 'Обмен запрошен',
@@ -1266,7 +1266,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 82,
+                id: '00000000-0000-0000-0000-000000000082',
                 state: 'EXCHANGE_LAUNCHED',
                 status: 'EXCHANGE_STARTED',
                 statusLabel: 'Обмен согласован',
@@ -1388,7 +1388,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 5,
+                id: '00000000-0000-0000-0000-000000000005',
                 state: 'REGISTERED_RETURN',
 status: 'Зарегистрирована',
                 statusLabel: 'Зарегистрирована',
@@ -1433,7 +1433,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 5,
+                id: '00000000-0000-0000-0000-000000000005',
                 state: 'REGISTERED_RETURN',
 status: 'Зарегистрирована',
                 statusLabel: 'Зарегистрирована',
@@ -1493,7 +1493,7 @@ status: 'Зарегистрирована',
         await Promise.resolve();
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/5/commands'));
+        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/00000000-0000-0000-0000-000000000005/commands'));
         const requestDto = readCommandRequestDto(requestCall);
         expectValidIdempotencyKey(requestDto.idempotencyKey);
         expect(requestDto.action).toBe('UPDATE_REVERSE_TRACK');
@@ -1510,7 +1510,7 @@ status: 'Зарегистрирована',
         expect(commentInfo).toBeDefined();
         expect(global.window.returnRequests.updateRow).toHaveBeenCalledWith(expect.objectContaining({
             parcelId: 12,
-            requestId: 5,
+            requestId: '00000000-0000-0000-0000-000000000005',
             reverseTrack: 'RR123456789BY',
             comment: 'Обновлённый комментарий'
         }));
@@ -1533,7 +1533,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 6,
+                id: '00000000-0000-0000-0000-000000000006',
                 state: 'REGISTERED_RETURN',
 status: 'Зарегистрирована',
                 statusLabel: 'Зарегистрирована',
@@ -1579,7 +1579,7 @@ status: 'Зарегистрирована',
 
         expect(global.window.returnRequests.updateRow).toHaveBeenCalledWith(expect.objectContaining({
             parcelId: 14,
-            requestId: 6,
+            requestId: '00000000-0000-0000-0000-000000000006',
             returnReceiptConfirmed: true,
             returnReceiptConfirmedAt: '2024-03-01T09:00:00Z'
         }));
@@ -1668,7 +1668,7 @@ status: 'Зарегистрирована',
         setupDom();
         const headers = { get: jest.fn(() => 'application/json') };
         const responsePayload = {
-            id: 12,
+            id: '00000000-0000-0000-0000-000000000012',
             number: 'BY123',
             deliveryService: null,
             systemStatus: 'Вручена',
@@ -1701,7 +1701,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 5,
+                id: '00000000-0000-0000-0000-000000000005',
                 state: 'REGISTERED_RETURN',
                 status: 'REGISTERED',
                 statusLabel: 'Зарегистрирована',
@@ -1751,7 +1751,7 @@ status: 'Зарегистрирована',
         await Promise.resolve();
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/5/commands'));
+        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/00000000-0000-0000-0000-000000000005/commands'));
         const requestDto = readCommandRequestDto(requestCall);
         expectValidIdempotencyKey(requestDto.idempotencyKey);
         expect(requestDto.action).toBe('SET_MODE_EXCHANGE');
@@ -1763,9 +1763,9 @@ status: 'Зарегистрирована',
         setupDom();
 
         const headers = { get: jest.fn(() => 'application/json') };
-        const responsePayload = { id: 6, state: { stage: 'REGISTERED_EXCHANGE' } };
+        const responsePayload = { id: '00000000-0000-0000-0000-000000000006', state: { stage: 'REGISTERED_EXCHANGE' } };
         global.fetch.mockImplementation((url) => {
-            if (String(url).includes('/api/v1/returns/6/commands')) {
+            if (String(url).includes('/api/v1/returns/00000000-0000-0000-0000-000000000006/commands')) {
                 return Promise.resolve({ ok: true, headers, json: () => Promise.resolve(responsePayload) });
             }
             if (String(url).includes('/api/v1/tracks/14')) {
@@ -1788,7 +1788,7 @@ status: 'Зарегистрирована',
             exchange: false, returnShipment: false,
             chain: [],
             returnRequest: {
-                id: 6,
+                id: '00000000-0000-0000-0000-000000000006',
                 state: 'REGISTERED_EXCHANGE',
                 status: 'REGISTERED',
                 statusLabel: 'Зарегистрирована',
@@ -1845,7 +1845,7 @@ status: 'Зарегистрирована',
         await Promise.resolve();
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/6/commands'));
+        const requestCall = global.fetch.mock.calls.find((call) => String(call[0]).includes('/api/v1/returns/00000000-0000-0000-0000-000000000006/commands'));
         const requestDto = readCommandRequestDto(requestCall);
         expectValidIdempotencyKey(requestDto.idempotencyKey);
         expect(requestDto.action).toBe('REGISTER_EXCHANGE_PARCEL');
@@ -1875,7 +1875,7 @@ status: 'Зарегистрирована',
         });
         const driver = new ReturnRequestActionTestDriver(exchangeDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 15, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000015', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -1915,7 +1915,7 @@ status: 'Зарегистрирована',
         });
         const driver = new ReturnRequestActionTestDriver(returnDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 16, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000016', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -1955,7 +1955,7 @@ status: 'Зарегистрирована',
         disableExchangeLaunch(refreshedDetails);
         const driver = new ReturnRequestActionTestDriver(returnDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 17, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000017', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -1994,7 +1994,7 @@ status: 'Зарегистрирована',
         disableExchangeLaunch(refreshedDetails);
         const driver = new ReturnRequestActionTestDriver(returnDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 18, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000018', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -2035,7 +2035,7 @@ status: 'Зарегистрирована',
         disableExchangeLaunch(refreshedDetails);
         const driver = new ReturnRequestActionTestDriver(returnDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 19, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000019', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -2072,7 +2072,7 @@ status: 'Зарегистрирована',
         });
         const driver = new ReturnRequestActionTestDriver(exchangeDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 20, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000020', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -2109,7 +2109,7 @@ status: 'Зарегистрирована',
         });
         const driver = new ReturnRequestActionTestDriver(exchangeDetails);
         driver.mockSuccessfulCommandFlow({
-            requestDto: { id: 21, status: 'QUEUED' },
+            requestDto: { id: '00000000-0000-0000-0000-000000000021', status: 'QUEUED' },
             refreshedDetails
         });
 
@@ -2143,7 +2143,7 @@ status: 'Зарегистрирована',
             chain: [],
             exchangeParcel: { id: 77, number: 'EX777', statusLabel: 'В пути' },
             returnRequest: {
-                id: 9,
+                id: '00000000-0000-0000-0000-000000000009',
                 state: 'REGISTERED_RETURN',
 status: 'Обмен запускается',
                 statusLabel: 'Обмен запускается',
@@ -2206,7 +2206,7 @@ status: 'Обмен запускается',
                 { id: 31, number: 'BY999', exchange: false, returnShipment: false, current: true }
             ],
             returnRequest: {
-                id: 11,
+                id: '00000000-0000-0000-0000-000000000011',
                 state: 'REGISTERED_EXCHANGE',
                 status: 'REGISTERED',
                 statusLabel: 'Возврат',
@@ -2269,7 +2269,7 @@ status: 'Обмен запускается',
                 { id: 21, number: 'BY111', exchange: false, returnShipment: false, current: true }
             ],
             returnRequest: {
-                id: 3,
+                id: '00000000-0000-0000-0000-000000000003',
                 state: 'REGISTERED_RETURN',
 status: 'Зарегистрирована',
                 reason: 'Размер не подошёл',
@@ -2324,7 +2324,7 @@ status: 'Зарегистрирована',
                 { id: 22, number: 'BY222', exchange: false, returnShipment: false, current: true }
             ],
             returnRequest: {
-                id: 4,
+                id: '00000000-0000-0000-0000-000000000004',
                 state: 'REGISTERED_RETURN',
 status: 'Закрыта',
                 reason: 'Не подошло',


### PR DESCRIPTION
## Summary
- parse UUID path variables in the returns controller before delegating to services
- add UUID-based lookup helpers in the return request service and repository fetch method by idempotency key
- update command service, unit tests, and front-end tests/fixtures to work with UUID request identifiers

## Testing
- `mvn -q test` *(fails: existing StatusTrackServiceTest and other unrelated suites due to environment/data setup)*
- `mvn -q -Dtest=ReturnsControllerTest,ReturnRequestCommandServiceTest test` *(fails: application context setup issues in other Spring tests outside the targeted suites)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c5fb01dc832db522dfda4c1fbc52)