### PR TITLE
Add exchange parcel registration option for return inbound stages

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -481,14 +481,16 @@ public class OrderReturnRequestService {
                                                      String exchangeTrack,
                                                      ZonedDateTime stageMoment) {
         OrderReturnRequest request = loadOwnedRequest(requestId, parcelId, user);
-        if (request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
-            throw new ActionNotAllowedException("Ручная регистрация доступна только для одобренного обмена");
-        }
         if (!canRegisterExchangeParcel(request)) {
             throw new ActionNotAllowedException("Обменная посылка уже зарегистрирована или ожидает обработки");
         }
         String normalizedTrack = normalizeExchangeTrackNumber(exchangeTrack);
         ZonedDateTime normalizedMoment = normalizeStageMoment(stageMoment);
+        if (request.getStatus() != OrderReturnRequestStatus.EXCHANGE_APPROVED) {
+            request = applyExchangeMode(request, user);
+        } else if (resolveMode(request) != ReturnRequestMode.EXCHANGE) {
+            request.setMode(ReturnRequestMode.EXCHANGE);
+        }
         assignExchangeTrack(request, normalizedTrack, normalizedMoment, user);
         returnRequestWorkflow.transitionSequentially(request, ReturnRequestStage.EXCHANGE_REGISTERED, true, user, normalizedMoment);
         OrderReturnRequest saved = returnRequestRepository.save(request);
@@ -1231,15 +1233,51 @@ public class OrderReturnRequestService {
         if (request == null) {
             return false;
         }
-        if (resolveMode(request) != ReturnRequestMode.EXCHANGE) {
+        if (hasExchangeTrack(request)) {
             return false;
         }
         ReturnRequestStage stage = resolveStage(request);
-        if (returnRequestWorkflow.adjustStageForMode(ReturnRequestMode.EXCHANGE, stage)
-                != ReturnRequestStage.EXCHANGE_REGISTERED) {
+        ReturnRequestStage exchangeStage = returnRequestWorkflow
+                .adjustStageForMode(ReturnRequestMode.EXCHANGE, stage);
+        if (!returnRequestWorkflow.canReachStage(ReturnRequestMode.EXCHANGE, exchangeStage,
+                ReturnRequestStage.EXCHANGE_REGISTERED)) {
             return false;
         }
-        return canCreateExchangeParcel(request);
+        OrderReturnRequestStatus status = request.getStatus();
+        ReturnRequestMode mode = resolveMode(request);
+        if (status == OrderReturnRequestStatus.EXCHANGE_APPROVED && mode == ReturnRequestMode.EXCHANGE) {
+            return ensureExchangeSlotAvailable(request);
+        }
+        if (status == OrderReturnRequestStatus.REGISTERED && mode == ReturnRequestMode.RETURN) {
+            ReturnRequestStage returnStage = returnRequestWorkflow
+                    .adjustStageForMode(ReturnRequestMode.RETURN, stage);
+            boolean eligibleInboundStage = returnStage == ReturnRequestStage.INBOUND_ARRIVED
+                    || returnStage == ReturnRequestStage.INBOUND_PICKED_UP;
+            if (!eligibleInboundStage) {
+                return false;
+            }
+            if (!canSetModeExchange(request)) {
+                return false;
+            }
+            return ensureExchangeSlotAvailable(request);
+        }
+        return false;
+    }
+
+    /**
+     * Проверяет, что по заявке свободен слот для регистрации обменной посылки.
+     * <p>
+     * Метод убеждается, что у заявки нет активной обменной отправки, и допускает повторную попытку
+     * только если предыдущая регистрация была отменена. Такой подход предотвращает дублирование
+     * посылок и сохраняет согласованность истории.
+     * </p>
+     */
+    private boolean ensureExchangeSlotAvailable(OrderReturnRequest request) {
+        Optional<TrackParcel> latest = Optional
+                .ofNullable(orderExchangeService.findLatestExchangeParcel(request))
+                .orElse(Optional.empty());
+        return latest.map(parcel -> parcel.getStatus() == GlobalStatus.REGISTRATION_CANCELLED)
+                .orElse(true);
     }
 
     /**

--- a/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
+++ b/src/main/java/com/project/tracking_system/service/order/ReturnRequestWorkflow.java
@@ -306,6 +306,11 @@ public class ReturnRequestWorkflow {
                         actions.addAll(mapped);
                     }
                 }
+                if (mode == ReturnRequestMode.RETURN
+                        && (stage == ReturnRequestStage.INBOUND_ARRIVED
+                        || stage == ReturnRequestStage.INBOUND_PICKED_UP)) {
+                    actions.add(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+                }
                 if (!actions.isEmpty()) {
                     stageActions.put(stage, actions);
                 }

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -699,6 +699,35 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
+    void registerExchangeParcel_FromReturnModeSwitchesToExchange() {
+        TrackParcel parcel = buildParcel(143L, GlobalStatus.DELIVERED);
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setId(2103L);
+        request.setParcel(parcel);
+        request.setEpisode(parcel.getEpisode());
+        request.setStore(parcel.getStore());
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setStage(ReturnRequestStage.INBOUND_ARRIVED);
+
+        when(repository.findById(2103L)).thenReturn(Optional.of(request));
+        when(repository.save(any(OrderReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(repository.existsByEpisode_IdAndStatus(parcel.getEpisode().getId(), OrderReturnRequestStatus.EXCHANGE_APPROVED))
+                .thenReturn(false);
+
+        ZonedDateTime stageMoment = ZonedDateTime.of(2024, 5, 20, 18, 45, 0, 0, ZoneOffset.ofHours(3));
+
+        OrderReturnRequest result = service.registerExchangeParcel(2103L, parcel.getId(), user, "ex710", stageMoment);
+
+        assertThat(result.getMode()).isEqualTo(ReturnRequestMode.EXCHANGE);
+        assertThat(result.getStatus()).isEqualTo(OrderReturnRequestStatus.EXCHANGE_APPROVED);
+        assertThat(result.getStage()).isEqualTo(ReturnRequestStage.EXCHANGE_REGISTERED);
+        assertThat(result.getExchangeTrackNumber()).isEqualTo("EX710");
+        verify(repository).save(request);
+        verify(trackViewCacheInvalidator).evictTrackDetails(user.getId(), parcel.getId());
+    }
+
+    @Test
     void markExchangeSent_AssignsTrackAndTransitionsStage() {
         TrackParcel parcel = buildParcel(44L, GlobalStatus.DELIVERED);
         OrderReturnRequest request = buildExchangeRequest(1004L, parcel);
@@ -1230,7 +1259,9 @@ class OrderReturnRequestServiceTest {
 
         assertThat(actions)
                 .contains(ReturnRequestAction.MARK_OUTBOUND_SENT)
-                .doesNotContain(ReturnRequestAction.MARK_INBOUND_ARRIVED, ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+                .doesNotContain(ReturnRequestAction.MARK_INBOUND_ARRIVED,
+                        ReturnRequestAction.MARK_INBOUND_PICKED_UP,
+                        ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
 
         request.setStage(ReturnRequestStage.OUTBOUND_SENT);
 
@@ -1238,15 +1269,27 @@ class OrderReturnRequestServiceTest {
 
         assertThat(actions)
                 .contains(ReturnRequestAction.MARK_INBOUND_ARRIVED)
-                .doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT, ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+                .doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT,
+                        ReturnRequestAction.MARK_INBOUND_PICKED_UP,
+                        ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
 
         request.setStage(ReturnRequestStage.INBOUND_ARRIVED);
 
         actions = service.resolveAvailableActions(request);
 
         assertThat(actions)
-                .contains(ReturnRequestAction.MARK_INBOUND_PICKED_UP)
+                .contains(ReturnRequestAction.MARK_INBOUND_PICKED_UP, ReturnRequestAction.REGISTER_EXCHANGE_PARCEL)
                 .doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT, ReturnRequestAction.MARK_INBOUND_ARRIVED);
+
+        request.setStage(ReturnRequestStage.INBOUND_PICKED_UP);
+
+        actions = service.resolveAvailableActions(request);
+
+        assertThat(actions)
+                .contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL)
+                .doesNotContain(ReturnRequestAction.MARK_OUTBOUND_SENT,
+                        ReturnRequestAction.MARK_INBOUND_ARRIVED,
+                        ReturnRequestAction.MARK_INBOUND_PICKED_UP);
     }
 
     @Test

--- a/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/ReturnRequestWorkflowTest.java
@@ -131,6 +131,39 @@ class ReturnRequestWorkflowTest {
     }
 
     @Test
+    void resolveBaseActions_ReturnInboundStagesExposeExchangeRegistration() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+
+        ReturnRequestActionContext arrivedContext = ReturnRequestActionContext.builder(request)
+                .withMode(ReturnRequestMode.RETURN)
+                .withStage(ReturnRequestStage.INBOUND_ARRIVED)
+                .withStatus(OrderReturnRequestStatus.REGISTERED)
+                .allow(ReturnRequestAction.MARK_INBOUND_PICKED_UP, true)
+                .allow(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL, true)
+                .build();
+
+        EnumSet<ReturnRequestAction> arrivedActions = workflow.resolveBaseActions(arrivedContext);
+
+        assertThat(arrivedActions)
+                .contains(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL,
+                        ReturnRequestAction.MARK_INBOUND_PICKED_UP);
+
+        ReturnRequestActionContext pickedUpContext = ReturnRequestActionContext.builder(request)
+                .withMode(ReturnRequestMode.RETURN)
+                .withStage(ReturnRequestStage.INBOUND_PICKED_UP)
+                .withStatus(OrderReturnRequestStatus.REGISTERED)
+                .allow(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL, true)
+                .build();
+
+        EnumSet<ReturnRequestAction> pickedUpActions = workflow.resolveBaseActions(pickedUpContext);
+
+        assertThat(pickedUpActions)
+                .containsExactly(ReturnRequestAction.REGISTER_EXCHANGE_PARCEL);
+    }
+
+    @Test
     void transitionSequentially_AdvancesReturnThroughAllStages() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setMode(ReturnRequestMode.RETURN);


### PR DESCRIPTION
## Summary
- expose the register-exchange-parcel action for return requests once they reach inbound arrival or pickup
- relax service validation to convert return requests to exchange mode when registering a parcel and guard against duplicate parcels
- extend workflow and service unit tests to cover the new behaviour

## Testing
- `mvn -Dtest=ReturnRequestWorkflowTest,OrderReturnRequestServiceTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a6b31728832db8be2a0b681eee53)