### PR TITLE
Restrict closing return requests on transit stages

### DIFF
--- a/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
+++ b/src/main/java/com/project/tracking_system/service/order/OrderReturnRequestService.java
@@ -1167,14 +1167,25 @@ public class OrderReturnRequestService {
      * Проверяет, разрешено ли действие для конкретной заявки с учётом всех ограничений.
      */
     /**
-     * Проверяет, можно ли закрыть заявку на текущем этапе.
+     * Проверяет, можно ли закрыть заявку на текущем этапе, учитывая ограничения из ТЗ.
+     * <p>
+     * Закрытие разрешено только для активных заявок в статусе {@link OrderReturnRequestStatus#REGISTERED}
+     * и на стадиях, где по регламенту не требуется дальнейших действий: на этапах
+     * {@link ReturnRequestStage#OUTBOUND_SENT} и {@link ReturnRequestStage#INBOUND_ARRIVED}
+     * кнопка должна быть скрыта как во фронте, так и в боте, поэтому метод дополнительно
+     * нормализует стадию и блокирует закрытие.
+     * </p>
      */
     private boolean canCloseRequest(OrderReturnRequest request) {
         if (request == null) {
             return false;
         }
-        OrderReturnRequestStatus status = request.getStatus();
-        return status == OrderReturnRequestStatus.REGISTERED;
+        if (request.getStatus() != OrderReturnRequestStatus.REGISTERED) {
+            return false;
+        }
+        ReturnRequestMode mode = resolveMode(request);
+        ReturnRequestStage stage = returnRequestWorkflow.adjustStageForMode(mode, resolveStage(request));
+        return stage != ReturnRequestStage.OUTBOUND_SENT && stage != ReturnRequestStage.INBOUND_ARRIVED;
     }
 
     /**

--- a/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
+++ b/src/test/java/com/project/tracking_system/service/order/OrderReturnRequestServiceTest.java
@@ -1211,6 +1211,24 @@ class OrderReturnRequestServiceTest {
     }
 
     @Test
+    void resolveAvailableActions_DoesNotExposeCloseRequestForTransitStages() {
+        OrderReturnRequest request = new OrderReturnRequest();
+        request.setStatus(OrderReturnRequestStatus.REGISTERED);
+        request.setMode(ReturnRequestMode.RETURN);
+        request.setReverseTrackNumber("BY999");
+
+        for (ReturnRequestStage stage : List.of(ReturnRequestStage.OUTBOUND_SENT, ReturnRequestStage.INBOUND_ARRIVED)) {
+            request.setStage(stage);
+
+            EnumSet<ReturnRequestAction> actions = service.resolveAvailableActions(request);
+
+            assertThat(actions)
+                    .as("На стадии %s кнопка закрытия должна быть скрыта", stage)
+                    .doesNotContain(ReturnRequestAction.CLOSE_REQUEST);
+        }
+    }
+
+    @Test
     void resolveAvailableActions_ReturnsExchangeStageActions() {
         OrderReturnRequest request = new OrderReturnRequest();
         request.setStatus(OrderReturnRequestStatus.EXCHANGE_APPROVED);


### PR DESCRIPTION
## Summary
- prevent closing return requests on OUTBOUND_SENT and INBOUND_ARRIVED stages by normalizing stage constraints
- add a regression test confirming transit stages omit the close command from available actions

## Testing
- mvn -Dtest=OrderReturnRequestServiceTest,ReturnRequestWorkflowTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a89fd6b0832dad6084d8133aa8ad)