### PR TITLE
Handle return tracking events automatically

### DIFF
--- a/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
+++ b/src/main/java/com/project/tracking_system/service/analytics/DeliveryHistoryService.java
@@ -10,6 +10,9 @@ import com.project.tracking_system.repository.TrackParcelRepository;
 import com.project.tracking_system.repository.PostalServiceStatisticsRepository;
 import com.project.tracking_system.repository.StoreDailyStatisticsRepository;
 import com.project.tracking_system.repository.PostalServiceDailyStatisticsRepository;
+import com.project.tracking_system.service.order.ReturnTrackingEvent;
+import com.project.tracking_system.service.order.ReturnTrackingEventHandler;
+import com.project.tracking_system.service.order.ReturnTrackingEventType;
 import com.project.tracking_system.service.track.StatusTrackService;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
 import com.project.tracking_system.service.customer.CustomerService;
@@ -63,6 +66,7 @@ public class DeliveryHistoryService {
     private final SubscriptionService subscriptionService;
     private final DeliveryMetricsRollbackService deliveryMetricsRollbackService;
     private final OrderEpisodeLifecycleService orderEpisodeLifecycleService;
+    private final ReturnTrackingEventHandler returnTrackingEventHandler;
 
 
     /**
@@ -160,6 +164,7 @@ public class DeliveryHistoryService {
         }
 
         // Сохраняем историю, если что-то изменилось
+        publishReturnTrackingEvents(trackParcel, newStatus, deliveryDates);
         deliveryHistoryRepository.save(history);
         if (newStatus == GlobalStatus.PRE_REGISTERED) {
             log.debug("История доставки обновлена (PRE_REGISTERED): {}", trackParcel.getNumber());
@@ -186,6 +191,38 @@ public class DeliveryHistoryService {
             } else {
                 log.debug("Уведомление о статусе {} не было отправлено для трека {}", newStatus, trackParcel.getNumber());
             }
+        }
+    }
+
+    /**
+     * Публикует события трекинга для автоматического продвижения стадий заявок.
+     */
+    private void publishReturnTrackingEvents(TrackParcel trackParcel,
+                                             GlobalStatus newStatus,
+                                             DeliveryDates deliveryDates) {
+        if (trackParcel == null) {
+            return;
+        }
+        if (newStatus == GlobalStatus.RETURN_PENDING_PICKUP && !trackParcel.isExchange()) {
+            returnTrackingEventHandler.handle(new ReturnTrackingEvent(
+                    ReturnTrackingEventType.RETURN_ARRIVED_TO_STORE,
+                    trackParcel,
+                    deliveryDates != null ? deliveryDates.arrivedDate() : null
+            ));
+        }
+        if (newStatus == GlobalStatus.RETURNED && !trackParcel.isExchange()) {
+            returnTrackingEventHandler.handle(new ReturnTrackingEvent(
+                    ReturnTrackingEventType.RETURN_PICKED_UP_BY_STORE,
+                    trackParcel,
+                    deliveryDates != null ? deliveryDates.returnedDate() : null
+            ));
+        }
+        if (newStatus == GlobalStatus.DELIVERED && trackParcel.isExchange()) {
+            returnTrackingEventHandler.handle(new ReturnTrackingEvent(
+                    ReturnTrackingEventType.EXCHANGE_DELIVERED_TO_CUSTOMER,
+                    trackParcel,
+                    deliveryDates != null ? deliveryDates.receivedDate() : null
+            ));
         }
     }
 

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -574,7 +574,7 @@ public class OrderReturnRequestService {
                     request.getId(), request.getStatus());
             return Optional.empty();
         }
-        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        ZonedDateTime normalizedMoment = normalizeStageMomentForAutomation(stageMoment);
         returnRequestWorkflow.transitionSequentially(request, targetStage, false, null, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -643,7 +643,7 @@ public class OrderReturnRequestService {
             log.debug("Автоматическая отметка EXCHANGE_DELIVERED отклонена для заявки {}", request.getId());
             return Optional.empty();
         }
-        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        ZonedDateTime normalizedMoment = normalizeStageMomentForAutomation(stageMoment);
         returnRequestWorkflow.transitionSequentially(request, targetStage, false, null, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
         evictTrackDetailsCache(saved);
@@ -1570,7 +1570,9 @@ public class OrderReturnRequestService {
         if (request == null) {
             return;
         }
-        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        ZonedDateTime normalizedMoment = manualTransition
+                ? normalizeStageMoment(stageMoment)
+                : normalizeStageMomentForAutomation(stageMoment);
         if (!request.isReturnReceiptConfirmed()) {
             request.setReturnReceiptConfirmed(true);
             request.setReturnReceiptConfirmedAt(normalizedMoment);
@@ -1693,6 +1695,27 @@ public class OrderReturnRequestService {
         ZonedDateTime utc = stageMoment.withZoneSameInstant(ZoneOffset.UTC);
         if (utc.isAfter(now.plusMinutes(1))) {
             throw new ValidationException("Момент фиксации стадии не может быть в будущем");
+        }
+        return utc;
+    }
+
+    /**
+     * Нормализует момент фиксации стадии для автоматических переходов.
+     * <p>
+     * Если внешний сервис передал время с опережением (например, из-за расхождения часовых поясов),
+     * значение приравнивается к текущему времени. Такой подход защищает обновление истории доставки
+     * от сбоев и сохраняет идемпотентность, оставаясь в рамках инвариантов доменной модели.
+     * </p>
+     */
+    private ZonedDateTime normalizeStageMomentForAutomation(ZonedDateTime stageMoment) {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        if (stageMoment == null) {
+            return now;
+        }
+        ZonedDateTime utc = stageMoment.withZoneSameInstant(ZoneOffset.UTC);
+        if (utc.isAfter(now.plusMinutes(1))) {
+            log.debug("Автоматический момент {} скорректирован до текущего времени {}", utc, now);
+            return now;
         }
         return utc;
     }

--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -545,6 +545,113 @@ public class OrderReturnRequestService {
     }
 
     /**
+     * Автоматически фиксирует прибытие возврата по данным трекинга.
+     * <p>
+     * Метод идемпотентен: повторные события для одной и той же стадии только
+     * логируются и не вызывают повторного сохранения сущности. Это позволяет
+     * безопасно обрабатывать шум в источнике статусов и соответствует
+     * требованиям к интеграции с автоматическими обновлениями.
+     * </p>
+     *
+     * @param parcelId    идентификатор исходной посылки
+     * @param stageMoment момент события из системы трекинга
+     * @return обновлённая заявка или пустой результат, если переход недоступен
+     */
+    @Transactional
+    public Optional<OrderReturnRequest> autoMarkInboundArrived(Long parcelId, ZonedDateTime stageMoment) {
+        Optional<OrderReturnRequest> requestOpt = findCurrentForParcel(parcelId);
+        if (requestOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        OrderReturnRequest request = requestOpt.get();
+        ReturnRequestStage targetStage = ReturnRequestStage.INBOUND_ARRIVED;
+        if (hasReachedStage(request, targetStage)) {
+            log.debug("Повторное событие прибытия возврата для заявки {} пропущено", request.getId());
+            return Optional.empty();
+        }
+        if (!canMarkInboundArrived(request)) {
+            log.debug("Автоматическая отметка INBOUND_ARRIVED отклонена для заявки {} со статусом {}",
+                    request.getId(), request.getStatus());
+            return Optional.empty();
+        }
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        returnRequestWorkflow.transitionSequentially(request, targetStage, false, null, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия INBOUND_ARRIVED зафиксирована автоматически для заявки {}", saved.getId());
+        return Optional.of(saved);
+    }
+
+    /**
+     * Автоматически подтверждает получение возврата магазином.
+     * <p>
+     * Использует те же проверки, что и ручная команда, и предотвращает повторную
+     * фиксацию при приходе идентичных событий трекинга.
+     * </p>
+     *
+     * @param parcelId    идентификатор исходной посылки
+     * @param stageMoment момент события трекинга
+     * @return обновлённая заявка или пустой результат, если переход невозможен
+     */
+    @Transactional
+    public Optional<OrderReturnRequest> autoMarkInboundPickedUp(Long parcelId, ZonedDateTime stageMoment) {
+        Optional<OrderReturnRequest> requestOpt = findCurrentForParcel(parcelId);
+        if (requestOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        OrderReturnRequest request = requestOpt.get();
+        ReturnRequestStage targetStage = ReturnRequestStage.INBOUND_PICKED_UP;
+        if (hasReachedStage(request, targetStage)) {
+            log.debug("Повторное подтверждение приёма возврата для заявки {} пропущено", request.getId());
+            return Optional.empty();
+        }
+        if (!canMarkInboundPickedUp(request)) {
+            log.debug("Автоматическое подтверждение INBOUND_PICKED_UP отклонено для заявки {}", request.getId());
+            return Optional.empty();
+        }
+        confirmReturnProcessing(request, null, stageMoment, false);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия INBOUND_PICKED_UP зафиксирована автоматически для заявки {}", saved.getId());
+        return Optional.of(saved);
+    }
+
+    /**
+     * Автоматически отмечает доставку обменной посылки покупателю.
+     * <p>
+     * Метод проверяет, что обмен действительно запущен и подтверждён трекингом,
+     * после чего продвигает стадию вперёд без участия пользователя.
+     * </p>
+     *
+     * @param parcelId    идентификатор исходной посылки, инициировавшей обмен
+     * @param stageMoment момент доставки обменной посылки
+     * @return обновлённая заявка или пустой результат при отсутствии перехода
+     */
+    @Transactional
+    public Optional<OrderReturnRequest> autoMarkExchangeDelivered(Long parcelId, ZonedDateTime stageMoment) {
+        Optional<OrderReturnRequest> requestOpt = findCurrentForParcel(parcelId);
+        if (requestOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        OrderReturnRequest request = requestOpt.get();
+        ReturnRequestStage targetStage = ReturnRequestStage.EXCHANGE_DELIVERED;
+        if (hasReachedStage(request, targetStage)) {
+            log.debug("Повторное событие доставки обмена для заявки {} пропущено", request.getId());
+            return Optional.empty();
+        }
+        if (!canMarkExchangeDelivered(request)) {
+            log.debug("Автоматическая отметка EXCHANGE_DELIVERED отклонена для заявки {}", request.getId());
+            return Optional.empty();
+        }
+        ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        returnRequestWorkflow.transitionSequentially(request, targetStage, false, null, normalizedMoment);
+        OrderReturnRequest saved = returnRequestRepository.save(request);
+        evictTrackDetailsCache(saved);
+        log.info("Стадия EXCHANGE_DELIVERED зафиксирована автоматически для заявки {}", saved.getId());
+        return Optional.of(saved);
+    }
+
+    /**
      * Регистрирует запрос покупателя магазину по активной заявке обмена.
      * <p>
      * Используется, когда отмена или перевод обмена невозможны автоматически,
@@ -1189,6 +1296,18 @@ public class OrderReturnRequestService {
     }
 
     /**
+     * Проверяет, достигла ли заявка указанной стадии или продвинулась дальше.
+     */
+    private boolean hasReachedStage(OrderReturnRequest request, ReturnRequestStage targetStage) {
+        if (request == null || targetStage == null) {
+            return false;
+        }
+        ReturnRequestMode mode = resolveMode(request);
+        ReturnRequestStage normalized = returnRequestWorkflow.adjustStageForMode(mode, resolveStage(request));
+        return returnRequestWorkflow.canReachStage(mode, targetStage, normalized);
+    }
+
+    /**
      * Проверяет, разрешён ли переход на указанную стадию.
      */
     private boolean canTransitionToStage(OrderReturnRequest request, ReturnRequestStage targetStage) {
@@ -1432,11 +1551,38 @@ public class OrderReturnRequestService {
         if (request == null || request.isReturnReceiptConfirmed()) {
             return;
         }
+        confirmReturnProcessing(request, actor, stageMoment, true);
+    }
+
+    /**
+     * Фиксирует получение возврата с учётом источника события.
+     * <p>
+     * Метод переиспользуется как ручными, так и автоматическими сценариями,
+     * поэтому устанавливает ответственного менеджера только при явном указании
+     * пользователя. Это позволяет не затирать данные при обработке триггеров
+     * из трекинга и соблюсти принцип единой ответственности.
+     * </p>
+     */
+    private void confirmReturnProcessing(OrderReturnRequest request,
+                                         User actor,
+                                         ZonedDateTime stageMoment,
+                                         boolean manualTransition) {
+        if (request == null) {
+            return;
+        }
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
-        request.setReturnReceiptConfirmed(true);
-        request.setReturnReceiptConfirmedAt(normalizedMoment);
-        request.setResponsibleManager(actor);
-        returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.INBOUND_PICKED_UP, true, actor, normalizedMoment);
+        if (!request.isReturnReceiptConfirmed()) {
+            request.setReturnReceiptConfirmed(true);
+            request.setReturnReceiptConfirmedAt(normalizedMoment);
+        }
+        if (actor != null) {
+            request.setResponsibleManager(actor);
+        }
+        returnRequestWorkflow.transitionSequentially(request,
+                ReturnRequestStage.INBOUND_PICKED_UP,
+                manualTransition,
+                actor,
+                normalizedMoment);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnTrackingEvent.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnTrackingEvent.java
@@ -1,0 +1,17 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.TrackParcel;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Событие, зафиксированное в трекинге и влияющее на стадию заявки возврата.
+ * <p>
+ * Запись агрегирует тип события, посылку-источник и момент времени,
+ * чтобы обработчик мог выбрать корректную бизнес-логику.
+ * </p>
+ */
+public record ReturnTrackingEvent(ReturnTrackingEventType type,
+                                  TrackParcel parcel,
+                                  ZonedDateTime occurredAt) {
+}

--- a/src/main/java/com/project/tracking_system/service/order/ReturnTrackingEventHandler.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnTrackingEventHandler.java
@@ -1,0 +1,81 @@
+package com.project.tracking_system.service.order;
+
+import com.project.tracking_system.entity.TrackParcel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+/**
+ * Обрабатывает события трекинга, продвигая стадии заявок возврата и обмена.
+ * <p>
+ * Компонент выступает прослойкой между модулем обновления статусов и
+ * {@link OrderReturnRequestService}, чтобы не смешивать ответственность
+ * и упростить тестирование автоматических переходов.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReturnTrackingEventHandler {
+
+    private final OrderReturnRequestService orderReturnRequestService;
+
+    /**
+     * Обрабатывает событие трекинга и делегирует переход стадий в сервис заявок.
+     *
+     * @param event доменное событие трекинга
+     */
+    public void handle(ReturnTrackingEvent event) {
+        if (event == null) {
+            return;
+        }
+        ReturnTrackingEventType type = event.type();
+        TrackParcel parcel = event.parcel();
+        if (type == null || parcel == null) {
+            log.debug("Событие трекинга проигнорировано из-за отсутствующих данных");
+            return;
+        }
+        switch (type) {
+            case RETURN_ARRIVED_TO_STORE -> handleReturnArrival(parcel, event.occurredAt());
+            case RETURN_PICKED_UP_BY_STORE -> handleReturnPickup(parcel, event.occurredAt());
+            case EXCHANGE_DELIVERED_TO_CUSTOMER -> handleExchangeDelivery(parcel, event.occurredAt());
+            default -> log.debug("Неизвестный тип события трекинга: {}", type);
+        }
+    }
+
+    private void handleReturnArrival(TrackParcel parcel, ZonedDateTime moment) {
+        Long parcelId = parcel.getId();
+        if (parcelId == null) {
+            log.debug("Невозможно зафиксировать прибытие возврата: не указан идентификатор посылки");
+            return;
+        }
+        orderReturnRequestService.autoMarkInboundArrived(parcelId, moment);
+    }
+
+    private void handleReturnPickup(TrackParcel parcel, ZonedDateTime moment) {
+        Long parcelId = parcel.getId();
+        if (parcelId == null) {
+            log.debug("Невозможно подтвердить получение возврата: не указан идентификатор посылки");
+            return;
+        }
+        orderReturnRequestService.autoMarkInboundPickedUp(parcelId, moment);
+    }
+
+    private void handleExchangeDelivery(TrackParcel exchangeParcel, ZonedDateTime moment) {
+        if (exchangeParcel.getReplacementOf() == null) {
+            log.debug("Обменная посылка {} не связана с исходной, событие доставки пропущено", exchangeParcel.getId());
+            return;
+        }
+        Long originalParcelId = Optional.ofNullable(exchangeParcel.getReplacementOf())
+                .map(TrackParcel::getId)
+                .orElse(null);
+        if (originalParcelId == null) {
+            log.debug("Не удалось определить исходную посылку для обмена {}, событие пропущено", exchangeParcel.getId());
+            return;
+        }
+        orderReturnRequestService.autoMarkExchangeDelivered(originalParcelId, moment);
+    }
+}

--- a/src/main/java/com/project/tracking_system/service/order/ReturnTrackingEventType.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnTrackingEventType.java
@@ -1,0 +1,13 @@
+package com.project.tracking_system.service.order;
+
+/**
+ * Тип события трекинга, которое влияет на стадии обработки возврата или обмена.
+ */
+public enum ReturnTrackingEventType {
+    /** Возврат прибыл на склад магазина и ожидает обработки. */
+    RETURN_ARRIVED_TO_STORE,
+    /** Магазин получил возврат и завершил обработку поступления. */
+    RETURN_PICKED_UP_BY_STORE,
+    /** Обменная посылка успешно доставлена покупателю. */
+    EXCHANGE_DELIVERED_TO_CUSTOMER
+}

--- a/src/test/java/com/project/tracking_system/service/analytics/DeliveryHistoryServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/analytics/DeliveryHistoryServiceTest.java
@@ -8,8 +8,12 @@ import com.project.tracking_system.repository.*;
 import com.project.tracking_system.service.SubscriptionService;
 import com.project.tracking_system.service.customer.CustomerService;
 import com.project.tracking_system.service.customer.CustomerStatsService;
+import com.project.tracking_system.service.order.ReturnTrackingEvent;
+import com.project.tracking_system.service.order.ReturnTrackingEventHandler;
+import com.project.tracking_system.service.order.ReturnTrackingEventType;
 import com.project.tracking_system.service.track.StatusTrackService;
 import com.project.tracking_system.service.track.TypeDefinitionTrackPostService;
+import org.mockito.ArgumentCaptor;
 import com.project.tracking_system.service.telegram.TelegramNotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,13 +24,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.project.tracking_system.service.order.OrderEpisodeLifecycleService;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -73,13 +80,15 @@ class DeliveryHistoryServiceTest {
     private DeliveryMetricsRollbackService deliveryMetricsRollbackService;
     @Mock
     private OrderEpisodeLifecycleService orderEpisodeLifecycleService;
+    @Mock
+    private ReturnTrackingEventHandler returnTrackingEventHandler;
 
     @InjectMocks
     private DeliveryHistoryService deliveryHistoryService;
 
     @BeforeEach
     void setupEpisodes() {
-        doAnswer(invocation -> {
+        lenient().doAnswer(invocation -> {
             TrackParcel parcel = invocation.getArgument(0);
             OrderEpisode episode = parcel.getEpisode();
             if (episode == null) {
@@ -89,13 +98,38 @@ class DeliveryHistoryServiceTest {
             return episode;
         }).when(orderEpisodeLifecycleService).ensureEpisode(any());
 
-        doAnswer(invocation -> {
+        lenient().doAnswer(invocation -> {
             TrackParcel parcel = invocation.getArgument(0);
             if (parcel.getEpisode() == null) {
                 parcel.setEpisode(new OrderEpisode());
             }
             return null;
         }).when(orderEpisodeLifecycleService).syncEpisodeCustomer(any());
+
+        lenient().when(storeAnalyticsRepository.findByStoreId(anyLong()))
+                .thenReturn(Optional.of(new StoreStatistics()));
+        lenient().when(storeAnalyticsRepository.save(any(StoreStatistics.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(postalServiceStatisticsRepository.findByStoreIdAndPostalServiceType(anyLong(), any()))
+                .thenReturn(Optional.of(new PostalServiceStatistics()));
+        lenient().when(postalServiceStatisticsRepository.save(any(PostalServiceStatistics.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(storeAnalyticsRepository.incrementDelivered(anyLong(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(storeAnalyticsRepository.incrementReturned(anyLong(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(postalServiceStatisticsRepository.incrementDelivered(anyLong(), any(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(postalServiceStatisticsRepository.incrementReturned(anyLong(), any(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(storeDailyStatisticsRepository.incrementDelivered(anyLong(), any(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(storeDailyStatisticsRepository.incrementReturned(anyLong(), any(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(postalServiceDailyStatisticsRepository.incrementDelivered(anyLong(), any(), any(), anyInt(), any(), any()))
+                .thenReturn(1);
+        lenient().when(postalServiceDailyStatisticsRepository.incrementReturned(anyLong(), any(), any(), anyInt(), any(), any()))
+                .thenReturn(1);
     }
 
     /**
@@ -150,12 +184,10 @@ class DeliveryHistoryServiceTest {
         trackParcel.setDeliveryHistory(history);
 
         when(deliveryHistoryRepository.findByTrackParcelId(trackParcel.getId())).thenReturn(Optional.of(history));
-        when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
-        when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.WAITING_FOR_CUSTOMER);
-        when(trackParcelRepository.save(trackParcel)).thenReturn(trackParcel);
-        when(customerStatsService.incrementSent(any(Customer.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        doNothing().when(customerService).rollbackStatsOnTrackDelete(any(TrackParcel.class));
-        doNothing().when(deliveryMetricsRollbackService).rollbackFinalStatusMetrics(history, trackParcel, GlobalStatus.DELIVERED);
+        lenient().when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
+        lenient().when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.WAITING_FOR_CUSTOMER);
+        lenient().when(trackParcelRepository.save(trackParcel)).thenReturn(trackParcel);
+        lenient().when(customerStatsService.incrementSent(any(Customer.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         TrackInfoListDTO trackInfoListDTO = new TrackInfoListDTO();
         trackInfoListDTO.setList(List.of(new TrackInfoDTO("10.03.2025, 12:00", "WAITING")));
@@ -179,11 +211,11 @@ class DeliveryHistoryServiceTest {
         TrackParcel trackParcel = buildParcelWithCustomer(2L);
 
         when(deliveryHistoryRepository.findByTrackParcelId(trackParcel.getId())).thenReturn(Optional.empty());
-        when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.UNKNOWN);
-        when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.DELIVERED);
-        when(subscriptionService.isFeatureEnabled(trackParcel.getStore().getOwner().getId(), FeatureKey.TELEGRAM_NOTIFICATIONS))
+        lenient().when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.UNKNOWN);
+        lenient().when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.DELIVERED);
+        lenient().when(subscriptionService.isFeatureEnabled(trackParcel.getStore().getOwner().getId(), FeatureKey.TELEGRAM_NOTIFICATIONS))
                 .thenReturn(true);
-        when(deliveryHistoryRepository.save(any(DeliveryHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(deliveryHistoryRepository.save(any(DeliveryHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         TrackInfoListDTO trackInfoListDTO = buildDeliveredTrackInfo();
 
@@ -192,6 +224,88 @@ class DeliveryHistoryServiceTest {
         verify(telegramNotificationService, never()).sendStatusUpdate(any(TrackParcel.class), any(GlobalStatus.class));
         verify(customerNotificationLogRepository, never())
                 .existsByParcelIdAndStatusAndNotificationType(anyLong(), any(), any());
+    }
+
+    @Test
+    void updateDeliveryHistory_WhenReturnArrives_PublishesTrackingEvent() {
+        TrackParcel trackParcel = buildParcelWithCustomer(6L);
+
+        when(deliveryHistoryRepository.findByTrackParcelId(trackParcel.getId())).thenReturn(Optional.empty());
+        lenient().when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
+        lenient().when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.RETURN_PENDING_PICKUP);
+        lenient().when(deliveryHistoryRepository.save(any(DeliveryHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(subscriptionService.isFeatureEnabled(anyLong(), any())).thenReturn(false);
+
+        TrackInfoDTO dto = new TrackInfoDTO("10.03.2025, 12:00", "Возврат прибыл");
+        TrackInfoListDTO trackInfoListDTO = new TrackInfoListDTO(List.of(dto));
+
+        deliveryHistoryService.updateDeliveryHistory(
+                trackParcel,
+                GlobalStatus.RETURN_IN_PROGRESS,
+                GlobalStatus.RETURN_PENDING_PICKUP,
+                trackInfoListDTO
+        );
+
+        ArgumentCaptor<ReturnTrackingEvent> captor = ArgumentCaptor.forClass(ReturnTrackingEvent.class);
+        verify(returnTrackingEventHandler).handle(captor.capture());
+        ReturnTrackingEvent event = captor.getValue();
+        assertEquals(ReturnTrackingEventType.RETURN_ARRIVED_TO_STORE, event.type());
+        assertEquals(trackParcel, event.parcel());
+    }
+
+    @Test
+    void updateDeliveryHistory_WhenReturnPickedUp_PublishesTrackingEvent() {
+        TrackParcel trackParcel = buildParcelWithCustomer(7L);
+
+        when(deliveryHistoryRepository.findByTrackParcelId(trackParcel.getId())).thenReturn(Optional.empty());
+        lenient().when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
+        lenient().when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.RETURNED);
+        lenient().when(deliveryHistoryRepository.save(any(DeliveryHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(subscriptionService.isFeatureEnabled(anyLong(), any())).thenReturn(false);
+
+        TrackInfoDTO dto = new TrackInfoDTO("11.03.2025, 14:30", "Возврат получен");
+        TrackInfoListDTO trackInfoListDTO = new TrackInfoListDTO(List.of(dto));
+
+        deliveryHistoryService.updateDeliveryHistory(
+                trackParcel,
+                GlobalStatus.RETURN_PENDING_PICKUP,
+                GlobalStatus.RETURNED,
+                trackInfoListDTO
+        );
+
+        ArgumentCaptor<ReturnTrackingEvent> captor = ArgumentCaptor.forClass(ReturnTrackingEvent.class);
+        verify(returnTrackingEventHandler).handle(captor.capture());
+        ReturnTrackingEvent event = captor.getValue();
+        assertEquals(ReturnTrackingEventType.RETURN_PICKED_UP_BY_STORE, event.type());
+        assertEquals(trackParcel, event.parcel());
+    }
+
+    @Test
+    void updateDeliveryHistory_WhenExchangeDelivered_PublishesTrackingEvent() {
+        TrackParcel trackParcel = buildParcelWithCustomer(8L);
+        trackParcel.setExchange(true);
+
+        when(deliveryHistoryRepository.findByTrackParcelId(trackParcel.getId())).thenReturn(Optional.empty());
+        lenient().when(typeDefinitionTrackPostService.detectPostalService(anyString())).thenReturn(PostalServiceType.BELPOST);
+        lenient().when(statusTrackService.setStatus(anyList())).thenReturn(GlobalStatus.DELIVERED);
+        lenient().when(deliveryHistoryRepository.save(any(DeliveryHistory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(subscriptionService.isFeatureEnabled(anyLong(), any())).thenReturn(false);
+
+        TrackInfoDTO dto = new TrackInfoDTO("12.03.2025, 09:15", "Обмен доставлен");
+        TrackInfoListDTO trackInfoListDTO = new TrackInfoListDTO(List.of(dto));
+
+        deliveryHistoryService.updateDeliveryHistory(
+                trackParcel,
+                GlobalStatus.IN_TRANSIT,
+                GlobalStatus.DELIVERED,
+                trackInfoListDTO
+        );
+
+        ArgumentCaptor<ReturnTrackingEvent> captor = ArgumentCaptor.forClass(ReturnTrackingEvent.class);
+        verify(returnTrackingEventHandler).handle(captor.capture());
+        ReturnTrackingEvent event = captor.getValue();
+        assertEquals(ReturnTrackingEventType.EXCHANGE_DELIVERED_TO_CUSTOMER, event.type());
+        assertEquals(trackParcel, event.parcel());
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -13,6 +13,8 @@ import com.project.tracking_system.entity.ReturnRequestAction;
 import com.project.tracking_system.entity.OrderReturnRequestStatus;
 import com.project.tracking_system.entity.TrackParcel;
 import com.project.tracking_system.entity.User;
+import com.project.tracking_system.exception.ActionNotAllowedException;
+import com.project.tracking_system.exception.IdempotencyConflictException;
 import com.project.tracking_system.repository.OrderReturnRequestActionRequestRepository;
 import com.project.tracking_system.repository.OrderReturnRequestRepository;
 import com.project.tracking_system.service.track.TrackParcelService;
@@ -219,7 +221,7 @@ class OrderReturnRequestServiceTest {
                 DEFAULT_REVERSE_TRACK,
                 NO_EXCHANGE_REQUESTED
         ))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("доступна только для статуса");
     }
 
@@ -249,7 +251,7 @@ class OrderReturnRequestServiceTest {
                 DEFAULT_REVERSE_TRACK,
                 NO_EXCHANGE_REQUESTED
         ))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(IdempotencyConflictException.class)
                 .hasMessageContaining("другими данными");
     }
 
@@ -267,7 +269,7 @@ class OrderReturnRequestServiceTest {
                 .thenReturn(true);
 
         assertThatThrownBy(() -> service.setModeExchange(200L, 12L, user))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("уже запущен обмен");
     }
 
@@ -344,7 +346,7 @@ class OrderReturnRequestServiceTest {
         when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(activeReplacement));
 
         assertThatThrownBy(() -> service.createExchangeParcel(702L, 45L, user))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("уже создана");
         verify(orderExchangeService, never()).createExchangeParcel(any());
     }
@@ -431,7 +433,7 @@ class OrderReturnRequestServiceTest {
         when(repository.findById(903L)).thenReturn(Optional.of(request));
 
         assertThatThrownBy(() -> service.confirmReturnProcessing(903L, 33L, user))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("активной заявки или закрытия без обмена");
     }
 
@@ -509,6 +511,107 @@ class OrderReturnRequestServiceTest {
         assertThat(result.getResponsibleManager()).isEqualTo(user);
         verify(repository).save(request);
         verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void trackingEventAdvancesReturnStagesAndIsIdempotent() {
+        TrackParcel parcel = buildParcel(52L, GlobalStatus.RETURN_PENDING_PICKUP);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(2001L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.OUTBOUND_SENT);
+        request.setReverseTrackNumber("BY777000000");
+        request.setStageStartedAt(ZonedDateTime.now(ZoneOffset.UTC).minusDays(2));
+        request.setStageUpdatedAt(request.getStageStartedAt());
+
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(parcel.getId()), any())).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime arrivalMoment = ZonedDateTime.now(ZoneOffset.UTC).minusHours(5);
+        ReturnTrackingEventHandler handler = new ReturnTrackingEventHandler(service);
+
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.RETURN_ARRIVED_TO_STORE, parcel, arrivalMoment));
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.INBOUND_ARRIVED);
+        assertThat(request.isManualStageOverride()).isFalse();
+        assertThat(request.getStageUpdatedAt()).isEqualTo(arrivalMoment);
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.RETURN_ARRIVED_TO_STORE, parcel, arrivalMoment));
+
+        verify(repository, times(1)).save(any(OrderReturnRequest.class));
+        verify(trackViewCacheInvalidator, times(1)).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void trackingEventConfirmsReturnReceiptAndIsIdempotent() {
+        TrackParcel parcel = buildParcel(53L, GlobalStatus.RETURNED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(2002L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.INBOUND_ARRIVED);
+        request.setReverseTrackNumber("BY777111111");
+
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(parcel.getId()), any())).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime pickupMoment = ZonedDateTime.now(ZoneOffset.UTC).minusHours(2);
+        ReturnTrackingEventHandler handler = new ReturnTrackingEventHandler(service);
+
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.RETURN_PICKED_UP_BY_STORE, parcel, pickupMoment));
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        assertThat(request.isReturnReceiptConfirmed()).isTrue();
+        assertThat(request.getReturnReceiptConfirmedAt()).isEqualTo(pickupMoment);
+        assertThat(request.isManualStageOverride()).isFalse();
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.RETURN_PICKED_UP_BY_STORE, parcel, pickupMoment));
+
+        verify(repository, times(1)).save(any(OrderReturnRequest.class));
+        verify(trackViewCacheInvalidator, times(1)).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void trackingEventMarksExchangeDeliveredAndIsIdempotent() {
+        TrackParcel parcel = buildParcel(54L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = buildExchangeRequest(2003L, parcel);
+        request.setStage(ReturnRequestStage.EXCHANGE_SENT);
+        request.setExchangeTrackNumber("EX123456789");
+
+        TrackParcel exchangeParcel = buildParcel(960L, GlobalStatus.DELIVERED);
+        exchangeParcel.setExchange(true);
+        exchangeParcel.setReplacementOf(parcel);
+
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(parcel.getId()), any())).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(orderExchangeService.findLatestExchangeParcel(request)).thenReturn(Optional.of(exchangeParcel));
+
+        ZonedDateTime deliveryMoment = ZonedDateTime.now(ZoneOffset.UTC).minusHours(1);
+        ReturnTrackingEventHandler handler = new ReturnTrackingEventHandler(service);
+
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.EXCHANGE_DELIVERED_TO_CUSTOMER, exchangeParcel, deliveryMoment));
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_DELIVERED);
+        assertThat(request.isManualStageOverride()).isFalse();
+        assertThat(request.getStageUpdatedAt()).isEqualTo(deliveryMoment);
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+        verify(orderExchangeService).findLatestExchangeParcel(request);
+
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.EXCHANGE_DELIVERED_TO_CUSTOMER, exchangeParcel, deliveryMoment));
+
+        verify(repository, times(1)).save(any(OrderReturnRequest.class));
+        verify(trackViewCacheInvalidator, times(1)).evictTrackDetails(user.getId(), parcel.getId());
+        verify(orderExchangeService, times(1)).findLatestExchangeParcel(request);
     }
 
     @Test
@@ -630,7 +733,7 @@ class OrderReturnRequestServiceTest {
                 21L,
                 user,
                 OrderReturnRequestService.ModeSwitchTrigger.EXCHANGE_CANCELLATION))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("Отмена недоступна");
         verify(repository, never()).save(any());
         verify(orderExchangeService, never()).cancelExchangeParcel(any(), any());
@@ -891,7 +994,7 @@ class OrderReturnRequestServiceTest {
                 "track",
                 "comment"
         ))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("нельзя изменить");
         verify(repository, never()).save(any());
     }
@@ -995,7 +1098,7 @@ class OrderReturnRequestServiceTest {
                 24L,
                 user,
                 OrderReturnRequestService.ModeSwitchTrigger.CUSTOMER_REQUEST))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ActionNotAllowedException.class)
                 .hasMessageContaining("Магазин уже указал трек");
         verify(repository, never()).save(any());
         verify(orderExchangeService, never()).cancelExchangeParcel(any(), any());

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -615,6 +615,68 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
+    void trackingEventWithFutureArrivalMomentClampedToNow() {
+        TrackParcel parcel = buildParcel(71L, GlobalStatus.RETURN_PENDING_PICKUP);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(3001L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.OUTBOUND_SENT);
+        request.setReverseTrackNumber("BY123000000");
+
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(parcel.getId()), any())).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime futureMoment = ZonedDateTime.now(ZoneOffset.UTC).plusHours(6);
+        ReturnTrackingEventHandler handler = new ReturnTrackingEventHandler(service);
+
+        ZonedDateTime before = ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(1);
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.RETURN_ARRIVED_TO_STORE, parcel, futureMoment));
+        ZonedDateTime after = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(1);
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.INBOUND_ARRIVED);
+        assertThat(request.isManualStageOverride()).isFalse();
+        assertThat(request.getStageUpdatedAt()).isAfterOrEqualTo(before);
+        assertThat(request.getStageUpdatedAt()).isBeforeOrEqualTo(after);
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
+    void trackingEventWithFuturePickupMomentClampedToNow() {
+        TrackParcel parcel = buildParcel(72L, GlobalStatus.RETURNED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(3002L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setStage(ReturnRequestStage.INBOUND_ARRIVED);
+        request.setReverseTrackNumber("BY123000001");
+
+        when(repository.findFirstByParcel_IdAndStatusIn(eq(parcel.getId()), any())).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ZonedDateTime futureMoment = ZonedDateTime.now(ZoneOffset.UTC).plusHours(4);
+        ReturnTrackingEventHandler handler = new ReturnTrackingEventHandler(service);
+
+        ZonedDateTime before = ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(1);
+        handler.handle(new ReturnTrackingEvent(ReturnTrackingEventType.RETURN_PICKED_UP_BY_STORE, parcel, futureMoment));
+        ZonedDateTime after = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(1);
+
+        assertThat(request.getStage()).isEqualTo(ReturnRequestStage.INBOUND_PICKED_UP);
+        assertThat(request.isReturnReceiptConfirmed()).isTrue();
+        assertThat(request.getReturnReceiptConfirmedAt()).isAfterOrEqualTo(before);
+        assertThat(request.getReturnReceiptConfirmedAt()).isBeforeOrEqualTo(after);
+        assertThat(request.getStageUpdatedAt()).isAfterOrEqualTo(before);
+        assertThat(request.getStageUpdatedAt()).isBeforeOrEqualTo(after);
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
     void registerExchangeParcel_AssignsTrackAndKeepsStage() {
         TrackParcel parcel = buildParcel(43L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = buildExchangeRequest(1003L, parcel);


### PR DESCRIPTION
## Summary
- add tracking event domain objects and handler to trigger return/exchange stage transitions from tracking updates
- implement idempotent auto stage transitions in OrderReturnRequestService shared with manual workflow checks
- publish tracking events during delivery history updates and expand tests to cover automatic progression and idempotency

## Testing
- `mvn -q -Dtest=OrderReturnRequestServiceTest,DeliveryHistoryServiceTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691590acb678832d9f2fd925eff5beaf)